### PR TITLE
Revert "Setup.py references a file that does not exist"

### DIFF
--- a/ClientRuntimes/Python/msrestazure/setup.py
+++ b/ClientRuntimes/Python/msrestazure/setup.py
@@ -36,6 +36,7 @@ setup(
     license='MIT License',
     description=('AutoRest swagger generator Python client runtime. '
                  'Azure-specific module.'),
+    long_description=open('readme.rst').read(),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',


### PR DESCRIPTION
Reverts Azure/autorest#799

Sorry, but as I said it is not the right fix, the right fix is in the PR 800... :(