### PR TITLE
Fix x-ms-pagable and Produces for "application/json; ..."

### DIFF
--- a/AutoRest/AutoRest.Core.Tests/Resource/RedisResource.json
+++ b/AutoRest/AutoRest.Core.Tests/Resource/RedisResource.json
@@ -12,7 +12,7 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis": {
       "get": {
         "description": "",
-        "x-ms-pageable": "true",
+        "x-ms-pageable": "nextLink",
         "operationId": "List",
         "consumes": [],
         "produces": [

--- a/AutoRest/AutoRest.Core/ClientModel/Method.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/Method.cs
@@ -94,6 +94,11 @@ namespace Microsoft.Rest.Generator.ClientModel
         public string Documentation { get; set; }
 
         /// <summary>
+        /// Gets or sets the content type.
+        /// </summary>
+        public string ContentType { get; set; }
+
+        /// <summary>
         /// Gets vendor extensions dictionary.
         /// </summary>
         public Dictionary<string, object> Extensions { get; private set; }

--- a/AutoRest/Generators/Azure.Common/Azure.Common.Tests/Swagger/swagger-odata-spec.json
+++ b/AutoRest/Generators/Azure.Common/Azure.Common.Tests/Swagger/swagger-odata-spec.json
@@ -25,7 +25,7 @@
     "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis": {
       "get": {
         "x-ms-odata": "#/definitions/Product",
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "list",
         "summary": "Product Types",
         "description": "The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.",

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Swagger/azure-paging.json
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Swagger/azure-paging.json
@@ -18,7 +18,7 @@
   "paths": {
     "/paging/single": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_getSinglePage",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {
@@ -34,7 +34,7 @@
         }
       },
       "put": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_putSinglePage",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {
@@ -56,7 +56,7 @@
         }
       },
       "post": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_postSinglePage",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {
@@ -78,7 +78,7 @@
         }
       },
       "delete": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_deleteSinglePage",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {

--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Rest.Generator.CSharp
 
             foreach (var method in serviceClient.Methods.Where(m => m.Extensions.ContainsKey(AzureCodeGenerator.PageableExtension)))
             {
+                string nextLinkString = (string)method.Extensions[AzureCodeGenerator.PageableExtension];
+
                 foreach (var responseStatus in method.Responses.Where(r => r.Value is CompositeType).Select(s => s.Key).ToArray())
                 {
                     var compositType = (CompositeType) method.Responses[responseStatus];
@@ -49,7 +51,7 @@ namespace Microsoft.Rest.Generator.CSharp
                     // if the type is a wrapper over page-able response
                     if(sequenceType != null &&
                        compositType.Properties.Count == 2 && 
-                       compositType.Properties.Any(p => p.SerializedName.Equals("nextLink", StringComparison.OrdinalIgnoreCase)))
+                       compositType.Properties.Any(p => p.SerializedName.Equals(nextLinkString, StringComparison.OrdinalIgnoreCase)))
                     {
                         var pagableTypeName = string.Format(CultureInfo.InvariantCulture, pageTypeFormat, sequenceType.ElementType.Name);
                         

--- a/AutoRest/Generators/CSharp/CSharp/Templates/MethodTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/MethodTemplate.cshtml
@@ -109,7 +109,7 @@ public async Task<@(Model.OperationResponseReturnTypeString)> @(Model.Name)WithH
     // Serialize Request
     string requestContent = JsonConvert.SerializeObject(@(Model.RequestBody.Name), @(Model.GetSerializationSettingsReference(Model.RequestBody.Type)));
     httpRequest.Content = new StringContent(requestContent, Encoding.UTF8);
-    httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+    httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("@(Model.ContentType)");
         </text>
     }
     // Send Request

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodTemplate.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodTemplate.cshtml
@@ -90,7 +90,7 @@
       }
     }
   }
