### PR TITLE
Allows to parse integer as enum valid values

### DIFF
--- a/ClientRuntimes/Python/msrest/msrest/serialization.py
+++ b/ClientRuntimes/Python/msrest/msrest/serialization.py
@@ -850,6 +850,12 @@ class Deserializer(object):
         :rtype: Enum
         :raises: DeserializationError if string is not valid enum value.
         """
+        if isinstance(data, int):
+            try:
+                return list(enum_obj.__members__.values())[data]
+            except IndexError:
+                error = "{!r} is not a valid index for enum {!r}"
+                raise DeserializationError(error.format(data, enum_obj))
         try:
             return enum_obj(str(data))
         except ValueError:

--- a/ClientRuntimes/Python/msrest/msrest/serialization.py
+++ b/ClientRuntimes/Python/msrest/msrest/serialization.py
@@ -851,6 +851,8 @@ class Deserializer(object):
         :raises: DeserializationError if string is not valid enum value.
         """
         if isinstance(data, int):
+            # Workaround. We might consider remove it in the future.
+            # https://github.com/Azure/azure-rest-api-specs/issues/141
             try:
                 return list(enum_obj.__members__.values())[data]
             except IndexError:


### PR DESCRIPTION
Hi,

This commit allows `msrest` to parse integer as valid enum value. Currently, only strings are accepted.
If some cases like this:
https://github.com/Azure/azure-rest-api-specs/issues/141
https://github.com/Azure/azure-rest-api-specs/issues/137

The REST API uses (wrongly) integer as enum value.

*this is a workaround which allows to be more robust for some ARM answer*. Otherwise, we will fail to parse the result, even if the specific enum value is not necessary (for instance, creating a App Service).

@zooba ran into this during his //build/ demo. 

We might want to log a warning. Tell me if you think it's necessary.