### PR TITLE
Fix bug: Uri drop the base uri last segment if it is not trail with slash

### DIFF
--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureReport/AutoRestReportServiceForAzure.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureReport/AutoRestReportServiceForAzure.cs
@@ -213,7 +213,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
                 ServiceClientTracing.Enter(invocationId, this, "GetReport", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "report/azure").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "report/azure").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/ApiVersionDefaultOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/ApiVersionDefaultOperations.cs
@@ -74,7 +74,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetMethodGlobalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview").ToString();
             List<string> queryParameters = new List<string>();
             if (this.Client.ApiVersion != null)
             {
@@ -187,7 +188,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetMethodGlobalNotProvidedValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview").ToString();
             List<string> queryParameters = new List<string>();
             if (this.Client.ApiVersion != null)
             {
@@ -300,7 +302,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetPathGlobalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview").ToString();
             List<string> queryParameters = new List<string>();
             if (this.Client.ApiVersion != null)
             {
@@ -413,7 +416,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetSwaggerGlobalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview").ToString();
             List<string> queryParameters = new List<string>();
             if (this.Client.ApiVersion != null)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/ApiVersionLocalOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/ApiVersionLocalOperations.cs
@@ -79,7 +79,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetMethodLocalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/apiVersion/method/string/none/query/local/2.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/apiVersion/method/string/none/query/local/2.0").ToString();
             List<string> queryParameters = new List<string>();
             if (apiVersion != null)
             {
@@ -193,7 +194,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetMethodLocalNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/apiVersion/method/string/none/query/local/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/apiVersion/method/string/none/query/local/null").ToString();
             List<string> queryParameters = new List<string>();
             if (apiVersion != null)
             {
@@ -311,7 +313,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetPathLocalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/apiVersion/path/string/none/query/local/2.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/apiVersion/path/string/none/query/local/2.0").ToString();
             List<string> queryParameters = new List<string>();
             if (apiVersion != null)
             {
@@ -429,7 +432,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetSwaggerLocalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/apiVersion/swagger/string/none/query/local/2.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/apiVersion/swagger/string/none/query/local/2.0").ToString();
             List<string> queryParameters = new List<string>();
             if (apiVersion != null)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/HeaderOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/HeaderOperations.cs
@@ -78,7 +78,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "CustomNamedRequestId", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/customNamedRequestId").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/customNamedRequestId").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SkipUrlEncodingOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SkipUrlEncodingOperations.cs
@@ -77,7 +77,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetMethodPathValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}").ToString();
             url = url.Replace("{unencodedPathParam}", unencodedPathParam);
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -190,7 +191,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetPathPathValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}").ToString();
             url = url.Replace("{unencodedPathParam}", unencodedPathParam);
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -304,7 +306,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetSwaggerPathValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}").ToString();
             url = url.Replace("{unencodedPathParam}", unencodedPathParam);
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -418,7 +421,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetMethodQueryValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/skipUrlEncoding/method/query/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/skipUrlEncoding/method/query/valid").ToString();
             List<string> queryParameters = new List<string>();
             if (q1 != null)
             {
@@ -530,7 +534,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetMethodQueryNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/skipUrlEncoding/method/query/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/skipUrlEncoding/method/query/null").ToString();
             List<string> queryParameters = new List<string>();
             if (q1 != null)
             {
@@ -647,7 +652,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetPathQueryValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/skipUrlEncoding/path/query/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/skipUrlEncoding/path/query/valid").ToString();
             List<string> queryParameters = new List<string>();
             if (q1 != null)
             {
@@ -762,7 +768,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "GetSwaggerQueryValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/skipUrlEncoding/swagger/query/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/skipUrlEncoding/swagger/query/valid").ToString();
             List<string> queryParameters = new List<string>();
             if (q1 != null)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInCredentialsOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInCredentialsOperations.cs
@@ -75,7 +75,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostMethodGlobalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(this.Client.SubscriptionId));
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -187,7 +188,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostMethodGlobalNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(this.Client.SubscriptionId));
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -302,7 +304,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostMethodGlobalNotProvidedValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(this.Client.SubscriptionId));
             List<string> queryParameters = new List<string>();
             if (this.Client.ApiVersion != null)
@@ -417,7 +420,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostPathGlobalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(this.Client.SubscriptionId));
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -528,7 +532,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostSwaggerGlobalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(this.Client.SubscriptionId));
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInMethodOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInMethodOperations.cs
@@ -78,7 +78,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostMethodLocalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(subscriptionId));
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -194,7 +195,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostMethodLocalNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(subscriptionId));
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -308,7 +310,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostPathLocalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(subscriptionId));
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
@@ -423,7 +426,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "PostSwaggerLocalValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(subscriptionId));
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/XMsClientRequestIdOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/XMsClientRequestIdOperations.cs
@@ -71,7 +71,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "Get", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/overwrite/x-ms-client-request-id/method").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/overwrite/x-ms-client-request-id/method").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -185,7 +186,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
                 ServiceClientTracing.Enter(invocationId, this, "ParamGet", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "azurespecials/overwrite/x-ms-client-request-id/via-param/method").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azurespecials/overwrite/x-ms-client-request-id/via-param/method").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Head/HttpSuccessOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Head/HttpSuccessOperations.cs
@@ -69,7 +69,8 @@ namespace Fixtures.Azure.AcceptanceTestsHead
                 ServiceClientTracing.Enter(invocationId, this, "Head204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/204").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -176,7 +177,8 @@ namespace Fixtures.Azure.AcceptanceTestsHead
                 ServiceClientTracing.Enter(invocationId, this, "Head404", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/404").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/404").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LRORetrysOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LRORetrysOperations.cs
