### PR TITLE
Added TypeScript support, generating .d.ts files alongside NodeJS JavaScript

### DIFF
--- a/AutoRest/Generators/NodeJS/NodeJS/AutoRest.Generator.NodeJS.csproj
+++ b/AutoRest/Generators/NodeJS/NodeJS/AutoRest.Generator.NodeJS.csproj
@@ -47,8 +47,14 @@
     <Compile Include="Templates\MethodGroupIndexTemplate.cs">
       <DependentUpon>MethodGroupIndexTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\MethodGroupIndexTemplateTS.cs">
+      <DependentUpon>MethodGroupIndexTemplateTS.cshtml</DependentUpon>
+    </Compile>
     <Compile Include="Templates\MethodGroupTemplate.cs">
       <DependentUpon>MethodGroupTemplate.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Templates\MethodGroupTemplateTS.cs">
+      <DependentUpon>MethodGroupTemplateTS.cshtml</DependentUpon>
     </Compile>
     <Compile Include="Templates\MethodJsonPipelineTemplate.cs">
       <DependentUpon>MethodJsonPipelineTemplate.cshtml</DependentUpon>
@@ -59,22 +65,40 @@
     <Compile Include="Templates\MethodTemplate.cs">
       <DependentUpon>MethodTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\MethodTemplateTS.cs">
+      <DependentUpon>MethodTemplateTS.cshtml</DependentUpon>
+    </Compile>
     <Compile Include="Templates\ModelIndexTemplate.cs">
       <DependentUpon>ModelIndexTemplate.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Templates\ModelIndexTemplateTS.cs">
+      <DependentUpon>ModelIndexTemplateTS.cshtml</DependentUpon>
     </Compile>
     <Compile Include="Templates\ModelTemplate.cs">
       <DependentUpon>ModelTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\ModelTemplateTS.cs">
+      <DependentUpon>ModelTemplateTS.cshtml</DependentUpon>
+    </Compile>
     <Compile Include="Templates\ServiceClientTemplate.cs">
       <DependentUpon>ServiceClientTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\ServiceClientTemplateTS.cs">
+      <DependentUpon>ServiceClientTemplateTS.cshtml</DependentUpon>
+    </Compile>
     <None Include="Templates\MethodGroupTemplate.cshtml" />
+    <None Include="Templates\MethodGroupTemplateTS.cshtml" />
     <None Include="Templates\MethodJsonPipelineTemplate.cshtml" />
     <None Include="Templates\MethodStreamPipelineTemplate.cshtml" />
+    <None Include="Templates\MethodTemplateTS.cshtml" />
     <None Include="Templates\ModelTemplate.cshtml" />
+    <None Include="Templates\ModelTemplateTS.cshtml" />
     <None Include="Templates\ModelIndexTemplate.cshtml" />
+    <None Include="Templates\ModelIndexTemplateTS.cshtml" />
     <None Include="Templates\MethodGroupIndexTemplate.cshtml" />
+    <None Include="Templates\MethodGroupIndexTemplateTS.cshtml" />
     <None Include="Templates\ServiceClientTemplate.cshtml" />
+    <None Include="Templates\ServiceClientTemplateTS.cshtml" />
     <None Include="Templates\MethodTemplate.cshtml" />
   </ItemGroup>
   <ItemGroup>

--- a/AutoRest/Generators/NodeJS/NodeJS/ClientModelExtensions.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/ClientModelExtensions.cs
@@ -242,6 +242,28 @@ namespace Microsoft.Rest.Generator.NodeJS.TemplateModels
             }
         }
 
+        /// <summary>
+        /// Returns the TypeScript type string for the specified primary type
+        /// </summary>
+        /// <param name="primary">primary type to query</param>
+        /// <returns>The TypeScript type correspoinding to this model primary type</returns>
+        private static string PrimaryTSType(this PrimaryType primary) {
+            if (primary == PrimaryType.Boolean)
+                return "boolean";
+            else if (primary == PrimaryType.Double || primary == PrimaryType.Int || primary == PrimaryType.Long)
+                return "number";
+            else if (primary == PrimaryType.String)
+                return "string";
+            else if (primary == PrimaryType.Date || primary == PrimaryType.DateTime)
+                return "Date";
+            else if (primary == PrimaryType.Object)
+                return "Object";   // TODO: test this
+            else {
+                throw new NotImplementedException(string.Format(CultureInfo.InvariantCulture,
+                    "Type '{0}' not implemented", primary));
+            }
+        }
+
         private static string ValidateEnumType(this EnumType enumType, IScopeProvider scope, string valueReference, bool isRequired)
         {
             if (scope == null)
@@ -424,6 +446,48 @@ namespace Microsoft.Rest.Generator.NodeJS.TemplateModels
 
             return null;
         }
