### PR TITLE
Fixing a polymorphism bug in the CSharp generator

### DIFF
--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Fish.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Fish.cs
@@ -17,7 +17,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     /// <summary>
     /// </summary>
-    [JsonObject("fish")]
     public partial class Fish
     {
         /// <summary>

--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/ModelTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/ModelTemplateModel.cs
@@ -44,8 +44,7 @@ namespace Microsoft.Rest.Generator.CSharp
         {
             get
             {
-                return (!string.IsNullOrEmpty(PolymorphicDiscriminator) && Name != SerializedName) ||
-                       (_baseModel != null && _baseModel.NeedsPolymorphicConverter);
+                return this.IsPolymorphicType && Name != SerializedName;
             }
         }
 
@@ -70,6 +69,15 @@ namespace Microsoft.Rest.Generator.CSharp
         public virtual IEnumerable<string> Usings
         {
             get { return Enumerable.Empty<string>(); }
+        }
+
+        private bool IsPolymorphicType
+        {
+            get
+            {
+                return !string.IsNullOrEmpty(PolymorphicDiscriminator) ||
+                    (_baseModel != null && _baseModel.IsPolymorphicType);
+            }
         }
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyarray/ArrayImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyarray/ArrayImpl.java
@@ -203,6 +203,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putEmpty(arrayBody);
@@ -302,6 +303,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putBooleanTfft(arrayBody);
@@ -489,6 +491,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putIntegerValid(arrayBody);
@@ -676,6 +679,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putLongValid(arrayBody);
@@ -863,6 +867,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putFloatValid(arrayBody);
@@ -1050,6 +1055,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDoubleValid(arrayBody);
@@ -1237,6 +1243,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putStringValid(arrayBody);
@@ -1424,6 +1431,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDateValid(arrayBody);
@@ -1611,6 +1619,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDateTimeValid(arrayBody);
@@ -1798,6 +1807,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDateTimeRfc1123Valid(arrayBody);
@@ -1897,6 +1907,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDurationValid(arrayBody);
@@ -1996,6 +2007,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putByteValid(arrayBody);
@@ -2315,6 +2327,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putComplexValid(arrayBody);
@@ -2590,6 +2603,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putArrayValid(arrayBody);
@@ -2865,6 +2879,7 @@ public class ArrayImpl implements Array {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDictionaryValid(arrayBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodybyte/ByteOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodybyte/ByteOperationsImpl.java
@@ -195,6 +195,7 @@ public class ByteOperationsImpl implements ByteOperations {
         if (byteBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter byteBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putNonAscii(byteBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/ArrayImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/ArrayImpl.java
@@ -109,6 +109,7 @@ public class ArrayImpl implements Array {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putValid(complexBody);
@@ -208,6 +209,7 @@ public class ArrayImpl implements Array {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putEmpty(complexBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/BasicOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/BasicOperationsImpl.java
@@ -109,6 +109,7 @@ public class BasicOperationsImpl implements BasicOperations {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putValid(complexBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/DictionaryImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/DictionaryImpl.java
@@ -109,6 +109,7 @@ public class DictionaryImpl implements Dictionary {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putValid(complexBody);
@@ -208,6 +209,7 @@ public class DictionaryImpl implements Dictionary {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putEmpty(complexBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/InheritanceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/InheritanceImpl.java
@@ -109,6 +109,7 @@ public class InheritanceImpl implements Inheritance {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putValid(complexBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/PolymorphicrecursiveImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/PolymorphicrecursiveImpl.java
@@ -213,6 +213,7 @@ public class PolymorphicrecursiveImpl implements Polymorphicrecursive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putValid(complexBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/PolymorphismImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/PolymorphismImpl.java
@@ -173,6 +173,7 @@ public class PolymorphismImpl implements Polymorphism {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putValid(complexBody);
@@ -278,6 +279,7 @@ public class PolymorphismImpl implements Polymorphism {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putValidMissingRequired(complexBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/PrimitiveImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/PrimitiveImpl.java
@@ -119,6 +119,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putInt(complexBody);
@@ -218,6 +219,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putLong(complexBody);
@@ -317,6 +319,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putFloat(complexBody);
@@ -416,6 +419,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putDouble(complexBody);
@@ -515,6 +519,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putBool(complexBody);
@@ -614,6 +619,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putString(complexBody);
@@ -713,6 +719,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putDate(complexBody);
@@ -812,6 +819,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putDateTime(complexBody);
@@ -911,6 +919,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putDateTimeRfc1123(complexBody);
@@ -1010,6 +1019,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putDuration(complexBody);
@@ -1109,6 +1119,7 @@ public class PrimitiveImpl implements Primitive {
         if (complexBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter complexBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(complexBody, serviceCallback);
         Call<ResponseBody> call = service.putByte(complexBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/models/Fish.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/models/Fish.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
  * The Fish model.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fishtype")
-@JsonTypeName("fish")
+@JsonTypeName("Fish")
 @JsonSubTypes({
     @JsonSubTypes.Type(name="salmon", value=Salmon.class),
     @JsonSubTypes.Type(name="shark", value=Shark.class)

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydate/DateOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydate/DateOperationsImpl.java
@@ -239,6 +239,7 @@ public class DateOperationsImpl implements DateOperations {
         if (dateBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter dateBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putMaxDate(dateBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -336,6 +337,7 @@ public class DateOperationsImpl implements DateOperations {
         if (dateBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter dateBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putMinDate(dateBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydatetime/DatetimeOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydatetime/DatetimeOperationsImpl.java
@@ -239,6 +239,7 @@ public class DatetimeOperationsImpl implements DatetimeOperations {
         if (datetimeBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putUtcMaxDateTime(datetimeBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -380,6 +381,7 @@ public class DatetimeOperationsImpl implements DatetimeOperations {
         if (datetimeBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putLocalPositiveOffsetMaxDateTime(datetimeBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -521,6 +523,7 @@ public class DatetimeOperationsImpl implements DatetimeOperations {
         if (datetimeBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putLocalNegativeOffsetMaxDateTime(datetimeBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -662,6 +665,7 @@ public class DatetimeOperationsImpl implements DatetimeOperations {
         if (datetimeBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putUtcMinDateTime(datetimeBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -759,6 +763,7 @@ public class DatetimeOperationsImpl implements DatetimeOperations {
         if (datetimeBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putLocalPositiveOffsetMinDateTime(datetimeBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -856,6 +861,7 @@ public class DatetimeOperationsImpl implements DatetimeOperations {
         if (datetimeBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putLocalNegativeOffsetMinDateTime(datetimeBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123Impl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123Impl.java
@@ -239,6 +239,7 @@ public class Datetimerfc1123Impl implements Datetimerfc1123 {
         if (datetimeBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putUtcMaxDateTime(datetimeBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -380,6 +381,7 @@ public class Datetimerfc1123Impl implements Datetimerfc1123 {
         if (datetimeBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putUtcMinDateTime(datetimeBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydictionary/DictionaryImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydictionary/DictionaryImpl.java
@@ -159,6 +159,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putEmpty(arrayBody);
@@ -434,6 +435,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putBooleanTfft(arrayBody);
@@ -621,6 +623,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putIntegerValid(arrayBody);
@@ -808,6 +811,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putLongValid(arrayBody);
@@ -995,6 +999,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putFloatValid(arrayBody);
@@ -1182,6 +1187,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDoubleValid(arrayBody);
@@ -1369,6 +1375,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putStringValid(arrayBody);
@@ -1556,6 +1563,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDateValid(arrayBody);
@@ -1743,6 +1751,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDateTimeValid(arrayBody);
@@ -1930,6 +1939,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDateTimeRfc1123Valid(arrayBody);
@@ -2029,6 +2039,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDurationValid(arrayBody);
@@ -2128,6 +2139,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putByteValid(arrayBody);
@@ -2447,6 +2459,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putComplexValid(arrayBody);
@@ -2722,6 +2735,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putArrayValid(arrayBody);
@@ -2997,6 +3011,7 @@ public class DictionaryImpl implements Dictionary {
         if (arrayBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter arrayBody is required and cannot be null.")));
+            return null;
         }
         Validator.validate(arrayBody, serviceCallback);
         Call<ResponseBody> call = service.putDictionaryValid(arrayBody);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyduration/DurationImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyduration/DurationImpl.java
@@ -107,6 +107,7 @@ public class DurationImpl implements Duration {
         if (durationBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter durationBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putPositiveDuration(durationBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodynumber/NumberImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodynumber/NumberImpl.java
@@ -595,6 +595,7 @@ public class NumberImpl implements Number {
         if (numberBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter numberBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putBigDecimal(numberBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -692,6 +693,7 @@ public class NumberImpl implements Number {
         if (numberBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter numberBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putBigDecimalPositiveDecimal(numberBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -789,6 +791,7 @@ public class NumberImpl implements Number {
         if (numberBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter numberBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putBigDecimalNegativeDecimal(numberBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1064,6 +1067,7 @@ public class NumberImpl implements Number {
         if (numberBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter numberBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putSmallDecimal(numberBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodystring/EnumOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodystring/EnumOperationsImpl.java
@@ -107,6 +107,7 @@ public class EnumOperationsImpl implements EnumOperations {
         if (stringBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter stringBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putNotExpandable(stringBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodystring/StringOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodystring/StringOperationsImpl.java
@@ -195,6 +195,7 @@ public class StringOperationsImpl implements StringOperations {
         if (stringBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter stringBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putEmpty(stringBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -292,6 +293,7 @@ public class StringOperationsImpl implements StringOperations {
         if (stringBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter stringBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putMbcs(stringBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -389,6 +391,7 @@ public class StringOperationsImpl implements StringOperations {
         if (stringBody == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter stringBody is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.putWhitespace(stringBody);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/header/HeaderOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/header/HeaderOperationsImpl.java
@@ -69,6 +69,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (userAgent == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter userAgent is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramExistingKey(userAgent);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -165,6 +166,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (contentType == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter contentType is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramProtectedKey(contentType);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -263,6 +265,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramInteger(scenario, value);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -316,6 +319,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseInteger(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -371,6 +375,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramLong(scenario, value);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -424,6 +429,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseLong(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -479,6 +485,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramFloat(scenario, value);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -532,6 +539,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseFloat(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -587,6 +595,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramDouble(scenario, value);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -640,6 +649,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseDouble(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -695,6 +705,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramBool(scenario, value);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -748,6 +759,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseBool(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -803,6 +815,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramString(scenario, value);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -856,6 +869,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseString(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -915,10 +929,12 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         if (value == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter value is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramDate(scenario, JacksonUtils.serializeRaw(value));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -972,6 +988,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseDate(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1031,10 +1048,12 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         if (value == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter value is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramDatetime(scenario, JacksonUtils.serializeRaw(value));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1088,6 +1107,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseDatetime(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1143,6 +1163,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramDatetimeRfc1123(scenario, value);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1196,6 +1217,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseDatetimeRfc1123(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1255,10 +1277,12 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         if (value == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter value is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramDuration(scenario, value);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1312,6 +1336,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseDuration(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1371,10 +1396,12 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         if (value == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter value is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramByte(scenario, Base64.encodeBase64String(value));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1428,6 +1455,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseByte(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1483,6 +1511,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.paramEnum(scenario, JacksonUtils.serializeRaw(value));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1536,6 +1565,7 @@ public class HeaderOperationsImpl implements HeaderOperations {
         if (scenario == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter scenario is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.responseEnum(scenario);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/requiredoptional/ExplicitImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/requiredoptional/ExplicitImpl.java
@@ -167,6 +167,7 @@ public class ExplicitImpl implements Explicit {
         if (bodyParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.")));
+            return null;
         }
         Validator.validate(bodyParameter, serviceCallback);
         Call<ResponseBody> call = service.postRequiredIntegerProperty(bodyParameter);
@@ -356,6 +357,7 @@ public class ExplicitImpl implements Explicit {
         if (bodyParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.postRequiredStringParameter(bodyParameter);
         call.enqueue(new ServiceResponseCallback<Error>(serviceCallback) {
@@ -455,6 +457,7 @@ public class ExplicitImpl implements Explicit {
         if (bodyParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.")));
+            return null;
         }
         Validator.validate(bodyParameter, serviceCallback);
         Call<ResponseBody> call = service.postRequiredStringProperty(bodyParameter);
@@ -554,6 +557,7 @@ public class ExplicitImpl implements Explicit {
         if (headerParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter headerParameter is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.postRequiredStringHeader(headerParameter);
         call.enqueue(new ServiceResponseCallback<Error>(serviceCallback) {
@@ -653,6 +657,7 @@ public class ExplicitImpl implements Explicit {
         if (bodyParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.")));
+            return null;
         }
         Validator.validate(bodyParameter, serviceCallback);
         Call<ResponseBody> call = service.postRequiredClassParameter(bodyParameter);
@@ -753,6 +758,7 @@ public class ExplicitImpl implements Explicit {
         if (bodyParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.")));
+            return null;
         }
         Validator.validate(bodyParameter, serviceCallback);
         Call<ResponseBody> call = service.postRequiredClassProperty(bodyParameter);
@@ -853,6 +859,7 @@ public class ExplicitImpl implements Explicit {
         if (bodyParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.")));
+            return null;
         }
         Validator.validate(bodyParameter, serviceCallback);
         Call<ResponseBody> call = service.postRequiredArrayParameter(bodyParameter);
@@ -953,6 +960,7 @@ public class ExplicitImpl implements Explicit {
         if (bodyParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.")));
+            return null;
         }
         Validator.validate(bodyParameter, serviceCallback);
         Call<ResponseBody> call = service.postRequiredArrayProperty(bodyParameter);
@@ -1053,6 +1061,7 @@ public class ExplicitImpl implements Explicit {
         if (headerParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter headerParameter is required and cannot be null.")));
+            return null;
         }
         Validator.validate(headerParameter, serviceCallback);
         Call<ResponseBody> call = service.postRequiredArrayHeader(JacksonUtils.serializeList(headerParameter, CollectionFormat.CSV));

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/requiredoptional/ImplicitImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/requiredoptional/ImplicitImpl.java
@@ -63,6 +63,7 @@ public class ImplicitImpl implements Implicit {
         if (pathParameter == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter pathParameter is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.getRequiredPath(pathParameter);
         call.enqueue(new ServiceResponseCallback<Error>(serviceCallback) {
@@ -249,6 +250,7 @@ public class ImplicitImpl implements Implicit {
         if (this.client.getRequiredGlobalPath() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.client.getRequiredGlobalPath() is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.getRequiredGlobalPath(this.client.getRequiredGlobalPath());
         call.enqueue(new ServiceResponseCallback<Error>(serviceCallback) {
@@ -300,6 +302,7 @@ public class ImplicitImpl implements Implicit {
         if (this.client.getRequiredGlobalQuery() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.client.getRequiredGlobalQuery() is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.getRequiredGlobalQuery(this.client.getRequiredGlobalQuery());
         call.enqueue(new ServiceResponseCallback<Error>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/url/PathItemsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/url/PathItemsImpl.java
@@ -76,14 +76,17 @@ public class PathItemsImpl implements PathItems {
         if (localStringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter localStringPath is required and cannot be null.")));
+            return null;
         }
         if (pathItemStringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null.")));
+            return null;
         }
         if (this.client.getGlobalStringPath() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.client.getGlobalStringPath() is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.getAllWithValues(localStringPath, pathItemStringPath, this.client.getGlobalStringPath(), localStringQuery, pathItemStringQuery, this.client.getGlobalStringQuery());
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -151,14 +154,17 @@ public class PathItemsImpl implements PathItems {
         if (localStringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter localStringPath is required and cannot be null.")));
+            return null;
         }
         if (pathItemStringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null.")));
+            return null;
         }
         if (this.client.getGlobalStringPath() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.client.getGlobalStringPath() is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.getGlobalQueryNull(localStringPath, pathItemStringPath, this.client.getGlobalStringPath(), localStringQuery, pathItemStringQuery, this.client.getGlobalStringQuery());
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -226,14 +232,17 @@ public class PathItemsImpl implements PathItems {
         if (localStringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter localStringPath is required and cannot be null.")));
+            return null;
         }
         if (pathItemStringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null.")));
+            return null;
         }
         if (this.client.getGlobalStringPath() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.client.getGlobalStringPath() is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.getGlobalAndLocalQueryNull(localStringPath, pathItemStringPath, this.client.getGlobalStringPath(), localStringQuery, pathItemStringQuery, this.client.getGlobalStringQuery());
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -301,14 +310,17 @@ public class PathItemsImpl implements PathItems {
         if (localStringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter localStringPath is required and cannot be null.")));
+            return null;
         }
         if (pathItemStringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null.")));
+            return null;
         }
         if (this.client.getGlobalStringPath() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.client.getGlobalStringPath() is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.getLocalPathItemQueryNull(localStringPath, pathItemStringPath, this.client.getGlobalStringPath(), localStringQuery, pathItemStringQuery, this.client.getGlobalStringQuery());
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/url/PathsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/url/PathsImpl.java
@@ -517,6 +517,7 @@ public class PathsImpl implements Paths {
         if (stringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter stringPath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.stringUnicode(stringPath);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -570,6 +571,7 @@ public class PathsImpl implements Paths {
         if (stringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter stringPath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.stringUrlEncoded(stringPath);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -623,6 +625,7 @@ public class PathsImpl implements Paths {
         if (stringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter stringPath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.stringEmpty(stringPath);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -676,6 +679,7 @@ public class PathsImpl implements Paths {
         if (stringPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter stringPath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.stringNull(stringPath);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -729,6 +733,7 @@ public class PathsImpl implements Paths {
         if (enumPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter enumPath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.enumValid(JacksonUtils.serializeRaw(enumPath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -782,6 +787,7 @@ public class PathsImpl implements Paths {
         if (enumPath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter enumPath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.enumNull(JacksonUtils.serializeRaw(enumPath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -835,6 +841,7 @@ public class PathsImpl implements Paths {
         if (bytePath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bytePath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.byteMultiByte(Base64.encodeBase64String(bytePath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -888,6 +895,7 @@ public class PathsImpl implements Paths {
         if (bytePath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bytePath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.byteEmpty(Base64.encodeBase64String(bytePath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -941,6 +949,7 @@ public class PathsImpl implements Paths {
         if (bytePath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter bytePath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.byteNull(Base64.encodeBase64String(bytePath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -994,6 +1003,7 @@ public class PathsImpl implements Paths {
         if (datePath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datePath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.dateValid(JacksonUtils.serializeRaw(datePath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1047,6 +1057,7 @@ public class PathsImpl implements Paths {
         if (datePath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter datePath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.dateNull(JacksonUtils.serializeRaw(datePath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1100,6 +1111,7 @@ public class PathsImpl implements Paths {
         if (dateTimePath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter dateTimePath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.dateTimeValid(JacksonUtils.serializeRaw(dateTimePath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
@@ -1153,6 +1165,7 @@ public class PathsImpl implements Paths {
         if (dateTimePath == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter dateTimePath is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.dateTimeNull(JacksonUtils.serializeRaw(dateTimePath));
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/validation/AutoRestValidationTestImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/validation/AutoRestValidationTestImpl.java
@@ -158,14 +158,17 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
         if (this.getSubscriptionId() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.getSubscriptionId() is required and cannot be null.")));
+            return null;
         }
         if (resourceGroupName == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null.")));
+            return null;
         }
         if (this.getApiVersion() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.getApiVersion() is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.validationOfMethodParameters(this.getSubscriptionId(), resourceGroupName, id, this.getApiVersion());
         call.enqueue(new ServiceResponseCallback<Product>(serviceCallback) {
@@ -232,14 +235,17 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
         if (this.getSubscriptionId() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.getSubscriptionId() is required and cannot be null.")));
+            return null;
         }
         if (resourceGroupName == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null.")));
+            return null;
         }
         if (this.getApiVersion() == null) {
             serviceCallback.failure(new ServiceException(
                 new IllegalArgumentException("Parameter this.getApiVersion() is required and cannot be null.")));
+            return null;
         }
         Call<ResponseBody> call = service.validationOfBody(this.getSubscriptionId(), resourceGroupName, id, body, this.getApiVersion());
         call.enqueue(new ServiceResponseCallback<Product>(serviceCallback) {

--- a/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/BodyComplex/models/index.js
+++ b/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/BodyComplex/models/index.js
@@ -39,7 +39,7 @@ exports.ByteWrapper = require('./byteWrapper');
 exports.ArrayWrapper = require('./arrayWrapper');
 exports.DictionaryWrapper = require('./dictionaryWrapper');
 exports.discriminators = {
-  'fish' : exports.Fish,
+  'Fish' : exports.Fish,
   'salmon' : exports.Salmon,
   'shark' : exports.Shark,
   'sawshark' : exports.Sawshark,

--- a/AutoRest/TestServer/swagger/body-complex.json
+++ b/AutoRest/TestServer/swagger/body-complex.json
@@ -946,7 +946,7 @@
           "200": {
             "description": "Returns an object like this: {\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1.0,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'length':20.0,\n            'species':'predator',\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'length':10.0,\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n          },\n          {\n            'fishtype': 'goblin',\n            'age': 1,\n            'birthday': '2015-08-08T00:00:00Z',\n            'length': 30.0,\n            'species': 'scary',\n            'jawsize': 5\n          }\n        ]\n      };",
             "schema": {
-              "$ref": "#/definitions/fish"
+              "$ref": "#/definitions/Fish"
             }
           },
           "default": {
@@ -966,7 +966,7 @@
             "in": "body",
             "description": "Please put a salmon that looks like this:\n{\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1.0,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'length':20.0,\n            'species':'predator',\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'length':10.0,\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n          },\n          {\n            'fishtype': 'goblin',\n            'age': 1,\n            'birthday': '2015-08-08T00:00:00Z',\n            'length': 30.0,\n            'species': 'scary',\n            'jawsize': 5\n          }\n        ]\n      };",
             "schema": {
-              "$ref": "#/definitions/fish"
+              "$ref": "#/definitions/Fish"
             },
             "required": true
           }
@@ -994,7 +994,7 @@
             "in": "body",
             "description": "Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:\n{\n    \"fishtype\": \"sawshark\",\n    \"species\": \"snaggle toothed\",\n    \"length\": 18.5,\n    \"age\": 2,\n    \"birthday\": \"2013-06-01T01:00:00Z\",\n    \"location\": \"alaska\",\n    \"picture\": base64(FF FF FF FF FE),\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"birthday\": \"2012-01-05T01:00:00Z\",\n            \"length\": 20,\n            \"age\": 6\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"picture\": base64(FF FF FF FF FE),\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}",
             "schema": {
-              "$ref": "#/definitions/fish"
+              "$ref": "#/definitions/Fish"
             },
             "required": true
           }
@@ -1020,7 +1020,7 @@
           "200": {
             "description": "Complex object that extends cat and pet, returns a Salmon like this:\n{\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'species':'predator',\n            'length':20,\n            'siblings':[\n                {\n                    'fishtype':'Salmon',\n                    'location':'atlantic',\n                    'iswild':true,\n                    'species':'coho',\n                    'length':2,\n                    'siblings':[\n                      {\n                        'fishtype':'Shark',\n                        'age':6,\n                        'birthday': '2012-01-05T01:00:00Z',\n                        'species':'predator',\n                        'length':20\n                      },\n                      {\n                        'fishtype':'Sawshark',\n                        'age':105,\n                        'birthday': '1900-01-05T01:00:00Z',\n                        'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n                        'species':'dangerous',\n                        'length':10\n                      }\n                    ]\n                },\n                {\n                    'fishtype':'Sawshark',\n                    'age':105,\n                    'birthday': '1900-01-05T01:00:00Z',\n                    'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n                    'species':'dangerous',\n                    'length':10,\n                    'siblings':[]\n                }\n            ]\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n            'length':10,'siblings':[]\n          }\n        ]\n    };",
             "schema": {
-              "$ref": "#/definitions/fish"
+              "$ref": "#/definitions/Fish"
             }
           },
           "default": {
@@ -1040,7 +1040,7 @@
             "in": "body",
             "description": "Please put a salmon that looks like this:\n{\n    \"fishtype\": \"salmon\",\n    \"species\": \"king\",\n    \"length\": 1,\n    \"age\": 1,\n    \"location\": \"alaska\",\n    \"iswild\": true,\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"length\": 20,\n            \"age\": 6,\n            \"siblings\": [\n                {\n                    \"fishtype\": \"salmon\",\n                    \"species\": \"coho\",\n                    \"length\": 2,\n                    \"age\": 2,\n                    \"location\": \"atlantic\",\n                    \"iswild\": true,\n                    \"siblings\": [\n                        {\n                            \"fishtype\": \"shark\",\n                            \"species\": \"predator\",\n                            \"length\": 20,\n                            \"age\": 6\n                        },\n                        {\n                            \"fishtype\": \"sawshark\",\n                            \"species\": \"dangerous\",\n                            \"length\": 10,\n                            \"age\": 105\n                        }\n                    ]\n                },\n                {\n                    \"fishtype\": \"sawshark\",\n                    \"species\": \"dangerous\",\n                    \"length\": 10,\n                    \"age\": 105\n                }\n            ]\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}",
             "schema": {
-              "$ref": "#/definitions/fish"
+              "$ref": "#/definitions/Fish"
             },
             "required": true
           }
@@ -1138,7 +1138,7 @@
         }
       }
     },
-    "fish": {
+    "Fish": {
       "discriminator": "fishtype",
       "required": [ "fishtype", "length" ],
       "properties": {
@@ -1155,7 +1155,7 @@
         "siblings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/fish"
+            "$ref": "#/definitions/Fish"
           }
         }
       }
@@ -1163,7 +1163,7 @@
     "salmon": {
       "allOf": [
         {
-          "$ref": "#/definitions/fish"
+          "$ref": "#/definitions/Fish"
         }
       ],
       "properties": {
@@ -1178,7 +1178,7 @@
     "shark": {
       "allOf": [
         {
-          "$ref": "#/definitions/fish"
+          "$ref": "#/definitions/Fish"
         }
       ],
       "required": [ "birthday" ],


### PR DESCRIPTION
If the base class name matched exactly its serialized name, the model template
would omit the [JsonObject] attribute, causing serialization and
deserialization to fail for types with custom discriminators.

There are a bunch of Java changes because it looks like somebody forgot to run
regenerated:expected.