### PR TITLE
Fix bug: any one of the produces start with "application/json" is enough.

### DIFF
--- a/AutoRest/Modelers/Swagger/OperationBuilder.cs
+++ b/AutoRest/Modelers/Swagger/OperationBuilder.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Rest.Modeler.Swagger
         private bool SwaggerOperationProducesJson()
         {
             return _effectiveProduces != null &&
-                   _effectiveProduces.Contains("application/json", StringComparer.OrdinalIgnoreCase);
+                   _effectiveProduces.Any(s => s.StartsWith("application/json", StringComparison.InvariantCultureIgnoreCase));
         }
 
         private bool SwaggerOperationProducesNotEmpty()


### PR DESCRIPTION
Any one of the produces start with "application/json" is enough to prove operation produce JSON. In our ODATA server, the produce has to be "application/json; odata=minimalmetadata", which will fail in original check.