+		
+        /// <summary>
+        /// Return the TypeScript type (as a string) for specified type.
+        /// </summary>
+        public static string TSType(this IType type, bool inModelsModule) {
+            CompositeType composite = type as CompositeType;
+            SequenceType sequence = type as SequenceType;
+            DictionaryType dictionary = type as DictionaryType;
+            PrimaryType primary = type as PrimaryType;
+            EnumType enumType = type as EnumType;
+
+            string tsType;
+            if (primary != null)
+            {
+                tsType = primary.PrimaryTSType();
+            }
+            else if (enumType != null)
+            {
+                tsType = "string";
+            }
+            else if (composite != null)
+            {
+                if (inModelsModule)
+                    tsType = composite.Name;
+                else tsType = "models." + composite.Name;
+            }
+            else if (sequence != null)
+            {
+                tsType = sequence.ElementType.TSType(inModelsModule) + "[]";
+            }
+            else if (dictionary != null)
+            {
+                // TODO: Confirm with Mark exactly what cases for additionalProperties AutoRest intends to handle (what about
+                // additonalProperties combined with explicit properties?) and add support for those if needed to at least match
+                // C# target level of functionality
+                tsType = "{ [propertyName: string]: " + dictionary.ValueType.TSType(inModelsModule) + " }";
+            }
+            else throw new NotImplementedException(string.Format(CultureInfo.InvariantCulture, "Type '{0}' not implemented", type));
+
+            return tsType;
+        }
+		
 
         private static string SerializePrimaryType(this PrimaryType primary, IScopeProvider scope, string objectReference, string valueReference, bool isRequired)
         {

--- a/AutoRest/Generators/NodeJS/NodeJS/NodeJSCodeGenerator.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/NodeJSCodeGenerator.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Rest.Generator.NodeJS
     public class NodeJSCodeGenerator : CodeGenerator
     {
         private const string ClientRuntimePackage = "ms-rest version 1.1.0";
+        private static readonly bool DisableTypeScriptGeneration = false;    // Change to true if you want to no longer generate the 3 d.ts files, for some reason
 
         public NodeJsCodeNamer Namer { get; private set; }
 
@@ -74,11 +75,14 @@ namespace Microsoft.Rest.Generator.NodeJS
             };
             await Write(serviceClientTemplate, serviceClient.Name.ToCamelCase() + ".js");
 
-            var serviceClientTemplateTS = new ServiceClientTemplateTS
+            if (!DisableTypeScriptGeneration)
             {
-                Model = serviceClientTemplateModel,
-            };
-            await Write(serviceClientTemplateTS, serviceClient.Name.ToCamelCase() + ".d.ts");
+                var serviceClientTemplateTS = new ServiceClientTemplateTS
+                {
+                    Model = serviceClientTemplateModel,
+                };
+                await Write(serviceClientTemplateTS, serviceClient.Name.ToCamelCase() + ".d.ts");
+            }
 
             //Models
             if (serviceClient.ModelTypes.Any())
@@ -88,11 +92,15 @@ namespace Microsoft.Rest.Generator.NodeJS
                     Model = serviceClientTemplateModel
                 };
                 await Write(modelIndexTemplate, Path.Combine("models", "index.js"));
-                var modelIndexTemplateTS = new ModelIndexTemplateTS {
-                    Model = serviceClientTemplateModel
-                };
-                await Write(modelIndexTemplateTS, Path.Combine("models", "index.d.ts"));
-                
+                if (!DisableTypeScriptGeneration)
+                {
+                    var modelIndexTemplateTS = new ModelIndexTemplateTS
+                    {
+                        Model = serviceClientTemplateModel
+                    };
+                    await Write(modelIndexTemplateTS, Path.Combine("models", "index.d.ts"));
+                }
+
                 foreach (var modelType in serviceClientTemplateModel.ModelTemplateModels)
                 {
                     var modelTemplate = new ModelTemplate
@@ -100,14 +108,6 @@ namespace Microsoft.Rest.Generator.NodeJS
                         Model = modelType
                     };
                     await Write(modelTemplate, Path.Combine("models", modelType.Name.ToCamelCase() + ".js"));
