### PR TITLE
Change to the Azure code generator to pass settings

### DIFF
--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeGenerator.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeGenerator.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
 
         public AzureCSharpCodeGenerator(Settings settings) : base(settings)
         {
-            _namer = new AzureCSharpCodeNamer();
+
+            _namer = new AzureCSharpCodeNamer(settings);
             IsSingleFileGenerationSupported = true;
             pageClasses = new Dictionary<KeyValuePair<string, string>, string>();
         }

--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeGenerator.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeGenerator.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
 
         public AzureCSharpCodeGenerator(Settings settings) : base(settings)
         {
-
             _namer = new AzureCSharpCodeNamer(settings);
             IsSingleFileGenerationSupported = true;
             pageClasses = new Dictionary<KeyValuePair<string, string>, string>();

--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
@@ -26,13 +26,22 @@ namespace Microsoft.Rest.Generator.CSharp
 
         public AzureCSharpCodeNamer(Settings settings)
         {
-            foreach(var setting in settings.CustomSettings.Keys)
+            if (settings != null && settings.CustomSettings != null)
             {
-                if(setting.Equals("useDateTimeOffset", StringComparison.OrdinalIgnoreCase))
+                foreach (var setting in settings.CustomSettings.Keys)
                 {
-                    bool toUse = false;
-                    bool.TryParse(settings.CustomSettings[setting], out toUse);
-                    UseDateTimeOffset = toUse;
+                    if (setting.Equals("useDateTimeOffset", StringComparison.OrdinalIgnoreCase))
+                    {
+                        bool toUse;
+                        if (bool.TryParse(settings.CustomSettings[setting], out toUse))
+                        {
+                            UseDateTimeOffset = toUse;
+                        }
+                        else
+                        {
+                            UseDateTimeOffset = false;
+                        }
+                    }
                 }
             }
         }

--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
@@ -24,6 +24,17 @@ namespace Microsoft.Rest.Generator.CSharp
             // Do nothing
         }
 
+        public AzureCSharpCodeNamer(Settings settings)
+        {
+            foreach(var setting in settings.CustomSettings.Keys)
+            {
+                if(setting.Equals("useDateTimeOffset", StringComparison.OrdinalIgnoreCase))
+                {
+                    UseDateTimeOffset = bool.Parse(settings.CustomSettings[setting]);
+                }
+            }
+        }
+
         private static string GetPagingSetting(Dictionary<string, object> extensions, IDictionary<KeyValuePair<string, string>, string> pageClasses, out string nextLinkName)
         {
             // default value

--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
@@ -30,7 +30,9 @@ namespace Microsoft.Rest.Generator.CSharp
             {
                 if(setting.Equals("useDateTimeOffset", StringComparison.OrdinalIgnoreCase))
                 {
-                    UseDateTimeOffset = bool.Parse(settings.CustomSettings[setting]);
+                    bool toUse = false;
+                    bool.TryParse(settings.CustomSettings[setting], out toUse);
+                    UseDateTimeOffset = toUse;
                 }
             }
         }


### PR DESCRIPTION
This enables UseDateTimeOffset to work properly for Azure generated C#
clients which is part of issue: https://github.com/Azure/autorest/issues/825