### PR TITLE
Fixed cloning of the Method object

### DIFF
--- a/AutoRest/AutoRest.Core/ClientModel/Method.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/Method.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Rest.Generator.ClientModel
             newMethod.RequestHeaders = new Dictionary<string, string>();
             newMethod.Responses = new Dictionary<HttpStatusCode, IType>();
             this.Extensions.ForEach(e => newMethod.Extensions[e.Key] = e.Value);
-            this.Parameters.ForEach(p => newMethod.Parameters.Add(p));
+            this.Parameters.ForEach(p => newMethod.Parameters.Add((Parameter)p.Clone()));
             this.RequestHeaders.ForEach(r => newMethod.RequestHeaders[r.Key] = r.Value);
             this.Responses.ForEach(r => newMethod.Responses[r.Key] = r.Value);
             return newMethod;

--- a/AutoRest/AutoRest.Core/ClientModel/Parameter.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/Parameter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -79,6 +78,22 @@ namespace Microsoft.Rest.Generator.ClientModel
         public override string ToString()
         {
             return string.Format(CultureInfo.InvariantCulture, "{0} {1}", Type, Name);
+        }
+
+        /// <summary>
+        /// Performs a deep clone of a parameter.
+        /// </summary>
+        /// <returns>A deep clone of current object.</returns>
+        public object Clone()
+        {
+            Parameter param = (Parameter)this.MemberwiseClone();
+
+            if (param.GlobalProperty != null)
+            {
+                param.GlobalProperty = (Property)this.GlobalProperty.Clone();    
+            }            
+
+            return param;
         }
     }
 }

--- a/AutoRest/AutoRest.Core/ClientModel/Property.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/Property.cs
@@ -69,5 +69,15 @@ namespace Microsoft.Rest.Generator.ClientModel
         {
             return string.Format(CultureInfo.InvariantCulture, "{0} {1} {{get;{2}}}", Type, Name, IsReadOnly ? "" : "set;");
         }
+
+        /// <summary>
+        /// Performs a deep clone of a property.
+        /// </summary>
+        /// <returns>A deep clone of current object.</returns>
+        public object Clone()
+        {
+            var property = (Property) this.MemberwiseClone();
+            return property;
+        }
     }
 }


### PR DESCRIPTION
Currently when we create a LRO method - we copy it from the existing one. But the copy isn't "deep" enough. So when I update parameter of the LRO method - I'm updating parameter of the method it was cloned too (and vice versa).
This was revealed in the Ruby code generator because I was applying CodeNaming framework on method parameters.