-
-                    /*
-                    var modelTemplateTS = new ModelTemplateTS
-                    {
-                        Model = modelType
-                    };
-                    await Write(modelTemplateTS, Path.Combine("models", modelType.Name.ToCamelCase() + ".d.ts"));
-                    */
                 }
             }
 
@@ -120,10 +120,14 @@ namespace Microsoft.Rest.Generator.NodeJS
                 };
                 await Write(methodGroupIndexTemplate, Path.Combine("operations", "index.js"));
 
-                var methodGroupIndexTemplateTS = new MethodGroupIndexTemplateTS {
-                    Model = serviceClientTemplateModel
-                };
-                await Write(methodGroupIndexTemplateTS, Path.Combine("operations", "index.d.ts"));
+                if (!DisableTypeScriptGeneration)
+                {
+                    var methodGroupIndexTemplateTS = new MethodGroupIndexTemplateTS
+                    {
+                        Model = serviceClientTemplateModel
+                    };
+                    await Write(methodGroupIndexTemplateTS, Path.Combine("operations", "index.d.ts"));
+                }
 
                 foreach (var methodGroupModel in serviceClientTemplateModel.MethodGroupModels)
                 {
@@ -132,14 +136,6 @@ namespace Microsoft.Rest.Generator.NodeJS
                         Model = methodGroupModel
                     };
                     await Write(methodGroupTemplate, Path.Combine("operations", methodGroupModel.MethodGroupType.ToCamelCase() + ".js"));
-
-                    /*
-                    var methodGroupTemplateTS = new MethodGroupTemplateTS
-                    {
-                        Model = methodGroupModel
-                    };
-                    await Write(methodGroupTemplateTS, Path.Combine("operations", methodGroupModel.MethodGroupType.ToCamelCase() + ".d.ts"));
-                    */
                 }
             }
         }

--- a/AutoRest/Generators/NodeJS/NodeJS/NodeJSCodeGenerator.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/NodeJSCodeGenerator.cs
@@ -74,6 +74,12 @@ namespace Microsoft.Rest.Generator.NodeJS
             };
             await Write(serviceClientTemplate, serviceClient.Name.ToCamelCase() + ".js");
 
+            var serviceClientTemplateTS = new ServiceClientTemplateTS
+            {
+                Model = serviceClientTemplateModel,
+            };
+            await Write(serviceClientTemplateTS, serviceClient.Name.ToCamelCase() + ".d.ts");
+
             //Models
             if (serviceClient.ModelTypes.Any())
             {
@@ -82,6 +88,11 @@ namespace Microsoft.Rest.Generator.NodeJS
                     Model = serviceClientTemplateModel
                 };
                 await Write(modelIndexTemplate, Path.Combine("models", "index.js"));
+                var modelIndexTemplateTS = new ModelIndexTemplateTS {
+                    Model = serviceClientTemplateModel
+                };
+                await Write(modelIndexTemplateTS, Path.Combine("models", "index.d.ts"));
+                
                 foreach (var modelType in serviceClientTemplateModel.ModelTemplateModels)
                 {
                     var modelTemplate = new ModelTemplate
@@ -89,6 +100,14 @@ namespace Microsoft.Rest.Generator.NodeJS
                         Model = modelType
                     };
                     await Write(modelTemplate, Path.Combine("models", modelType.Name.ToCamelCase() + ".js"));
+
+                    /*
+                    var modelTemplateTS = new ModelTemplateTS
+                    {
+                        Model = modelType
+                    };
+                    await Write(modelTemplateTS, Path.Combine("models", modelType.Name.ToCamelCase() + ".d.ts"));
+                    */
                 }
             }
 
@@ -100,6 +119,12 @@ namespace Microsoft.Rest.Generator.NodeJS
                     Model = serviceClientTemplateModel
                 };
                 await Write(methodGroupIndexTemplate, Path.Combine("operations", "index.js"));
+
+                var methodGroupIndexTemplateTS = new MethodGroupIndexTemplateTS {
+                    Model = serviceClientTemplateModel
+                };
+                await Write(methodGroupIndexTemplateTS, Path.Combine("operations", "index.d.ts"));
+
                 foreach (var methodGroupModel in serviceClientTemplateModel.MethodGroupModels)
                 {
                     var methodGroupTemplate = new MethodGroupTemplate
@@ -107,6 +132,14 @@ namespace Microsoft.Rest.Generator.NodeJS
                         Model = methodGroupModel
                     };
                     await Write(methodGroupTemplate, Path.Combine("operations", methodGroupModel.MethodGroupType.ToCamelCase() + ".js"));
