### PR TITLE
Remove debug and release solution config which is useless and can't be used to build

### DIFF
--- a/AutoRest.sln
+++ b/AutoRest.sln
@@ -87,16 +87,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRest.Generator.Azure.Ja
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Net45-Debug|Any CPU = Net45-Debug|Any CPU
 		Net45-Release|Any CPU = Net45-Release|Any CPU
 		Portable-Debug|Any CPU = Portable-Debug|Any CPU
 		Portable-Release|Any CPU = Portable-Release|Any CPU
-		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -105,10 +101,6 @@ Global
 		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{C876085F-9DC3-41F0-B7B4-17022CD84684}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -117,10 +109,6 @@ Global
 		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{F589D8B7-1B0F-4182-842B-09866A4A2CEB}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -129,10 +117,6 @@ Global
 		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{31E6BAA3-C606-4D44-B0D7-46BE7AFAC656}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{9517265E-5127-460C-9DDE-FE017D73121C}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{9517265E-5127-460C-9DDE-FE017D73121C}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{9517265E-5127-460C-9DDE-FE017D73121C}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{9517265E-5127-460C-9DDE-FE017D73121C}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{9517265E-5127-460C-9DDE-FE017D73121C}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -141,10 +125,6 @@ Global
 		{9517265E-5127-460C-9DDE-FE017D73121C}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{9517265E-5127-460C-9DDE-FE017D73121C}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{9517265E-5127-460C-9DDE-FE017D73121C}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{9517265E-5127-460C-9DDE-FE017D73121C}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{9517265E-5127-460C-9DDE-FE017D73121C}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -153,10 +133,6 @@ Global
 		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{C6C4E139-D7AF-486C-95BA-2B879F58F18D}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -165,10 +141,6 @@ Global
 		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{2C062B51-EFD0-4FDC-8F75-3D76161FBCB5}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -177,10 +149,6 @@ Global
 		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{90B943AB-3879-4B64-B9FF-1A21297C0F26}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{4899B527-6815-4E89-84B3-DD5A507B205A}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{4899B527-6815-4E89-84B3-DD5A507B205A}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{4899B527-6815-4E89-84B3-DD5A507B205A}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{4899B527-6815-4E89-84B3-DD5A507B205A}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{4899B527-6815-4E89-84B3-DD5A507B205A}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -189,10 +157,6 @@ Global
 		{4899B527-6815-4E89-84B3-DD5A507B205A}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{4899B527-6815-4E89-84B3-DD5A507B205A}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{4899B527-6815-4E89-84B3-DD5A507B205A}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{4899B527-6815-4E89-84B3-DD5A507B205A}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{4899B527-6815-4E89-84B3-DD5A507B205A}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -201,10 +165,6 @@ Global
 		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{CA4DDAA2-9558-47B9-8838-A077A628E94C}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -213,10 +173,6 @@ Global
 		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{CC1EEC95-41EF-44B6-8761-00FA3E647248}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{84211169-9441-44F9-B626-10BF75FF25A6}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{84211169-9441-44F9-B626-10BF75FF25A6}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{84211169-9441-44F9-B626-10BF75FF25A6}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{84211169-9441-44F9-B626-10BF75FF25A6}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{84211169-9441-44F9-B626-10BF75FF25A6}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -225,10 +181,6 @@ Global
 		{84211169-9441-44F9-B626-10BF75FF25A6}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{84211169-9441-44F9-B626-10BF75FF25A6}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{84211169-9441-44F9-B626-10BF75FF25A6}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{84211169-9441-44F9-B626-10BF75FF25A6}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{84211169-9441-44F9-B626-10BF75FF25A6}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -237,10 +189,6 @@ Global
 		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{909BF4EF-4ECA-4AC4-8E21-CDCF05393161}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{77E73F37-9586-44EA-91B0-F244D08467D2}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{77E73F37-9586-44EA-91B0-F244D08467D2}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{77E73F37-9586-44EA-91B0-F244D08467D2}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{77E73F37-9586-44EA-91B0-F244D08467D2}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{77E73F37-9586-44EA-91B0-F244D08467D2}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -249,10 +197,6 @@ Global
 		{77E73F37-9586-44EA-91B0-F244D08467D2}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{77E73F37-9586-44EA-91B0-F244D08467D2}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{77E73F37-9586-44EA-91B0-F244D08467D2}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{77E73F37-9586-44EA-91B0-F244D08467D2}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{77E73F37-9586-44EA-91B0-F244D08467D2}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{A7780698-3072-486E-A105-81EDDF552598}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{A7780698-3072-486E-A105-81EDDF552598}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{A7780698-3072-486E-A105-81EDDF552598}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{A7780698-3072-486E-A105-81EDDF552598}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{A7780698-3072-486E-A105-81EDDF552598}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -261,10 +205,6 @@ Global
 		{A7780698-3072-486E-A105-81EDDF552598}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{A7780698-3072-486E-A105-81EDDF552598}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{A7780698-3072-486E-A105-81EDDF552598}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{A7780698-3072-486E-A105-81EDDF552598}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{A7780698-3072-486E-A105-81EDDF552598}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -273,10 +213,6 @@ Global
 		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{7F524559-93F9-4F3F-9E2C-AF41A0C2E6F4}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -285,10 +221,6 @@ Global
 		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{856A1D19-C3BF-439A-BEBF-E822A332BC12}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{31931998-7543-41DA-9E58-D9670D810352}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{31931998-7543-41DA-9E58-D9670D810352}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{31931998-7543-41DA-9E58-D9670D810352}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{31931998-7543-41DA-9E58-D9670D810352}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{31931998-7543-41DA-9E58-D9670D810352}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -297,10 +229,6 @@ Global
 		{31931998-7543-41DA-9E58-D9670D810352}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{31931998-7543-41DA-9E58-D9670D810352}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{31931998-7543-41DA-9E58-D9670D810352}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{31931998-7543-41DA-9E58-D9670D810352}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{31931998-7543-41DA-9E58-D9670D810352}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -309,10 +237,6 @@ Global
 		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{34B82690-0083-4F4C-8ABF-2D2A09304915}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
@@ -321,8 +245,6 @@ Global
 		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
 		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
-		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{AFD3F1C4-5C59-4018-B0BB-030E0DA57C5C}.Release|Any CPU.Build.0 = Portable-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This has caused the confusion that inside Visual Studio, people might not notice the current build configuration is "Debug", rather see hundreds of errors/warnings in the error list and then feel our project/solutions are very broken.