@@ -101,7 +101,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut201CreatingSucceeded200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/retryerror/put/201/creating/succeeded/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/retryerror/put/201/creating/succeeded/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -254,7 +255,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRelativeRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/retryerror/putasync/retry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/retryerror/putasync/retry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -393,7 +395,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteProvisioning202Accepted200Succeeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/retryerror/delete/provisioning/202/accepted/200/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/retryerror/delete/provisioning/202/accepted/200/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -532,7 +535,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDelete202Retry200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/retryerror/delete/202/retry/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/retryerror/delete/202/retry/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -659,7 +663,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncRelativeRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/retryerror/deleteasync/retry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/retryerror/deleteasync/retry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -792,7 +797,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPost202Retry200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/retryerror/post/202/retry/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/retryerror/post/202/retry/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -931,7 +937,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRelativeRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/retryerror/postasync/retry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/retryerror/postasync/retry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROSADsOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROSADsOperations.cs
@@ -95,7 +95,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutNonRetry400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/put/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/put/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -244,7 +245,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutNonRetry201Creating400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/put/201/creating/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/put/201/creating/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -395,7 +397,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRelativeRetry400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/putasync/retry/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/putasync/retry/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -528,7 +531,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteNonRetry400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/delete/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/delete/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -651,7 +655,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDelete202NonRetry400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/delete/202/retry/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/delete/202/retry/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -778,7 +783,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncRelativeRetry400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/deleteasync/retry/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/deleteasync/retry/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -907,7 +913,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostNonRetry400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/post/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/post/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1040,7 +1047,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPost202NonRetry400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/post/202/retry/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/post/202/retry/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1177,7 +1185,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRelativeRetry400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/nonretryerror/postasync/retry/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/nonretryerror/postasync/retry/400").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1314,7 +1323,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutError201NoProvisioningStatePayload", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/put/201/noprovisioningstatepayload").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/put/201/noprovisioningstatepayload").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1465,7 +1475,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRelativeRetryNoStatus", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/putasync/retry/nostatus").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/putasync/retry/nostatus").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1610,7 +1621,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRelativeRetryNoStatusPayload", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/putasync/retry/nostatuspayload").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/putasync/retry/nostatuspayload").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1745,7 +1757,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDelete204Succeeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/delete/204/nolocation").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/delete/204/nolocation").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1872,7 +1885,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncRelativeRetryNoStatus", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/deleteasync/retry/nostatus").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/deleteasync/retry/nostatus").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2003,7 +2017,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPost202NoLocation", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/post/202/nolocation").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/post/202/nolocation").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2140,7 +2155,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRelativeRetryNoPayload", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/postasync/retry/nopayload").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/postasync/retry/nopayload").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2277,7 +2293,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut200InvalidJson", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/put/200/invalidjson").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/put/200/invalidjson").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2422,7 +2439,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRelativeRetryInvalidHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/putasync/retry/invalidheader").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/putasync/retry/invalidheader").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2567,7 +2585,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRelativeRetryInvalidJsonPolling", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/putasync/retry/invalidjsonpolling").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/putasync/retry/invalidjsonpolling").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2702,7 +2721,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDelete202RetryInvalidHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/delete/202/retry/invalidheader").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/delete/202/retry/invalidheader").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2827,7 +2847,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncRelativeRetryInvalidHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/deleteasync/retry/invalidheader").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/deleteasync/retry/invalidheader").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2954,7 +2975,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncRelativeRetryInvalidJsonPolling", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/deleteasync/retry/invalidjsonpolling").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/deleteasync/retry/invalidjsonpolling").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3085,7 +3107,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPost202RetryInvalidHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/post/202/retry/invalidheader").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/post/202/retry/invalidheader").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3222,7 +3245,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRelativeRetryInvalidHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/postasync/retry/invalidheader").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/postasync/retry/invalidheader").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3359,7 +3383,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRelativeRetryInvalidJsonPolling", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/error/postasync/retry/invalidjsonpolling").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/error/postasync/retry/invalidjsonpolling").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROsCustomHeaderOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROsCustomHeaderOperations.cs
@@ -103,7 +103,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/customheader/putasync/retry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/customheader/putasync/retry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -252,7 +253,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut201CreatingSucceeded200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/customheader/put/201/creating/succeeded/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/customheader/put/201/creating/succeeded/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -403,7 +405,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPost202Retry200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/customheader/post/202/retry/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/customheader/post/202/retry/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -544,7 +547,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/customheader/postasync/retry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/customheader/postasync/retry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROsOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROsOperations.cs
@@ -97,7 +97,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut200Succeeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/put/200/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/put/200/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -240,7 +241,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut200SucceededNoState", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/put/200/succeeded/nostate").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/put/200/succeeded/nostate").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -385,7 +387,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut202Retry200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/put/202/retry/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/put/202/retry/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -532,7 +535,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut201CreatingSucceeded200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/put/201/creating/succeeded/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/put/201/creating/succeeded/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -685,7 +689,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut200UpdatingSucceeded204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/put/200/updating/succeeded/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/put/200/updating/succeeded/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -832,7 +837,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut201CreatingFailed200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/put/201/created/failed/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/put/201/created/failed/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -985,7 +991,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPut200Acceptedcanceled200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/put/200/accepted/canceled/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/put/200/accepted/canceled/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1130,7 +1137,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutNoHeaderInRetry", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/put/noheader/202/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/put/noheader/202/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1275,7 +1283,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putasync/retry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putasync/retry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1420,7 +1429,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncNoRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putasync/noretry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putasync/noretry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1565,7 +1575,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncRetryFailed", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putasync/retry/failed").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putasync/retry/failed").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1710,7 +1721,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncNoRetrycanceled", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putasync/noretry/canceled").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putasync/noretry/canceled").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1855,7 +1867,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncNoHeaderInRetry", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putasync/noheader/201/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putasync/noheader/201/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -1996,7 +2009,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutNonResource", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putnonresource/202/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putnonresource/202/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2137,7 +2151,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncNonResource", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putnonresourceasync/202/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putnonresourceasync/202/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2278,7 +2293,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutSubResource", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putsubresource/202/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putsubresource/202/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2419,7 +2435,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPutAsyncSubResource", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/putsubresourceasync/202/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/putsubresourceasync/202/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2558,7 +2575,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteProvisioning202Accepted200Succeeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/delete/provisioning/202/accepted/200/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/delete/provisioning/202/accepted/200/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2699,7 +2717,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteProvisioning202DeletingFailed200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/delete/provisioning/202/deleting/200/failed").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/delete/provisioning/202/deleting/200/failed").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2840,7 +2859,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteProvisioning202Deletingcanceled200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/delete/provisioning/202/deleting/200/canceled").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/delete/provisioning/202/deleting/200/canceled").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -2975,7 +2995,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDelete204Succeeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/delete/204/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/delete/204/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3102,7 +3123,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDelete202Retry200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/delete/202/retry/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/delete/202/retry/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3235,7 +3257,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDelete202NoRetry204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/delete/202/noretry/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/delete/202/noretry/204").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3368,7 +3391,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteNoHeaderInRetry", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/delete/noheader").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/delete/noheader").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3495,7 +3519,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncNoHeaderInRetry", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/deleteasync/noheader/202/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/deleteasync/noheader/202/204").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3622,7 +3647,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/deleteasync/retry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/deleteasync/retry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3749,7 +3775,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncNoRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/deleteasync/noretry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/deleteasync/noretry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -3876,7 +3903,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncRetryFailed", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/deleteasync/retry/failed").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/deleteasync/retry/failed").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -4003,7 +4031,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginDeleteAsyncRetrycanceled", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/deleteasync/retry/canceled").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/deleteasync/retry/canceled").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -4130,7 +4159,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPost200WithPayload", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/post/payload/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/post/payload/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -4275,7 +4305,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPost202Retry200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/post/202/retry/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/post/202/retry/200").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -4410,7 +4441,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPost202NoRetry204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/post/202/noretry/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/post/202/noretry/204").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -4553,7 +4585,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/postasync/retry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/postasync/retry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -4696,7 +4729,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncNoRetrySucceeded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/postasync/noretry/succeeded").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/postasync/noretry/succeeded").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -4839,7 +4873,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRetryFailed", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/postasync/retry/failed").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/postasync/retry/failed").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -4976,7 +5011,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
                 ServiceClientTracing.Enter(invocationId, this, "BeginPostAsyncRetrycanceled", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "lro/postasync/retry/canceled").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "lro/postasync/retry/canceled").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Paging/PagingOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Paging/PagingOperations.cs
@@ -70,7 +70,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
                 ServiceClientTracing.Enter(invocationId, this, "GetSinglePages", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paging/single").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paging/single").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -182,7 +183,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
                 ServiceClientTracing.Enter(invocationId, this, "GetMultiplePages", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paging/multiple").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paging/multiple").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -295,7 +297,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
                 ServiceClientTracing.Enter(invocationId, this, "GetMultiplePagesRetryFirst", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paging/multiple/retryfirst").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paging/multiple/retryfirst").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -409,7 +412,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
                 ServiceClientTracing.Enter(invocationId, this, "GetMultiplePagesRetrySecond", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paging/multiple/retrysecond").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paging/multiple/retrysecond").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -521,7 +525,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
                 ServiceClientTracing.Enter(invocationId, this, "GetSinglePagesFailure", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paging/single/failure").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paging/single/failure").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -633,7 +638,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
                 ServiceClientTracing.Enter(invocationId, this, "GetMultiplePagesFailure", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paging/multiple/failure").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paging/multiple/failure").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -745,7 +751,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
                 ServiceClientTracing.Enter(invocationId, this, "GetMultiplePagesFailureUri", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paging/multiple/failureuri").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paging/multiple/failureuri").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/ResourceFlattening/AutoRestResourceFlatteningTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/ResourceFlattening/AutoRestResourceFlatteningTestService.cs
@@ -216,7 +216,8 @@ namespace Fixtures.Azure.AcceptanceTestsResourceFlattening
                 ServiceClientTracing.Enter(invocationId, this, "PutArray", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "azure/resource-flatten/array").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azure/resource-flatten/array").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -325,7 +326,8 @@ namespace Fixtures.Azure.AcceptanceTestsResourceFlattening
                 ServiceClientTracing.Enter(invocationId, this, "GetArray", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "azure/resource-flatten/array").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azure/resource-flatten/array").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -439,7 +441,8 @@ namespace Fixtures.Azure.AcceptanceTestsResourceFlattening
                 ServiceClientTracing.Enter(invocationId, this, "PutDictionary", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "azure/resource-flatten/dictionary").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azure/resource-flatten/dictionary").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -548,7 +551,8 @@ namespace Fixtures.Azure.AcceptanceTestsResourceFlattening
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionary", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "azure/resource-flatten/dictionary").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azure/resource-flatten/dictionary").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -662,7 +666,8 @@ namespace Fixtures.Azure.AcceptanceTestsResourceFlattening
                 ServiceClientTracing.Enter(invocationId, this, "PutResourceCollection", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "azure/resource-flatten/resourcecollection").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azure/resource-flatten/resourcecollection").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {
