### PR TITLE
add in version and package name to ruby generator

### DIFF
--- a/AutoRest/AutoRest.Core.Tests/AutoRestSettingsTests.cs
+++ b/AutoRest/AutoRest.Core.Tests/AutoRestSettingsTests.cs
@@ -48,6 +48,20 @@ namespace Microsoft.Rest.Generator.Test
         }
 
         [Fact]
+        public void NonEmptyPackageVersionIsSet()
+        {
+            var settings = Settings.Create(new[] {"-pv", "1.2.1"});
+            Assert.Equal("1.2.1", settings.PackageVersion);
+        }
+
+        [Fact]
+        public void NonEmptyPackageNameIsSet()
+        {
+            var settings = Settings.Create(new[] {"-pn", "HelloWorld"});
+            Assert.Equal("HelloWorld", settings.PackageName);
+        }
+
+        [Fact]
         public void CreateWithValidParametersWorks()
         {
             var settings = Settings.Create(new[]

--- a/AutoRest/AutoRest.Core/Settings.cs
+++ b/AutoRest/AutoRest.Core/Settings.cs
@@ -36,7 +36,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ";
 
-        public const string MicrosoftMitLicenseHeader = @"Copyright (c) Microsoft Corporation. All rights reserved. 
+        public const string MicrosoftMitLicenseHeader = @"Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License. See License.txt in the project root for license information.
 ";
 
@@ -109,8 +109,8 @@ Licensed under the MIT License. See License.txt in the project root for license 
         #endregion
 
         /// <summary>
-        /// Gets or sets a name of the generated client type. If not specified, will use 
-        /// a value from the specification. For Swagger specifications, 
+        /// Gets or sets a name of the generated client type. If not specified, will use
+        /// a value from the specification. For Swagger specifications,
         /// the value of the 'Title' field is used.
         /// </summary>
         [SettingsInfo("Name to use for the generated client type. By default, uses " +
@@ -119,13 +119,13 @@ Licensed under the MIT License. See License.txt in the project root for license 
         public string ClientName { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum number of properties in the request body. 
-        /// If the number of properties in the request body is less than or 
+        /// Gets or sets the maximum number of properties in the request body.
+        /// If the number of properties in the request body is less than or
         /// equal to this value, then these properties will be represented as method arguments.
         /// </summary>
-        [SettingsInfo("The maximum number of properties in the request body. " + 
-                      "If the number of properties in the request body is less " + 
-                      "than or equal to this value, these properties will " + 
+        [SettingsInfo("The maximum number of properties in the request body. " +
+                      "If the number of properties in the request body is less " +
+                      "than or equal to this value, these properties will " +
                       "be represented as method arguments.")]
         [SettingsAlias("ft")]
         public int PayloadFlatteningThreshold { get; set; }
@@ -169,7 +169,7 @@ Licensed under the MIT License. See License.txt in the project root for license 
         }
 
         /// <summary>
-        /// If set to true, generate client with a ServiceClientCredentials property and optional constructor parameter. 
+        /// If set to true, generate client with a ServiceClientCredentials property and optional constructor parameter.
         /// </summary>
         [SettingsInfo(
             "If true, the generated client includes a ServiceClientCredentials property and constructor parameter. " +
@@ -177,18 +177,32 @@ Licensed under the MIT License. See License.txt in the project root for license 
         public bool AddCredentials { get; set; }
 
         /// <summary>
-        /// If set, will cause generated code to be output to a single file. Not supported by all code generators. 
+        /// If set, will cause generated code to be output to a single file. Not supported by all code generators.
         /// </summary>
         [SettingsInfo(
             "If set, will cause generated code to be output to a single file. Not supported by all code generators.")]
         public string OutputFileName { get; set; }
 
         /// <summary>
-        /// If set to true, print out help message. 
+        /// If set to true, print out help message.
         /// </summary>
         [SettingsAlias("?")]
         [SettingsAlias("h")]
         public bool ShowHelp { get; set; }
+
+        /// <summary>
+        /// PackageName of then generated code package. Should be then names wanted for the package in then package manager.
+        /// </summary>
+        [SettingsAlias("pn")]
+        [SettingsInfo("Package name of then generated code package. Should be then names wanted for the package in then package manager.")]
+        public string PackageName { get; set; }
+
+        /// <summary>
+        /// PackageName of then generated code package. Should be then names wanted for the package in then package manager.
+        /// </summary>
+        [SettingsAlias("pv")]
+        [SettingsInfo("Package version of then generated code package. Should be then version wanted for the package in then package manager.")]
+        public string PackageVersion { get; set; }
 
         /// <summary>
         /// Factory method to generate CodeGenerationSettings from command line arguments.
@@ -240,7 +254,7 @@ Licensed under the MIT License. See License.txt in the project root for license 
         }
 
         /// <summary>
-        /// Factory method to generate Settings from a dictionary. Matches dictionary 
+        /// Factory method to generate Settings from a dictionary. Matches dictionary
         /// keys to the settings properties.
         /// </summary>
         /// <param name="settings">Dictionary of settings</param>

--- a/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
@@ -139,10 +139,29 @@ namespace Microsoft.Rest.Generator.Azure.Ruby
             // Requirements
             var requirementsTemplate = new RequirementsTemplate
             {
-                Model = new AzureRequirementsTemplateModel(serviceClient, sdkName, this.ImplementationFileExtension),
+                Model = new AzureRequirementsTemplateModel(serviceClient, this.packageName ?? this.sdkName, this.ImplementationFileExtension),
             };
-            await Write(requirementsTemplate,
-                RubyCodeNamer.UnderscoreCase(sdkName) + ImplementationFileExtension);
+            await Write(requirementsTemplate, RubyCodeNamer.UnderscoreCase(this.packageName ?? this.sdkName) + ImplementationFileExtension);
+                
+                // Version File
+            if(this.packageVersion != null)
+            {
+                var versionTemplate = new VersionTemplate
+                {
+                    Model = new VersionTemplateModel(packageVersion),
+                };
+                await Write(versionTemplate, Path.Combine(sdkPath, "version" + ImplementationFileExtension));   
+            }
+            
+            // Module Definition File
+            if(Settings.Namespace != null)
+            {
+                var modTemplate = new ModuleDefinitionTemplate
+                {
+                    Model = new ModuleDefinitionTemplateModel(Settings.Namespace),
+                };
+                await Write(modTemplate, Path.Combine(sdkPath, "module_definition" + ImplementationFileExtension));   
+            }
         }
     }
 }

--- a/AutoRest/Generators/Ruby/Ruby/AutoRest.Generator.Ruby.csproj
+++ b/AutoRest/Generators/Ruby/Ruby/AutoRest.Generator.Ruby.csproj
@@ -46,6 +46,8 @@
     <Compile Include="TemplateModels\ParameterTemplateModel.cs" />
     <Compile Include="TemplateModels\PropertyTemplateModel.cs" />
     <Compile Include="TemplateModels\ModelTemplateModel.cs" />
+    <Compile Include="TemplateModels\ModuleDefinitionTemplateModel.cs" />
+    <Compile Include="TemplateModels\VersionTemplateModel.cs" />
     <Compile Include="Templates\EnumTemplate.cs">
       <DependentUpon>EnumTemplate.cshtml</DependentUpon>
     </Compile>
@@ -64,12 +66,20 @@
     <Compile Include="Templates\ServiceClientTemplate.cs">
       <DependentUpon>ServiceClientTemplate.cshtml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\ModuleDefinitionTemplate.cs">
+      <DependentUpon>ModuleDefinitionTemplate.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Templates\VersionTemplate.cs">
+      <DependentUpon>VersionTemplate.cshtml</DependentUpon>
+    </Compile>
     <None Include="Templates\EnumTemplate.cshtml" />
     <None Include="Templates\MethodGroupTemplate.cshtml" />
     <None Include="Templates\RequirementsTemplate.cshtml" />
     <None Include="Templates\ServiceClientTemplate.cshtml" />
     <None Include="Templates\MethodTemplate.cshtml" />
     <None Include="Templates\ModelTemplate.cshtml" />
+    <None Include="Templates\VersionTemplate.cshtml" />
+    <None Include="Templates\ModuleDefinitionTemplate.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
@@ -22,6 +22,16 @@ namespace Microsoft.Rest.Generator.Ruby
         protected readonly string sdkName;
 
         /// <summary>
+        /// The name of the package version to be used in creating a version.rb file
+        /// </summary>
+        protected readonly string packageVersion;
+        
+        /// <summary>
+        /// The name of the package name to be used in creating a version.rb file
+        /// </summary>
+        protected readonly string packageName;
+
+        /// <summary>
         /// Relative path to produced SDK files.
         /// </summary>
         protected readonly string sdkPath;
@@ -43,19 +53,21 @@ namespace Microsoft.Rest.Generator.Ruby
         public RubyCodeGenerator(Settings settings) : base(settings)
         {
             CodeNamer = new RubyCodeNamer();
+            this.packageVersion = Settings.PackageVersion;
+            this.packageName = Settings.PackageName;
 
             if (Settings.CustomSettings.ContainsKey("Name"))
             {
-                sdkName = Settings.CustomSettings["Name"];
+                this.sdkName = Settings.CustomSettings["Name"];
             }
             else
             {
-                sdkName = Path.GetFileNameWithoutExtension(Settings.Input);
+                this.sdkName = Path.GetFileNameWithoutExtension(Settings.Input);
             }
 
-            sdkName = RubyCodeNamer.UnderscoreCase(CodeNamer.RubyRemoveInvalidCharacters(sdkName));
-            sdkPath = sdkName;
-            modelsPath = Path.Combine(sdkPath, "models");
+            this.sdkName = RubyCodeNamer.UnderscoreCase(CodeNamer.RubyRemoveInvalidCharacters(this.sdkName));
+            this.sdkPath = this.packageName ?? this.sdkName;
+            this.modelsPath = Path.Combine(this.sdkPath, "models");
         }
 
         /// <summary>
@@ -171,10 +183,29 @@ namespace Microsoft.Rest.Generator.Ruby
             // Requirements
             var requirementsTemplate = new RequirementsTemplate
             {
-                Model = new RequirementsTemplateModel(serviceClient, sdkName, this.ImplementationFileExtension),
+                Model = new RequirementsTemplateModel(serviceClient, this.packageName ?? this.sdkName, this.ImplementationFileExtension),
             };
-            await Write(requirementsTemplate,
-                RubyCodeNamer.UnderscoreCase(sdkName) + ImplementationFileExtension);
+            await Write(requirementsTemplate, RubyCodeNamer.UnderscoreCase(this.packageName ?? this.sdkName) + ImplementationFileExtension);
+                
+            // Version File
+            if(this.packageVersion != null)
+            {
+                var versionTemplate = new VersionTemplate
+                {
+                    Model = new VersionTemplateModel(packageVersion),
+                };
+                await Write(versionTemplate, Path.Combine(sdkPath, "version" + ImplementationFileExtension));   
+            }
+            
+            // Module Definition File
+            if(Settings.Namespace != null)
+            {
+                var modTemplate = new ModuleDefinitionTemplate
+                {
+                    Model = new ModuleDefinitionTemplateModel(Settings.Namespace),
+                };
+                await Write(modTemplate, Path.Combine(sdkPath, "module_definition" + ImplementationFileExtension));   
+            }
         }
     }
 }

--- a/AutoRest/Generators/Ruby/Ruby/TemplateModels/ModuleDefinitionTemplateModel.cs
+++ b/AutoRest/Generators/Ruby/Ruby/TemplateModels/ModuleDefinitionTemplateModel.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+namespace Microsoft.Rest.Generator.Ruby
+{
+    /// <summary>
+    /// The model for the service client template.
+    /// </summary>
+    public class ModuleDefinitionTemplateModel
+    {
+        /// <summary>
+        /// the namespace in the following format 'Azure::ARM::Foo::Bar'
+        /// </summary>
+        protected string ns;
+        
+        /// <summary>
+        /// Initializes a new instance of ModuleDefinitionTemplateModel class.
+        /// </summary>
+        /// <param name="ns">namespace of the module</param>
+        public ModuleDefinitionTemplateModel(string ns)
+        {
+            this.ns = ns;
+        }
+
+        /// <summary>
+        /// Get the module declarations for the entire depth of modules generated.
+        /// </summary>
+        public string ModuleDeclarations { 
+            get 
+            { 
+                var modules = Regex.Split(this.ns, "::");
+                var sb = new StringBuilder(modules.Length);
+                for(int i = 0; i < modules.Length; i++ ){
+                    var joined = string.Join("::", modules.Take(i + 1));
+                    sb.Append(string.Format("module {0} end{1}", joined, Environment.NewLine));
+                }
+                return sb.ToString(); 
+            }
+        }
+    }
+}

--- a/AutoRest/Generators/Ruby/Ruby/TemplateModels/VersionTemplateModel.cs
+++ b/AutoRest/Generators/Ruby/Ruby/TemplateModels/VersionTemplateModel.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Rest.Generator.Ruby
+{
+    /// <summary>
+    /// The model for the service client template.
+    /// </summary>
+    public class VersionTemplateModel
+    {
+        /// <summary>
+        /// The package version of the Ruby Package
+        /// </summary>
+        protected string version;
+        
+        /// <summary>
+        /// Initializes a new instance of VersionClientTemplateModel class.
+        /// </summary>
+        /// <param name="version"></param>
+        public VersionTemplateModel(string version)
+        {
+            this.version = version;
+        }
+
+        /// <summary>
+        /// Gets the package version of the Ruby Package
+        /// </summary>
+        public string Version { get { return this.version; } }
+    }
+}

--- a/AutoRest/Generators/Ruby/Ruby/Templates/ModuleDefinitionTemplate.cshtml
+++ b/AutoRest/Generators/Ruby/Ruby/Templates/ModuleDefinitionTemplate.cshtml
@@ -1,0 +1,7 @@
+@using Microsoft.Rest.Generator.Ruby.Templates
+@using Microsoft.Rest.Generator.Ruby.TemplateModels
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.Ruby.ModuleDefinitionTemplateModel>
+# encoding: utf-8
+@Header("# ")
+@EmptyLine
+@Model.ModuleDeclarations

--- a/AutoRest/Generators/Ruby/Ruby/Templates/VersionTemplate.cshtml
+++ b/AutoRest/Generators/Ruby/Ruby/Templates/VersionTemplate.cshtml
@@ -1,0 +1,12 @@
+@using Microsoft.Rest.Generator.Ruby
+@using Microsoft.Rest.Generator.Ruby.Templates
+@using Microsoft.Rest.Generator.Utilities
+@using System.Linq
+@using Microsoft.Rest.Generator.Ruby.TemplateModels
+@inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.Ruby.VersionTemplateModel>
+# encoding: utf-8
+@Header("# ")
+@EmptyLine
+module @Settings.Namespace
+    VERSION = '@Model.Version'
+end


### PR DESCRIPTION
This adds version and package name to the ruby generator as the underpinnings for creating a full gem rather than just source code.

If you specify the package name, then the top level folder and .rb requirements file will be the package name.
```
Generated/{packageName}/models/
Generated/{packageName}/
Generated/{packageName}.rb
```

See: https://github.com/Azure/autorest/issues/752