+
+                    /*
+                    var methodGroupTemplateTS = new MethodGroupTemplateTS
+                    {
+                        Model = methodGroupModel
+                    };
+                    await Write(methodGroupTemplateTS, Path.Combine("operations", methodGroupModel.MethodGroupType.ToCamelCase() + ".d.ts"));
+                    */
                 }
             }
         }

--- a/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/MethodTemplateModel.cs
@@ -10,6 +10,7 @@ using Microsoft.Rest.Generator.ClientModel;
 using Microsoft.Rest.Generator.NodeJS.TemplateModels;
 using Microsoft.Rest.Generator.Utilities;
 using System.Collections;
+using System.Text;
 
 namespace Microsoft.Rest.Generator.NodeJS
 {
@@ -87,6 +88,35 @@ namespace Microsoft.Rest.Generator.NodeJS
                 return declaration;
             }
         }
+		
+        /// <summary>
+        /// Generate the method parameter declarations for a method, using TypeScript declaration syntax
+        /// </summary>
+        public string MethodParameterDeclarationTS {
+            get
+            {
+                StringBuilder declarations = new StringBuilder();
+
+                bool first = true;
+                foreach (var parameter in LocalParameters) {
+                    if (!first)
+                        declarations.Append(", ");
+
+                    declarations.Append(parameter.Name);
+                    declarations.Append(": ");
+                    declarations.Append(parameter.Type.TSType(false));
+
+                    first = false;
+                }
+
+                if (!first)
+                    declarations.Append(", ");
+                declarations.Append("options: RequestOptions");
+                
+                return declarations.ToString();
+            }
+        }
+
 
         /// <summary>
         /// Generate the method parameter declarations with callback for a method
@@ -97,6 +127,19 @@ namespace Microsoft.Rest.Generator.NodeJS
             {
                 var parameters = MethodParameterDeclaration;
                 parameters += "callback";
+                return parameters;
+            }
+        }
+
+        /// <summary>
+        /// Generate the method parameter declarations with callback for a method, using TypeScript method syntax
+        /// </summary>
+        public string MethodParameterDeclarationWithCallbackTS {
+            get
+            {
+                var parameters = MethodParameterDeclarationTS;
+                var returnTypeTSString = ReturnType == null ? "void" : ReturnType.TSType(false);
+                parameters += ", callback: (err: Error, result: HttpOperationResponse<" + returnTypeTSString + ">) => void";
                 return parameters;
             }
         }

--- a/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/ModelTemplateModel.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/ModelTemplateModel.cs
@@ -152,6 +152,24 @@ namespace Microsoft.Rest.Generator.NodeJS
             return sample != null;
         }
 
