### PR TITLE
Paging Extension: use object instead of bool literal.

### DIFF
--- a/AutoRest/AutoRest.Core.Tests/Resource/RedisResource.json
+++ b/AutoRest/AutoRest.Core.Tests/Resource/RedisResource.json
@@ -12,7 +12,7 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis": {
       "get": {
         "description": "",
-        "x-ms-pageable": "true",
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "List",
         "consumes": [],
         "produces": [

--- a/AutoRest/Generators/Azure.Common/Azure.Common.Tests/Swagger/swagger-odata-spec.json
+++ b/AutoRest/Generators/Azure.Common/Azure.Common.Tests/Swagger/swagger-odata-spec.json
@@ -25,7 +25,7 @@
     "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis": {
       "get": {
         "x-ms-odata": "#/definitions/Product",
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "list",
         "summary": "Product Types",
         "description": "The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.",

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Swagger/azure-paging.json
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Swagger/azure-paging.json
@@ -18,7 +18,7 @@
   "paths": {
     "/paging/single": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_getSinglePage",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {
@@ -34,7 +34,7 @@
         }
       },
       "put": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_putSinglePage",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {
@@ -56,7 +56,7 @@
         }
       },
       "post": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_postSinglePage",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {
@@ -78,7 +78,7 @@
         }
       },
       "delete": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_deleteSinglePage",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {

--- a/AutoRest/TestServer/swagger/paging.json
+++ b/AutoRest/TestServer/swagger/paging.json
@@ -18,7 +18,7 @@
   "paths": {
     "/paging/single": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_getSinglePages",
         "description": "A paging operation that finishes on the first call without a nextlink",
         "responses": {
@@ -36,7 +36,7 @@
     },
     "/paging/multiple": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_getMultiplePages",
         "description": "A paging operation that includes a nextLink that has 10 pages",
         "responses": {
@@ -54,7 +54,7 @@
     },
     "/paging/multiple/retryfirst": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_getMultiplePagesRetryFirst",
         "description": "A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages",
         "responses": {
@@ -72,7 +72,7 @@
     },
     "/paging/multiple/retrysecond": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_getMultiplePagesRetrySecond",
         "description": "A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.",
         "responses": {
@@ -90,7 +90,7 @@
     },
     "/paging/single/failure": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_getSinglePagesFailure",
         "description": "A paging operation that receives a 400 on the first call",
         "responses": {
@@ -108,7 +108,7 @@
     },
     "/paging/multiple/failure": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_getMultiplePagesFailure",
         "description": "A paging operation that receives a 400 on the second call",
         "responses": {
@@ -126,7 +126,7 @@
     },
     "/paging/multiple/failureuri": {
       "get": {
-        "x-ms-pageable": true,
+        "x-ms-pageable": { "path": "nextLink" },
         "operationId": "Paging_getMultiplePagesFailureUri",
         "description": "A paging operation that receives an invalid nextLink",
         "responses": {

--- a/AutoRest/TestServer/swagger/storage.json
+++ b/AutoRest/TestServer/swagger/storage.json
@@ -285,7 +285,7 @@
             }
           }
         },
-        "x-ms-pageable": true      
+        "x-ms-pageable": { "path": "nextLink" }      
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts": {
@@ -318,7 +318,7 @@
             }
           }
         },
-        "x-ms-pageable": true
+        "x-ms-pageable": { "path": "nextLink" }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey": {


### PR DESCRIPTION
The path in object define the nextlink literal in the response body. In ODATA scenario, the nextLink could be "odata.nextLink" or "@odata.nextLink".