### PR TITLE
Wait() must raises Exception if query failed

### DIFF
--- a/ClientRuntimes/Python/msrestazure/msrestazure/azure_operation.py
+++ b/ClientRuntimes/Python/msrestazure/msrestazure/azure_operation.py
@@ -623,12 +623,9 @@ class AzureOperationPoller(object):
 
         :returns: The deserialized resource of the long running operation,
          if one is available.
+        :raises CloudError: Server problem with the query.
         """
         self.wait(timeout)
-        try:
-            raise self._exception
-        except TypeError:
-            pass
         if self._operation.raw:
             return self._operation.raw
         else:
@@ -640,8 +637,13 @@ class AzureOperationPoller(object):
 
         :param int timeout: Perion of time to wait for the long running
          operation to complete.
+        :raises CloudError: Server problem with the query.
         """
         self._thread.join(timeout=timeout)
+        try:
+            raise self._exception
+        except TypeError:
+            pass
 
     def done(self):
         """Check status of the long running operation.


### PR DESCRIPTION
Using the AzureOperationPoller instance, the wait() method must throw the exception got from the server as result() does

Discussed with @annatisch 