@@ -771,7 +776,8 @@ namespace Fixtures.Azure.AcceptanceTestsResourceFlattening
                 ServiceClientTracing.Enter(invocationId, this, "GetResourceCollection", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "azure/resource-flatten/resourcecollection").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "azure/resource-flatten/resourcecollection").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameters.Count > 0)
             {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/GroupOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/GroupOperations.cs
@@ -85,7 +85,8 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
                 ServiceClientTracing.Enter(invocationId, this, "GetSampleResourceGroup", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(this.Client.SubscriptionId));
             url = url.Replace("{resourceGroupName}", Uri.EscapeDataString(resourceGroupName));
             List<string> queryParameters = new List<string>();

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyArray/Array.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyArray/Array.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -157,7 +158,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -244,7 +246,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -338,7 +341,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -423,7 +427,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanTfft", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/boolean/tfft").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/boolean/tfft").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -517,7 +522,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutBooleanTfft", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/boolean/tfft").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/boolean/tfft").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -602,7 +608,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/boolean/true.null.false").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/boolean/true.null.false").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -689,7 +696,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/boolean/true.boolean.false").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/boolean/true.boolean.false").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -776,7 +784,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetIntegerValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/integer/1.-1.3.300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/integer/1.-1.3.300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -870,7 +879,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutIntegerValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/integer/1.-1.3.300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/integer/1.-1.3.300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -955,7 +965,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetIntInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/integer/1.null.zero").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/integer/1.null.zero").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1042,7 +1053,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetIntInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/integer/1.integer.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/integer/1.integer.0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1129,7 +1141,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetLongValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/long/1.-1.3.300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/long/1.-1.3.300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1223,7 +1236,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutLongValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/long/1.-1.3.300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/long/1.-1.3.300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1308,7 +1322,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetLongInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/long/1.null.zero").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/long/1.null.zero").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1395,7 +1410,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetLongInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/long/1.integer.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/long/1.integer.0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1482,7 +1498,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetFloatValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/float/0--0.01-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/float/0--0.01-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1576,7 +1593,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutFloatValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/float/0--0.01-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/float/0--0.01-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1661,7 +1679,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetFloatInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/float/0.0-null-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/float/0.0-null-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1748,7 +1767,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetFloatInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/float/1.number.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/float/1.number.0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1835,7 +1855,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDoubleValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/double/0--0.01-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/double/0--0.01-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1929,7 +1950,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutDoubleValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/double/0--0.01-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/double/0--0.01-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -2014,7 +2036,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDoubleInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/double/0.0-null-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/double/0.0-null-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2101,7 +2124,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDoubleInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/double/1.number.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/double/1.number.0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2188,7 +2212,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetStringValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/string/foo1.foo2.foo3").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/string/foo1.foo2.foo3").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2282,7 +2307,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutStringValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/string/foo1.foo2.foo3").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/string/foo1.foo2.foo3").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -2367,7 +2393,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetStringWithNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/string/foo.null.foo2").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/string/foo.null.foo2").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2454,7 +2481,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetStringWithInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/string/foo.123.foo2").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/string/foo.123.foo2").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2541,7 +2569,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDateValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/date/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/date/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2635,7 +2664,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutDateValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/date/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/date/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -2720,7 +2750,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDateInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/date/invalidnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/date/invalidnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2807,7 +2838,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDateInvalidChars", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/date/invalidchars").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/date/invalidchars").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2895,7 +2927,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDateTimeValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/date-time/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/date-time/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2990,7 +3023,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutDateTimeValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/date-time/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/date-time/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -3075,7 +3109,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDateTimeInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/date-time/invalidnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/date-time/invalidnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3162,7 +3197,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDateTimeInvalidChars", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/date-time/invalidchars").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/date-time/invalidchars").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3250,7 +3286,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetByteValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/byte/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/byte/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3345,7 +3382,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutByteValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/byte/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/byte/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -3431,7 +3469,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetByteInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/prim/byte/invalidnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/prim/byte/invalidnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3518,7 +3557,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/complex/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/complex/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3605,7 +3645,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/complex/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/complex/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3693,7 +3734,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexItemNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/complex/itemnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/complex/itemnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3781,7 +3823,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexItemEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/complex/itemempty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/complex/itemempty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3869,7 +3912,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/complex/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/complex/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3964,7 +4008,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutComplexValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/complex/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/complex/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -4049,7 +4094,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/array/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/array/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4136,7 +4182,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/array/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/array/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4223,7 +4270,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayItemNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/array/itemnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/array/itemnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4310,7 +4358,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayItemEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/array/itemempty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/array/itemempty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4398,7 +4447,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/array/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/array/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4493,7 +4543,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutArrayValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/array/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/array/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -4578,7 +4629,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/dictionary/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/dictionary/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4665,7 +4717,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/dictionary/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/dictionary/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4754,7 +4807,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryItemNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/dictionary/itemnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/dictionary/itemnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4843,7 +4897,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryItemEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/dictionary/itemempty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/dictionary/itemempty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4932,7 +4987,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/dictionary/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/dictionary/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -5028,7 +5084,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
                 ServiceClientTracing.Enter(invocationId, this, "PutDictionaryValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "array/dictionary/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "array/dictionary/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyBoolean/BoolModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyBoolean/BoolModel.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
                 ServiceClientTracing.Enter(invocationId, this, "GetTrue", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "bool/true").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "bool/true").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -164,7 +165,8 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
                 ServiceClientTracing.Enter(invocationId, this, "PutTrue", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "bool/true").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "bool/true").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -249,7 +251,8 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
                 ServiceClientTracing.Enter(invocationId, this, "GetFalse", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "bool/false").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "bool/false").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -343,7 +346,8 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
                 ServiceClientTracing.Enter(invocationId, this, "PutFalse", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "bool/false").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "bool/false").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -428,7 +432,8 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "bool/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "bool/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -515,7 +520,8 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "bool/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "bool/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyByte/ByteModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyByte/ByteModel.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyByte
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "byte/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "byte/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -157,7 +158,8 @@ namespace Fixtures.AcceptanceTestsBodyByte
                 ServiceClientTracing.Enter(invocationId, this, "GetEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "byte/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "byte/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -244,7 +246,8 @@ namespace Fixtures.AcceptanceTestsBodyByte
                 ServiceClientTracing.Enter(invocationId, this, "GetNonAscii", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "byte/nonAscii").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "byte/nonAscii").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -338,7 +341,8 @@ namespace Fixtures.AcceptanceTestsBodyByte
                 ServiceClientTracing.Enter(invocationId, this, "PutNonAscii", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "byte/nonAscii").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "byte/nonAscii").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -423,7 +427,8 @@ namespace Fixtures.AcceptanceTestsBodyByte
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "byte/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "byte/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Array.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Array.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/array/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/array/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -165,7 +166,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/array/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/array/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -250,7 +252,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/array/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/array/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -344,7 +347,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/array/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/array/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -430,7 +434,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetNotProvided", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/array/notprovided").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/array/notprovided").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/BasicOperations.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/BasicOperations.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/basic/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/basic/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -164,7 +165,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/basic/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/basic/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -249,7 +251,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/basic/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/basic/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -336,7 +339,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/basic/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/basic/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -423,7 +427,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/basic/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/basic/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -511,7 +516,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetNotProvided", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/basic/notprovided").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/basic/notprovided").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Dictionary.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Dictionary.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/dictionary/typed/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/dictionary/typed/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -165,7 +166,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/dictionary/typed/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/dictionary/typed/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -250,7 +252,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/dictionary/typed/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/dictionary/typed/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -344,7 +347,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/dictionary/typed/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/dictionary/typed/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -429,7 +433,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/dictionary/typed/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/dictionary/typed/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -517,7 +522,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetNotProvided", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/dictionary/typed/notprovided").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/dictionary/typed/notprovided").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Inheritance.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Inheritance.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/inheritance/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/inheritance/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -167,7 +168,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/inheritance/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/inheritance/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Polymorphicrecursive.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Polymorphicrecursive.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/polymorphicrecursive/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/polymorphicrecursive/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -220,7 +221,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/polymorphicrecursive/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/polymorphicrecursive/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Polymorphism.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Polymorphism.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/polymorphism/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/polymorphism/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -193,7 +194,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/polymorphism/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/polymorphism/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -316,7 +318,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutValidMissingRequired", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/polymorphism/missingrequired/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/polymorphism/missingrequired/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Primitive.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Primitive.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetInt", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/integer").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/integer").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -164,7 +165,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutInt", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/integer").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/integer").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -249,7 +251,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetLong", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/long").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/long").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -343,7 +346,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutLong", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/long").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/long").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -428,7 +432,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/float").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/float").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -522,7 +527,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/float").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/float").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -607,7 +613,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/double").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/double").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -702,7 +709,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/double").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/double").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -787,7 +795,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetBool", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/bool").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/bool").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -881,7 +890,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutBool", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/bool").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/bool").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -966,7 +976,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/string").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/string").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1060,7 +1071,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/string").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/string").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1145,7 +1157,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/date").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/date").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1239,7 +1252,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/date").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/date").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1324,7 +1338,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/datetime").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/datetime").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1418,7 +1433,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/datetime").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/datetime").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1503,7 +1519,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "GetByte", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/byte").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/byte").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1597,7 +1614,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 ServiceClientTracing.Enter(invocationId, this, "PutByte", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "complex/primitive/byte").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "complex/primitive/byte").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDate/Date.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDate/Date.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyDate
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "date/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "date/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -157,7 +158,8 @@ namespace Fixtures.AcceptanceTestsBodyDate
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalidDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "date/invaliddate").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "date/invaliddate").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -244,7 +246,8 @@ namespace Fixtures.AcceptanceTestsBodyDate
                 ServiceClientTracing.Enter(invocationId, this, "GetOverflowDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "date/overflowdate").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "date/overflowdate").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -331,7 +334,8 @@ namespace Fixtures.AcceptanceTestsBodyDate
                 ServiceClientTracing.Enter(invocationId, this, "GetUnderflowDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "date/underflowdate").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "date/underflowdate").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -425,7 +429,8 @@ namespace Fixtures.AcceptanceTestsBodyDate
                 ServiceClientTracing.Enter(invocationId, this, "PutMaxDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "date/max").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "date/max").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -510,7 +515,8 @@ namespace Fixtures.AcceptanceTestsBodyDate
                 ServiceClientTracing.Enter(invocationId, this, "GetMaxDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "date/max").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "date/max").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -604,7 +610,8 @@ namespace Fixtures.AcceptanceTestsBodyDate
                 ServiceClientTracing.Enter(invocationId, this, "PutMinDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "date/min").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "date/min").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -689,7 +696,8 @@ namespace Fixtures.AcceptanceTestsBodyDate
                 ServiceClientTracing.Enter(invocationId, this, "GetMinDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "date/min").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "date/min").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDateTime/Datetime.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDateTime/Datetime.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -157,7 +158,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -244,7 +246,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetOverflow", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/overflow").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/overflow").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -331,7 +334,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetUnderflow", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/underflow").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/underflow").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -425,7 +429,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "PutUtcMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/utc").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/utc").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -510,7 +515,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetUtcLowercaseMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/utc/lowercase").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/utc/lowercase").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -597,7 +603,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetUtcUppercaseMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/utc/uppercase").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/utc/uppercase").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -692,7 +699,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "PutLocalPositiveOffsetMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/localpositiveoffset").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/localpositiveoffset").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -778,7 +786,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetLocalPositiveOffsetLowercaseMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/localpositiveoffset/lowercase").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/localpositiveoffset/lowercase").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -866,7 +875,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetLocalPositiveOffsetUppercaseMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/localpositiveoffset/uppercase").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/localpositiveoffset/uppercase").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -961,7 +971,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "PutLocalNegativeOffsetMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/localnegativeoffset").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/localnegativeoffset").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1047,7 +1058,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetLocalNegativeOffsetUppercaseMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/localnegativeoffset/uppercase").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/localnegativeoffset/uppercase").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1135,7 +1147,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetLocalNegativeOffsetLowercaseMaxDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/max/localnegativeoffset/lowercase").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/max/localnegativeoffset/lowercase").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1229,7 +1242,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "PutUtcMinDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/min/utc").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/min/utc").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1314,7 +1328,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetUtcMinDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/min/utc").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/min/utc").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1408,7 +1423,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "PutLocalPositiveOffsetMinDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/min/localpositiveoffset").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/min/localpositiveoffset").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1493,7 +1509,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetLocalPositiveOffsetMinDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/min/localpositiveoffset").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/min/localpositiveoffset").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1587,7 +1604,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "PutLocalNegativeOffsetMinDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/min/localnegativeoffset").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/min/localnegativeoffset").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1672,7 +1690,8 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
                 ServiceClientTracing.Enter(invocationId, this, "GetLocalNegativeOffsetMinDateTime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "datetime/min/localnegativeoffset").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datetime/min/localnegativeoffset").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/Dictionary.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/Dictionary.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -157,7 +158,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -251,7 +253,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -336,7 +339,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetNullValue", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/nullvalue").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/nullvalue").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -423,7 +427,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetNullKey", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/nullkey").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/nullkey").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -510,7 +515,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetEmptyStringKey", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/keyemptystring").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/keyemptystring").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -597,7 +603,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -685,7 +692,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanTfft", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/boolean/tfft").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/boolean/tfft").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -779,7 +787,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutBooleanTfft", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/boolean/tfft").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/boolean/tfft").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -864,7 +873,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/boolean/true.null.false").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/boolean/true.null.false").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -951,7 +961,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/boolean/true.boolean.false").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/boolean/true.boolean.false").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1038,7 +1049,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetIntegerValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/integer/1.-1.3.300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/integer/1.-1.3.300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1132,7 +1144,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutIntegerValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/integer/1.-1.3.300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/integer/1.-1.3.300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1217,7 +1230,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetIntInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/integer/1.null.zero").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/integer/1.null.zero").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1304,7 +1318,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetIntInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/integer/1.integer.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/integer/1.integer.0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1391,7 +1406,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetLongValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/long/1.-1.3.300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/long/1.-1.3.300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1485,7 +1501,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutLongValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/long/1.-1.3.300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/long/1.-1.3.300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1570,7 +1587,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetLongInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/long/1.null.zero").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/long/1.null.zero").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1657,7 +1675,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetLongInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/long/1.integer.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/long/1.integer.0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1744,7 +1763,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetFloatValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/float/0--0.01-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/float/0--0.01-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1838,7 +1858,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutFloatValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/float/0--0.01-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/float/0--0.01-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1923,7 +1944,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetFloatInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/float/0.0-null-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/float/0.0-null-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2010,7 +2032,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetFloatInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/float/1.number.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/float/1.number.0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2097,7 +2120,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDoubleValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/double/0--0.01-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/double/0--0.01-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2191,7 +2215,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutDoubleValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/double/0--0.01-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/double/0--0.01-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -2276,7 +2301,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDoubleInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/double/0.0-null-1.2e20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/double/0.0-null-1.2e20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2363,7 +2389,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDoubleInvalidString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/double/1.number.0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/double/1.number.0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2450,7 +2477,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetStringValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/string/foo1.foo2.foo3").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/string/foo1.foo2.foo3").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2544,7 +2572,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutStringValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/string/foo1.foo2.foo3").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/string/foo1.foo2.foo3").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -2629,7 +2658,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetStringWithNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/string/foo.null.foo2").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/string/foo.null.foo2").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2716,7 +2746,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetStringWithInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/string/foo.123.foo2").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/string/foo.123.foo2").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2804,7 +2835,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDateValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/date/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/date/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2899,7 +2931,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutDateValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/date/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/date/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -2984,7 +3017,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDateInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/date/invalidnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/date/invalidnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3071,7 +3105,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDateInvalidChars", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/date/invalidchars").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/date/invalidchars").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3159,7 +3194,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDateTimeValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/date-time/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/date-time/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3254,7 +3290,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutDateTimeValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/date-time/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/date-time/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -3339,7 +3376,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDateTimeInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/date-time/invalidnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/date-time/invalidnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3426,7 +3464,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDateTimeInvalidChars", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/date-time/invalidchars").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/date-time/invalidchars").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3514,7 +3553,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetByteValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/byte/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/byte/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3609,7 +3649,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutByteValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/byte/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/byte/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -3695,7 +3736,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetByteInvalidNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/prim/byte/invalidnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/prim/byte/invalidnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3782,7 +3824,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/complex/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/complex/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3869,7 +3912,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/complex/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/complex/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -3957,7 +4001,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexItemNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/complex/itemnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/complex/itemnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4045,7 +4090,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexItemEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/complex/itemempty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/complex/itemempty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4133,7 +4179,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetComplexValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/complex/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/complex/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4229,7 +4276,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutComplexValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/complex/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/complex/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -4314,7 +4362,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/array/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/array/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4401,7 +4450,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/array/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/array/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4489,7 +4539,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayItemNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/array/itemnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/array/itemnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4577,7 +4628,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayItemEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/array/itemempty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/array/itemempty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4665,7 +4717,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetArrayValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/array/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/array/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4760,7 +4813,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutArrayValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/array/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/array/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -4845,7 +4899,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/dictionary/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/dictionary/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -4933,7 +4988,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/dictionary/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/dictionary/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -5022,7 +5078,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryItemNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/dictionary/itemnull").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/dictionary/itemnull").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -5111,7 +5168,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryItemEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/dictionary/itemempty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/dictionary/itemempty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -5200,7 +5258,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "GetDictionaryValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/dictionary/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/dictionary/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -5296,7 +5355,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
                 ServiceClientTracing.Enter(invocationId, this, "PutDictionaryValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "dictionary/dictionary/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "dictionary/dictionary/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDuration/Duration.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDuration/Duration.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyDuration
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "duration/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "duration/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -164,7 +165,8 @@ namespace Fixtures.AcceptanceTestsBodyDuration
                 ServiceClientTracing.Enter(invocationId, this, "PutPositiveDuration", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "duration/positiveduration").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "duration/positiveduration").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -249,7 +251,8 @@ namespace Fixtures.AcceptanceTestsBodyDuration
                 ServiceClientTracing.Enter(invocationId, this, "GetPositiveDuration", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "duration/positiveduration").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "duration/positiveduration").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -336,7 +339,8 @@ namespace Fixtures.AcceptanceTestsBodyDuration
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "duration/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "duration/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFile/Files.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFile/Files.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyFile
                 ServiceClientTracing.Enter(invocationId, this, "GetFile", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "files/stream/nonempty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "files/stream/nonempty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -156,7 +157,8 @@ namespace Fixtures.AcceptanceTestsBodyFile
                 ServiceClientTracing.Enter(invocationId, this, "GetEmptyFile", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "files/stream/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "files/stream/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/IntModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/IntModel.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -157,7 +158,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -244,7 +246,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "GetOverflowInt32", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/overflowint32").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/overflowint32").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -331,7 +334,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "GetUnderflowInt32", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/underflowint32").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/underflowint32").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -418,7 +422,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "GetOverflowInt64", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/overflowint64").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/overflowint64").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -505,7 +510,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "GetUnderflowInt64", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/underflowint64").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/underflowint64").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -599,7 +605,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "PutMax32", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/max/32").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/max/32").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -691,7 +698,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "PutMax64", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/max/64").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/max/64").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -783,7 +791,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "PutMin32", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/min/32").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/min/32").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -875,7 +884,8 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 ServiceClientTracing.Enter(invocationId, this, "PutMin64", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "int/min/64").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "int/min/64").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyNumber/Number.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyNumber/Number.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -157,7 +158,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalidFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/invalidfloat").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/invalidfloat").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -244,7 +246,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetInvalidDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/invaliddouble").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/invaliddouble").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -338,7 +341,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "PutBigFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/big/float/3.402823e+20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/big/float/3.402823e+20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -423,7 +427,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetBigFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/big/float/3.402823e+20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/big/float/3.402823e+20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -517,7 +522,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "PutBigDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/big/double/2.5976931e+101").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/big/double/2.5976931e+101").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -602,7 +608,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetBigDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/big/double/2.5976931e+101").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/big/double/2.5976931e+101").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -696,7 +703,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "PutBigDoublePositiveDecimal", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/big/double/99999999.99").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/big/double/99999999.99").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -781,7 +789,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetBigDoublePositiveDecimal", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/big/double/99999999.99").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/big/double/99999999.99").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -875,7 +884,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "PutBigDoubleNegativeDecimal", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/big/double/-99999999.99").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/big/double/-99999999.99").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -960,7 +970,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetBigDoubleNegativeDecimal", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/big/double/-99999999.99").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/big/double/-99999999.99").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1054,7 +1065,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "PutSmallFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/small/float/3.402823e-20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/small/float/3.402823e-20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1139,7 +1151,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetSmallFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/small/float/3.402823e-20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/small/float/3.402823e-20").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1233,7 +1246,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "PutSmallDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/small/double/2.5976931e-101").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/small/double/2.5976931e-101").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1318,7 +1332,8 @@ namespace Fixtures.AcceptanceTestsBodyNumber
                 ServiceClientTracing.Enter(invocationId, this, "GetSmallDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "number/small/double/2.5976931e-101").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "number/small/double/2.5976931e-101").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyString/EnumModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyString/EnumModel.cs
@@ -71,7 +71,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "GetNotExpandable", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/enum/notExpandable").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/enum/notExpandable").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -167,7 +168,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "PutNotExpandable", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/enum/notExpandable").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/enum/notExpandable").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyString/StringModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyString/StringModel.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "GetNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -160,7 +161,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "PutNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/null").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -245,7 +247,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "GetEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -339,7 +342,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "PutEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/empty").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -425,7 +429,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "GetMbcs", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/mbcs").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/mbcs").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -521,7 +526,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "PutMbcs", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/mbcs").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/mbcs").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -608,7 +614,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "GetWhitespace", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/whitespace").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/whitespace").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -705,7 +712,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "PutWhitespace", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/whitespace").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/whitespace").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -790,7 +798,8 @@ namespace Fixtures.AcceptanceTestsBodyString
                 ServiceClientTracing.Enter(invocationId, this, "GetNotProvided", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "string/notProvided").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "string/notProvided").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Header/Header.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Header/Header.cs
