### PR TITLE
Added TypeScript support, generating .d.ts files alongside NodeJS JavaScript

### DIFF
--- a/AutoRest/Generators/NodeJS/NodeJS/AutoRest.Generator.NodeJS.csproj
+++ b/AutoRest/Generators/NodeJS/NodeJS/AutoRest.Generator.NodeJS.csproj
@@ -47,8 +47,14 @@
     <Compile Include="Templates\MethodGroupIndexTemplate.cs">
       <DependentUpon>MethodGroupIndexTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\MethodGroupIndexTemplateTS.cs">
+      <DependentUpon>MethodGroupIndexTemplateTS.cshtml</DependentUpon>
+    </Compile>
     <Compile Include="Templates\MethodGroupTemplate.cs">
       <DependentUpon>MethodGroupTemplate.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Templates\MethodGroupTemplateTS.cs">
+      <DependentUpon>MethodGroupTemplateTS.cshtml</DependentUpon>
     </Compile>
     <Compile Include="Templates\MethodJsonPipelineTemplate.cs">
       <DependentUpon>MethodJsonPipelineTemplate.cshtml</DependentUpon>
@@ -59,22 +65,40 @@
     <Compile Include="Templates\MethodTemplate.cs">
       <DependentUpon>MethodTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\MethodTemplateTS.cs">
+      <DependentUpon>MethodTemplateTS.cshtml</DependentUpon>
+    </Compile>
     <Compile Include="Templates\ModelIndexTemplate.cs">
       <DependentUpon>ModelIndexTemplate.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Templates\ModelIndexTemplateTS.cs">
+      <DependentUpon>ModelIndexTemplateTS.cshtml</DependentUpon>
     </Compile>
     <Compile Include="Templates\ModelTemplate.cs">
       <DependentUpon>ModelTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\ModelTemplateTS.cs">
+      <DependentUpon>ModelTemplateTS.cshtml</DependentUpon>
+    </Compile>
     <Compile Include="Templates\ServiceClientTemplate.cs">
       <DependentUpon>ServiceClientTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\ServiceClientTemplateTS.cs">
+      <DependentUpon>ServiceClientTemplateTS.cshtml</DependentUpon>
+    </Compile>
     <None Include="Templates\MethodGroupTemplate.cshtml" />
+    <None Include="Templates\MethodGroupTemplateTS.cshtml" />
     <None Include="Templates\MethodJsonPipelineTemplate.cshtml" />
     <None Include="Templates\MethodStreamPipelineTemplate.cshtml" />
+    <None Include="Templates\MethodTemplateTS.cshtml" />
     <None Include="Templates\ModelTemplate.cshtml" />
+    <None Include="Templates\ModelTemplateTS.cshtml" />
     <None Include="Templates\ModelIndexTemplate.cshtml" />
+    <None Include="Templates\ModelIndexTemplateTS.cshtml" />
     <None Include="Templates\MethodGroupIndexTemplate.cshtml" />
+    <None Include="Templates\MethodGroupIndexTemplateTS.cshtml" />
     <None Include="Templates\ServiceClientTemplate.cshtml" />
+    <None Include="Templates\ServiceClientTemplateTS.cshtml" />
     <None Include="Templates\MethodTemplate.cshtml" />
   </ItemGroup>
   <ItemGroup>

--- a/AutoRest/Generators/NodeJS/NodeJS/ClientModelExtensions.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/ClientModelExtensions.cs
@@ -242,6 +242,28 @@ namespace Microsoft.Rest.Generator.NodeJS.TemplateModels
             }
         }
 
+        /// <summary>
+        /// Returns the TypeScript type string for the specified primary type
+        /// </summary>
+        /// <param name="primary">primary type to query</param>
+        /// <returns>The TypeScript type correspoinding to this model primary type</returns>
+        private static string PrimaryTSType(this PrimaryType primary) {
+            if (primary == PrimaryType.Boolean)
+                return "boolean";
+            else if (primary == PrimaryType.Double || primary == PrimaryType.Int || primary == PrimaryType.Long)
+                return "number";
+            else if (primary == PrimaryType.String)
+                return "string";
+            else if (primary == PrimaryType.Date || primary == PrimaryType.DateTime)
+                return "Date";
+            else if (primary == PrimaryType.Object)
+                return "Object";   // TODO: test this
+            else {
+                throw new NotImplementedException(string.Format(CultureInfo.InvariantCulture,
+                    "Type '{0}' not implemented", primary));
+            }
+        }
+
         private static string ValidateEnumType(this EnumType enumType, IScopeProvider scope, string valueReference, bool isRequired)
         {
             if (scope == null)
@@ -424,6 +446,48 @@ namespace Microsoft.Rest.Generator.NodeJS.TemplateModels
 
             return null;
         }