+        /// <summary>
+        /// Returns the TypeScript string to define the specified property, including its type and whether it's optional or not
+        /// </summary>
+        /// <param name="property">Model property to query</param>
+        /// <param name="inModelsModule">Pass true if generating the code for the models module, thus model types don't need a "models." prefix</param>
+        /// <returns>TypeScript property definition</returns>
+        public string PropertyTS(Property property, bool inModelsModule) {
+            if (property == null) {
+                throw new ArgumentNullException("property");
+            }
+
+            string typeString = property.Type.TSType(inModelsModule);
+
+            if (! property.IsRequired)
+                return property.Name + "?: " + typeString;
+            else return property.Name + ": " + typeString;
+        }
+
         public string InitializeProperty(string objectName, string valueName, Property property)
         {
             if (property == null || property.Type == null)

--- a/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/ServiceClientTemplateModel.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/ServiceClientTemplateModel.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.Rest.Generator.ClientModel;
 using Microsoft.Rest.Generator.Utilities;
+using System.Text;
+using Microsoft.Rest.Generator.NodeJS.TemplateModels;
 
 namespace Microsoft.Rest.Generator.NodeJS
 {
@@ -71,6 +73,36 @@ namespace Microsoft.Rest.Generator.NodeJS
                     .ForEach(p => requireParams.Add(p.Name.ToCamelCase()));
                 requireParams.Add("baseUri");
                 return string.Join(", ", requireParams);
+            }
+        }
+
+        /// <summary>
+        /// Return the service client constructor required parameters, in TypeScript syntax.
+        /// </summary>
+        public string RequiredConstructorParametersTS {
+            get {
+                StringBuilder requiredParams = new StringBuilder();
+
+                bool first = true;
+                foreach (var p in this.Properties) {
+                    if (! p.IsRequired)
+                        continue;
+
+                    if (!first)
+                        requiredParams.Append(", ");
+
+                    requiredParams.Append(p.Name);
+                    requiredParams.Append(": ");
+                    requiredParams.Append(p.Type.TSType(false));
+
+                    first = false;
+                }
+
+                if (!first)
+                    requiredParams.Append(", ");
+
+                requiredParams.Append("baseUri: string");
+                return requiredParams.ToString();
             }
         }
     }

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
@@ -1,0 +1,18 @@
+﻿@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@using Microsoft.Rest.Generator.Utilities
+@using System.Linq
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.ServiceClientTemplateModel>
+/*
+@Header(" * ")
+*/
+@EmptyLine
+import { RequestOptions, HttpOperationResponse } from "../node_modules/ms-rest/lib";
+@if (Model.ModelTypes.Any()) {
+@:import * as models from "../models";
+}
+@EmptyLine
+@foreach (var methodGroup in Model.MethodGroupModels) {
+@EmptyLine
+@:@(Include(new MethodGroupTemplateTS(), methodGroup))
+}

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupTemplateTS.cshtml
@@ -1,0 +1,17 @@
+﻿@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@using System.Linq;
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.MethodGroupTemplateModel>
+/**
+ * @@class
+ * @Model.MethodGroupType
+ * __NOTE__: An instance of this class is automatically created for an
+ * instance of the @Model.Name.
+ */
+export interface @(Model.MethodGroupType) {
+    @foreach (var method in Model.MethodTemplateModels)
+    {
+    @EmptyLine
+    @:@(Include(new MethodTemplateTS(), method))
+    }
+}

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodTemplateTS.cshtml
@@ -1,0 +1,44 @@
+﻿@using System;
+@using System.Linq;
+@using Microsoft.Rest.Generator.ClientModel
+@using Microsoft.Rest.Generator.Utilities
+@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.TemplateModels
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@inherits Microsoft.Rest.Generator.Template<MethodTemplateModel>
+
+/**
+@if (!String.IsNullOrEmpty(Model.Summary)) {
+    @WrapComment(" * ", "@summary " + Model.Summary)@:
+    @: *
+}
+@if (!String.IsNullOrEmpty(Model.Description)) {
+    @WrapComment(" * ", Model.Description)@:
+    @: *
+}
+@foreach (var parameter in Model.DocumentationParameters) {
+    @MethodTemplateModel.ConstructParameterDocumentation(
+                      WrapComment(" * ", "@param {"
+                                        + MethodTemplateModel.GetParameterDocumentationType(parameter)
+                                        + "} " + MethodTemplateModel.GetParameterDocumentationName(parameter)
+                                        + " " + parameter.Documentation))
+}
+@WrapComment(" * ", " @param {object} [options]")
+ *
+@WrapComment(" * ", " @param {object} [options.customHeaders] headers that will be added to request")
+ *
+@WrapComment(" * ", " @param {function} callback")
+ *
+@WrapComment(" * ", " @returns {function} callback(err, result, request, response)")
+ *
+ *                      {Error}  err        - The Error object if an error occurred, null otherwise.
+ *
+ *                      {@Model.DocumentReturnTypeString} [result]   - The deserialized result object.
+@WrapComment(" *                      ", Model.ReturnTypeInfo)
+ *
+ *                      {object} [request]  - The HTTP Request object if an error did not occur.
+ *
+ *                      {stream} [response] - The HTTP Response stream if an error did not occur.
+ */
+@(Model.Name.ToCamelCase())(@(Model.MethodParameterDeclarationWithCallbackTS)): void;
+ 

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ModelIndexTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ModelIndexTemplateTS.cshtml
@@ -1,0 +1,20 @@
+﻿@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@using Microsoft.Rest.Generator.Utilities
+@using System.Linq
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.ServiceClientTemplateModel>
+/*
+@Header(" * ")
+ */
+@EmptyLine
+@foreach (var model in Model.ModelTemplateModels) {
+@EmptyLine
+@:@(Include(new ModelTemplateTS(), model))
+}
+//TODO: What about PolymorphicDictionary?
+@if (!string.IsNullOrWhiteSpace(Model.PolymorphicDictionary))
+{
+@:exports.discriminators = {
+@:  @(Model.PolymorphicDictionary)
+@:};
+} 

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ModelTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ModelTemplateTS.cshtml
@@ -1,0 +1,28 @@
+﻿@using System.Linq
+@using System.Collections.Generic
+@using Microsoft.Rest.Generator.ClientModel
+@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.TemplateModels
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.ModelTemplateModel>
+
+/**
+ * @@class
+ * Initializes a new instance of the @(Model.Name) class.
+ * @@constructor
+@WrapComment(" * ", Model.Documentation)
+@foreach (var property in Model.DocumentationPropertyList) {
+    @ModelTemplateModel.ConstructPropertyDocumentation(
+              WrapComment(" * ", "@member {" + ModelTemplateModel.GetPropertyDocumentationType(property)
+                                             + "} " + ModelTemplateModel.GetPropertyDocumentationName(property)
+                                             + " " + property.Documentation))
+}
+*/
+export interface @(Model.Name) {
+    @{
+    var propertyList = new List<Property>(Model.ComposedProperties);
+    for (int i = 0; i < propertyList.Count; i++)
+    {
+    @:@(Model.PropertyTS(propertyList[i], true));
+    }
+}
+}

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
@@ -1,0 +1,54 @@
+﻿@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@using Microsoft.Rest.Generator.Utilities
+@using System.Linq
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.ServiceClientTemplateModel>
+/*
+@Header(" * ")
+ */
+@EmptyLine
+import { ServiceClientOptions } from "./node_modules/ms-rest/lib";
+@if (Model.ModelTypes.Any())
+{
+@EmptyLine
+@:import * as models from "./models";
+}
+@if (Model.MethodGroups.Any()) {
+@:import * as operations from "./operations";
+}
+@EmptyLine
+export default class @(Model.Name) {
+    @{var parameters = Model.Properties.Where(p => p.IsRequired);}
+    /**
+     * @@class
+     * Initializes a new instance of the @Model.Name class.
+     * @@constructor
+     *
+    @foreach (var param in parameters)
+    {
+    @: * @@param {@param.Type.Name} @param.Name @param.Documentation
+    @: *
+    }
+     * @@param {string} [baseUri] - The base URI of the service.
+     *
+     * @@param {object} [options] - The parameter options
+     *
+     * @@param {Array} [options.filters] - Filters to be added to the request pipeline
+     *
+     * @@param {object} [options.requestOptions] - Options for the underlying request object
+     * {@@link https://github.com/request/request#requestoptions-callback Options doc}
+     *
+     * @@param {bool} [options.noRetryPolicy] - If set to true, turn off default retry policy
+     */
+    constructor(@(Model.RequiredConstructorParametersTS), options: ServiceClientOptions);
+
+    @if (Model.MethodGroupModels.Any())
+    {
+    @EmptyLine
+    @:// Operation groups
+    foreach (var methodGroup in Model.MethodGroupModels)
+    {
+    @:@(methodGroup.MethodGroupName): operations.@(methodGroup.MethodGroupType);
+    }
+    }
+}