@@ -77,7 +77,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamExistingKey", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/existingkey").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/existingkey").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -166,7 +167,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseExistingKey", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/existingkey").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/existingkey").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -254,7 +256,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamProtectedKey", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/protectedkey").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/protectedkey").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -343,7 +346,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseProtectedKey", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/protectedkey").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/protectedkey").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -439,7 +443,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamInteger", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/integer").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/integer").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -543,7 +548,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseInteger", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/integer").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/integer").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -647,7 +653,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamLong", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/long").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/long").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -751,7 +758,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseLong", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/long").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/long").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -855,7 +863,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/float").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/float").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -959,7 +968,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseFloat", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/float").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/float").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1063,7 +1073,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/double").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/double").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1167,7 +1178,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseDouble", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/double").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/double").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1271,7 +1283,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamBool", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/bool").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/bool").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1375,7 +1388,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseBool", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/bool").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/bool").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1478,7 +1492,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/string").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/string").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1584,7 +1599,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseString", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/string").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/string").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1688,7 +1704,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/date").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/date").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1792,7 +1809,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseDate", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/date").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/date").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1898,7 +1916,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamDatetime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/datetime").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/datetime").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2003,7 +2022,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseDatetime", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/datetime").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/datetime").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2107,7 +2127,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamDuration", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/duration").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/duration").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2211,7 +2232,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseDuration", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/duration").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/duration").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2315,7 +2337,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamByte", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/byte").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/byte").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2419,7 +2442,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseByte", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/byte").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/byte").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2521,7 +2545,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ParamEnum", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/param/prim/enum").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/param/prim/enum").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2626,7 +2651,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "ResponseEnum", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/response/prim/enum").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/response/prim/enum").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2716,7 +2742,8 @@ namespace Fixtures.AcceptanceTestsHeader
                 ServiceClientTracing.Enter(invocationId, this, "CustomRequestId", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpClientFailure.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpClientFailure.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/400").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -153,7 +154,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/400").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -239,7 +241,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/400").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -329,7 +332,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/400").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -419,7 +423,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/400").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -509,7 +514,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete400", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/400").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/400").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");
