### PR TITLE
Fixing various setup and build issues

### DIFF
--- a/AutoRest/AutoRest.Core/Extensibility/ExtensionsLoader.cs
+++ b/AutoRest/AutoRest.Core/Extensibility/ExtensionsLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -121,6 +122,7 @@ namespace Microsoft.Rest.Generator.Extensibility
             return settings.FileSystem.ReadFileAsText(path);
         }
 
+        [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFrom")]
         private static T LoadTypeFromAssembly<T>(IDictionary<string, AutoRestProviderConfiguration> section,
             string key, Settings settings)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/AcceptanceTests.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/AcceptanceTests.cs
@@ -1615,7 +1615,7 @@ namespace Microsoft.Rest.Generator.CSharp.Tests
                 float executedTests = report.Values.Count(v => v > 0);
                 Trace.WriteLine(string.Format(CultureInfo.CurrentCulture, "The test coverage is {0}/{1}.",
                     executedTests, totalTests));
-                Assert.Equal(executedTests, totalTests);
+                Assert.Equal(totalTests, executedTests);
             }
         }
 

--- a/AutoRest/NuGetTests/NugetPackageTest/NugetPackageCSharpTest.csproj
+++ b/AutoRest/NuGetTests/NugetPackageTest/NugetPackageCSharpTest.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Rest.ClientRuntime">
-      <HintPath>packages\Microsoft.Rest.ClientRuntime.1.2.0\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>packages\Microsoft.Rest.ClientRuntime.1.3.0\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ By default, Ruby installs to C:\Ruby21 or Ruby22, etc. Ensure that C:\Ruby21\bin
 The DevKit installer just unpacks files. Navigate to the directory and run the following:
 >ruby dk.rb init
 >ruby dk.rb install
+>gem install bundler
 
 ## Build the Code
 We use [gulp](http://gulpjs.com) and msbuild / xbuild to handle the builds. Install for global use with
 >npm install gulp -g
-If you would like to see what commands are
-available to you, run `gulp -T`. That will list all of the gulp tasks you can run. By default, just running `gulp` will
-run a build that will execute clean, build, code analysis, package and test.
+
+If you would like to see what commands are available to you, run `gulp -T`. That will list all of the gulp tasks you can run. By default, just running `gulp` will run a build that will execute clean, build, code analysis, package and test.
 
 ### Output from gulp -T
 ```bash
@@ -89,8 +89,7 @@ run a build that will execute clean, build, code analysis, package and test.
 ```
 
 ### Running the tests
-Prior to executing `gulp build test` to build and then test the code. Make sure that the latest tools are setup for your
-build environment.
+Prior to executing `gulp` to build and then test the code, make sure that the latest tools are setup for your build environment.
 
 - run `bundle install` from the root directory
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,13 +139,19 @@ gulp.task('regenerate:expected:cs', function(cb){
   }, cb);
 });
 
+var msbuildDefaults = {
+  stdout: process.stdout,
+  stderr: process.stderr,
+  maxBuffer: MAX_BUFFER,
+  verbosity: 'minimal',
+  errorOnFail: true,
+  toolsVersion: 12.0
+};
+
 gulp.task('clean:build', function (cb) {
-  return gulp.src('build.proj').pipe(msbuild({
-    targets: ['clean'],
-    stdout: process.stdout,
-    stderr: process.stderr,
-    maxBuffer: MAX_BUFFER
-  }));
+  return gulp.src('build.proj').pipe(msbuild(mergeOptions(msbuildDefaults, {
+    targets: ['clean'] 
+  })));
 });
 
 gulp.task('clean:templates', function(cb) {
@@ -199,14 +205,6 @@ gulp.task('syncDependencies:nuspec', function() {
 gulp.task('syncDependencies:runtime', ['syncDependencies:runtime:cs', 'syncDependencies:runtime:csazure', 'syncDependencies:runtime:node', 'syncDependencies:runtime:nodeazure']);
 
 gulp.task('syncDependencies', ['syncDependencies:nugetProj', 'syncDependencies:nuspec', 'syncDependencies:runtime']);
-
-var msbuildDefaults = {
-  stdout: process.stdout,
-  stderr: process.stderr,
-  maxBuffer: MAX_BUFFER,
-  verbosity: 'minimal',
-  errorOnFail: true,
-};
 
 gulp.task('build', function(cb) {
   // warning 0219 is for unused variables, which causes the build to fail on xbuild


### PR DESCRIPTION
- Bumped Microsoft.Rest.ClientRuntime package version to 1.3.0 in
  NugetPackageTest to fix test failure.
- Suppressed Code Analysis error that was breaking the build
- Swapped expected and actual in AcceptanceTests.EnsureTestCoverage
  since the output was misleading when it failed.
- Added missing Ruby setup step to README and changed instructions
  for running gulp. 'gulp build test' fails because 'packages' is
  actually a prerequisite of 'test', so just running 'gulp' to invoke
  the default task is safer.
- Added msbuild targetVersion to gulpfile to prevent gulp-msbuild from
  loading an older version of msbuild. This was causing the C# URL tests
  to fail since URL parsing behavior is different between .NET 4.0 and
  .NET 4.5. See the Remarks for System.Uri on MSDN for more details:
  https://msdn.microsoft.com/en-us/library/system.uri(v=vs.110).aspx