### PR TITLE
Change file upload type to java.io.File

### DIFF
--- a/AutoRest/Generators/Java/Azure.Java/TemplateModels/AzureMethodTemplateModel.cs
+++ b/AutoRest/Generators/Java/Azure.Java/TemplateModels/AzureMethodTemplateModel.cs
@@ -112,7 +112,14 @@ namespace Microsoft.Rest.Generator.Java.Azure
                     List<string> declarations = new List<string>();
                     foreach (var parameter in LocalParameters.Where(p => !p.IsConstant))
                     {
-                        declarations.Add("final " + parameter.Type.ToString() + " " + parameter.Name);
+                        if (parameter.Type.IsPrimaryType(KnownPrimaryType.Stream))
+                        {
+                            declarations.Add("final File " + parameter.Name);
+                        }
+                        else
+                        {
+                            declarations.Add("final " + parameter.Type.ToString() + " " + parameter.Name);
+                        }
                     }
 
                     var declaration = string.Join(", ", declarations);

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperations.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperations.java
@@ -14,6 +14,8 @@ import com.microsoft.rest.ServiceCall;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceResponse;
 import fixtures.bodyformdata.models.ErrorException;
+
+import java.io.File;
 import java.io.InputStream;
 import java.io.IOException;
 
@@ -54,7 +56,7 @@ public interface FormdataOperations {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException;
+    ServiceResponse<InputStream> uploadFileViaBody(File fileContent) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Upload file.
@@ -64,6 +66,6 @@ public interface FormdataOperations {
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link ServiceCall} object
      */
-    ServiceCall uploadFileViaBodyAsync(byte[] fileContent, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException;
+    ServiceCall uploadFileViaBodyAsync(File fileContent, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException;
 
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperations.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperations.java
@@ -14,7 +14,6 @@ import com.microsoft.rest.ServiceCall;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceResponse;
 import fixtures.bodyformdata.models.ErrorException;
-
 import java.io.File;
 import java.io.InputStream;
 import java.io.IOException;
@@ -34,7 +33,7 @@ public interface FormdataOperations {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException;
+    ServiceResponse<InputStream> uploadFile(File fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Upload file.
@@ -45,7 +44,7 @@ public interface FormdataOperations {
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link ServiceCall} object
      */
-    ServiceCall uploadFileAsync(byte[] fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException;
+    ServiceCall uploadFileAsync(File fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException;
 
     /**
      * Upload file.

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperationsImpl.java
@@ -17,7 +17,6 @@ import com.microsoft.rest.ServiceResponse;
 import com.microsoft.rest.ServiceResponseBuilder;
 import com.microsoft.rest.ServiceResponseCallback;
 import fixtures.bodyformdata.models.ErrorException;
-
 import java.io.File;
 import java.io.InputStream;
 import java.io.IOException;
@@ -80,7 +79,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException {
+    public ServiceResponse<InputStream> uploadFile(File fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
@@ -100,7 +99,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link Call} object
      */
-    public ServiceCall uploadFileAsync(byte[] fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException {
+    public ServiceCall uploadFileAsync(File fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException {
         if (serviceCallback == null) {
             throw new IllegalArgumentException("ServiceCallback is required for async calls.");
         }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperationsImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/FormdataOperationsImpl.java
@@ -17,6 +17,8 @@ import com.microsoft.rest.ServiceResponse;
 import com.microsoft.rest.ServiceResponseBuilder;
 import com.microsoft.rest.ServiceResponseCallback;
 import fixtures.bodyformdata.models.ErrorException;
+
+import java.io.File;
 import java.io.InputStream;
 import java.io.IOException;
 import okhttp3.MediaType;
@@ -141,7 +143,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException {
+    public ServiceResponse<InputStream> uploadFileViaBody(File fileContent) throws ErrorException, IOException, IllegalArgumentException {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
@@ -157,7 +159,7 @@ public final class FormdataOperationsImpl implements FormdataOperations {
      * @throws IllegalArgumentException thrown if callback is null
      * @return the {@link Call} object
      */
-    public ServiceCall uploadFileViaBodyAsync(byte[] fileContent, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException {
+    public ServiceCall uploadFileViaBodyAsync(File fileContent, final ServiceCallback<InputStream> serviceCallback) throws IllegalArgumentException {
         if (serviceCallback == null) {
             throw new IllegalArgumentException("ServiceCallback is required for async calls.");
         }

--- a/AutoRest/Generators/Java/Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
@@ -19,21 +19,30 @@ public class FormdataTests {
 
     @BeforeClass
     public static void setup() {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder().connectTimeout(1, TimeUnit.MINUTES).readTimeout(1, TimeUnit.MINUTES).writeTimeout(1, TimeUnit.MINUTES);
         client = new AutoRestSwaggerBATFormDataServiceImpl("http://localhost.:3000");
     }
 
     @Test
     public void uploadFile() throws Exception {
-        String testString = "Upload file test case";
-        InputStream result = client.getFormdataOperations().uploadFile(testString.getBytes("UTF-8"), "UploadFile.txt").getBody();
-        Assert.assertEquals(testString, IOUtils.toString(result));
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("upload.txt").getFile());
+        InputStream result = client.getFormdataOperations().uploadFile(file, "sample.png").getBody();
+        try {
+            Assert.assertEquals(IOUtils.toString(new FileInputStream(file)), IOUtils.toString(result));
+        } finally {
+            result.close();
+        }
     }
 
     @Test
     public void uploadFileViaBody() throws Exception {
-        File file = new File("E:\\pycharm-community-4.5.4.exe");
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("upload.txt").getFile());
         InputStream result = client.getFormdataOperations().uploadFileViaBody(file).getBody();
-        result.close();
+        try {
+            Assert.assertEquals(IOUtils.toString(new FileInputStream(file)), IOUtils.toString(result));
+        } finally {
+            result.close();
+        }
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
@@ -5,17 +5,22 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 
+import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
 
 public class FormdataTests {
     private static AutoRestSwaggerBATFormDataService client;
 
     @BeforeClass
     public static void setup() {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder().connectTimeout(1, TimeUnit.MINUTES).readTimeout(1, TimeUnit.MINUTES).writeTimeout(1, TimeUnit.MINUTES);
         client = new AutoRestSwaggerBATFormDataServiceImpl("http://localhost.:3000");
-        client.setLogLevel(HttpLoggingInterceptor.Level.BODY);
     }
 
     @Test
@@ -27,8 +32,8 @@ public class FormdataTests {
 
     @Test
     public void uploadFileViaBody() throws Exception {
-        String testString = "Upload file test case";
-        InputStream result = client.getFormdataOperations().uploadFileViaBody(testString.getBytes("UTF-8")).getBody();
-        Assert.assertEquals(testString, IOUtils.toString(result));
+        File file = new File("E:\\pycharm-community-4.5.4.exe");
+        InputStream result = client.getFormdataOperations().uploadFileViaBody(file).getBody();
+        result.close();
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
@@ -8,11 +8,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
-
-import okhttp3.OkHttpClient;
-import okhttp3.logging.HttpLoggingInterceptor;
-import retrofit2.Retrofit;
 
 public class FormdataTests {
     private static AutoRestSwaggerBATFormDataService client;

--- a/AutoRest/Generators/Java/Java.Tests/src/test/resources/upload.txt
+++ b/AutoRest/Generators/Java/Java.Tests/src/test/resources/upload.txt
@@ -1,0 +1,1 @@
+The quick brown fox jumps over the lazy dog

--- a/AutoRest/Generators/Java/Java/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/Java/Java/TemplateModels/MethodTemplateModel.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Rest.Generator.Java
                 {
                     if (parameter.Type.IsPrimaryType(KnownPrimaryType.Stream))
                     {
-                        declarations.Add("byte[] " + parameter.Name);
+                        declarations.Add("File " + parameter.Name);
                     }
                     else
                     {
@@ -723,6 +723,10 @@ namespace Microsoft.Rest.Generator.Java
                         string exceptionImport = JavaCodeNamer.GetJavaException(ex, ServiceClient);
                         if (exceptionImport != null) imports.Add(JavaCodeNamer.GetJavaException(ex, ServiceClient));
                     });
+                if (this.Parameters.Any(p => p.Type.IsPrimaryType(KnownPrimaryType.Stream)))
+                {
+                    imports.Add("java.io.File");
+                }
                 return imports.ToList();
             }
         }
@@ -806,6 +810,10 @@ namespace Microsoft.Rest.Generator.Java
                         string exceptionImport = JavaCodeNamer.GetJavaException(ex, ServiceClient);
                         if (exceptionImport != null) imports.Add(JavaCodeNamer.GetJavaException(ex, ServiceClient));
                     });
+                if (this.Parameters.Any(p => p.Type.IsPrimaryType(KnownPrimaryType.Stream)))
+                {
+                    imports.Add("java.io.File");
+                }
                 return imports.ToList();
             }
         }

--- a/AutoRest/TestServer/server/routes/formData.js
+++ b/AutoRest/TestServer/server/routes/formData.js
@@ -35,7 +35,7 @@ var formData = function (coverage) {
   coverage['StreamUploadFile'] = 0;
   router.put('/stream/uploadfile', function (req, res, next) {
     coverage['StreamUploadFile']++;
-    res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     req.pipe(res);
   });
 }

--- a/AutoRest/TestServer/server/routes/formData.js
+++ b/AutoRest/TestServer/server/routes/formData.js
@@ -35,7 +35,7 @@ var formData = function (coverage) {
   coverage['StreamUploadFile'] = 0;
   router.put('/stream/uploadfile', function (req, res, next) {
     coverage['StreamUploadFile']++;
-    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
     req.pipe(res);
   });
 }

--- a/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
+++ b/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
@@ -109,7 +109,6 @@ public class AzureClient extends AzureServiceClient {
 
         // Check provisioning state
         while (!AzureAsyncOperation.getTerminalStatuses().contains(pollingState.getStatus())) {
-            System.err.println(pollingState.getStatus());
             Thread.sleep(pollingState.getDelayInMilliseconds());
 
             if (pollingState.getAzureAsyncOperationHeaderLink() != null
@@ -285,7 +284,6 @@ public class AzureClient extends AzureServiceClient {
         // Check provisioning state
         while (!AzureAsyncOperation.getTerminalStatuses().contains(pollingState.getStatus())) {
             Thread.sleep(pollingState.getDelayInMilliseconds());
-            System.err.println(pollingState.getStatus());
 
             if (pollingState.getAzureAsyncOperationHeaderLink() != null
                     && !pollingState.getAzureAsyncOperationHeaderLink().isEmpty()) {

--- a/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
+++ b/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
@@ -99,6 +99,7 @@ public class AzureClient extends AzureServiceClient {
             exception.setResponse(response);
             if (responseBody != null) {
                 exception.setBody((CloudError) mapperAdapter.deserialize(responseBody.string(), CloudError.class));
+                responseBody.close();
             }
             throw exception;
         }
@@ -108,6 +109,7 @@ public class AzureClient extends AzureServiceClient {
 
         // Check provisioning state
         while (!AzureAsyncOperation.getTerminalStatuses().contains(pollingState.getStatus())) {
+            System.err.println(pollingState.getStatus());
             Thread.sleep(pollingState.getDelayInMilliseconds());
 
             if (pollingState.getAzureAsyncOperationHeaderLink() != null
@@ -186,6 +188,7 @@ public class AzureClient extends AzureServiceClient {
             try {
                 if (responseBody != null) {
                     exception.setBody((CloudError) mapperAdapter.deserialize(responseBody.string(), CloudError.class));
+                    responseBody.close();
                 }
             } catch (Exception e) { /* ignore serialization errors on top of service errors */ }
             callback.failure(exception);
@@ -272,6 +275,7 @@ public class AzureClient extends AzureServiceClient {
             exception.setResponse(response);
             if (responseBody != null) {
                 exception.setBody((CloudError) mapperAdapter.deserialize(responseBody.string(), CloudError.class));
+                responseBody.close();
             }
             throw exception;
         }
@@ -281,6 +285,7 @@ public class AzureClient extends AzureServiceClient {
         // Check provisioning state
         while (!AzureAsyncOperation.getTerminalStatuses().contains(pollingState.getStatus())) {
             Thread.sleep(pollingState.getDelayInMilliseconds());
+            System.err.println(pollingState.getStatus());
 
             if (pollingState.getAzureAsyncOperationHeaderLink() != null
                     && !pollingState.getAzureAsyncOperationHeaderLink().isEmpty()) {
@@ -358,6 +363,7 @@ public class AzureClient extends AzureServiceClient {
             try {
                 if (responseBody != null) {
                     exception.setBody((CloudError) mapperAdapter.deserialize(responseBody.string(), CloudError.class));
+                    responseBody.close();
                 }
             } catch (Exception e) { /* ignore serialization errors on top of service errors */ }
             callback.failure(exception);
@@ -581,6 +587,7 @@ public class AzureClient extends AzureServiceClient {
         AzureAsyncOperation body = null;
         if (response.body() != null) {
             body = mapperAdapter.deserialize(response.body().string(), AzureAsyncOperation.class);
+            response.body().close();
         }
 
         if (body == null || body.getStatus() == null) {
@@ -588,6 +595,7 @@ public class AzureClient extends AzureServiceClient {
             exception.setResponse(response);
             if (response.errorBody() != null) {
                 exception.setBody((CloudError) mapperAdapter.deserialize(response.errorBody().string(), CloudError.class));
+                response.errorBody().close();
             }
             throw exception;
         }
@@ -619,12 +627,14 @@ public class AzureClient extends AzureServiceClient {
                     AzureAsyncOperation body = null;
                     if (result.getBody() != null) {
                         body = mapperAdapter.deserialize(result.getBody().string(), AzureAsyncOperation.class);
+                        result.getBody().close();
                     }
                     if (body == null || body.getStatus() == null) {
                         CloudException exception = new CloudException("no body");
                         exception.setResponse(result.getResponse());
                         if (result.getResponse().errorBody() != null) {
                             exception.setBody((CloudError) mapperAdapter.deserialize(result.getResponse().errorBody().string(), CloudError.class));
+                            result.getResponse().errorBody().close();
                         }
                         failure(exception);
                     } else {
@@ -664,8 +674,10 @@ public class AzureClient extends AzureServiceClient {
             exception.setResponse(response);
             if (response.body() != null) {
                 exception.setBody((CloudError) mapperAdapter.deserialize(response.body().string(), CloudError.class));
+                response.body().close();
             } else if (response.errorBody() != null) {
                 exception.setBody((CloudError) mapperAdapter.deserialize(response.errorBody().string(), CloudError.class));
+                response.errorBody().close();
             }
             throw exception;
         }
@@ -704,8 +716,10 @@ public class AzureClient extends AzureServiceClient {
                         exception.setResponse(response);
                         if (response.body() != null) {
                             exception.setBody((CloudError) mapperAdapter.deserialize(response.body().string(), CloudError.class));
+                            response.body().close();
                         } else if (response.errorBody() != null) {
                             exception.setBody((CloudError) mapperAdapter.deserialize(response.errorBody().string(), CloudError.class));
+                            response.errorBody().close();
                         }
                         callback.failure(exception);
                         return;

--- a/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
+++ b/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
@@ -60,6 +60,7 @@ public class PollingState<T> {
         PollingResource resource = null;
         if (response.body() != null) {
             responseContent = response.body().string();
+            response.body().close();
         }
         if (responseContent != null && !responseContent.isEmpty()) {
             this.resource = mapperAdapter.deserialize(responseContent, resourceType);
@@ -95,6 +96,7 @@ public class PollingState<T> {
         String responseContent = null;
         if (response.body() != null) {
             responseContent = response.body().string();
+            response.body().close();
         }
 
         if (responseContent == null || responseContent.isEmpty()) {
@@ -130,6 +132,7 @@ public class PollingState<T> {
         String responseContent = null;
         if (response.body() != null) {
             responseContent = response.body().string();
+            response.body().close();
         }
         this.setResource(mapperAdapter.<T>deserialize(responseContent, resourceType));
         setStatus(AzureAsyncOperation.SUCCESS_STATUS);

--- a/ClientRuntimes/Java/client-runtime/build.gradle
+++ b/ClientRuntimes/Java/client-runtime/build.gradle
@@ -24,7 +24,8 @@ checkstyle {
 dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
-    compile 'com.squareup.okhttp3:okhttp:3.1.2'
+    compile 'com.squareup.okhttp3:okhttp:3.2.0'
+    compile 'com.squareup.okio:okio:1.7.0-SNAPSHOT'
     compile 'com.squareup.okhttp3:logging-interceptor:3.1.1'
     compile 'com.squareup.okhttp3:okhttp-urlconnection:3.1.1'
     compile 'com.squareup.retrofit2:converter-jackson:2.0.0-beta4'

--- a/ClientRuntimes/Java/client-runtime/build.gradle
+++ b/ClientRuntimes/Java/client-runtime/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
     compile 'com.squareup.okhttp3:okhttp:3.2.0'
-    compile 'com.squareup.okio:okio:1.7.0-SNAPSHOT'
+    compile ('com.squareup.okio:okio:1.7.0-SNAPSHOT') { changing = true }
     compile 'com.squareup.okhttp3:logging-interceptor:3.1.1'
     compile 'com.squareup.okhttp3:okhttp-urlconnection:3.1.1'
     compile 'com.squareup.retrofit2:converter-jackson:2.0.0-beta4'

--- a/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceResponseBuilder.java
+++ b/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceResponseBuilder.java
@@ -181,6 +181,7 @@ public class ServiceResponseBuilder<T, E extends AutoRestException> {
             try {
                 E exception = (E) exceptionType.getConstructor(String.class).newInstance("Invalid status code " + statusCode);
                 exceptionType.getMethod("setResponse", response.getClass()).invoke(exception, response);
+                response.errorBody().close();
                 throw exception;
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 throw new IOException("Invalid status code " + statusCode + ", but an instance of " + exceptionType.getCanonicalName()
@@ -213,6 +214,7 @@ public class ServiceResponseBuilder<T, E extends AutoRestException> {
         THeader headers = mapperAdapter.deserialize(
                 mapperAdapter.serialize(response.headers()),
                 headerType);
+        response.errorBody().close();
         return new ServiceResponseWithHeaders<>(bodyResponse.getBody(), headers, bodyResponse.getResponse());
     }
 
@@ -238,6 +240,7 @@ public class ServiceResponseBuilder<T, E extends AutoRestException> {
         THeader headers = mapperAdapter.deserialize(
                 mapperAdapter.serialize(response.headers()),
                 headerType);
+        response.errorBody().close();
         return new ServiceResponseWithHeaders<>(headers, bodyResponse.getHeadResponse());
     }
 
@@ -277,6 +280,7 @@ public class ServiceResponseBuilder<T, E extends AutoRestException> {
         // Deserialize
         else {
             String responseContent = responseBody.string();
+            responseBody.close();
             if (responseContent.length() <= 0) {
                 return null;
             }

--- a/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceResponseBuilder.java
+++ b/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceResponseBuilder.java
@@ -270,7 +270,9 @@ public class ServiceResponseBuilder<T, E extends AutoRestException> {
         }
         // Return raw response if InputStream is the target type
         else if (type == InputStream.class) {
-            return responseBody.byteStream();
+            InputStream stream = responseBody.byteStream();
+            responseBody.close();
+            return stream;
         }
         // Deserialize
         else {

--- a/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceResponseBuilder.java
+++ b/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceResponseBuilder.java
@@ -214,7 +214,6 @@ public class ServiceResponseBuilder<T, E extends AutoRestException> {
         THeader headers = mapperAdapter.deserialize(
                 mapperAdapter.serialize(response.headers()),
                 headerType);
-        response.errorBody().close();
         return new ServiceResponseWithHeaders<>(bodyResponse.getBody(), headers, bodyResponse.getResponse());
     }
 
@@ -240,7 +239,6 @@ public class ServiceResponseBuilder<T, E extends AutoRestException> {
         THeader headers = mapperAdapter.deserialize(
                 mapperAdapter.serialize(response.headers()),
                 headerType);
-        response.errorBody().close();
         return new ServiceResponseWithHeaders<>(headers, bodyResponse.getHeadResponse());
     }
 

--- a/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/retry/RetryHandler.java
+++ b/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/retry/RetryHandler.java
@@ -67,6 +67,7 @@ public class RetryHandler implements Interceptor {
 
         // try the request
         Response response = chain.proceed(request);
+        response.body().close();
 
         int tryCount = 0;
         while (retryStrategy.shouldRetry(tryCount, response)) {

--- a/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/retry/RetryHandler.java
+++ b/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/retry/RetryHandler.java
@@ -67,11 +67,11 @@ public class RetryHandler implements Interceptor {
 
         // try the request
         Response response = chain.proceed(request);
-        response.body().close();
 
         int tryCount = 0;
         while (retryStrategy.shouldRetry(tryCount, response)) {
             tryCount++;
+            response.body().close();
             // retry the request
             response = chain.proceed(request);
         }

--- a/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/retry/RetryHandler.java
+++ b/ClientRuntimes/Java/client-runtime/src/main/java/com/microsoft/rest/retry/RetryHandler.java
@@ -71,7 +71,9 @@ public class RetryHandler implements Interceptor {
         int tryCount = 0;
         while (retryStrategy.shouldRetry(tryCount, response)) {
             tryCount++;
-            response.body().close();
+            if (response.body() != null) {
+                response.body().close();
+            }
             // retry the request
             response = chain.proceed(request);
         }


### PR DESCRIPTION
So that OkHttp will stream directly from file stream to socket stream.

There seems to be a significant performance downturn when the file hits > 512k. Running against some other online services confirmed it's an issue for our Express server. Will need run against Azure to see how well it really performs.