-  httpRequest.headers['Content-Type'] = 'application/json; charset=utf-8';
+  httpRequest.headers['Content-Type'] = '@(Model.ContentType)';
 
   @if (Model.RequestBody != null)
   {

--- a/AutoRest/Modelers/Swagger/OperationBuilder.cs
+++ b/AutoRest/Modelers/Swagger/OperationBuilder.cs
@@ -54,6 +54,17 @@ namespace Microsoft.Rest.Modeler.Swagger
             };
 
             method.Documentation = _operation.Description;
+            method.ContentType = "application/json";
+            if (this._effectiveProduces != null && this._effectiveProduces.Count > 0)
+            {
+                method.ContentType = this._effectiveProduces[0];
+            }
+
+            if (method.ContentType.IndexOf("charset=", StringComparison.InvariantCultureIgnoreCase) == -1)
+            {
+                // Enable UTF-8 charset
+                method.ContentType += "; charset=utf-8";
+            }
 
             // Service parameters
             if (_operation.Parameters != null)
@@ -333,7 +344,7 @@ namespace Microsoft.Rest.Modeler.Swagger
         private bool SwaggerOperationProducesJson()
         {
             return _effectiveProduces != null &&
-                   _effectiveProduces.Any(s => s.IndexOf("application/json", StringComparison.InvariantCultureIgnoreCase) >= 0);
+                   _effectiveProduces.Any(s => s.StartsWith("application/json", StringComparison.InvariantCultureIgnoreCase));
         }
 
         private bool SwaggerOperationProducesNotEmpty()

--- a/AutoRest/Modelers/Swagger/OperationBuilder.cs
+++ b/AutoRest/Modelers/Swagger/OperationBuilder.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Rest.Modeler.Swagger
         private bool SwaggerOperationProducesJson()
         {
             return _effectiveProduces != null &&
-                   _effectiveProduces.Contains("application/json", StringComparer.OrdinalIgnoreCase);
+                   _effectiveProduces.Any(s => s.IndexOf("application/json", StringComparison.InvariantCultureIgnoreCase) >= 0);
         }
 
         private bool SwaggerOperationProducesNotEmpty()

--- a/AutoRest/TestServer/swagger/paging.json
+++ b/AutoRest/TestServer/swagger/paging.json
@@ -18,7 +18,7 @@
   "paths": {
     "/paging/single": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_getSinglePages",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {
@@ -36,7 +36,7 @@
     },
     "/paging/multiple": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_getMultiplePages",
         "description": "A paging operation that includes a nextLink that has 10 pages",
         "responses": {
@@ -54,7 +54,7 @@
     },
     "/paging/multiple/retryfirst": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_getMultiplePagesRetryFirst",
         "description": "A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages",
         "responses": {
@@ -72,7 +72,7 @@
     },
     "/paging/multiple/retrysecond": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_getMultiplePagesRetrySecond",
         "description": "A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.",
         "responses": {
@@ -90,7 +90,7 @@
     },
     "/paging/single/failure": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_getSinglePagesFailure",
         "description": "A paging operation that receives a 400 on the first call",
         "responses": {
@@ -108,7 +108,7 @@
     },
     "/paging/multiple/failure": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_getMultiplePagesFailure",
         "description": "A paging operation that receives a 400 on the second call",
         "responses": {
@@ -126,7 +126,7 @@
     },
     "/paging/multiple/failureuri": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": "nextLink",
         "operationId": "Paging_getMultiplePagesFailureUri",
         "description": "A paging operation that receives an invalid nextLink",
         "responses": {


### PR DESCRIPTION
1. Change "x-ms-pageable" extension to use "string" instead of bool literal  

In ODATA, the nextLink string in response is "odata.nextLink", so the extension should be:
"x-ms-pageable" : "odata.nextLink"

2. JSON is part of produces string is good enough

For example: this produces should be good enough to present for JSON request body.

 "produces": [
    "application/json; odata=minimalmetadata"
  ]
