### PR TITLE
Adding a User-Agent header to the request done in FileSystem.ReadFileAsText

### DIFF
--- a/AutoRest/AutoRest.Core/Utilities/FileSystem.cs
+++ b/AutoRest/AutoRest.Core/Utilities/FileSystem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Rest.Generator.Utilities
         {
             using (var client = new WebClient())
             {
+                client.Headers.Add("User-Agent: AutoRest");
                 return client.DownloadString(path);
             }
         }


### PR DESCRIPTION
Fixes problem in issue #940 
(Not being able to read the swagger json definition from a URL if the API requires a User-Agent header)