@@ -596,7 +602,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head401", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/401").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/401").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -679,7 +686,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get402", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/402").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/402").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -762,7 +770,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get403", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/403").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/403").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -848,7 +857,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put404", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/404").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/404").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -938,7 +948,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch405", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/405").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/405").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -1028,7 +1039,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post406", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/406").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/406").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1118,7 +1130,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete407", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/407").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/407").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");
@@ -1208,7 +1221,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put409", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/409").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/409").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1295,7 +1309,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head410", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/410").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/410").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -1378,7 +1393,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get411", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/411").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/411").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1461,7 +1477,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get412", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/412").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/412").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1547,7 +1564,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put413", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/413").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/413").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1637,7 +1655,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch414", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/414").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/414").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -1727,7 +1746,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post415", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/415").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/415").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1814,7 +1834,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get416", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/416").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/416").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1900,7 +1921,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete417", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/417").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/417").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");
@@ -1987,7 +2009,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head429", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/client/429").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/client/429").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpFailure.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpFailure.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetEmptyError", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/emptybody/error").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/emptybody/error").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpRedirects.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpRedirects.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head300", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -151,7 +152,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get300", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/300").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/300").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -238,7 +240,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head301", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/301").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/301").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -319,7 +322,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get301", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/301").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/301").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -405,7 +409,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put301", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/301").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/301").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -490,7 +495,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head302", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/302").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/302").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -571,7 +577,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get302", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/302").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/302").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -657,7 +664,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch302", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/302").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/302").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -747,7 +755,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post303", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/303").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/303").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -832,7 +841,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head307", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/307").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/307").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -913,7 +923,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get307", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/307").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/307").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -997,7 +1008,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put307", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/307").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/307").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1085,7 +1097,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch307", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/307").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/307").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -1173,7 +1186,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post307", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/307").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/307").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1261,7 +1275,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete307", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/redirect/307").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/redirect/307").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpRetry.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpRetry.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head408", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/retry/408").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/retry/408").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -154,7 +155,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put500", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/retry/500").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/retry/500").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -242,7 +244,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch500", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/retry/500").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/retry/500").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -327,7 +330,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get502", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/retry/502").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/retry/502").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -411,7 +415,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post503", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/retry/503").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/retry/503").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -499,7 +504,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete503", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/retry/503").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/retry/503").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");
@@ -587,7 +593,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put504", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/retry/504").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/retry/504").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -675,7 +682,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch504", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/retry/504").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/retry/504").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpServerFailure.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpServerFailure.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head501", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/server/501").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/server/501").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -153,7 +154,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get501", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/server/501").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/server/501").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -239,7 +241,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post505", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/server/505").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/server/505").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -329,7 +332,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete505", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/failure/server/505").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/failure/server/505").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpSuccess.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/HttpSuccess.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/200").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -151,7 +152,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/200").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -241,7 +243,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/200").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -329,7 +332,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/200").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -417,7 +421,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/200").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -505,7 +510,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete200", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/200").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/200").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");
@@ -593,7 +599,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put201", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/201").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/201").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -681,7 +688,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post201", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/201").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/201").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -769,7 +777,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put202", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/202").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/202").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -857,7 +866,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch202", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/202").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/202").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -945,7 +955,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post202", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/202").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/202").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1033,7 +1044,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete202", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/202").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/202").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");
@@ -1118,7 +1130,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/204").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");
@@ -1202,7 +1215,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Put204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/204").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -1290,7 +1304,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Patch204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/204").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");
@@ -1378,7 +1393,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Post204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/204").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1466,7 +1482,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Delete204", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/204").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/204").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("DELETE");
@@ -1551,7 +1568,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Head404", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/success/404").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/success/404").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("HEAD");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/MultipleResponses.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/MultipleResponses.cs
@@ -70,7 +70,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200Model204NoModelDefaultError200Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/204/none/default/Error/response/200/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/204/none/default/Error/response/200/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -157,7 +158,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200Model204NoModelDefaultError204Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/204/none/default/Error/response/204/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/204/none/default/Error/response/204/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -244,7 +246,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200Model204NoModelDefaultError201Invalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/204/none/default/Error/response/201/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/204/none/default/Error/response/201/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -331,7 +334,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200Model204NoModelDefaultError202None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/204/none/default/Error/response/202/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/204/none/default/Error/response/202/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -419,7 +423,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200Model204NoModelDefaultError400Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/204/none/default/Error/response/400/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/204/none/default/Error/response/400/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -506,7 +511,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200Model201ModelDefaultError200Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/201/B/default/Error/response/200/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/201/B/default/Error/response/200/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -600,7 +606,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200Model201ModelDefaultError201Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/201/B/default/Error/response/201/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/201/B/default/Error/response/201/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -694,7 +701,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200Model201ModelDefaultError400Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/201/B/default/Error/response/400/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/201/B/default/Error/response/400/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -787,7 +795,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA201ModelC404ModelDDefaultError200Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/201/C/404/D/default/Error/response/200/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/201/C/404/D/default/Error/response/200/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -886,7 +895,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA201ModelC404ModelDDefaultError201Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/201/C/404/D/default/Error/response/201/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/201/C/404/D/default/Error/response/201/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -985,7 +995,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA201ModelC404ModelDDefaultError404Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/201/C/404/D/default/Error/response/404/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/201/C/404/D/default/Error/response/404/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1085,7 +1096,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA201ModelC404ModelDDefaultError400Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/201/C/404/D/default/Error/response/400/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/201/C/404/D/default/Error/response/400/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1184,7 +1196,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get202None204NoneDefaultError202None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/202/none/204/none/default/Error/response/202/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/202/none/204/none/default/Error/response/202/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1265,7 +1278,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get202None204NoneDefaultError204None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/202/none/204/none/default/Error/response/204/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/202/none/204/none/default/Error/response/204/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1347,7 +1361,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get202None204NoneDefaultError400Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/202/none/204/none/default/Error/response/400/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/202/none/204/none/default/Error/response/400/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1428,7 +1443,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get202None204NoneDefaultNone202Invalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/202/none/204/none/default/none/response/202/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/202/none/204/none/default/none/response/202/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1503,7 +1519,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get202None204NoneDefaultNone204None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/202/none/204/none/default/none/response/204/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/202/none/204/none/default/none/response/204/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1578,7 +1595,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get202None204NoneDefaultNone400None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/202/none/204/none/default/none/response/400/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/202/none/204/none/default/none/response/400/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1653,7 +1671,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get202None204NoneDefaultNone400Invalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/202/none/204/none/default/none/response/400/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/202/none/204/none/default/none/response/400/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1728,7 +1747,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetDefaultModelA200Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/default/A/response/200/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/default/A/response/200/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1811,7 +1831,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetDefaultModelA200None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/default/A/response/200/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/default/A/response/200/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1894,7 +1915,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetDefaultModelA400Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/default/A/response/400/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/default/A/response/400/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1977,7 +1999,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetDefaultModelA400None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/default/A/response/400/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/default/A/response/400/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2060,7 +2083,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetDefaultNone200Invalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/default/none/response/200/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/default/none/response/200/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2135,7 +2159,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetDefaultNone200None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/default/none/response/200/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/default/none/response/200/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2210,7 +2235,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetDefaultNone400Invalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/default/none/response/400/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/default/none/response/400/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2285,7 +2311,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "GetDefaultNone400None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/default/none/response/400/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/default/none/response/400/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2361,7 +2388,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA200None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/response/200/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/response/200/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2442,7 +2470,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA200Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/response/200/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/response/200/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2523,7 +2552,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA200Invalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/response/200/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/response/200/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2605,7 +2635,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA400None", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/response/400/none").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/response/400/none").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2686,7 +2717,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA400Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/response/400/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/response/400/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2767,7 +2799,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA400Invalid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/response/400/invalid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/response/400/invalid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -2848,7 +2881,8 @@ namespace Fixtures.AcceptanceTestsHttp
                 ServiceClientTracing.Enter(invocationId, this, "Get200ModelA202Valid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "http/payloads/200/A/response/202/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "http/payloads/200/A/response/202/valid").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Report/AutoRestReportService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Report/AutoRestReportService.cs
