### PR TITLE
[#105719632] Fix for x-ms-enum with modelAsString being true

### DIFF
--- a/AutoRest/AutoRest.Core.Tests/CodeNamingFrameworkTests.cs
+++ b/AutoRest/AutoRest.Core.Tests/CodeNamingFrameworkTests.cs
@@ -7,7 +7,12 @@ namespace Microsoft.Rest.Generator.Test
 {
     public class FakeCodeNamer : CodeNamer
     {
-        public override ClientModel.IType NormalizeType(ClientModel.IType type)
+        public override ClientModel.IType NormalizeTypeReference(ClientModel.IType type)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override ClientModel.IType NormalizeTypeDeclaration(ClientModel.IType type)
         {
             throw new System.NotImplementedException();
         }

--- a/AutoRest/AutoRest.Core/CodeNamer.cs
+++ b/AutoRest/AutoRest.Core/CodeNamer.cs
@@ -83,13 +83,13 @@ namespace Microsoft.Rest.Generator
             foreach (var property in client.Properties)
             {
                 property.Name = GetPropertyName(property.Name);
-                property.Type = NormalizeType(property.Type);
+                property.Type = NormalizeTypeReference(property.Type);
             }
 
             var normalizedModels = new List<CompositeType>();
             foreach (var modelType in client.ModelTypes)
             {
-                normalizedModels.Add(NormalizeType(modelType) as CompositeType);
+                normalizedModels.Add(NormalizeTypeDeclaration(modelType) as CompositeType);
             }
             client.ModelTypes.Clear();
             normalizedModels.ForEach( (item) => client.ModelTypes.Add(item));
@@ -97,10 +97,10 @@ namespace Microsoft.Rest.Generator
             var normalizedEnums = new List<EnumType>();
             foreach (var enumType in client.EnumTypes)
             {
-                var normalizedType = NormalizeType(enumType) as EnumType;
+                var normalizedType = NormalizeTypeDeclaration(enumType) as EnumType;
                 if (normalizedType != null)
                 {
-                    normalizedEnums.Add(NormalizeType(enumType) as EnumType);
+                    normalizedEnums.Add(NormalizeTypeDeclaration(enumType) as EnumType);
                 }
             }
             client.EnumTypes.Clear();
@@ -110,12 +110,12 @@ namespace Microsoft.Rest.Generator
             {
                 method.Name = GetMethodName(method.Name);
                 method.Group = GetMethodGroupName(method.Group);
-                method.ReturnType = NormalizeType(method.ReturnType);
-                method.DefaultResponse = NormalizeType(method.DefaultResponse);
+                method.ReturnType = NormalizeTypeReference(method.ReturnType);
+                method.DefaultResponse = NormalizeTypeReference(method.DefaultResponse);
                 var normalizedResponses = new Dictionary<HttpStatusCode, IType>();
                 foreach (var statusCode in method.Responses.Keys)
                 {
-                    normalizedResponses[statusCode] = NormalizeType(method.Responses[statusCode]);
+                    normalizedResponses[statusCode] = NormalizeTypeReference(method.Responses[statusCode]);
                 }
 
                 method.Responses.Clear();
@@ -126,15 +126,15 @@ namespace Microsoft.Rest.Generator
                 foreach (var parameter in method.Parameters)
                 {
                     parameter.Name = GetParameterName(parameter.Name);
-                    parameter.Type = NormalizeType(parameter.Type);
+                    parameter.Type = NormalizeTypeReference(parameter.Type);
                 }
 
                 foreach (var parameterMapping in method.InputParameterMappings)
                 {
                     parameterMapping.InputParameter.Name = GetParameterName(parameterMapping.InputParameter.Name);
-                    parameterMapping.InputParameter.Type = NormalizeType(parameterMapping.InputParameter.Type);
+                    parameterMapping.InputParameter.Type = NormalizeTypeReference(parameterMapping.InputParameter.Type);
                     parameterMapping.OutputParameter.Name = GetParameterName(parameterMapping.OutputParameter.Name);
-                    parameterMapping.OutputParameter.Type = NormalizeType(parameterMapping.OutputParameter.Type);
+                    parameterMapping.OutputParameter.Type = NormalizeTypeReference(parameterMapping.OutputParameter.Type);
 
                     if (parameterMapping.InputParameterProperty != null)
                     {
@@ -294,11 +294,19 @@ namespace Microsoft.Rest.Generator
         }
 
         /// <summary>
-        /// Returns language specific type name.
+        /// Returns language specific type reference name.
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        public abstract IType NormalizeType(IType type);
+        public abstract IType NormalizeTypeReference(IType type);
+
+        /// <summary>
+        /// Returns language specific type declaration name.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public abstract IType NormalizeTypeDeclaration(IType type);
+
 
         /// <summary>
         /// Formats a string as upper or lower case. Two-letter inputs that are all upper case are both lowered.

--- a/AutoRest/AutoRest/AutoRest.Release.json
+++ b/AutoRest/AutoRest/AutoRest.Release.json
@@ -19,6 +19,16 @@
         "includeCredentials": "true",
         "requireOperationId": "true"
       }
+    },
+    "Ruby": {
+      "type": "RubyCodeGenerator, AutoRest.Generator.Ruby"
+    },
+    "Azure.Ruby": {
+      "type": "AzureRubyCodeGenerator, AutoRest.Generator.Azure.Ruby",
+      "settings": {
+        "includeCredentials": "true",
+        "requireOperationId": "true"
+      }
     }
   },
   "modelers": {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/CSharpAzureCodeNamingFrameworkTests.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/CSharpAzureCodeNamingFrameworkTests.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
             SwaggerModeler modeler = new SwaggerModeler(settings);
             var serviceClient = modeler.Build();
             var codeNamer = new AzureCSharpCodeNamer();
-            var objName = codeNamer.NormalizeType(PrimaryType.Object).Name;
-            var strName = codeNamer.NormalizeType(PrimaryType.String).Name;
+            var objName = codeNamer.NormalizeTypeReference(PrimaryType.Object).Name;
+            var strName = codeNamer.NormalizeTypeReference(PrimaryType.String).Name;
             IDictionary<KeyValuePair<string, string>, string> pageClass = new Dictionary<KeyValuePair<string, string>, string>();
 
             codeNamer.NormalizePaginatedMethods(serviceClient, pageClass);

--- a/AutoRest/Generators/CSharp/CSharp/CSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/CSharp/CSharpCodeNamer.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Rest.Generator.CSharp
         public override IType NormalizeTypeReference(IType type)
         {
             var enumType = type as EnumType;
-            if (type != null && enumType.ModelAsString)
+            if (enumType != null && enumType.ModelAsString)
             {
                 return PrimaryType.String;
             }

--- a/AutoRest/Generators/CSharp/CSharp/CSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/CSharp/CSharpCodeNamer.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Rest.Generator.CSharp
                     {
                         parameter.Name = scope.GetVariableName(parameter.Name);
                     }
-                }
+                }                
             }
         }
 