+		
+        /// <summary>
+        /// Return the TypeScript type (as a string) for specified type.
+        /// </summary>
+        public static string TSType(this IType type, bool inModelsModule) {
+            CompositeType composite = type as CompositeType;
+            SequenceType sequence = type as SequenceType;
+            DictionaryType dictionary = type as DictionaryType;
+            PrimaryType primary = type as PrimaryType;
+            EnumType enumType = type as EnumType;
+
+            string tsType;
+            if (primary != null)
+            {
+                tsType = primary.PrimaryTSType();
+            }
+            else if (enumType != null)
+            {
+                tsType = "string";
+            }
+            else if (composite != null)
+            {
+                if (inModelsModule)
+                    tsType = composite.Name;
+                else tsType = "models." + composite.Name;
+            }
+            else if (sequence != null)
+            {
+                tsType = sequence.ElementType.TSType(inModelsModule) + "[]";
+            }
+            else if (dictionary != null)
+            {
+                // TODO: Confirm with Mark exactly what cases for additionalProperties AutoRest intends to handle (what about
+                // additonalProperties combined with explicit properties?) and add support for those if needed to at least match
+                // C# target level of functionality
+                tsType = "{ [propertyName: string]: " + dictionary.ValueType.TSType(inModelsModule) + " }";
+            }
+            else throw new NotImplementedException(string.Format(CultureInfo.InvariantCulture, "Type '{0}' not implemented", type));
+
+            return tsType;
+        }
+		
 
         private static string SerializePrimaryType(this PrimaryType primary, IScopeProvider scope, string objectReference, string valueReference, bool isRequired)
         {

--- a/AutoRest/Generators/NodeJS/NodeJS/ClientModelExtensions.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/ClientModelExtensions.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Rest.Generator.NodeJS.TemplateModels
             else if (primary == PrimaryType.Date || primary == PrimaryType.DateTime)
                 return "Date";
             else if (primary == PrimaryType.Object)
-                return "Object";   // TODO: test this
+                return "any";   // TODO: test this
             else {
                 throw new NotImplementedException(string.Format(CultureInfo.InvariantCulture,
                     "Type '{0}' not implemented", primary));

--- a/AutoRest/Generators/NodeJS/NodeJS/NodeJSCodeGenerator.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/NodeJSCodeGenerator.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Rest.Generator.NodeJS
     public class NodeJSCodeGenerator : CodeGenerator
     {
         private const string ClientRuntimePackage = "ms-rest version 1.1.0";
+        private static readonly bool DisableTypeScriptGeneration = false;    // Change to true if you want to no longer generate the 3 d.ts files, for some reason
 
         public NodeJsCodeNamer Namer { get; private set; }
 
@@ -74,6 +75,15 @@ namespace Microsoft.Rest.Generator.NodeJS
             };
             await Write(serviceClientTemplate, serviceClient.Name.ToCamelCase() + ".js");
 
+            if (!DisableTypeScriptGeneration)
+            {
+                var serviceClientTemplateTS = new ServiceClientTemplateTS
+                {
+                    Model = serviceClientTemplateModel,
+                };
+                await Write(serviceClientTemplateTS, serviceClient.Name.ToCamelCase() + ".d.ts");
+            }
+
             //Models
             if (serviceClient.ModelTypes.Any())
             {
@@ -82,6 +92,15 @@ namespace Microsoft.Rest.Generator.NodeJS
                     Model = serviceClientTemplateModel
                 };
                 await Write(modelIndexTemplate, Path.Combine("models", "index.js"));
+                if (!DisableTypeScriptGeneration)
+                {
+                    var modelIndexTemplateTS = new ModelIndexTemplateTS
+                    {
+                        Model = serviceClientTemplateModel
+                    };
+                    await Write(modelIndexTemplateTS, Path.Combine("models", "index.d.ts"));
+                }
+
                 foreach (var modelType in serviceClientTemplateModel.ModelTemplateModels)
                 {
                     var modelTemplate = new ModelTemplate
@@ -100,6 +119,16 @@ namespace Microsoft.Rest.Generator.NodeJS
                     Model = serviceClientTemplateModel
                 };
                 await Write(methodGroupIndexTemplate, Path.Combine("operations", "index.js"));
+
+                if (!DisableTypeScriptGeneration)
+                {
+                    var methodGroupIndexTemplateTS = new MethodGroupIndexTemplateTS
+                    {
+                        Model = serviceClientTemplateModel
+                    };
+                    await Write(methodGroupIndexTemplateTS, Path.Combine("operations", "index.d.ts"));
+                }
+
                 foreach (var methodGroupModel in serviceClientTemplateModel.MethodGroupModels)
                 {
                     var methodGroupTemplate = new MethodGroupTemplate

--- a/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/MethodTemplateModel.cs
@@ -10,6 +10,7 @@ using Microsoft.Rest.Generator.ClientModel;
 using Microsoft.Rest.Generator.NodeJS.TemplateModels;
 using Microsoft.Rest.Generator.Utilities;
 using System.Collections;
+using System.Text;
 
 namespace Microsoft.Rest.Generator.NodeJS
 {
@@ -87,6 +88,35 @@ namespace Microsoft.Rest.Generator.NodeJS
                 return declaration;
             }
         }
+		
+        /// <summary>
+        /// Generate the method parameter declarations for a method, using TypeScript declaration syntax
+        /// </summary>
+        public string MethodParameterDeclarationTS {
+            get
+            {
+                StringBuilder declarations = new StringBuilder();
+
+                bool first = true;
+                foreach (var parameter in LocalParameters) {
+                    if (!first)
+                        declarations.Append(", ");
+
+                    declarations.Append(parameter.Name);
+                    declarations.Append(": ");
+                    declarations.Append(parameter.Type.TSType(false));
+
+                    first = false;
+                }
+
+                if (!first)
+                    declarations.Append(", ");
+                declarations.Append("options: RequestOptions");
+                
+                return declarations.ToString();
+            }
+        }
+
 
         /// <summary>
         /// Generate the method parameter declarations with callback for a method
@@ -97,6 +127,19 @@ namespace Microsoft.Rest.Generator.NodeJS
             {
                 var parameters = MethodParameterDeclaration;
                 parameters += "callback";
+                return parameters;
+            }
+        }
+
+        /// <summary>
+        /// Generate the method parameter declarations with callback for a method, using TypeScript method syntax
+        /// </summary>
+        public string MethodParameterDeclarationWithCallbackTS {
+            get
+            {
+                var parameters = MethodParameterDeclarationTS;
+                var returnTypeTSString = ReturnType == null ? "void" : ReturnType.TSType(false);
+                parameters += ", callback: (err: Error, result: HttpOperationResponse<" + returnTypeTSString + ">) => void";
                 return parameters;
             }
         }

--- a/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/MethodTemplateModel.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Rest.Generator.NodeJS
             {
                 var parameters = MethodParameterDeclarationTS;
                 var returnTypeTSString = ReturnType == null ? "void" : ReturnType.TSType(false);
-                parameters += ", callback: (err: Error, result: HttpOperationResponse<" + returnTypeTSString + ">) => void";
+                parameters += ", callback: (err: Error, result: " + returnTypeTSString + ", request: WebResource, response: stream.Readable) => void";
                 return parameters;
             }
         }