@@ -149,7 +149,8 @@ namespace Fixtures.AcceptanceTestsReport
                 ServiceClientTracing.Enter(invocationId, this, "GetReport", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "report").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "report").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/ExplicitModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/ExplicitModel.cs
@@ -78,7 +78,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredIntegerParameter", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/integer/parameter").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/integer/parameter").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -168,7 +169,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalIntegerParameter", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/integer/parameter").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/integer/parameter").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -266,7 +268,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredIntegerProperty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/integer/property").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/integer/property").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -357,7 +360,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalIntegerProperty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/integer/property").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/integer/property").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -450,7 +454,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredIntegerHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/integer/header").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/integer/header").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -545,7 +550,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalIntegerHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/integer/header").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/integer/header").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -642,7 +648,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredStringParameter", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/string/parameter").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/string/parameter").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -732,7 +739,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalStringParameter", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/string/parameter").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/string/parameter").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -830,7 +838,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredStringProperty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/string/property").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/string/property").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -921,7 +930,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalStringProperty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/string/property").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/string/property").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1014,7 +1024,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredStringHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/string/header").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/string/header").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1109,7 +1120,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalStringHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/string/header").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/string/header").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1210,7 +1222,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredClassParameter", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/class/parameter").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/class/parameter").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1304,7 +1317,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalClassParameter", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/class/parameter").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/class/parameter").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1402,7 +1416,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredClassProperty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/class/property").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/class/property").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1497,7 +1512,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalClassProperty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/class/property").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/class/property").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1590,7 +1606,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredArrayParameter", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/array/parameter").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/array/parameter").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1680,7 +1697,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalArrayParameter", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/array/parameter").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/array/parameter").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1778,7 +1796,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredArrayProperty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/array/property").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/array/property").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1869,7 +1888,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalArrayProperty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/array/property").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/array/property").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1962,7 +1982,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostRequiredArrayHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/requied/array/header").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/requied/array/header").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -2057,7 +2078,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PostOptionalArrayHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/optional/array/header").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/optional/array/header").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/ImplicitModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/ImplicitModel.cs
@@ -77,7 +77,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "GetRequiredPath", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/implicit/required/path/{pathParameter}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/implicit/required/path/{pathParameter}").ToString();
             url = url.Replace("{pathParameter}", Uri.EscapeDataString(pathParameter));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -164,7 +165,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PutOptionalQuery", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/implicit/optional/query").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/implicit/optional/query").ToString();
             List<string> queryParameters = new List<string>();
             if (queryParameter != null)
             {
@@ -257,7 +259,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PutOptionalHeader", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/implicit/optional/header").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/implicit/optional/header").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -349,7 +352,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "PutOptionalBody", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/implicit/optional/body").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/implicit/optional/body").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -438,7 +442,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "GetRequiredGlobalPath", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/global/required/path/{required-global-path}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/global/required/path/{required-global-path}").ToString();
             url = url.Replace("{required-global-path}", Uri.EscapeDataString(this.Client.RequiredGlobalPath));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -526,7 +531,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "GetRequiredGlobalQuery", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/global/required/query").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/global/required/query").ToString();
             List<string> queryParameters = new List<string>();
             if (this.Client.RequiredGlobalQuery != null)
             {
@@ -618,7 +624,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 ServiceClientTracing.Enter(invocationId, this, "GetOptionalGlobalQuery", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "reqopt/global/optional/query").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "reqopt/global/optional/query").ToString();
             List<string> queryParameters = new List<string>();
             if (this.Client.OptionalGlobalQuery != null)
             {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/PathItems.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/PathItems.cs
@@ -98,7 +98,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetAllWithValues", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery").ToString();
             url = url.Replace("{localStringPath}", Uri.EscapeDataString(localStringPath));
             url = url.Replace("{pathItemStringPath}", Uri.EscapeDataString(pathItemStringPath));
             url = url.Replace("{globalStringPath}", Uri.EscapeDataString(this.Client.GlobalStringPath));
@@ -227,7 +228,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetGlobalQueryNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery").ToString();
             url = url.Replace("{localStringPath}", Uri.EscapeDataString(localStringPath));
             url = url.Replace("{pathItemStringPath}", Uri.EscapeDataString(pathItemStringPath));
             url = url.Replace("{globalStringPath}", Uri.EscapeDataString(this.Client.GlobalStringPath));
@@ -355,7 +357,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetGlobalAndLocalQueryNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null").ToString();
             url = url.Replace("{localStringPath}", Uri.EscapeDataString(localStringPath));
             url = url.Replace("{pathItemStringPath}", Uri.EscapeDataString(pathItemStringPath));
             url = url.Replace("{globalStringPath}", Uri.EscapeDataString(this.Client.GlobalStringPath));
