### PR TITLE
Define a flag to warn on missing document

### DIFF
--- a/Microsoft.Rest/ClientRuntime.Etw/ClientRuntime.Etw.csproj
+++ b/Microsoft.Rest/ClientRuntime.Etw/ClientRuntime.Etw.csproj
@@ -12,7 +12,6 @@
     <AssemblyName>Microsoft.Rest.ClientRuntime.Etw</AssemblyName>
     <OutputType>Library</OutputType>
     <RestorePackages>true</RestorePackages>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NuGetPackageImportStamp>644881db</NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\tools\AutoRest.Settings.targets" />

--- a/Microsoft.Rest/ClientRuntime.Log4Net/ClientRuntime.Log4Net.csproj
+++ b/Microsoft.Rest/ClientRuntime.Log4Net/ClientRuntime.Log4Net.csproj
@@ -12,7 +12,6 @@
     <AssemblyName>Microsoft.Rest.ClientRuntime.Log4Net</AssemblyName>
     <OutputType>Library</OutputType>
     <RestorePackages>true</RestorePackages>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NuGetPackageImportStamp>e31a3ee2</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Net40-Debug'">

--- a/Microsoft.Rest/ClientRuntime/ClientRuntime.csproj
+++ b/Microsoft.Rest/ClientRuntime/ClientRuntime.csproj
@@ -12,7 +12,6 @@
     <AssemblyName>Microsoft.Rest.ClientRuntime</AssemblyName>
     <OutputType>Library</OutputType>
     <RestorePackages>true</RestorePackages>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NuGetPackageImportStamp>d6eb8bcd</NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\tools\AutoRest.Settings.targets" />

--- a/tools/AutoRest.Settings.targets
+++ b/tools/AutoRest.Settings.targets
@@ -26,8 +26,9 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(AssemblyName).xml</DocumentationFile>
     <AdditionalBinariesFolder>$(LibraryFxTarget)\</AdditionalBinariesFolder>
+    <WarnOnMissingDocument Condition="'$(WarnOnMissingDocument)' == ''">false</WarnOnMissingDocument>
     <!-- Turn off XML documentation warnings. -->
-    <NoWarn>1591</NoWarn>
+    <NoWarn Condition="'$(WarnOnMissingDocument)' == 'false'">1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)' == ''">AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>


### PR DESCRIPTION
I also removed the redundant "TreatWarningsAsErrors" property on each individual project since i have defined in the common setting file
