### PR TITLE
Fix the warning of “npm WARN package.json autorest-test@0.1.1 No README data”

### DIFF
--- a/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/package.json
+++ b/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/Azure/AutoRest"
   },
   "version": "0.1.1",
+  "private": true, 
   "description": "Tests for Autorest Azure nodejs codegen",
   "engines": {
     "node": ">= 0.8.26"

--- a/AutoRest/Generators/NodeJS/NodeJS.Tests/package.json
+++ b/AutoRest/Generators/NodeJS/NodeJS.Tests/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/Azure/AutoRest"
   },
   "version": "0.1.1",
+  "private": true,
   "description": "Tests for Autorest nodejs codegen",
   "engines": {
     "node": ">= 0.8.26"


### PR DESCRIPTION
I turn on the private tag in those test project's package.json files since we will never publish them