--- a/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/ModelTemplateModel.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/ModelTemplateModel.cs
@@ -152,6 +152,24 @@ namespace Microsoft.Rest.Generator.NodeJS
             return sample != null;
         }
 
+        /// <summary>
+        /// Returns the TypeScript string to define the specified property, including its type and whether it's optional or not
+        /// </summary>
+        /// <param name="property">Model property to query</param>
+        /// <param name="inModelsModule">Pass true if generating the code for the models module, thus model types don't need a "models." prefix</param>
+        /// <returns>TypeScript property definition</returns>
+        public string PropertyTS(Property property, bool inModelsModule) {
+            if (property == null) {
+                throw new ArgumentNullException("property");
+            }
+
+            string typeString = property.Type.TSType(inModelsModule);
+
+            if (! property.IsRequired)
+                return property.Name + "?: " + typeString;
+            else return property.Name + ": " + typeString;
+        }
+
         public string InitializeProperty(string objectName, string valueName, Property property)
         {
             if (property == null || property.Type == null)

--- a/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/ServiceClientTemplateModel.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/TemplateModels/ServiceClientTemplateModel.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.Rest.Generator.ClientModel;
 using Microsoft.Rest.Generator.Utilities;
+using System.Text;
+using Microsoft.Rest.Generator.NodeJS.TemplateModels;
 
 namespace Microsoft.Rest.Generator.NodeJS
 {
@@ -71,6 +73,36 @@ namespace Microsoft.Rest.Generator.NodeJS
                     .ForEach(p => requireParams.Add(p.Name.ToCamelCase()));
                 requireParams.Add("baseUri");
                 return string.Join(", ", requireParams);
+            }
+        }
+
+        /// <summary>
+        /// Return the service client constructor required parameters, in TypeScript syntax.
+        /// </summary>
+        public string RequiredConstructorParametersTS {
+            get {
+                StringBuilder requiredParams = new StringBuilder();
+
+                bool first = true;
+                foreach (var p in this.Properties) {
+                    if (! p.IsRequired)
+                        continue;
+
+                    if (!first)
+                        requiredParams.Append(", ");
+
+                    requiredParams.Append(p.Name);
+                    requiredParams.Append(": ");
+                    requiredParams.Append(p.Type.TSType(false));
+
+                    first = false;
+                }
+
+                if (!first)
+                    requiredParams.Append(", ");
+
+                requiredParams.Append("baseUri: string");
+                return requiredParams.ToString();
             }
         }
     }

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
@@ -7,7 +7,8 @@
 @Header(" * ")
 */
 @EmptyLine
