### PR TITLE
Fix deserialization of CloudError

### DIFF
--- a/ClientRuntimes/Java/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/ApplicationTokenCredentials.java
+++ b/ClientRuntimes/Java/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/ApplicationTokenCredentials.java
@@ -89,7 +89,8 @@ public class ApplicationTokenCredentials extends TokenCredentials {
 
     @Override
     public String getToken() throws IOException {
-        if (authenticationResult.getAccessToken() == null) {
+        if (authenticationResult == null
+            || authenticationResult.getAccessToken() == null) {
             acquireAccessToken();
         }
         return authenticationResult.getAccessToken();

--- a/ClientRuntimes/Java/azure-client-runtime/build.gradle
+++ b/ClientRuntimes/Java/azure-client-runtime/build.gradle
@@ -21,6 +21,7 @@ checkstyle {
 
 dependencies {
     compile 'com.microsoft.rest:client-runtime:1.0.0-SNAPSHOT'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
     testCompile 'junit:junit:4.11'
     testCompile 'junit:junit-dep:4.11'
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.10"

--- a/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/CloudException.java
+++ b/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/CloudException.java
@@ -92,4 +92,13 @@ public class CloudException extends AutoRestException {
     public void setBody(CloudError body) {
         this.body = body;
     }
+
+    @Override
+    public String toString() {
+        String message = super.toString();
+        if (body.getMessage() != null) {
+            message = message + ": " + body.getMessage();
+        }
+        return message;
+    }
 }

--- a/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/AzureJacksonMapperAdapter.java
+++ b/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/AzureJacksonMapperAdapter.java
@@ -27,7 +27,8 @@ public final class AzureJacksonMapperAdapter extends JacksonMapperAdapter {
             initializeObjectMapper(azureObjectMapper);
             azureObjectMapper
                     .registerModule(FlatteningDeserializer.getModule())
-                    .registerModule(FlatteningSerializer.getModule());
+                    .registerModule(FlatteningSerializer.getModule())
+                    .registerModule(CloudErrorDeserializer.getModule());
         }
         return azureObjectMapper;
     }

--- a/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
+++ b/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
@@ -1,0 +1,52 @@
+/**
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *
+ */
+
+package com.microsoft.azure.serializer;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.microsoft.azure.CloudError;
+import com.microsoft.rest.serializer.JacksonMapperAdapter;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for serializing {@link CloudError} objects.
+ */
+public class CloudErrorDeserializer extends JsonDeserializer<CloudError> {
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule() {
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(CloudError.class, new CloudErrorDeserializer());
+        return module;
+    }
+
+    @Override
+    public CloudError deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        JsonNode topNode = p.readValueAsTree();
+        if (topNode == null) {
+            return null;
+        }
+        JsonNode errorNode = topNode.get("error");
+        if (errorNode == null) {
+            return null;
+        }
+        JsonParser parser = new JsonFactory().createParser(errorNode.toString());
+        parser.setCodec(new JacksonMapperAdapter().getObjectMapper());
+        return parser.readValueAs(CloudError.class);
+    }
+}

--- a/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/serializer/HeadersSerializer.java
+++ b/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/serializer/HeadersSerializer.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Custom serializer for serializing {@link Byte[]} objects into Base64 strings.
+ * Custom serializer for serializing {@link Headers} objects.
  */
 public class HeadersSerializer extends JsonSerializer<Headers> {
     /**


### PR DESCRIPTION
so that error message gets printed when a `CloudException` is thrown.