### PR TITLE
Rolled back adding ID to IResource

### DIFF
--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeGenerator.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeGenerator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
     {
         private readonly AzureCSharpCodeNamer _namer;
 
-        private const string ClientRuntimePackage = "Microsoft.Rest.ClientRuntime.Azure.3.0.0";
+        private const string ClientRuntimePackage = "Microsoft.Rest.ClientRuntime.Azure.3.0.1";
 
         // page extensions class dictionary.
         private IDictionary<KeyValuePair<string, string>, string> pageClasses;

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure/IResource.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure/IResource.cs
@@ -8,9 +8,5 @@ namespace Microsoft.Rest.Azure
     /// </summary>
     public interface IResource
     {
-        /// <summary>
-        /// Resource Id
-        /// </summary>
-        string Id { get; }
     }
 }

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure/Properties/AssemblyInfo.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Rest Azure Client Runtime")]
 [assembly: AssemblyDescription("Client infrastructure for Azure client libraries.")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure/project.json
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime.Azure/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "3.0.1",
   "copyright": "Copyright (c) Microsoft Corporation",
   "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288890",
   "title": "Client Runtime for Microsoft Azure Libraries",


### PR DESCRIPTION
This change broke a number of clients that had custom CreateOrUpdateParameter objects