### PR TITLE
Added support for ADAL 2.18 in Microsoft.Rest.ClientRuntime.Azure.Authentication package and re-enabled Authentication tests

### DIFF
--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/ActiveDirectoryClientSettings.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/ActiveDirectoryClientSettings.cs
@@ -3,11 +3,7 @@
 
 using System;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
-#if PORTABLE
-using ClientRuntime.Azure.Authentication.Properties;
-#else
-using Microsoft.Rest.Azure.Authentication.Properties;
-#endif
+using Microsoft.Rest.ClientRuntime.Azure.Authentication.Properties;
 
 namespace Microsoft.Rest.Azure.Authentication
 {

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/ActiveDirectoryServiceSettings.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/ActiveDirectoryServiceSettings.cs
@@ -3,11 +3,7 @@
 
 using System;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
-#if PORTABLE
-using ClientRuntime.Azure.Authentication.Properties;
-#else
-using Microsoft.Rest.Azure.Authentication.Properties;
-#endif
+using Microsoft.Rest.ClientRuntime.Azure.Authentication.Properties;
 
 namespace Microsoft.Rest.Azure.Authentication
 {
@@ -71,7 +67,8 @@ namespace Microsoft.Rest.Azure.Authentication
             UriBuilder builder = new UriBuilder(authenticationEndpoint);
             if (!string.IsNullOrEmpty(builder.Query))
             {
-                throw new ArgumentOutOfRangeException(Resources.AuthenticationEndpointContainsQuery);
+                throw new ArgumentOutOfRangeException(nameof(authenticationEndpoint), 
+                    Resources.AuthenticationEndpointContainsQuery);
             }
 
             var path = builder.Path;

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/ApplicationTokenProvider.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/ApplicationTokenProvider.cs
@@ -9,11 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
-#if PORTABLE
-using ClientRuntime.Azure.Authentication.Properties;
-#else
-using Microsoft.Rest.Azure.Authentication.Properties;
-#endif
+using Microsoft.Rest.Azure.Authentication.Internal;
+using Microsoft.Rest.ClientRuntime.Azure.Authentication.Properties;
 
 namespace Microsoft.Rest.Azure.Authentication
 {
@@ -255,8 +252,14 @@ namespace Microsoft.Rest.Azure.Authentication
             string domain, string clientId, byte[] certificate, string password,
            ActiveDirectoryServiceSettings settings, TokenCache cache)
         {
+#if PORTABLE
             return await LoginSilentAsync(domain, new ClientAssertionCertificate(clientId, certificate, password), 
                 settings, cache);
+#else
+            return await LoginSilentAsync(domain, new ClientAssertionCertificate(clientId, 
+                new System.Security.Cryptography.X509Certificates.X509Certificate2(certificate)),
+                settings, cache);
+#endif
         }
 
         /// <summary>

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/CertificateAuthenticationProvider.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/CertificateAuthenticationProvider.cs
@@ -10,7 +10,12 @@ namespace Microsoft.Rest.Azure.Authentication
 
         public CertificateAuthenticationProvider(byte[] certificate, string password)
         {
+#if PORTABLE
             this._assertionProvider = (s) => Task.FromResult(new ClientAssertionCertificate(s, certificate, password));
+#else
+            this._assertionProvider = (s) => Task.FromResult(new ClientAssertionCertificate(s, 
+                new System.Security.Cryptography.X509Certificates.X509Certificate2(certificate)));
+#endif
         }
 
         /// <summary>

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/ClientRuntime.Azure.Authentication.xproj
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/ClientRuntime.Azure.Authentication.xproj
@@ -7,7 +7,7 @@
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>6319205d-bbfc-4150-beae-31b1c9b911dd</ProjectGuid>
-    <RootNamespace>ClientRuntime.Azure.Authentication</RootNamespace>
+    <RootNamespace>Microsoft.Rest.ClientRuntime.Azure.Authentication</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">bin</OutputPath>
   </PropertyGroup>

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/MemoryApplicationAuthenticationProvider.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/MemoryApplicationAuthenticationProvider.cs
@@ -6,12 +6,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
-namespace Microsoft.Rest.Azure.Authentication
+namespace Microsoft.Rest.Azure.Authentication.Internal
 {
     /// <summary>
     /// In memory store for application credentials.
     /// </summary>
-    internal class MemoryApplicationAuthenticationProvider : IApplicationAuthenticationProvider
+    public class MemoryApplicationAuthenticationProvider : IApplicationAuthenticationProvider
     {
         private IDictionary<string, ClientCredential> _credentials;
 

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/Properties/Resources.Designer.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/Properties/Resources.Designer.cs
@@ -7,11 +7,8 @@
 //     the code is regenerated.
 // </auto-generated>
 //------------------------------------------------------------------------------
-#if PORTABLE
-namespace ClientRuntime.Azure.Authentication.Properties {
-#else
-namespace Microsoft.Rest.Azure.Authentication.Properties {
-#endif
+
+namespace Microsoft.Rest.ClientRuntime.Azure.Authentication.Properties {
     using System;
     using System.Reflection;
     
@@ -41,11 +38,7 @@ namespace Microsoft.Rest.Azure.Authentication.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-#if PORTABLE
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ClientRuntime.Azure.Authentication.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
-#else
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Rest.Azure.Authentication.Properties.Resources", typeof(Resources).Assembly);
-#endif
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Rest.ClientRuntime.Azure.Authentication.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/project.json
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Authentication/project.json
@@ -10,15 +10,20 @@
   "requireLicenseAcceptance":  true,
 
   "dependencies": {
-    "Microsoft.Rest.ClientRuntime": "[1.5,2.0)",
-    "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.6.210231457-alpha"
+    "Microsoft.Rest.ClientRuntime": "[1.5,2.0)"
    },
 
   "frameworks": {
     "dnxcore50": {
       "compilationOptions": { "define": [ "PORTABLE" ] },
       "dependencies": {
-        "Microsoft.Cci": "4.0.0-beta-23409"
+        "Microsoft.Cci": "4.0.0-beta-23409",
+        "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.6.210231457-alpha"
+      }
+    },
+    "net45": {
+      "dependencies": {
+        "Microsoft.IdentityModel.Clients.ActiveDirectory": "2.18.206251556"
       }
     }
   }

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Tests/ActiveDirectorySettingsTest.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Tests/ActiveDirectorySettingsTest.cs
@@ -59,6 +59,18 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
         }
 
         [Fact]
+        public void AzureEnvironmenThrowsOnQueryInUri()
+        {
+            var error = Assert.Throws<ArgumentOutOfRangeException>(() => new ActiveDirectoryServiceSettings
+            {
+                ValidateAuthority = true,
+                TokenAudience = new Uri("https://contoso.com/widgets/"),
+                AuthenticationEndpoint = new Uri("https://contoso.com/widgets/?api=123"),
+            });
+            Assert.True(error.Message.StartsWith("The authentication endpoint must not contain a query string.", StringComparison.CurrentCulture));
+        }
+
+        [Fact]
         public void AzureEnvironmenThrowsOnNullUri()
         {
             Assert.Throws<ArgumentNullException>(() => new ActiveDirectoryServiceSettings
@@ -77,7 +89,9 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
             var settings = ActiveDirectoryClientSettings.UsePromptOnly(clientId, clientUri);
             Assert.Equal(clientId, settings.ClientId);
             Assert.Equal(clientUri, settings.ClientRedirectUri);
+#if !PORTABLE
             Assert.Equal(PromptBehavior.Always, settings.PromptBehavior);
+#endif
             Assert.Equal(ActiveDirectoryClientSettings.EnableEbdMagicCookie, settings.AdditionalQueryParameters);
         }
 
@@ -89,7 +103,9 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
             var settings = ActiveDirectoryClientSettings.UseCacheOrCookiesOnly(clientId, clientUri);
             Assert.Equal(clientId, settings.ClientId);
             Assert.Equal(clientUri, settings.ClientRedirectUri);
+#if !PORTABLE
             Assert.Equal(PromptBehavior.Never, settings.PromptBehavior);
+#endif
             Assert.Equal(ActiveDirectoryClientSettings.EnableEbdMagicCookie, settings.AdditionalQueryParameters);
         }
 
@@ -101,7 +117,9 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
             var settings = ActiveDirectoryClientSettings.UseCacheCookiesOrPrompt(clientId, clientUri);
             Assert.Equal(clientId, settings.ClientId);
             Assert.Equal(clientUri, settings.ClientRedirectUri);
+#if !PORTABLE
             Assert.Equal(PromptBehavior.Auto, settings.PromptBehavior);
+#endif
             Assert.Equal(ActiveDirectoryClientSettings.EnableEbdMagicCookie, settings.AdditionalQueryParameters);
         }
 
@@ -113,7 +131,9 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
             var settings = new ActiveDirectoryClientSettings(clientId, clientUri);
             Assert.Equal(clientId, settings.ClientId);
             Assert.Equal(clientUri, settings.ClientRedirectUri);
+#if !PORTABLE
             Assert.Equal(PromptBehavior.Auto, settings.PromptBehavior);
+#endif
             Assert.Equal(ActiveDirectoryClientSettings.EnableEbdMagicCookie, settings.AdditionalQueryParameters);
         }
 }

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Tests/project.json
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure.Tests/project.json
@@ -8,8 +8,9 @@
   "commands": {
     "test": "xunit.runner.dnx"
   },
-  "frameworks": {   
+  "frameworks": {
     "dnxcore50": {
+      "compilationOptions": { "define": [ "PORTABLE" ] },
       "dependencies": {
         "System.Diagnostics.Tools": "4.0.0",
         "System.Net.Http": "4.0.0",
@@ -20,9 +21,9 @@
       }
     }
   },
-  "exclude": [ "ActiveDirectory*.*" ],
   "dependencies": {
     "Microsoft.Rest.ClientRuntime.Azure": "",
+    "Microsoft.Rest.ClientRuntime.Azure.Authentication": "",
     "xunit": "2.1.0"
   }
 }


### PR DESCRIPTION
* Fixed resource cs file namespace