### PR TITLE
Relax version constrain on JSON gem, to match version in Windows release

### DIFF
--- a/ClientRuntimes/Ruby/ms-rest-azure/ms_rest_azure.gemspec
+++ b/ClientRuntimes/Ruby/ms-rest-azure/ms_rest_azure.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3.0'
 
-  spec.add_runtime_dependency 'json', '~> 1.8.3'
+  spec.add_runtime_dependency 'json', '~> 1.8.0'
   spec.add_runtime_dependency 'concurrent-ruby', ['>= 1.0.0.pre1', '<2']
   spec.add_runtime_dependency 'faraday', '~> 0.9.1'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0.6'

--- a/ClientRuntimes/Ruby/ms-rest/ms_rest.gemspec
+++ b/ClientRuntimes/Ruby/ms-rest/ms_rest.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3.0'
 
-  spec.add_runtime_dependency 'json', '~> 1.8.3'
+  spec.add_runtime_dependency 'json', '~> 1.8.0'
   spec.add_runtime_dependency 'timeliness', '~> 0.3.7'
   spec.add_runtime_dependency 'concurrent-ruby', ['>= 1.0.0.pre1', '<2']
   spec.add_runtime_dependency 'faraday', '~> 0.9.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :development, :local, :test do
   gem 'rspec'
-  gem 'json'
+  gem 'json', '1.8.1' # the Windows Ruby packages from 2.1.0 to 2.2.3 ship 1.8.1
   gem 'concurrent-ruby-ext'
   gem 'faraday'
   gem 'faraday-cookie_jar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       http-cookie (~> 1.0.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    json (1.8.3)
+    json (1.8.1)
     multipart-post (2.0.0)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)


### PR DESCRIPTION
The JSON gem carries with it native C extensions, that require a
compiler toolchain be present on any machine that installs the latest
1.8.3 gem (since there are no precompiled binaries available for this
gem).

Ruby carries the following JSON gem versions with the distribution by
default:

* JSON 1.4.2 with 1.9.2 - https://github.com/ruby/ruby/blob/ruby_1_9_2/ext/json/lib/json/version.rb
* JSON 1.5.5 with 1.9.3 - https://github.com/ruby/ruby/blob/ruby_1_9_3/ext/json/lib/json/version.rb
* JSON 1.7.7 with 2.0.0 series - https://github.com/ruby/ruby/blob/ruby_2_0_0/ext/json/lib/json/version.rb
* JSON 1.8.1 with 2.1.0 - through 2.1.7 - https://github.com/ruby/ruby/blob/v2_1_7/ext/json/lib/json/version.rb
* JSON 1.8.1 with 2.2.0 - through 2.2.3 - https://github.com/ruby/ruby/blob/v2_2_3/ext/json/lib/json/version.rb

By relaxing the constraint we allow people to use the SDK without
installing DevKit (and the compiler toolchain) everywhere.