### PR TITLE
respect zero when initialize the ExponentialRetryPolicyFilter

### DIFF
--- a/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/AcceptanceTests/head.js
+++ b/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/AcceptanceTests/head.js
@@ -26,7 +26,7 @@ describe('nodejs', function () {
     describe('Head Operations', function () {
       var testOptions = clientOptions;
       testOptions.requestOptions = { jar: true };
-      testOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0.1, 0.1, 0.1)];
+      testOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0, 0, 0)];
       testOptions.noRetryPolicy = true;
       var testClient = new headClient(credentials, baseUri, clientOptions);
 

--- a/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/AcceptanceTests/lro.js
+++ b/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/AcceptanceTests/lro.js
@@ -23,7 +23,7 @@ describe('nodejs', function () {
   
   describe('Swagger LRO Happy BAT', function () {
     clientOptions.requestOptions = { jar: true };
-    clientOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0.0001, 0.0001, 0.0001)];
+    clientOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0, 0, 0)];
     clientOptions.noRetryPolicy = true;
     clientOptions.longRunningOperationRetryTimeoutInSeconds = 0;
     
@@ -368,7 +368,7 @@ describe('nodejs', function () {
 
   describe('Swagger LRO Sad BAT', function () {
     clientOptions.requestOptions = { jar: true };
-    clientOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0.0001, 0.0001, 0.0001)];
+    clientOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0, 0, 0)];
     clientOptions.noRetryPolicy = true;
     
     var testClient = new lroClient(credentials, baseUri, clientOptions);

--- a/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/AcceptanceTests/paging.js
+++ b/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/AcceptanceTests/paging.js
@@ -25,7 +25,7 @@ describe('nodejs', function () {
     
     describe('Pageable Operations', function () {
       clientOptions.requestOptions = { jar: true };
-      clientOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0.1, 0.1, 0.1)];
+      clientOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0, 0, 0)];
       clientOptions.noRetryPolicy = true;
       var testClient = new pagingClient(credentials, baseUri, clientOptions);
       

--- a/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/AcceptanceTests/resourceFlattening.js
+++ b/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/AcceptanceTests/resourceFlattening.js
@@ -26,7 +26,7 @@ describe('nodejs', function () {
     describe('Resource Flattening Operations', function () {
       var testOptions = clientOptions;
       testOptions.requestOptions = { jar: true };
-      testOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0.1, 0.1, 0.1)];
+      testOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0, 0, 0)];
       testOptions.noRetryPolicy = true;
       var testClient = new flatteningClient(credentials, baseUri, clientOptions);
       

--- a/AutoRest/Generators/NodeJS/NodeJS.Tests/AcceptanceTests/swaggerbatTests.js
+++ b/AutoRest/Generators/NodeJS/NodeJS.Tests/AcceptanceTests/swaggerbatTests.js
@@ -1627,7 +1627,7 @@ describe('nodejs', function () {
     describe('Http infrastructure Client', function () {
       var testOptions = clientOptions;
       testOptions.requestOptions = { jar: true };
-      testOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0.1, 0.1, 0.1)];
+      testOptions.filters = [new msRest.ExponentialRetryPolicyFilter(3, 0, 0, 0)];
       testOptions.noRetryPolicy = true
       var testClient = new httpClient(credentials, baseUri, testOptions);
       it('should work for all http success status codes with different verbs', function (done) {

--- a/ClientRuntimes/NodeJS/ClientRuntime/lib/filters/exponentialretrypolicyfilter.js
+++ b/ClientRuntimes/NodeJS/ClientRuntime/lib/filters/exponentialretrypolicyfilter.js
@@ -145,10 +145,10 @@ function ExponentialRetryPolicyFilter(retryCount, retryInterval, minRetryInterva
   }
 
   _.extend(newFilter, {
-    retryCount: retryCount || ExponentialRetryPolicyFilter.DEFAULT_CLIENT_RETRY_COUNT,
-    retryInterval: retryInterval || ExponentialRetryPolicyFilter.DEFAULT_CLIENT_RETRY_INTERVAL,
-    minRetryInterval: minRetryInterval || ExponentialRetryPolicyFilter.DEFAULT_CLIENT_MIN_RETRY_INTERVAL,
-    maxRetryInterval: maxRetryInterval || ExponentialRetryPolicyFilter.DEFAULT_CLIENT_MAX_RETRY_INTERVAL,
+    retryCount: isNaN(retryCount) ? ExponentialRetryPolicyFilter.DEFAULT_CLIENT_RETRY_COUNT : retryCount,
+    retryInterval: isNaN(retryInterval) ? ExponentialRetryPolicyFilter.DEFAULT_CLIENT_RETRY_INTERVAL : retryInterval,
+    minRetryInterval: isNaN(minRetryInterval) ? ExponentialRetryPolicyFilter.DEFAULT_CLIENT_MIN_RETRY_INTERVAL : minRetryInterval,
+    maxRetryInterval: isNaN(maxRetryInterval) ? ExponentialRetryPolicyFilter.DEFAULT_CLIENT_MAX_RETRY_INTERVAL : maxRetryInterval,
     handle: handle,
     shouldRetry: shouldRetry,
     updateRetryData: updateRetryData


### PR DESCRIPTION
Using 'isNaN' is not perfect, because of JS's 'coercing' behavior. But the existing code doesn't do better on this either, and I still want to get the code clearly that when we run tests, we just don't want to wait