### PR TITLE
fix version dependency for ms_rest

### DIFF
--- a/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/version.rb
+++ b/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/version.rb
@@ -3,5 +3,5 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 module MsRestAzure
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/ClientRuntimes/Ruby/ms-rest-azure/ms_rest_azure.gemspec
+++ b/ClientRuntimes/Ruby/ms-rest-azure/ms_rest_azure.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0.6'
-  spec.add_runtime_dependency 'ms_rest', '~> 0.2'
+  spec.add_runtime_dependency 'ms_rest', '~> 0.2.1'
 end


### PR DESCRIPTION
ms_rest_azure should take pessimistic version dependencies within a minor version range until all breaking changes in the client runtime are solidified. We are guaranteeing no bearing changes between patch versions, but possible breaking changes between minor versions until 1.0.