### PR TITLE
Fix PythonSDK bug 544

### DIFF
--- a/ClientRuntimes/Python/msrest/msrest/serialization.py
+++ b/ClientRuntimes/Python/msrest/msrest/serialization.py
@@ -770,6 +770,8 @@ class Deserializer(object):
         :rtype: dict
         :raises: TypeError if non-builtin datatype encountered.
         """
+        if attr is None:
+            return None
         if isinstance(attr, basestring):
             return self.deserialize_basic(attr, 'str')
         obj_type = type(attr)


### PR DESCRIPTION
Fix this bug https://github.com/Azure/azure-sdk-for-python/issues/544

In fact, sometimes JSON properties of generic resource can contains `null` value (ServerFarms) and this was not handled by the deserializer.

```json
{
  "id": "/subscriptions/X/resourceGroups/X/providers/Microsoft.Web/serverfarms/X",
  "name": "X",
  "type": "Microsoft.Web/serverfarms",
  "location": "West US",
  "tags": null,
  "properties": {
    "serverFarmId": 0,
    "name": "X",
    "workerSize": 0,
    "workerSizeId": 0,
    "workerTierName": null,
    "numberOfWorkers": 1,
    "currentWorkerSize": 0,
    "currentWorkerSizeId": 0,
    "currentNumberOfWorkers": 1,
    "status": 0,
    "webSpace": "X",
    "subscription": "X",
    "adminSiteName": null,
    "hostingEnvironment": null,
    "hostingEnvironmentProfile": null,
    "maximumNumberOfWorkers": 10,
    "planName": "VirtualDedicatedPlan",
    "adminRuntimeSiteName": null,
    "computeMode": 0,
    "siteMode": null,
    "geoRegion": "West US",
    "perSiteScaling": false,
    "numberOfSites": 2,
    "hostingEnvironmentId": null,
    "tags": null,
    "kind": null,
    "resourceGroup": "X"
  },
  "sku": {
    "name": "S1",
    "tier": "Standard",
    "size": "S1",
    "family": "S",
    "capacity": 1
  }
}
```