-        public override IType NormalizeType(IType type)
+        public override IType NormalizeTypeDeclaration(IType type)
         {
             if (type == null)
             {
@@ -109,6 +109,15 @@ namespace Microsoft.Rest.Generator.CSharp
                 "Type {0} is not supported.", type.GetType()));
         }
 
+        public override IType NormalizeTypeReference(IType type)
+        {
+            if (type is EnumType && ((EnumType)type).ModelAsString)
+            {
+                return PrimaryType.String;
+            }
+            return NormalizeTypeDeclaration(type);
+        }
+
         private IType NormalizeCompositeType(CompositeType compositeType)
         {
             compositeType.Name = GetTypeName(compositeType.Name);
@@ -116,7 +125,7 @@ namespace Microsoft.Rest.Generator.CSharp
             foreach (var property in compositeType.Properties)
             {
                 property.Name = GetPropertyName(property.Name);
-                property.Type = NormalizeType(property.Type);
+                property.Type = NormalizeTypeReference(property.Type);
             }
 
             return compositeType;
@@ -124,15 +133,8 @@ namespace Microsoft.Rest.Generator.CSharp
 
         private IType NormalizeEnumType(EnumType enumType)
         {
-            if (enumType.ModelAsString)
-            {
-                // We will keep SerializedName to use for the constant wrapper class name 
-                enumType.Name = "string";
-            }
-            else
-            {
-                enumType.Name = GetTypeName(enumType.Name) + "?";
-            }
+            enumType.Name = GetTypeName(enumType.Name) + "?";
+
             for (int i = 0; i < enumType.Values.Count; i++)
             {
                 enumType.Values[i].Name = GetEnumMemberName(enumType.Values[i].Name);
@@ -196,14 +198,14 @@ namespace Microsoft.Rest.Generator.CSharp
 
         private IType NormalizeSequenceType(SequenceType sequenceType)
         {
-            sequenceType.ElementType = NormalizeType(sequenceType.ElementType);
+            sequenceType.ElementType = NormalizeTypeReference(sequenceType.ElementType);
             sequenceType.NameFormat = "IList<{0}>";
             return sequenceType;
         }
 
         private IType NormalizeDictionaryType(DictionaryType dictionaryType)
         {
-            dictionaryType.ValueType = NormalizeType(dictionaryType.ValueType);
+            dictionaryType.ValueType = NormalizeTypeReference(dictionaryType.ValueType);
             dictionaryType.NameFormat = "IDictionary<string, {0}>";
             return dictionaryType;
         }

--- a/AutoRest/Generators/CSharp/CSharp/CSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/CSharp/CSharpCodeNamer.cs
@@ -111,7 +111,8 @@ namespace Microsoft.Rest.Generator.CSharp
 
         public override IType NormalizeTypeReference(IType type)
         {
-            if (type is EnumType && ((EnumType)type).ModelAsString)
+            var enumType = type as EnumType;
+            if (type != null && enumType.ModelAsString)
             {
                 return PrimaryType.String;
             }

--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/EnumTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/EnumTemplateModel.cs
@@ -20,10 +20,6 @@ namespace Microsoft.Rest.Generator.CSharp
         {
             get
             {
-                if(this.ModelAsString)
-                {
-                    return this.SerializedName.TrimEnd('?');
-                }
                 return this.Name.TrimEnd('?');
             }
         }

--- a/AutoRest/Generators/Java/Java/JavaCodeNamer.cs
+++ b/AutoRest/Generators/Java/Java/JavaCodeNamer.cs
@@ -139,8 +139,12 @@ namespace Microsoft.Rest.Generator.Java
                 }
             }
         }
+        public override IType NormalizeTypeDeclaration(IType type)
+        {
+            return NormalizeTypeReference(type);
+        }
 
-        public override IType NormalizeType(IType type)
+        public override IType NormalizeTypeReference(IType type)
         {
             if (type == null)
             {
@@ -210,7 +214,7 @@ namespace Microsoft.Rest.Generator.Java
             foreach (var property in compositeType.Properties)
             {
                 property.Name = GetPropertyName(property.Name);
-                property.Type = NormalizeType(property.Type);
+                property.Type = NormalizeTypeReference(property.Type);
                 if (!property.IsRequired)
                 {
                     property.Type = WrapPrimitiveType(property.Type);
@@ -315,14 +319,14 @@ namespace Microsoft.Rest.Generator.Java
 
         private IType NormalizeSequenceType(SequenceType sequenceType)
         {
-            sequenceType.ElementType = WrapPrimitiveType(NormalizeType(sequenceType.ElementType));
+            sequenceType.ElementType = WrapPrimitiveType(NormalizeTypeReference(sequenceType.ElementType));
             sequenceType.NameFormat = "List<{0}>";
             return sequenceType;
         }
 
         private IType NormalizeDictionaryType(DictionaryType dictionaryType)
         {
-            dictionaryType.ValueType = WrapPrimitiveType(NormalizeType(dictionaryType.ValueType));
+            dictionaryType.ValueType = WrapPrimitiveType(NormalizeTypeReference(dictionaryType.ValueType));
             dictionaryType.NameFormat = "Map<String, {0}>";
             return dictionaryType;
         }

--- a/AutoRest/Generators/NodeJS/NodeJS/NodeJsCodeNamer.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/NodeJsCodeNamer.cs
@@ -156,8 +156,12 @@ namespace Microsoft.Rest.Generator.NodeJS
                 }
             }
         }
+        public override IType NormalizeTypeDeclaration(IType type)
+        {
+            return NormalizeTypeReference(type);
+        }
 
-        public override IType NormalizeType(IType type)
+        public override IType NormalizeTypeReference(IType type)
         {
             if (type == null)
             {
@@ -214,7 +218,7 @@ namespace Microsoft.Rest.Generator.NodeJS
             foreach (var property in compositeType.Properties)
             {
                 property.Name = GetPropertyName(property.Name);
-                property.Type = NormalizeType(property.Type);
+                property.Type = NormalizeTypeReference(property.Type);
             }
 
             return compositeType;
@@ -276,14 +280,14 @@ namespace Microsoft.Rest.Generator.NodeJS
 
         private IType NormalizeSequenceType(SequenceType sequenceType)
         {
-            sequenceType.ElementType = NormalizeType(sequenceType.ElementType);
+            sequenceType.ElementType = NormalizeTypeReference(sequenceType.ElementType);
             sequenceType.NameFormat = "Array";
             return sequenceType;
         }
 
         private IType NormalizeDictionaryType(DictionaryType dictionaryType)
         {
-            dictionaryType.ValueType = NormalizeType(dictionaryType.ValueType);
+            dictionaryType.ValueType = NormalizeTypeReference(dictionaryType.ValueType);
             dictionaryType.NameFormat = "Object";
             return dictionaryType;
         }

--- a/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Rest.Generator.Azure.Ruby
         /// </summary>
         public override string UsageInstructions
         {
-            get { return "The gem 'ms-rest-azure' is required for working with generated code."; }
+            get { return "The gem 'ms_rest_azure' is required for working with generated code."; }
         }
 
         /// <summary>

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Rest.Generator.Ruby
         /// </summary>
         public override string UsageInstructions
         {
-            get { return "The gem 'ms-rest' is required for working with generated code."; }
+            get { return "The gem 'ms_rest' is required for working with generated code."; }
         }
 
         /// <summary>

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeNamer.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeNamer.cs
@@ -163,13 +163,17 @@ namespace Microsoft.Rest.Generator.Ruby
                 }
             }
         }
+        public override IType NormalizeTypeDeclaration(IType type)
+        {
+            return NormalizeTypeReference(type);
+        }
 
         /// <summary>
         /// Normalizes given type.
         /// </summary>
         /// <param name="type">Type to normalize.</param>
         /// <returns>Normalized type.</returns>
-        public override IType NormalizeType(IType type)
+        public override IType NormalizeTypeReference(IType type)
         {
             if (type == null)
             {
@@ -222,7 +226,7 @@ namespace Microsoft.Rest.Generator.Ruby
             foreach (var property in compositeType.Properties)
             {
                 property.Name = GetPropertyName(property.Name);
-                property.Type = NormalizeType(property.Type);
+                property.Type = NormalizeTypeReference(property.Type);
             }
 
             return compositeType;
@@ -309,7 +313,7 @@ namespace Microsoft.Rest.Generator.Ruby
         /// <returns>Normalized sequence type.</returns>
         private IType NormalizeSequenceType(SequenceType sequenceType)
         {
-            sequenceType.ElementType = NormalizeType(sequenceType.ElementType);
+            sequenceType.ElementType = NormalizeTypeReference(sequenceType.ElementType);
             sequenceType.NameFormat = "Array";
             return sequenceType;
         }
@@ -321,7 +325,7 @@ namespace Microsoft.Rest.Generator.Ruby
         /// <returns>Normalized dictionary type.</returns>
         private IType NormalizeDictionaryType(DictionaryType dictionaryType)
         {
-            dictionaryType.ValueType = NormalizeType(dictionaryType.ValueType);
+            dictionaryType.ValueType = NormalizeTypeReference(dictionaryType.ValueType);
             dictionaryType.NameFormat = "Hash";
             return dictionaryType;
         }

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,4 @@
 2015.10.23 Version 0.12.0
-* Added Java language support
 * Added Ruby language support
 * Implemented validation in C#
 * Added support for dotnet (CoreClr) to Microsoft.Rest.ClientRuntime and Microsoft.Rest.ClientRuntime.Azure


### PR DESCRIPTION
Split NormalizeType into NormalizeTypeReference and NormalizeTypeDeclaration to have a proper support for enums as string