### PR TITLE
Support rfc1123 datetime in AzureCodeGenerator for Csharp

### DIFF
--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDuration/DurationOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDuration/DurationOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureParameterGrouping/ParameterGroupingOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureParameterGrouping/ParameterGroupingOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/ApiVersionDefaultOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/ApiVersionDefaultOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/ApiVersionLocalOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/ApiVersionLocalOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/HeaderOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/HeaderOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/OdataOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/OdataOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure.OData;
     using Microsoft.Rest.Azure;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SkipUrlEncodingOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SkipUrlEncodingOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInCredentialsOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInCredentialsOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInMethodOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInMethodOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/XMsClientRequestIdOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/XMsClientRequestIdOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Head/HttpSuccessOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Head/HttpSuccessOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsHead
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
 

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LRORetrysOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LRORetrysOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROSADsOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROSADsOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROsCustomHeaderOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROsCustomHeaderOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROsOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/LROsOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Paging/PagingOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Paging/PagingOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/GroupOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/GroupOperations.cs
@@ -19,6 +19,7 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
     using Microsoft.Rest.Azure;
     using Models;

--- a/AutoRest/Generators/CSharp/Azure.CSharp/Templates/AzureMethodGroupTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/Templates/AzureMethodGroupTemplate.cshtml
@@ -18,6 +18,7 @@ namespace @Settings.Namespace
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
 @foreach (var usingString in Model.Usings) {
 @:    using @usingString;

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Tests/JsonSerializationTests.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Tests/JsonSerializationTests.cs
@@ -258,7 +258,9 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             message.Headers.Add("h2", "");
             message.Headers.Add("h3", new string[] {"value1", "value2"});
             var json = message.Headers.ToJson().ToString();
-            Assert.Equal("{\r\n  \"h1\": \"value\",\r\n  \"h2\": \"\",\r\n  \"h3\": [\r\n    \"value1\",\r\n    \"value2\"\r\n  ]\r\n}", json);
+            var expectedJsonString = string.Format("{{{0}  \"h1\": \"value\",{0}  \"h2\": \"\",{0}  \"h3\": [{0}    \"value1\",{0}    \"value2\"{0}  ]{0}}}", 
+                Environment.NewLine);
+            Assert.Equal(expectedJsonString, json);
         }
     }
 }


### PR DESCRIPTION
We missed an include in the MethodGroup files, which is now fixed