### PR TITLE
Add support for file uploading

### DIFF
--- a/AutoRest/Generators/CSharp/CSharp.Tests/AcceptanceTests.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/AcceptanceTests.cs
@@ -373,7 +373,7 @@ namespace Microsoft.Rest.Generator.CSharp.Tests
                 {
                     memStream.Write(testBytes, 0, testBytes.Length);
                     memStream.Seek(0, SeekOrigin.Begin);
-                    using (StreamReader reader = new StreamReader(client.Formdata.UploadFileViaBody(memStream, "UploadFile.txt"), Encoding.Unicode))
+                    using (StreamReader reader = new StreamReader(client.Formdata.UploadFileViaBody(memStream), Encoding.Unicode))
                     {
                         string actual = reader.ReadToEnd();
                         Assert.Equal(testString, actual);

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFormData/Formdata.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFormData/Formdata.cs
@@ -197,9 +197,6 @@ namespace Fixtures.AcceptanceTestsBodyFormData
         /// <param name='fileContent'>
         /// File to upload.
         /// </param>
-        /// <param name='fileName'>
-        /// File name to upload. Name has to be spelled exactly as written here.
-        /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>
@@ -209,15 +206,11 @@ namespace Fixtures.AcceptanceTestsBodyFormData
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<System.IO.Stream>> UploadFileViaBodyWithHttpMessagesAsync(System.IO.Stream fileContent, string fileName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<System.IO.Stream>> UploadFileViaBodyWithHttpMessagesAsync(System.IO.Stream fileContent, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (fileContent == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "fileContent");
-            }
-            if (fileName == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "fileName");
             }
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
@@ -227,7 +220,6 @@ namespace Fixtures.AcceptanceTestsBodyFormData
                 _invocationId = ServiceClientTracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("fileContent", fileContent);
-                tracingParameters.Add("fileName", fileName);
                 tracingParameters.Add("cancellationToken", cancellationToken);
                 ServiceClientTracing.Enter(_invocationId, this, "UploadFileViaBody", tracingParameters);
             }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFormData/FormdataExtensions.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFormData/FormdataExtensions.cs
@@ -69,12 +69,9 @@ namespace Fixtures.AcceptanceTestsBodyFormData
             /// <param name='fileContent'>
             /// File to upload.
             /// </param>
-            /// <param name='fileName'>
-            /// File name to upload. Name has to be spelled exactly as written here.
-            /// </param>
-            public static System.IO.Stream UploadFileViaBody(this IFormdata operations, System.IO.Stream fileContent, string fileName)
+            public static System.IO.Stream UploadFileViaBody(this IFormdata operations, System.IO.Stream fileContent)
             {
-                return Task.Factory.StartNew(s => ((IFormdata)s).UploadFileViaBodyAsync(fileContent, fileName), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return Task.Factory.StartNew(s => ((IFormdata)s).UploadFileViaBodyAsync(fileContent), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -86,15 +83,12 @@ namespace Fixtures.AcceptanceTestsBodyFormData
             /// <param name='fileContent'>
             /// File to upload.
             /// </param>
-            /// <param name='fileName'>
-            /// File name to upload. Name has to be spelled exactly as written here.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<System.IO.Stream> UploadFileViaBodyAsync(this IFormdata operations, System.IO.Stream fileContent, string fileName, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<System.IO.Stream> UploadFileViaBodyAsync(this IFormdata operations, System.IO.Stream fileContent, CancellationToken cancellationToken = default(CancellationToken))
             {
-                var _result = await operations.UploadFileViaBodyWithHttpMessagesAsync(fileContent, fileName, null, cancellationToken).ConfigureAwait(false);
+                var _result = await operations.UploadFileViaBodyWithHttpMessagesAsync(fileContent, null, cancellationToken).ConfigureAwait(false);
                 _result.Request.Dispose();
                 return _result.Body;
             }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFormData/IFormdata.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFormData/IFormdata.cs
@@ -44,16 +44,12 @@ namespace Fixtures.AcceptanceTestsBodyFormData
         /// <param name='fileContent'>
         /// File to upload.
         /// </param>
-        /// <param name='fileName'>
-        /// File name to upload. Name has to be spelled exactly as written
-        /// here.
-        /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<HttpOperationResponse<System.IO.Stream>> UploadFileViaBodyWithHttpMessagesAsync(System.IO.Stream fileContent, string fileName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<System.IO.Stream>> UploadFileViaBodyWithHttpMessagesAsync(System.IO.Stream fileContent, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/AutoRest/Generators/Java/Azure.Java/Templates/AzureMethodGroupRetrofitTemplate.cshtml
+++ b/AutoRest/Generators/Java/Azure.Java/Templates/AzureMethodGroupRetrofitTemplate.cshtml
@@ -11,7 +11,14 @@
 interface @Model.MethodGroupServiceType {
 @foreach (AzureMethodTemplateModel method in Model.MethodTemplateModels)
 {
+if (method.RequestContentType == "multipart/form-data" || method.RequestContentType == "application/x-www-form-urlencoded")
+{
+@:    @@Multipart
+}
+else
+{
 @:    @@Headers("Content-Type: @method.RequestContentType")
+}
 if (method.HttpMethod == Microsoft.Rest.Generator.ClientModel.HttpMethod.Delete)
 {
 @:    @@HTTP(path = "@(method.Url.TrimStart('/'))", method = "DELETE", hasBody = true)

--- a/AutoRest/Generators/Java/Azure.Java/Templates/AzureServiceClientRetrofitTemplate.cshtml
+++ b/AutoRest/Generators/Java/Azure.Java/Templates/AzureServiceClientRetrofitTemplate.cshtml
@@ -11,7 +11,14 @@
 interface @Model.ServiceClientServiceType {
 @foreach (AzureMethodTemplateModel method in Model.MethodTemplateModels)
 {
+if (method.RequestContentType == "multipart/form-data" || method.RequestContentType == "application/x-www-form-urlencoded")
+{
+@:    @@Multipart
+}
+else
+{
 @:    @@Headers("Content-Type: @method.RequestContentType")
+}
 if (method.HttpMethod == Microsoft.Rest.Generator.ClientModel.HttpMethod.Delete)
 {
 @:    @@HTTP(path = "@(method.Url.TrimStart('/'))", method = "DELETE", hasBody = true)

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperations.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperations.java
@@ -32,7 +32,7 @@ public interface FormdataOperations {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> uploadFile(InputStream fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException;
+    ServiceResponse<InputStream> uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Upload file.
@@ -43,29 +43,27 @@ public interface FormdataOperations {
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link ServiceCall} object
      */
-    ServiceCall uploadFileAsync(InputStream fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException;
+    ServiceCall uploadFileAsync(byte[] fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException;
 
     /**
      * Upload file.
      *
      * @param fileContent File to upload.
-     * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> uploadFileViaBody(InputStream fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException;
+    ServiceResponse<InputStream> uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Upload file.
      *
      * @param fileContent File to upload.
-     * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link ServiceCall} object
      */
-    ServiceCall uploadFileViaBodyAsync(InputStream fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException;
+    ServiceCall uploadFileViaBodyAsync(byte[] fileContent, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException;
 
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperationsImpl.java
@@ -145,7 +145,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
-        Call<ResponseBody> call = service.uploadFileViaBody(RequestBody.create(MediaType.parse("multipart/form-data"), fileContent));
+        Call<ResponseBody> call = service.uploadFileViaBody(RequestBody.create(MediaType.parse("application/octet-stream"), fileContent));
         return uploadFileViaBodyDelegate(call.execute());
     }
 
@@ -165,7 +165,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
             serviceCallback.failure(new IllegalArgumentException("Parameter fileContent is required and cannot be null."));
             return null;
         }
-        Call<ResponseBody> call = service.uploadFileViaBody(RequestBody.create(MediaType.parse("multipart/form-data"), fileContent));
+        Call<ResponseBody> call = service.uploadFileViaBody(RequestBody.create(MediaType.parse("application/octet-stream"), fileContent));
         final ServiceCall serviceCall = new ServiceCall(call);
         call.enqueue(new ServiceResponseCallback<InputStream>(serviceCallback) {
             @Override

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperationsImpl.java
@@ -19,10 +19,14 @@ import com.microsoft.rest.ServiceResponseCallback;
 import fixtures.bodyformdata.models.ErrorException;
 import java.io.InputStream;
 import java.io.IOException;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.Headers;
+import retrofit2.http.Multipart;
+import retrofit2.http.Part;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.Response;
@@ -54,13 +58,13 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * used by Retrofit to perform actually REST calls.
      */
     interface FormdataService {
-        @Headers("Content-Type: multipart/form-data")
+        @Multipart
         @POST("formdata/stream/uploadfile")
-        Call<ResponseBody> uploadFile(InputStream fileContent, String fileName);
+        Call<ResponseBody> uploadFile(@Part("fileContent") RequestBody fileContent, @Part("fileName") String fileName);
 
         @Headers("Content-Type: application/octet-stream")
         @PUT("formdata/stream/uploadfile")
-        Call<ResponseBody> uploadFileViaBody(@Body InputStream fileContent, String fileName);
+        Call<ResponseBody> uploadFileViaBody(@Body RequestBody fileContent);
 
     }
 
@@ -74,14 +78,14 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> uploadFile(InputStream fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException {
+    public ServiceResponse<InputStream> uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
         if (fileName == null) {
             throw new IllegalArgumentException("Parameter fileName is required and cannot be null.");
         }
-        Call<ResponseBody> call = service.uploadFile(fileContent, fileName);
+        Call<ResponseBody> call = service.uploadFile(RequestBody.create(MediaType.parse("multipart/form-data"), fileContent), fileName);
         return uploadFileDelegate(call.execute());
     }
 
@@ -94,7 +98,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link Call} object
      */
-    public ServiceCall uploadFileAsync(InputStream fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException {
+    public ServiceCall uploadFileAsync(byte[] fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException {
         if (serviceCallback == null) {
             throw new IllegalArgumentException("ServiceCallback is required for async calls.");
         }
@@ -106,7 +110,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
             serviceCallback.failure(new IllegalArgumentException("Parameter fileName is required and cannot be null."));
             return null;
         }
-        Call<ResponseBody> call = service.uploadFile(fileContent, fileName);
+        Call<ResponseBody> call = service.uploadFile(RequestBody.create(MediaType.parse("multipart/form-data"), fileContent), fileName);
         final ServiceCall serviceCall = new ServiceCall(call);
         call.enqueue(new ServiceResponseCallback<InputStream>(serviceCallback) {
             @Override
@@ -132,20 +136,16 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * Upload file.
      *
      * @param fileContent File to upload.
-     * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> uploadFileViaBody(InputStream fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException {
+    public ServiceResponse<InputStream> uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
-        if (fileName == null) {
-            throw new IllegalArgumentException("Parameter fileName is required and cannot be null.");
-        }
-        Call<ResponseBody> call = service.uploadFileViaBody(fileContent, fileName);
+        Call<ResponseBody> call = service.uploadFileViaBody(RequestBody.create(MediaType.parse("multipart/form-data"), fileContent));
         return uploadFileViaBodyDelegate(call.execute());
     }
 
@@ -153,12 +153,11 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * Upload file.
      *
      * @param fileContent File to upload.
-     * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link Call} object
      */
-    public ServiceCall uploadFileViaBodyAsync(InputStream fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException {
+    public ServiceCall uploadFileViaBodyAsync(byte[] fileContent, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException {
         if (serviceCallback == null) {
             throw new IllegalArgumentException("ServiceCallback is required for async calls.");
         }
@@ -166,11 +165,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
             serviceCallback.failure(new IllegalArgumentException("Parameter fileContent is required and cannot be null."));
             return null;
         }
-        if (fileName == null) {
-            serviceCallback.failure(new IllegalArgumentException("Parameter fileName is required and cannot be null."));
-            return null;
-        }
-        Call<ResponseBody> call = service.uploadFileViaBody(fileContent, fileName);
+        Call<ResponseBody> call = service.uploadFileViaBody(RequestBody.create(MediaType.parse("multipart/form-data"), fileContent));
         final ServiceCall serviceCall = new ServiceCall(call);
         call.enqueue(new ServiceResponseCallback<InputStream>(serviceCallback) {
             @Override

--- a/AutoRest/Generators/Java/Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
@@ -1,0 +1,34 @@
+package fixtures.bodyformdata;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import okhttp3.logging.HttpLoggingInterceptor;
+
+public class FormdataTests {
+    private static AutoRestSwaggerBATFormDataService client;
+
+    @BeforeClass
+    public static void setup() {
+        client = new AutoRestSwaggerBATFormDataServiceImpl("http://localhost.:3000");
+        client.setLogLevel(HttpLoggingInterceptor.Level.BODY);
+    }
+
+    @Test
+    public void uploadFile() throws Exception {
+        String testString = "Upload file test case";
+        InputStream result = client.getFormdataOperations().uploadFile(testString.getBytes("UTF-8"), "UploadFile.txt").getBody();
+        Assert.assertEquals(testString, IOUtils.toString(result));
+    }
+
+    @Test
+    public void uploadFileViaBody() throws Exception {
+        String testString = "Upload file test case";
+        InputStream result = client.getFormdataOperations().uploadFileViaBody(testString.getBytes("UTF-8")).getBody();
+        Assert.assertEquals(testString, IOUtils.toString(result));
+    }
+}

--- a/AutoRest/Generators/Java/Java/ClientModelExtensions.cs
+++ b/AutoRest/Generators/Java/Java/ClientModelExtensions.cs
@@ -38,11 +38,7 @@ namespace Microsoft.Rest.Generator.Java.TemplateModels
             var type = parameter.Type;
             var known = type as PrimaryType;
             var sequence = type as SequenceType;
-            if (type.IsPrimaryType(KnownPrimaryType.Stream))
-            {
-                return "RequestBody.create(MediaType.parse(\"multipart/form-data\"), " + reference + ")";
-            }
-            else if (known != null && known.Name != "LocalDate" && known.Name != "DateTime")
+            if (known != null && known.Name != "LocalDate" && known.Name != "DateTime")
             {
                 if (known.Type == KnownPrimaryType.ByteArray)
                 {

--- a/AutoRest/Generators/Java/Java/ClientModelExtensions.cs
+++ b/AutoRest/Generators/Java/Java/ClientModelExtensions.cs
@@ -38,7 +38,11 @@ namespace Microsoft.Rest.Generator.Java.TemplateModels
             var type = parameter.Type;
             var known = type as PrimaryType;
             var sequence = type as SequenceType;
-            if (known != null && known.Name != "LocalDate" && known.Name != "DateTime")
+            if (type.IsPrimaryType(KnownPrimaryType.Stream))
+            {
+                return "RequestBody.create(MediaType.parse(\"multipart/form-data\"), " + reference + ")";
+            }
+            else if (known != null && known.Name != "LocalDate" && known.Name != "DateTime")
             {
                 if (known.Type == KnownPrimaryType.ByteArray)
                 {
@@ -143,6 +147,11 @@ namespace Microsoft.Rest.Generator.Java.TemplateModels
             var type = parameter.Type;
 
             SequenceType sequenceType = type as SequenceType;
+            if (type.IsPrimaryType(KnownPrimaryType.Stream))
+            {
+                imports.Add("okhttp3.RequestBody");
+                imports.Add("okhttp3.MediaType");
+            }
             if (parameter.Location != ParameterLocation.Body
                 && parameter.Location != ParameterLocation.None)
             {
@@ -175,11 +184,18 @@ namespace Microsoft.Rest.Generator.Java.TemplateModels
 
         public static string ImportFrom(this ParameterLocation parameterLocation)
         {
-            if (parameterLocation != ParameterLocation.None &&
-                parameterLocation != ParameterLocation.FormData)
+            if (parameterLocation == ParameterLocation.FormData)
+            {
+                return "retrofit2.http.Part";
+            }
+            else if (parameterLocation != ParameterLocation.None)
+            {
                 return "retrofit2.http." + parameterLocation.ToString();
+            }
             else
+            {
                 return null;
+            }
         }
 
         public static IEnumerable<IType> ParseGenericType(this CompositeType type)

--- a/AutoRest/Generators/Java/Java/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/Java/Java/TemplateModels/MethodTemplateModel.cs
@@ -100,8 +100,18 @@ namespace Microsoft.Rest.Generator.Java
                             "@{0} ", 
                             parameter.Location.ToString()));
                     }
+                    else if (parameter.Location == ParameterLocation.FormData)
+                    {
+                        declarationBuilder.Append(string.Format(CultureInfo.InvariantCulture,
+                            "@Part(\"{0}\") ",
+                            parameter.SerializedName));
+                    }
                     var declarativeName = parameter.ClientProperty != null ? parameter.ClientProperty.Name : parameter.Name;
-                    if ((parameter.Location != ParameterLocation.Body)
+                    if (parameter.Type.IsPrimaryType(KnownPrimaryType.Stream))
+                    {
+                        declarationBuilder.Append("RequestBody");
+                    }
+                    else if ((parameter.Location != ParameterLocation.Body)
                         && parameter.Type.NeedsSpecialSerialization())
                     {
                         declarationBuilder.Append("String");
@@ -131,7 +141,14 @@ namespace Microsoft.Rest.Generator.Java
                 List<string> declarations = new List<string>();
                 foreach (var parameter in LocalParameters.Where(p => !p.IsConstant))
                 {
-                    declarations.Add(parameter.Type.ToString() + " " + parameter.Name);
+                    if (parameter.Type.IsPrimaryType(KnownPrimaryType.Stream))
+                    {
+                        declarations.Add("byte[] " + parameter.Name);
+                    }
+                    else
+                    {
+                        declarations.Add(parameter.Type.ToString() + " " + parameter.Name);
+                    }
                 }
 
                 var declaration = string.Join(", ", declarations);
@@ -178,6 +195,10 @@ namespace Microsoft.Rest.Generator.Java
                 {
                     if ((parameter.Location != ParameterLocation.Body)
                          && parameter.Type.NeedsSpecialSerialization())
+                    {
+                        declarations.Add(parameter.ToString(parameter.Name, ClientReference));
+                    }
+                    else if (parameter.Type.IsPrimaryType(KnownPrimaryType.Stream))
                     {
                         declarations.Add(parameter.ToString(parameter.Name, ClientReference));
                     }
@@ -711,7 +732,14 @@ namespace Microsoft.Rest.Generator.Java
                 HashSet<string> imports = new HashSet<string>();
                 // static imports
                 imports.Add("retrofit2.Call");
-                imports.Add("retrofit2.http.Headers");
+                if (RequestContentType == "multipart/form-data")
+                {
+                    imports.Add("retrofit2.http.Multipart");
+                }
+                else
+                {
+                    imports.Add("retrofit2.http.Headers");
+                }
                 imports.Add("retrofit2.Response");
                 imports.Add("retrofit2.Retrofit");
                 if (this.HttpMethod != HttpMethod.Head)

--- a/AutoRest/Generators/Java/Java/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/Java/Java/TemplateModels/MethodTemplateModel.cs
@@ -732,7 +732,7 @@ namespace Microsoft.Rest.Generator.Java
                 HashSet<string> imports = new HashSet<string>();
                 // static imports
                 imports.Add("retrofit2.Call");
-                if (RequestContentType == "multipart/form-data")
+                if (RequestContentType == "multipart/form-data" || RequestContentType == "application/x-www-form-urlencoded")
                 {
                     imports.Add("retrofit2.http.Multipart");
                 }

--- a/AutoRest/Generators/Java/Java/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/Java/Java/TemplateModels/MethodTemplateModel.cs
@@ -200,7 +200,9 @@ namespace Microsoft.Rest.Generator.Java
                     }
                     else if (parameter.Type.IsPrimaryType(KnownPrimaryType.Stream))
                     {
-                        declarations.Add(parameter.ToString(parameter.Name, ClientReference));
+                        declarations.Add(string.Format(CultureInfo.InvariantCulture, 
+                            "RequestBody.create(MediaType.parse(\"{0}\"), {1})",
+                            RequestContentType, parameter.Name));
                     }
                     else
                     {

--- a/AutoRest/Generators/Java/Java/Templates/MethodGroupRetrofitTemplate.cshtml
+++ b/AutoRest/Generators/Java/Java/Templates/MethodGroupRetrofitTemplate.cshtml
@@ -11,7 +11,7 @@
 interface @Model.MethodGroupServiceType {
 @foreach (var method in Model.MethodTemplateModels)
 {
-if (method.RequestContentType == "multipart/form-data")
+if (method.RequestContentType == "multipart/form-data" || method.RequestContentType == "application/x-www-form-urlencoded")
 {
 @:    @@Multipart
 }

--- a/AutoRest/Generators/Java/Java/Templates/MethodGroupRetrofitTemplate.cshtml
+++ b/AutoRest/Generators/Java/Java/Templates/MethodGroupRetrofitTemplate.cshtml
@@ -11,7 +11,14 @@
 interface @Model.MethodGroupServiceType {
 @foreach (var method in Model.MethodTemplateModels)
 {
+if (method.RequestContentType == "multipart/form-data")
+{
+@:    @@Multipart
+}
+else
+{
 @:    @@Headers("Content-Type: @method.RequestContentType")
+}
 if (method.HttpMethod == Microsoft.Rest.Generator.ClientModel.HttpMethod.Delete)
 {
 @:    @@HTTP(path = "@(method.Url.TrimStart('/'))", method = "DELETE", hasBody = true)

--- a/AutoRest/Generators/Java/Java/Templates/ServiceClientRetrofitTemplate.cshtml
+++ b/AutoRest/Generators/Java/Java/Templates/ServiceClientRetrofitTemplate.cshtml
@@ -11,7 +11,14 @@
 interface @Model.ServiceClientServiceType {
 @foreach (var method in Model.MethodTemplateModels)
 {
+if (method.RequestContentType == "multipart/form-data" || method.RequestContentType == "application/x-www-form-urlencoded")
+{
+@:    @@Multipart
+}
+else
+{
 @:    @@Headers("Content-Type: @method.RequestContentType")
+}
 if (method.HttpMethod == Microsoft.Rest.Generator.ClientModel.HttpMethod.Delete)
 {
 @:    @@HTTP(path = "@(method.Url.TrimStart('/'))", method = "DELETE", hasBody = true)

--- a/AutoRest/Generators/NodeJS/NodeJS.Tests/AcceptanceTests/acceptanceTests.ts
+++ b/AutoRest/Generators/NodeJS/NodeJS.Tests/AcceptanceTests/acceptanceTests.ts
@@ -1746,7 +1746,7 @@ describe('nodejs', function () {
       });
 
       it('should correctly accept file via body', function(done) {
-        testClient.formdata.uploadFileViaBody(fs.createReadStream(__dirname + '/sample.png'), 'sample.png', function(error, result) {
+        testClient.formdata.uploadFileViaBody(fs.createReadStream(__dirname + '/sample.png'), function(error, result) {
           should.not.exist(error);
           should.exist(result);
           readStreamToBuffer(result, function(err, buff) {

--- a/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/BodyFormData/operations/formdata.js
+++ b/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/BodyFormData/operations/formdata.js
@@ -149,9 +149,6 @@ Formdata.prototype.uploadFile = function (fileContent, fileName, options, callba
  *
  * @param {object} fileContent File to upload.
  * 
- * @param {string} fileName File name to upload. Name has to be spelled
- * exactly as written here.
- * 
  * @param {object} [options] Optional Parameters.
  * 
  * @param {object} [options.customHeaders] Headers that will be added to the
@@ -169,7 +166,7 @@ Formdata.prototype.uploadFile = function (fileContent, fileName, options, callba
  *
  *                      {stream} [response] - The HTTP Response stream if an error did not occur.
  */
-Formdata.prototype.uploadFileViaBody = function (fileContent, fileName, options, callback) {
+Formdata.prototype.uploadFileViaBody = function (fileContent, options, callback) {
   var client = this.client;
   if(!callback && typeof options === 'function') {
     callback = options;
@@ -182,9 +179,6 @@ Formdata.prototype.uploadFileViaBody = function (fileContent, fileName, options,
   try {
     if (fileContent === null || fileContent === undefined) {
       throw new Error('fileContent cannot be null or undefined and it must be of type object.');
-    }
-    if (fileName === null || fileName === undefined || typeof fileName.valueOf() !== 'string') {
-      throw new Error('fileName cannot be null or undefined and it must be of type string.');
     }
   } catch (error) {
     return callback(error);

--- a/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/BodyFormData/operations/index.d.ts
+++ b/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/BodyFormData/operations/index.d.ts
@@ -45,9 +45,6 @@ export interface Formdata {
      *
      * @param {object} fileContent File to upload.
      * 
-     * @param {string} fileName File name to upload. Name has to be spelled
-     * exactly as written here.
-     * 
      * @param {object} [options] Optional Parameters.
      * 
      * @param {object} [options.customHeaders] Headers that will be added to the
@@ -56,6 +53,6 @@ export interface Formdata {
      * @param {ServiceCallback} [callback] callback function; see ServiceCallback
      * doc in ms-rest index.d.ts for details
      */
-    uploadFileViaBody(fileContent: stream.Readable, fileName: string, options: { customHeaders? : { [headerName: string]: string; } }, callback: ServiceCallback<stream.Readable>): void;
-    uploadFileViaBody(fileContent: stream.Readable, fileName: string, callback: ServiceCallback<stream.Readable>): void;
+    uploadFileViaBody(fileContent: stream.Readable, options: { customHeaders? : { [headerName: string]: string; } }, callback: ServiceCallback<stream.Readable>): void;
+    uploadFileViaBody(fileContent: stream.Readable, callback: ServiceCallback<stream.Readable>): void;
 }

--- a/AutoRest/Generators/Python/Python.Tests/AcceptanceTests/form_data_tests.py
+++ b/AutoRest/Generators/Python/Python.Tests/AcceptanceTests/form_data_tests.py
@@ -165,15 +165,14 @@ class FormDataTests(unittest.TestCase):
         
         result = io.BytesIO()
         with io.BytesIO(test_bytes) as stream_data:
-            resp = client.formdata.upload_file_via_body(stream_data, "UploadFile.txt", callback=test_callback)
+            resp = client.formdata.upload_file_via_body(stream_data, callback=test_callback)
             for r in resp:
                 result.write(r)
             self.assertEqual(result.getvalue().decode(), test_string)
 
-        name = os.path.basename(self.dummy_file)
         result = io.BytesIO()
         with open(self.dummy_file, 'rb') as upload_data:
-            resp = client.formdata.upload_file_via_body(upload_data, name, callback=test_callback)
+            resp = client.formdata.upload_file_via_body(upload_data, callback=test_callback)
             for r in resp:
                 print(r)
                 result.write(r)

--- a/AutoRest/Generators/Python/Python.Tests/AcceptanceTests/form_data_tests.py
+++ b/AutoRest/Generators/Python/Python.Tests/AcceptanceTests/form_data_tests.py
@@ -188,15 +188,14 @@ class FormDataTests(unittest.TestCase):
         test_bytes = bytearray(test_string, encoding='utf-8')
         result = io.BytesIO()
         with io.BytesIO(test_bytes) as stream_data:
-            resp = client.formdata.upload_file_via_body(stream_data, "UploadFile.txt")
+            resp = client.formdata.upload_file_via_body(stream_data)
             for r in resp:
                 result.write(r)
             self.assertEqual(result.getvalue().decode(), test_string)
 
-        name = os.path.basename(self.dummy_file)
         result = io.BytesIO()
         with open(self.dummy_file, 'rb') as upload_data:
-            resp = client.formdata.upload_file_via_body(upload_data, name, raw=True)
+            resp = client.formdata.upload_file_via_body(upload_data, raw=True)
             for r in resp.output:
                 result.write(r)
             self.assertEqual(result.getvalue().decode(), "Test file")

--- a/AutoRest/Generators/Python/Python.Tests/Expected/AcceptanceTests/BodyFormData/autorestswaggerbatformdataservice/operations/formdata.py
+++ b/AutoRest/Generators/Python/Python.Tests/Expected/AcceptanceTests/BodyFormData/autorestswaggerbatformdataservice/operations/formdata.py
@@ -93,15 +93,12 @@ class Formdata(object):
         return deserialized
 
     def upload_file_via_body(
-            self, file_content, file_name, custom_headers={}, raw=False, callback=None, **operation_config):
+            self, file_content, custom_headers={}, raw=False, callback=None, **operation_config):
         """
         Upload file
 
         :param file_content: File to upload.
         :type file_content: Generator
-        :param file_name: File name to upload. Name has to be spelled exactly
-         as written here.
-        :type file_name: str
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
          deserialized response

--- a/AutoRest/TestServer/server/app.js
+++ b/AutoRest/TestServer/server/app.js
@@ -482,6 +482,7 @@ app.use(function(req, res, next) {
 
 app.use(function(err, req, res, next) {
   res.status(err.status || 500);
+  console.log(err.stack);
   res.end(JSON.stringify(err));
 });
 

--- a/AutoRest/TestServer/server/app.js
+++ b/AutoRest/TestServer/server/app.js
@@ -482,7 +482,6 @@ app.use(function(req, res, next) {
 
 app.use(function(err, req, res, next) {
   res.status(err.status || 500);
-  console.log(err.stack);
   res.end(JSON.stringify(err));
 });
 

--- a/AutoRest/TestServer/server/routes/formData.js
+++ b/AutoRest/TestServer/server/routes/formData.js
@@ -35,6 +35,7 @@ var formData = function (coverage) {
   coverage['StreamUploadFile'] = 0;
   router.put('/stream/uploadfile', function (req, res, next) {
     coverage['StreamUploadFile']++;
+    console.log(req.body);
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     req.pipe(res);
   });

--- a/AutoRest/TestServer/server/routes/formData.js
+++ b/AutoRest/TestServer/server/routes/formData.js
@@ -35,7 +35,6 @@ var formData = function (coverage) {
   coverage['StreamUploadFile'] = 0;
   router.put('/stream/uploadfile', function (req, res, next) {
     coverage['StreamUploadFile']++;
-    console.log(req.body);
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     req.pipe(res);
   });

--- a/AutoRest/TestServer/swagger/body-formdata.json
+++ b/AutoRest/TestServer/swagger/body-formdata.json
@@ -81,13 +81,6 @@
                 "type": "object",
                 "format": "file"
             }
-          },
-          {
-            "name": "fileName",
-            "description": "File name to upload. Name has to be spelled exactly as written here.",
-            "required": true,
-            "in": "formData",
-            "type": "string"
           }
         ],
         "responses": {

--- a/Samples/petstore/Java/SwaggerPetstore.java
+++ b/Samples/petstore/Java/SwaggerPetstore.java
@@ -404,7 +404,7 @@ public interface SwaggerPetstore {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> uploadFile(long petId, String additionalMetadata, InputStream file) throws ServiceException, IOException;
+    ServiceResponse<Void> uploadFile(long petId, String additionalMetadata, byte[] file) throws ServiceException, IOException;
 
     /**
      * uploads an image.
@@ -416,7 +416,7 @@ public interface SwaggerPetstore {
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link ServiceCall} object
      */
-    ServiceCall uploadFileAsync(long petId, String additionalMetadata, InputStream file, final ServiceCallback<Void> serviceCallback) throws IllegalArgumentException;
+    ServiceCall uploadFileAsync(long petId, String additionalMetadata, byte[] file, final ServiceCallback<Void> serviceCallback) throws IllegalArgumentException;
 
     /**
      * Returns pet inventories by status.

--- a/Samples/petstore/Java/SwaggerPetstoreImpl.java
+++ b/Samples/petstore/Java/SwaggerPetstoreImpl.java
@@ -151,7 +151,7 @@ public final class SwaggerPetstoreImpl extends ServiceClient implements SwaggerP
         @GET("pet/{petId}")
         Call<ResponseBody> getPetById(@Path("petId") long petId);
 
-        @Headers("Content-Type: application/x-www-form-urlencoded")
+        @Multipart
         @POST("pet/{petId}")
         Call<ResponseBody> updatePetWithForm(@Path("petId") String petId, @Part("name") String name, @Part("status") String status);
 
@@ -159,7 +159,7 @@ public final class SwaggerPetstoreImpl extends ServiceClient implements SwaggerP
         @HTTP(path = "pet/{petId}", method = "DELETE", hasBody = true)
         Call<ResponseBody> deletePet(@Path("petId") long petId, @Header("api_key") String apiKey);
 
-        @Headers("Content-Type: multipart/form-data")
+        @Multipart
         @POST("pet/{petId}/uploadImage")
         Call<ResponseBody> uploadFile(@Path("petId") long petId, @Part("additionalMetadata") String additionalMetadata, @Part("file") RequestBody file);
 

--- a/Samples/petstore/Java/SwaggerPetstoreImpl.java
+++ b/Samples/petstore/Java/SwaggerPetstoreImpl.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import petstore.models.Order;
 import petstore.models.Pet;
@@ -31,6 +33,8 @@ import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.Headers;
 import retrofit2.http.HTTP;
+import retrofit2.http.Multipart;
+import retrofit2.http.Part;
 import retrofit2.http.Path;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
@@ -149,7 +153,7 @@ public final class SwaggerPetstoreImpl extends ServiceClient implements SwaggerP
 
         @Headers("Content-Type: application/x-www-form-urlencoded")
         @POST("pet/{petId}")
-        Call<ResponseBody> updatePetWithForm(@Path("petId") String petId, String name, String status);
+        Call<ResponseBody> updatePetWithForm(@Path("petId") String petId, @Part("name") String name, @Part("status") String status);
 
         @Headers("Content-Type: application/json; charset=utf-8")
         @HTTP(path = "pet/{petId}", method = "DELETE", hasBody = true)
@@ -157,7 +161,7 @@ public final class SwaggerPetstoreImpl extends ServiceClient implements SwaggerP
 
         @Headers("Content-Type: multipart/form-data")
         @POST("pet/{petId}/uploadImage")
-        Call<ResponseBody> uploadFile(@Path("petId") long petId, String additionalMetadata, InputStream file);
+        Call<ResponseBody> uploadFile(@Path("petId") long petId, @Part("additionalMetadata") String additionalMetadata, @Part("file") RequestBody file);
 
         @Headers("Content-Type: application/json; charset=utf-8")
         @GET("store/inventory")
@@ -970,7 +974,7 @@ public final class SwaggerPetstoreImpl extends ServiceClient implements SwaggerP
     public ServiceResponse<Void> uploadFile(long petId) throws ServiceException, IOException {
         String additionalMetadata = null;
         InputStream file = null;
-        Call<ResponseBody> call = service.uploadFile(petId, additionalMetadata, file);
+        Call<ResponseBody> call = service.uploadFile(petId, additionalMetadata, RequestBody.create(MediaType.parse("multipart/form-data"), file));
         return uploadFileDelegate(call.execute());
     }
 
@@ -988,7 +992,7 @@ public final class SwaggerPetstoreImpl extends ServiceClient implements SwaggerP
         }
         final String additionalMetadata = null;
         final InputStream file = null;
-        Call<ResponseBody> call = service.uploadFile(petId, additionalMetadata, file);
+        Call<ResponseBody> call = service.uploadFile(petId, additionalMetadata, RequestBody.create(MediaType.parse("multipart/form-data"), file));
         final ServiceCall serviceCall = new ServiceCall(call);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
             @Override
@@ -1013,8 +1017,8 @@ public final class SwaggerPetstoreImpl extends ServiceClient implements SwaggerP
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> uploadFile(long petId, String additionalMetadata, InputStream file) throws ServiceException, IOException {
-        Call<ResponseBody> call = service.uploadFile(petId, additionalMetadata, file);
+    public ServiceResponse<Void> uploadFile(long petId, String additionalMetadata, byte[] file) throws ServiceException, IOException {
+        Call<ResponseBody> call = service.uploadFile(petId, additionalMetadata, RequestBody.create(MediaType.parse("multipart/form-data"), file));
         return uploadFileDelegate(call.execute());
     }
 
@@ -1028,11 +1032,11 @@ public final class SwaggerPetstoreImpl extends ServiceClient implements SwaggerP
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link Call} object
      */
-    public ServiceCall uploadFileAsync(long petId, String additionalMetadata, InputStream file, final ServiceCallback<Void> serviceCallback) throws IllegalArgumentException {
+    public ServiceCall uploadFileAsync(long petId, String additionalMetadata, byte[] file, final ServiceCallback<Void> serviceCallback) throws IllegalArgumentException {
         if (serviceCallback == null) {
             throw new IllegalArgumentException("ServiceCallback is required for async calls.");
         }
-        Call<ResponseBody> call = service.uploadFile(petId, additionalMetadata, file);
+        Call<ResponseBody> call = service.uploadFile(petId, additionalMetadata, RequestBody.create(MediaType.parse("multipart/form-data"), file));
         final ServiceCall serviceCall = new ServiceCall(call);
         call.enqueue(new ServiceResponseCallback<Void>(serviceCallback) {
             @Override


### PR DESCRIPTION
In body-formdata.json, fileName in `formData` with another `body` parameter is removed - in [2.0 spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md), there is a description about form data parameters: 

> they cannot be declared together with a body parameter for the same operation.