@@ -483,7 +486,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetLocalPathItemQueryNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null").ToString();
             url = url.Replace("{localStringPath}", Uri.EscapeDataString(localStringPath));
             url = url.Replace("{pathItemStringPath}", Uri.EscapeDataString(pathItemStringPath));
             url = url.Replace("{globalStringPath}", Uri.EscapeDataString(this.Client.GlobalStringPath));

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/Paths.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/Paths.cs
@@ -77,7 +77,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanTrue", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/bool/true/{boolPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/bool/true/{boolPath}").ToString();
             url = url.Replace("{boolPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(boolPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -166,7 +167,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanFalse", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/bool/false/{boolPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/bool/false/{boolPath}").ToString();
             url = url.Replace("{boolPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(boolPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -255,7 +257,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetIntOneMillion", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/int/1000000/{intPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/int/1000000/{intPath}").ToString();
             url = url.Replace("{intPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(intPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -344,7 +347,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetIntNegativeOneMillion", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/int/-1000000/{intPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/int/-1000000/{intPath}").ToString();
             url = url.Replace("{intPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(intPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -433,7 +437,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetTenBillion", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/long/10000000000/{longPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/long/10000000000/{longPath}").ToString();
             url = url.Replace("{longPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(longPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -522,7 +527,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetNegativeTenBillion", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/long/-10000000000/{longPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/long/-10000000000/{longPath}").ToString();
             url = url.Replace("{longPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(longPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -611,7 +617,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "FloatScientificPositive", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/float/1.034E+20/{floatPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/float/1.034E+20/{floatPath}").ToString();
             url = url.Replace("{floatPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(floatPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -700,7 +707,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "FloatScientificNegative", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/float/-1.034E-20/{floatPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/float/-1.034E-20/{floatPath}").ToString();
             url = url.Replace("{floatPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(floatPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -789,7 +797,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DoubleDecimalPositive", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/double/9999999.999/{doublePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/double/9999999.999/{doublePath}").ToString();
             url = url.Replace("{doublePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(doublePath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -878,7 +887,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DoubleDecimalNegative", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/double/-9999999.999/{doublePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/double/-9999999.999/{doublePath}").ToString();
             url = url.Replace("{doublePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(doublePath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -968,7 +978,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "StringUnicode", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/string/unicode/{stringPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/string/unicode/{stringPath}").ToString();
             url = url.Replace("{stringPath}", Uri.EscapeDataString(stringPath));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1058,7 +1069,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "StringUrlEncoded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}").ToString();
             url = url.Replace("{stringPath}", Uri.EscapeDataString(stringPath));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1147,7 +1159,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "StringEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/string/empty/{stringPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/string/empty/{stringPath}").ToString();
             url = url.Replace("{stringPath}", Uri.EscapeDataString(stringPath));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1236,7 +1249,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "StringNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/string/null/{stringPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/string/null/{stringPath}").ToString();
             url = url.Replace("{stringPath}", Uri.EscapeDataString(stringPath));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1326,7 +1340,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "EnumValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/enum/green%20color/{enumPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/enum/green%20color/{enumPath}").ToString();
             url = url.Replace("{enumPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(enumPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1416,7 +1431,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "EnumNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/string/null/{enumPath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/string/null/{enumPath}").ToString();
             url = url.Replace("{enumPath}", Uri.EscapeDataString(JsonConvert.SerializeObject(enumPath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1505,7 +1521,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ByteMultiByte", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/byte/multibyte/{bytePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/byte/multibyte/{bytePath}").ToString();
             url = url.Replace("{bytePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(bytePath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1594,7 +1611,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ByteEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/byte/empty/{bytePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/byte/empty/{bytePath}").ToString();
             url = url.Replace("{bytePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(bytePath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1683,7 +1701,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ByteNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/byte/null/{bytePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/byte/null/{bytePath}").ToString();
             url = url.Replace("{bytePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(bytePath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1772,7 +1791,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DateValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/date/2012-01-01/{datePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/date/2012-01-01/{datePath}").ToString();
             url = url.Replace("{datePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(datePath, new DateJsonConverter()).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1862,7 +1882,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DateNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/date/null/{datePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/date/null/{datePath}").ToString();
             url = url.Replace("{datePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(datePath, new DateJsonConverter()).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1951,7 +1972,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DateTimeValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}").ToString();
             url = url.Replace("{dateTimePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(dateTimePath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -2041,7 +2063,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DateTimeNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "paths/datetime/null/{dateTimePath}").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "paths/datetime/null/{dateTimePath}").ToString();
             url = url.Replace("{dateTimePath}", Uri.EscapeDataString(JsonConvert.SerializeObject(dateTimePath, this.Client.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/Queries.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/Queries.cs
@@ -73,7 +73,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanTrue", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/bool/true").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/bool/true").ToString();
             List<string> queryParameters = new List<string>();
             if (boolQuery != null)
             {
@@ -166,7 +167,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanFalse", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/bool/false").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/bool/false").ToString();
             List<string> queryParameters = new List<string>();
             if (boolQuery != null)
             {
@@ -259,7 +261,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetBooleanNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/bool/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/bool/null").ToString();
             List<string> queryParameters = new List<string>();
             if (boolQuery != null)
             {
@@ -352,7 +355,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetIntOneMillion", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/int/1000000").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/int/1000000").ToString();
             List<string> queryParameters = new List<string>();
             if (intQuery != null)
             {
@@ -445,7 +449,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetIntNegativeOneMillion", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/int/-1000000").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/int/-1000000").ToString();
             List<string> queryParameters = new List<string>();
             if (intQuery != null)
             {
@@ -538,7 +543,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetIntNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/int/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/int/null").ToString();
             List<string> queryParameters = new List<string>();
             if (intQuery != null)
             {
@@ -631,7 +637,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetTenBillion", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/long/10000000000").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/long/10000000000").ToString();
             List<string> queryParameters = new List<string>();
             if (longQuery != null)
             {
@@ -724,7 +731,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetNegativeTenBillion", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/long/-10000000000").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/long/-10000000000").ToString();
             List<string> queryParameters = new List<string>();
             if (longQuery != null)
             {
@@ -817,7 +825,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "GetLongNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/long/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/long/null").ToString();
             List<string> queryParameters = new List<string>();
             if (longQuery != null)
             {
@@ -910,7 +919,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "FloatScientificPositive", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/float/1.034E+20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/float/1.034E+20").ToString();
             List<string> queryParameters = new List<string>();
             if (floatQuery != null)
             {
@@ -1003,7 +1013,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "FloatScientificNegative", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/float/-1.034E-20").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/float/-1.034E-20").ToString();
             List<string> queryParameters = new List<string>();
             if (floatQuery != null)
             {
@@ -1096,7 +1107,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "FloatNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/float/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/float/null").ToString();
             List<string> queryParameters = new List<string>();
             if (floatQuery != null)
             {
@@ -1189,7 +1201,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DoubleDecimalPositive", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/double/9999999.999").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/double/9999999.999").ToString();
             List<string> queryParameters = new List<string>();
             if (doubleQuery != null)
             {
@@ -1282,7 +1295,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DoubleDecimalNegative", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/double/-9999999.999").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/double/-9999999.999").ToString();
             List<string> queryParameters = new List<string>();
             if (doubleQuery != null)
             {
@@ -1375,7 +1389,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DoubleNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/double/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/double/null").ToString();
             List<string> queryParameters = new List<string>();
             if (doubleQuery != null)
             {
@@ -1469,7 +1484,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "StringUnicode", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/string/unicode").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/string/unicode").ToString();
             List<string> queryParameters = new List<string>();
             if (stringQuery != null)
             {
@@ -1563,7 +1579,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "StringUrlEncoded", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend").ToString();
             List<string> queryParameters = new List<string>();
             if (stringQuery != null)
             {
@@ -1656,7 +1673,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "StringEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/string/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/string/empty").ToString();
             List<string> queryParameters = new List<string>();
             if (stringQuery != null)
             {
@@ -1749,7 +1767,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "StringNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/string/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/string/null").ToString();
             List<string> queryParameters = new List<string>();
             if (stringQuery != null)
             {
@@ -1843,7 +1862,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "EnumValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/enum/green%20color").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/enum/green%20color").ToString();
             List<string> queryParameters = new List<string>();
             if (enumQuery != null)
             {
@@ -1937,7 +1957,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "EnumNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/enum/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/enum/null").ToString();
             List<string> queryParameters = new List<string>();
             if (enumQuery != null)
             {
@@ -2030,7 +2051,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ByteMultiByte", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/byte/multibyte").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/byte/multibyte").ToString();
             List<string> queryParameters = new List<string>();
             if (byteQuery != null)
             {
@@ -2123,7 +2145,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ByteEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/byte/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/byte/empty").ToString();
             List<string> queryParameters = new List<string>();
             if (byteQuery != null)
             {
@@ -2216,7 +2239,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ByteNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/byte/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/byte/null").ToString();
             List<string> queryParameters = new List<string>();
             if (byteQuery != null)
             {
@@ -2309,7 +2333,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DateValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/date/2012-01-01").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/date/2012-01-01").ToString();
             List<string> queryParameters = new List<string>();
             if (dateQuery != null)
             {
@@ -2402,7 +2427,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DateNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/date/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/date/null").ToString();
             List<string> queryParameters = new List<string>();
             if (dateQuery != null)
             {
@@ -2495,7 +2521,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DateTimeValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/datetime/2012-01-01T01%3A01%3A01Z").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/datetime/2012-01-01T01%3A01%3A01Z").ToString();
             List<string> queryParameters = new List<string>();
             if (dateTimeQuery != null)
             {
@@ -2588,7 +2615,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "DateTimeNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/datetime/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/datetime/null").ToString();
             List<string> queryParameters = new List<string>();
             if (dateTimeQuery != null)
             {
@@ -2683,7 +2711,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ArrayStringCsvValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/array/csv/string/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/array/csv/string/valid").ToString();
             List<string> queryParameters = new List<string>();
             if (arrayQuery != null)
             {
@@ -2776,7 +2805,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ArrayStringCsvNull", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/array/csv/string/null").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/array/csv/string/null").ToString();
             List<string> queryParameters = new List<string>();
             if (arrayQuery != null)
             {
@@ -2869,7 +2899,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ArrayStringCsvEmpty", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/array/csv/string/empty").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/array/csv/string/empty").ToString();
             List<string> queryParameters = new List<string>();
             if (arrayQuery != null)
             {
@@ -2964,7 +2995,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ArrayStringSsvValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/array/ssv/string/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/array/ssv/string/valid").ToString();
             List<string> queryParameters = new List<string>();
             if (arrayQuery != null)
             {
@@ -3059,7 +3091,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ArrayStringTsvValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/array/tsv/string/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/array/tsv/string/valid").ToString();
             List<string> queryParameters = new List<string>();
             if (arrayQuery != null)
             {
@@ -3154,7 +3187,8 @@ namespace Fixtures.AcceptanceTestsUrl
                 ServiceClientTracing.Enter(invocationId, this, "ArrayStringPipesValid", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.Client.BaseUri, "queries/array/pipes/string/valid").ToString();
+            var baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "queries/array/pipes/string/valid").ToString();
             List<string> queryParameters = new List<string>();
             if (arrayQuery != null)
             {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Validation/AutoRestValidationTest.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Validation/AutoRestValidationTest.cs
@@ -219,7 +219,8 @@ namespace Fixtures.AcceptanceTestsValidation
                 ServiceClientTracing.Enter(invocationId, this, "ValidationOfMethodParameters", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "fakepath/{subscriptionId}/{resourceGroupName}/{id}?api-version={apiVersion}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "fakepath/{subscriptionId}/{resourceGroupName}/{id}?api-version={apiVersion}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(this.SubscriptionId));
             url = url.Replace("{resourceGroupName}", Uri.EscapeDataString(resourceGroupName));
             url = url.Replace("{id}", Uri.EscapeDataString(JsonConvert.SerializeObject(id, this.SerializationSettings).Trim('"')));
@@ -384,7 +385,8 @@ namespace Fixtures.AcceptanceTestsValidation
                 ServiceClientTracing.Enter(invocationId, this, "ValidationOfBody", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "fakepath/{subscriptionId}/{resourceGroupName}/{id}?api-version={apiVersion}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "fakepath/{subscriptionId}/{resourceGroupName}/{id}?api-version={apiVersion}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(this.SubscriptionId));
             url = url.Replace("{resourceGroupName}", Uri.EscapeDataString(resourceGroupName));
             url = url.Replace("{id}", Uri.EscapeDataString(JsonConvert.SerializeObject(id, this.SerializationSettings).Trim('"')));

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Polymorphic/PolymorphicAnimalStore.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Polymorphic/PolymorphicAnimalStore.cs
@@ -158,7 +158,8 @@ namespace Fixtures.MirrorPolymorphic
                 ServiceClientTracing.Enter(invocationId, this, "CreateOrUpdatePolymorphicAnimals", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "getpolymorphicAnimals").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "getpolymorphicAnimals").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Primitives/SwaggerDataTypesClient.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Primitives/SwaggerDataTypesClient.cs
@@ -155,7 +155,8 @@ namespace Fixtures.MirrorPrimitives
                 ServiceClientTracing.Enter(invocationId, this, "GetProduct", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "datatypes").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datatypes").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -260,7 +261,8 @@ namespace Fixtures.MirrorPrimitives
                 ServiceClientTracing.Enter(invocationId, this, "PutProduct", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "datatypes").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datatypes").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -365,7 +367,8 @@ namespace Fixtures.MirrorPrimitives
                 ServiceClientTracing.Enter(invocationId, this, "PostProduct", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "datatypes").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datatypes").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -470,7 +473,8 @@ namespace Fixtures.MirrorPrimitives
                 ServiceClientTracing.Enter(invocationId, this, "PatchProduct", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "datatypes").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "datatypes").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PATCH");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.RecursiveTypes/RecursiveTypesAPI.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.RecursiveTypes/RecursiveTypesAPI.cs
@@ -177,7 +177,8 @@ namespace Fixtures.MirrorRecursiveTypes
                 ServiceClientTracing.Enter(invocationId, this, "Post", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis?api-version={apiVersion}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis?api-version={apiVersion}").ToString();
             url = url.Replace("{subscriptionId}", Uri.EscapeDataString(subscriptionId));
             url = url.Replace("{resourceGroupName}", Uri.EscapeDataString(resourceGroupName));
             url = url.Replace("{apiVersion}", Uri.EscapeDataString(apiVersion));

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Sequences/SequenceRequestResponseTest.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Sequences/SequenceRequestResponseTest.cs
@@ -167,7 +167,8 @@ namespace Fixtures.MirrorSequences
                 ServiceClientTracing.Enter(invocationId, this, "AddPet", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "pets").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pets").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -265,7 +266,8 @@ namespace Fixtures.MirrorSequences
                 ServiceClientTracing.Enter(invocationId, this, "AddPetStyles", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "primitives").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "primitives").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -363,7 +365,8 @@ namespace Fixtures.MirrorSequences
                 ServiceClientTracing.Enter(invocationId, this, "UpdatePetStyles", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "primitives").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "primitives").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/PetstoreV2/SwaggerPetstoreV2.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/PetstoreV2/SwaggerPetstoreV2.cs
@@ -164,7 +164,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "AddPet", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "pet").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pet").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -260,7 +261,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "UpdatePet", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "pet").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pet").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("PUT");
@@ -347,7 +349,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "FindPetsByStatus", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "pet/findByStatus").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pet/findByStatus").ToString();
             List<string> queryParameters = new List<string>();
             if (status != null)
             {
@@ -446,7 +449,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "FindPetsByTags", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "pet/findByTags").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pet/findByTags").ToString();
             List<string> queryParameters = new List<string>();
             if (tags != null)
             {
@@ -544,7 +548,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "GetPetById", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "pet/{petId}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pet/{petId}").ToString();
             url = url.Replace("{petId}", Uri.EscapeDataString(JsonConvert.SerializeObject(petId, this.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -639,7 +644,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "UpdatePetWithForm", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "pet/{petId}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pet/{petId}").ToString();
             url = url.Replace("{petId}", Uri.EscapeDataString(JsonConvert.SerializeObject(petId, this.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -725,7 +731,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "DeletePet", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "pet/{petId}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "pet/{petId}").ToString();
             url = url.Replace("{petId}", Uri.EscapeDataString(JsonConvert.SerializeObject(petId, this.SerializationSettings).Trim('"')));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -810,7 +817,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "GetInventory", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "store/inventory").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "store/inventory").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -898,7 +906,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "PlaceOrder", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "store/order").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "store/order").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1003,7 +1012,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "GetOrderById", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "store/order/{orderId}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "store/order/{orderId}").ToString();
             url = url.Replace("{orderId}", Uri.EscapeDataString(orderId));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1101,7 +1111,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "DeleteOrder", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "store/order/{orderId}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "store/order/{orderId}").ToString();
             url = url.Replace("{orderId}", Uri.EscapeDataString(orderId));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1185,7 +1196,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "CreateUser", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "user").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "user").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1271,7 +1283,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "CreateUsersWithArrayInput", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "user/createWithArray").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "user/createWithArray").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1357,7 +1370,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "CreateUsersWithListInput", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "user/createWithList").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "user/createWithList").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
@@ -1450,7 +1464,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "LoginUser", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "user/login").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "user/login").ToString();
             List<string> queryParameters = new List<string>();
             if (username != null)
             {
@@ -1544,7 +1559,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "LogoutUser", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "user/logout").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "user/logout").ToString();
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("GET");
@@ -1626,7 +1642,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "GetUserByName", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "user/{username}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "user/{username}").ToString();
             url = url.Replace("{username}", Uri.EscapeDataString(username));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1723,7 +1740,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "UpdateUser", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "user/{username}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "user/{username}").ToString();
             url = url.Replace("{username}", Uri.EscapeDataString(username));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
@@ -1811,7 +1829,8 @@ namespace Fixtures.PetstoreV2
                 ServiceClientTracing.Enter(invocationId, this, "DeleteUser", tracingParameters);
             }
             // Construct URL
-            var url = new Uri(this.BaseUri, "user/{username}").ToString();
+            var baseUrl = this.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "user/{username}").ToString();
             url = url.Replace("{username}", Uri.EscapeDataString(username));
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();

--- a/AutoRest/Generators/CSharp/CSharp/Templates/MethodTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/MethodTemplate.cshtml
@@ -67,7 +67,8 @@ public async Task<@(Model.OperationResponseReturnTypeString)> @(Model.Name)WithH
     }
     else
     {
-    @:var url = new Uri(@(Model.ClientReference).BaseUri, "@(Model.Url.Trim('/'))").ToString();
+    @:var baseUrl = @(Model.ClientReference).BaseUri.AbsoluteUri;
+    @:var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? "" : "/")), "@(Model.Url.Trim('/'))").ToString();
     }
     @(Model.BuildUrl("url"))
     // Create HTTP transport objects


### PR DESCRIPTION
If the baseUri (with some path) is not end with "/", the Uri constructor will drop the last segment from baseUri. The fix is automatic append "/" if the baseUri is not end with slash.