-import { RequestOptions, HttpOperationResponse } from "../node_modules/ms-rest/lib";
+/// <reference path="../typings/tsd.d.ts" />
+import { RequestOptions, WebResource } from "../node_modules/ms-rest/lib";
 @if (Model.ModelTypes.Any()) {
 @:import * as models from "../models";
 }

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
@@ -7,8 +7,8 @@
 @Header(" * ")
 */
 @EmptyLine
-/// <reference path="../typings/tsd.d.ts" />
 import { RequestOptions, WebResource } from "../node_modules/ms-rest/lib";
+import * as stream from "stream";
 @if (Model.ModelTypes.Any()) {
 @:import * as models from "../models";
 }

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
@@ -7,7 +7,7 @@
 @Header(" * ")
 */
 @EmptyLine
-import { RequestOptions, WebResource } from "../node_modules/ms-rest/lib";
+import { RequestOptions, WebResource } from "ms-rest";
 import * as stream from "stream";
 @if (Model.ModelTypes.Any()) {
 @:import * as models from "../models";

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupIndexTemplateTS.cshtml
@@ -1,0 +1,18 @@
+﻿@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@using Microsoft.Rest.Generator.Utilities
+@using System.Linq
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.ServiceClientTemplateModel>
+/*
+@Header(" * ")
+*/
+@EmptyLine
+import { RequestOptions, HttpOperationResponse } from "../node_modules/ms-rest/lib";
+@if (Model.ModelTypes.Any()) {
+@:import * as models from "../models";
+}
+@EmptyLine
+@foreach (var methodGroup in Model.MethodGroupModels) {
+@EmptyLine
+@:@(Include(new MethodGroupTemplateTS(), methodGroup))
+}

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodGroupTemplateTS.cshtml
@@ -1,0 +1,17 @@
+﻿@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@using System.Linq;
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.MethodGroupTemplateModel>
+/**
+ * @@class
+ * @Model.MethodGroupType
+ * __NOTE__: An instance of this class is automatically created for an
+ * instance of the @Model.Name.
+ */
+export interface @(Model.MethodGroupType) {
+    @foreach (var method in Model.MethodTemplateModels)
+    {
+    @EmptyLine
+    @:@(Include(new MethodTemplateTS(), method))
+    }
+}

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodTemplateTS.cshtml
@@ -1,0 +1,44 @@
+﻿@using System;
+@using System.Linq;
+@using Microsoft.Rest.Generator.ClientModel
+@using Microsoft.Rest.Generator.Utilities
+@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.TemplateModels
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@inherits Microsoft.Rest.Generator.Template<MethodTemplateModel>
+
+/**
+@if (!String.IsNullOrEmpty(Model.Summary)) {
+    @WrapComment(" * ", "@summary " + Model.Summary)@:
+    @: *
+}
+@if (!String.IsNullOrEmpty(Model.Description)) {
+    @WrapComment(" * ", Model.Description)@:
+    @: *
+}
+@foreach (var parameter in Model.DocumentationParameters) {
+    @MethodTemplateModel.ConstructParameterDocumentation(
+                      WrapComment(" * ", "@param {"
+                                        + MethodTemplateModel.GetParameterDocumentationType(parameter)
+                                        + "} " + MethodTemplateModel.GetParameterDocumentationName(parameter)
+                                        + " " + parameter.Documentation))
+}
+@WrapComment(" * ", " @param {object} [options]")
+ *
+@WrapComment(" * ", " @param {object} [options.customHeaders] headers that will be added to request")
+ *
+@WrapComment(" * ", " @param {function} callback")
+ *
+@WrapComment(" * ", " @returns {function} callback(err, result, request, response)")
+ *
+ *                      {Error}  err        - The Error object if an error occurred, null otherwise.
+ *
+ *                      {@Model.DocumentReturnTypeString} [result]   - The deserialized result object.
+@WrapComment(" *                      ", Model.ReturnTypeInfo)
+ *
+ *                      {object} [request]  - The HTTP Request object if an error did not occur.
+ *
+ *                      {stream} [response] - The HTTP Response stream if an error did not occur.
+ */
+@(Model.Name.ToCamelCase())(@(Model.MethodParameterDeclarationWithCallbackTS)): void;
+ 

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/MethodTemplateTS.cshtml
@@ -9,12 +9,12 @@
 
 /**
 @if (!String.IsNullOrEmpty(Model.Summary)) {
-    @WrapComment(" * ", "@summary " + Model.Summary)@:
-    @: *
+@WrapComment(" * ", "@summary " + Model.Summary)@:
+@: *
 }
 @if (!String.IsNullOrEmpty(Model.Description)) {
-    @WrapComment(" * ", Model.Description)@:
-    @: *
+@WrapComment(" * ", Model.Description)@:
+@: *
 }
 @foreach (var parameter in Model.DocumentationParameters) {
     @MethodTemplateModel.ConstructParameterDocumentation(

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ModelIndexTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ModelIndexTemplateTS.cshtml
@@ -1,0 +1,20 @@
+﻿@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@using Microsoft.Rest.Generator.Utilities
+@using System.Linq
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.ServiceClientTemplateModel>
+/*
+@Header(" * ")
+ */
+@EmptyLine
+@foreach (var model in Model.ModelTemplateModels) {
+@EmptyLine
+@:@(Include(new ModelTemplateTS(), model))
+}
+//TODO: What about PolymorphicDictionary?
+@if (!string.IsNullOrWhiteSpace(Model.PolymorphicDictionary))
+{
+@:exports.discriminators = {
+@:  @(Model.PolymorphicDictionary)
+@:};
+} 

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ModelTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ModelTemplateTS.cshtml
@@ -1,0 +1,28 @@
+﻿@using System.Linq
+@using System.Collections.Generic
+@using Microsoft.Rest.Generator.ClientModel
+@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.TemplateModels
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.ModelTemplateModel>
+
+/**
+ * @@class
+ * Initializes a new instance of the @(Model.Name) class.
+ * @@constructor
+@WrapComment(" * ", Model.Documentation)
+@foreach (var property in Model.DocumentationPropertyList) {
+    @ModelTemplateModel.ConstructPropertyDocumentation(
+              WrapComment(" * ", "@member {" + ModelTemplateModel.GetPropertyDocumentationType(property)
+                                             + "} " + ModelTemplateModel.GetPropertyDocumentationName(property)
+                                             + " " + property.Documentation))
+}
+*/
+export interface @(Model.Name) {
+    @{
+    var propertyList = new List<Property>(Model.ComposedProperties);
+    for (int i = 0; i < propertyList.Count; i++)
+    {
+    @:@(Model.PropertyTS(propertyList[i], true));
+    }
+}
+}

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
@@ -7,7 +7,8 @@
 @Header(" * ")
  */
 @EmptyLine
-import { ServiceClientOptions } from "./node_modules/ms-rest/lib";
+/// <reference path="./typings/tsd.d.ts" />
+import { ServiceClientOptions, RequestOptions, WebResource } from "./node_modules/ms-rest/lib";
 @if (Model.ModelTypes.Any())
 {
 @EmptyLine

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
@@ -1,0 +1,54 @@
+﻿@using Microsoft.Rest.Generator.NodeJS
+@using Microsoft.Rest.Generator.NodeJS.Templates
+@using Microsoft.Rest.Generator.Utilities
+@using System.Linq
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.NodeJS.ServiceClientTemplateModel>
+/*
+@Header(" * ")
+ */
+@EmptyLine
+import { ServiceClientOptions } from "./node_modules/ms-rest/lib";
+@if (Model.ModelTypes.Any())
+{
+@EmptyLine
+@:import * as models from "./models";
+}
+@if (Model.MethodGroups.Any()) {
+@:import * as operations from "./operations";
+}
+@EmptyLine
+export default class @(Model.Name) {
+    @{var parameters = Model.Properties.Where(p => p.IsRequired);}
+    /**
+     * @@class
+     * Initializes a new instance of the @Model.Name class.
+     * @@constructor
+     *
+    @foreach (var param in parameters)
+    {
+    @: * @@param {@param.Type.Name} @param.Name @param.Documentation
+    @: *
+    }
+     * @@param {string} [baseUri] - The base URI of the service.
+     *
+     * @@param {object} [options] - The parameter options
+     *
+     * @@param {Array} [options.filters] - Filters to be added to the request pipeline
+     *
+     * @@param {object} [options.requestOptions] - Options for the underlying request object
+     * {@@link https://github.com/request/request#requestoptions-callback Options doc}
+     *
+     * @@param {bool} [options.noRetryPolicy] - If set to true, turn off default retry policy
+     */
+    constructor(@(Model.RequiredConstructorParametersTS), options: ServiceClientOptions);
+
+    @if (Model.MethodGroupModels.Any())
+    {
+    @EmptyLine
+    @:// Operation groups
+    foreach (var methodGroup in Model.MethodGroupModels)
+    {
+    @:@(methodGroup.MethodGroupName): operations.@(methodGroup.MethodGroupType);
+    }
+    }
+}

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
@@ -7,7 +7,7 @@
 @Header(" * ")
  */
 @EmptyLine
-import { ServiceClientOptions, RequestOptions, WebResource } from "./node_modules/ms-rest/lib";
+import { ServiceClientOptions, RequestOptions, WebResource } from "ms-rest";
 @if (Model.MethodTemplateModels.Any())
 {
 @:import * as models from "./models";

--- a/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
+++ b/AutoRest/Generators/NodeJS/NodeJS/Templates/ServiceClientTemplateTS.cshtml
@@ -7,12 +7,11 @@
 @Header(" * ")
  */
 @EmptyLine
-/// <reference path="./typings/tsd.d.ts" />
 import { ServiceClientOptions, RequestOptions, WebResource } from "./node_modules/ms-rest/lib";
-@if (Model.ModelTypes.Any())
+@if (Model.MethodTemplateModels.Any())
 {
-@EmptyLine
 @:import * as models from "./models";
+@:import * as stream from "stream";
 }
 @if (Model.MethodGroups.Any()) {
 @:import * as operations from "./operations";
@@ -51,5 +50,9 @@ export default class @(Model.Name) {
     {
     @:@(methodGroup.MethodGroupName): operations.@(methodGroup.MethodGroupType);
     }
+    }
+    @foreach (var method in Model.MethodTemplateModels) {
+    @EmptyLine
+    @:@(Include(new MethodTemplateTS(), method))
     }
 }

--- a/ClientRuntimes/NodeJS/ms-rest/lib/index.d.ts
+++ b/ClientRuntimes/NodeJS/ms-rest/lib/index.d.ts
@@ -1,7 +1,3 @@
-/// <reference path="../typings/tsd.d.ts" />
-// TODO: Ask Dan how to best handle the reference above (and whether to just check tsd.json).   It doesn't quite seem to work.
-// But shouldn't we really just get rid of the Node stream dependency completley, to make the generated code universal (work on client too)?
-
 /**
  * REST request options
  *  

--- a/ClientRuntimes/NodeJS/ms-rest/lib/index.d.ts
+++ b/ClientRuntimes/NodeJS/ms-rest/lib/index.d.ts
@@ -1,15 +1,6 @@
-/**
- * HTTP REST operation response, passed to the client callback. 
- * 
- * @property {object} request       - Raw HTTP request
- * @property {object} response      - Raw HTTP response   
- * @property {T} body               - The deserialized response model object   
- */
-export interface HttpOperationResponse<T> {
-	request: any
-	response: any
-	body: T
-}
+/// <reference path="../typings/tsd.d.ts" />
+// TODO: Ask Dan how to best handle the reference above (and whether to just check tsd.json).   It doesn't quite seem to work.
+// But shouldn't we really just get rid of the Node stream dependency completley, to make the generated code universal (work on client too)?
 
 /**
  * REST request options
@@ -31,4 +22,163 @@ export interface ServiceClientOptions {
 	filters?: any[]
 	requestOptions?: RequestOptions;
 	noRetryPolicy?: boolean;
+}
+
+/**
+ * This class provides an abstraction over a REST call by being library / implementation agnostic and wrapping the necessary
+ * properties to initiate a request.
+ */
+export class WebResource {
+  constructor();
+
+	/**
+	* Creates a new put request web resource.
+	*
+	* @param {string} path The path for the put operation.
+	* @return {WebResource} A new WebResource with a put operation for the given path.
+	*/
+	static put(path: string): WebResource;
+	
+	/**
+	* Creates a new get request web resource.
+	*
+	* @param {string} path The path for the get operation.
+	* @return {WebResource} A new WebResource with a get operation for the given path.
+	*/
+	static get(path: string): WebResource;
+	
+	/**
+	* Creates a new head request web resource.
+	*
+	* @param {string} path The path for the head operation.
+	* @return {WebResource} A new WebResource with a head operation for the given path.
+	*/
+	static head(path: string): WebResource;
+
+	/**
+	* Creates a new delete request web resource.
+	*
+	* @param {string} path The path for the delete operation.
+	* @return {WebResource} A new WebResource with a delete operation for the given path.
+	*/
+	static del(path: string): WebResource;
+  
+  /**
+  * Creates a new post request web resource.
+  *
+  * @param {string} path The path for the post operation.
+  * @return {WebResource} A new WebResource with a post operation for the given path.
+  */
+  static post(path: string): WebResource;
+
+  /**
+  * Creates a new merge request web resource.
+  *
+  * @param {string} path The path for the merge operation.
+  * @return {WebResource} A new WebResource with a merge operation for the given path.
+  */
+  static merge(path: string): WebResource;
+
+  /**
+  * Creates a new patch request web resource.
+  *
+  * @param {string} path The path for the patch operation.
+  * @return {WebResource} A new WebResource with a patch operation for the given path.
+  */
+  static patch(path: string): WebResource;
+
+  /**
+  * Specifies a custom property in the web resource.
+  *
+  * @param {string} name  The property name.
+  * @param {string} value The property value.
+  * @return {WebResource} The WebResource.
+  */
+  withProperty(name: string, value: string): WebResource;
+
+  /**
+  * Specifies if the response should be parsed or not.
+  *
+  * @param {bool} rawResponse true if the response should not be parse; false otherwise.
+  * @return {WebResource} The WebResource.
+  */
+  withRawResponse(rawResponse: boolean): WebResource;
+
+  withHeadersOnly(headersOnly: boolean): WebResource;
+
+  /**
+  * Adds an optional query string parameter.
+  *
+  * @param {Object} name          The name of the query string parameter.
+  * @param {Object} value         The value of the query string parameter.
+  * @param {Object} defaultValue  The default value for the query string parameter to be used if no value is passed.
+  * @return {Object} The web resource.
+  */
+  // TODO: Have Amar check this.  Should name, value, and defaultValue all be any, not strings? 
+  withQueryOption(name: any, value:  any, defaultValue:  any): WebResource;
+
+  /**
+  * Adds optional query string parameters.
+  *
+  * Additional arguments will be the needles to search in the haystack. 
+  *
+  * @param {Object} object  The haystack of query string parameters.
+  * @return {Object} The web resource.
+  */
+  // TODO: Have Amar check this.  Should the dctionary really be any type for the index & value, not string?
+  // Make consistent with withQueryOption, however we change that 
+  withQueryOptions(object: { [option: string]: any; }): WebResource; 
+
+  /**
+  * Adds an optional header parameter.
+  *
+  * @param {Object} name  The name of the header parameter.
+  * @param {Object} value The value of the header parameter.
+  * @return {Object} The web resource.
+  */
+  // TODO: Have Amar check this.  Should name and value be any, not strings? 
+  withHeader(name: any, value: any): WebResource;
+
+  /**
+  * Adds an optional body.
+  *
+  * @param {Object} body  The request body.
+  * @return {Object} The web resource.
+  */
+  // TODO: Have Amar check this.  Should we use a more specific type, than any, for body? 
+  withBody(body: any): WebResource;
+
+  /**
+  * Adds optional query string parameters.
+  *
+  * Additional arguments will be the needles to search in the haystack. 
+  *
+  * @param {Object} object  The haystack of headers.
+  * @return {Object} The web resource.
+  */
+  // TODO: Have Amar check this.  If change type for withHeader, change type here too.
+  withHeaders(object: { [header: string]: any; }): WebResource;
+  
+  // TODO: Have Amar check this & change to the appropriate type.
+  addOptionalMetadataHeaders(metadata: { [header: string]: any; }): WebResource;
+
+  /**
+  * Determines if a status code corresponds to a valid response according to the WebResource's expected status codes.
+  *
+  * @param {int} statusCode The response status code.
+  * @return true if the response is valid; false otherwise.
+  */
+  // TODO: Have Amar check this.   Should it be a static method instead, not defined on prototype?   If so, change the implementation in the .js file 
+  validResponse(statusCode: number): boolean;
+
+  /**
+  * Hook up the given input stream to a destination output stream if the WebResource method
+  * requires a request body and a body is not already set.
+  *
+  * @param {Stream} inputStream the stream to pipe from
+  * @param {Stream} outputStream the stream to pipe to
+  *
+  * @return destStream
+  */
+  pipeInput(inputStream: stream.Readable, destStream: stream.Writeable): stream.Writeable;
 }

--- a/ClientRuntimes/NodeJS/ms-rest/lib/index.d.ts
+++ b/ClientRuntimes/NodeJS/ms-rest/lib/index.d.ts
@@ -1,0 +1,34 @@
+/**
+ * HTTP REST operation response, passed to the client callback. 
+ * 
+ * @property {object} request       - Raw HTTP request
+ * @property {object} response      - Raw HTTP response   
+ * @property {T} body               - The deserialized response model object   
+ */
+export interface HttpOperationResponse<T> {
+	request: any
+	response: any
+	body: T
+}
+
+/**
+ * REST request options
+ *  
+ * @property {Object.<string, string>} customHeaders - Any additional HTTP headers to be added to the request
+ */
+export interface RequestOptions {
+	customHeaders?: { [headerName: string]: string; }	
+}
+
+/**
+ * Service client options, used for all REST requests initiated by the service client.
+ * 
+ * @property {Array} [filters]                  - Filters to be added to the request pipeline
+ * @property {RequestOptions} requestOptions    - Default RequestOptions to use for requests 
+ * @property {boolean}  noRetryPolicy           - If set to true, turn off default retry policy
+ */
+export interface ServiceClientOptions {
+	filters?: any[]
+	requestOptions?: RequestOptions;
+	noRetryPolicy?: boolean;
+}

--- a/ClientRuntimes/NodeJS/ms-rest/package.json
+++ b/ClientRuntimes/NodeJS/ms-rest/package.json
@@ -10,6 +10,7 @@
   "tags": ["node", "microsoft", "autorest", "clientruntime"],
   "keywords": ["node", "microsoft", "autorest", "clientruntime"],
   "main": "./lib/msRest.js",
+  "typings": "./lib/index.d.ts",
   "engines": {
     "node": ">= 0.6.15"
   },

--- a/ClientRuntimes/NodeJS/ms-rest/tsd.json
+++ b/ClientRuntimes/NodeJS/ms-rest/tsd.json
@@ -1,0 +1,12 @@
+{
+  "version": "v4",
+  "repo": "borisyankov/DefinitelyTyped",
+  "ref": "master",
+  "path": "typings",
+  "bundle": "typings/tsd.d.ts",
+  "installed": {
+    "node/node.d.ts": {
+      "commit": "ffceea9dd124d277c4597c7bd12930666ec074c5"
+    }
+  }
+}


### PR DESCRIPTION
Here's the updated pull request for TypeScript support. Now the d.ts files are consolidated, so it'll generate at most 3 d.ts files: .d.ts, models/index.d.t.s, and operations/index.d.ts.

d.ts generation is pretty harmless, but to disable, if that's desired for any reason, can do this:
Change NodeJSCodeGenerator.DisableTypeScriptGeneration to true
Don't include index.d.ts addition in ms-rest npm update (though, again, it's pretty harmless if included)