### PR TITLE
Fix status code validation in java client

### DIFF
--- a/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
+++ b/ClientRuntimes/Java/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
@@ -355,7 +355,7 @@ public class AzureClient extends AzureServiceClient {
         } else {
             responseBody = response.errorBody();
         }
-        if (statusCode != 200 && statusCode != 201 && statusCode != 202) {
+        if (statusCode != 200 && statusCode != 202 && statusCode != 204) {
             CloudException exception = new CloudException(statusCode + " is not a valid polling status code");
             exception.setResponse(response);
             try {


### PR DESCRIPTION
This is the fix for issue Azure/azure-sdk-for-java#628 where in `AzureClient` in `getPostOrDeleteResult()` and `getPostOrDeleteResultAsync()` methods was used different status code validation.