### PR TITLE
Call Initialize in third constructor

### DIFF
--- a/AutoRest/Generators/CSharp/CSharp/Templates/ServiceClientTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/ServiceClientTemplate.cshtml
@@ -181,6 +181,7 @@ namespace @Settings.Namespace
         {
         @:    this.@(param.Name) = @(param.Name.ToCamelCase());
         }
+        @:    this.Initialize();
         @:}
         @:@EmptyLine
         }


### PR DESCRIPTION
A call to Initialize is missing in the third constructor

    /// <summary>
    /// Initializes a new instance of the CatFactory class.
    /// </summary>
    /// <param name='baseUri'>
    /// Optional. The base URI of the service.
    /// </param>
    /// <param name='credentials'>
    /// Required. Subscription credentials which uniquely identify client subscription.
    /// </param>
    /// <param name='handlers'>
    /// Optional. The delegating handlers to add to the http client pipeline.
    /// </param>
    public CatFactory(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
    {
        if (baseUri == null)
        {
            throw new ArgumentNullException("baseUri");
        }
        if (credentials == null)
        {
            throw new ArgumentNullException("credentials");
        }
        this.BaseUri = baseUri;
        this.Credentials = credentials;
        // Missing call to this.Initialize()?
    }

Nb. this ought to be tested, as I'm just passing by.