### PR TITLE
Enabling returning of the headers in extensions

### DIFF
--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/MethodTemplateModel.cs
@@ -206,6 +206,11 @@ namespace Microsoft.Rest.Generator.CSharp
                     return string.Format(CultureInfo.InvariantCulture,
                         "Task<{0}>", ReturnType.Body.Name);
                 }
+                else if(ReturnType.Headers != null)
+                {
+                    return string.Format(CultureInfo.InvariantCulture,
+                        "Task<{0}>", ReturnType.Headers.Name);
+                }
                 else
                 {
                     return "Task";

--- a/AutoRest/Generators/CSharp/CSharp/Templates/ExtensionMethodTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/ExtensionMethodTemplate.cshtml
@@ -31,6 +31,10 @@ foreach (var parameter in Model.LocalParameters)
     {
     @:return Task.Factory.StartNew(s => ((I@(Model.MethodGroupName))s).@(Model.Name)Async(@(Model.SyncMethodInvocationArgs)), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
     }
+    else if (Model.ReturnType.Headers != null)
+    {
+        @:return Task.Factory.StartNew(s => ((I@(Model.MethodGroupName))s).@(Model.Name)Async(@(Model.SyncMethodInvocationArgs)), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+    }
     else
     {
     @:Task.Factory.StartNew(s => ((I@(Model.MethodGroupName))s).@(Model.Name)Async(@(Model.SyncMethodInvocationArgs)), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
@@ -65,6 +69,11 @@ foreach (var parameter in Model.LocalParameters)
     {
     @:var result = await operations.@(Model.Name)WithHttpMessagesAsync(@(Model.GetAsyncMethodInvocationArgs("null"))).ConfigureAwait(false);
     @:return result.Body;
+    }
+    else if (Model.ReturnType.Headers != null)
+    {
+        @:var result = await operations.@(Model.Name)WithHttpMessagesAsync(@(Model.GetAsyncMethodInvocationArgs("null"))).ConfigureAwait(false);
+        @:return result.Headers;
     }
     else
     {


### PR DESCRIPTION
This will enable returning extension methods with header objects so long
as they are the only thing being returned by the swagger spec.