--- a/ClientRuntimes/NodeJS/ms-rest/lib/index.d.ts
+++ b/ClientRuntimes/NodeJS/ms-rest/lib/index.d.ts
@@ -1,0 +1,34 @@
+/**
+ * HTTP REST operation response, passed to the client callback. 
+ * 
+ * @property {object} request       - Raw HTTP request
+ * @property {object} response      - Raw HTTP response   
+ * @property {T} body               - The deserialized response model object   
+ */
+export interface HttpOperationResponse<T> {
+	request: any
+	response: any
+	body: T
+}
+
+/**
+ * REST request options
+ *  
+ * @property {Object.<string, string>} customHeaders - Any additional HTTP headers to be added to the request
+ */
+export interface RequestOptions {
+	customHeaders?: { [headerName: string]: string; }	
+}
+
+/**
+ * Service client options, used for all REST requests initiated by the service client.
+ * 
+ * @property {Array} [filters]                  - Filters to be added to the request pipeline
+ * @property {RequestOptions} requestOptions    - Default RequestOptions to use for requests 
+ * @property {boolean}  noRetryPolicy           - If set to true, turn off default retry policy
+ */
+export interface ServiceClientOptions {
+	filters?: any[]
+	requestOptions?: RequestOptions;
+	noRetryPolicy?: boolean;
+}


### PR DESCRIPTION
Here's the updated pull request for TypeScript support.   Now the d.ts files are consolidated, so it'll generate at most 3 d.ts files:  <service-client>.d.ts, models/index.d.t.s, and operations/index.d.ts.

d.ts generation is pretty harmless, but to disable, if that's desired for any reason, can do this:
Change NodeJSCodeGenerator.DisableTypeScriptGeneration to true
Don't include index.d.ts addition in ms-rest npm update (though, again, it's pretty harmless if included)