### PR TITLE
Adding support for Unix time formatted dates in C#

### DIFF
--- a/AutoRest/AutoRest.Core/ClientModel/KnownPrimaryType.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/KnownPrimaryType.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Rest.Generator.ClientModel
         Boolean,
         Credentials,
         Uuid,
-        Base64Url
+        Base64Url,
+        UnixTime
     }
 }

--- a/AutoRest/AutoRest.Core/Utilities/Extensions.cs
+++ b/AutoRest/AutoRest.Core/Utilities/Extensions.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Rest.Generator.Utilities
         }
 
         /// <summary>
-        /// Returns true is the type is a PrimaryType with KnownPrimaryType matching typeToMatch.
+        /// Returns true if the type is a PrimaryType with KnownPrimaryType matching typeToMatch.
         /// </summary>
         /// <param name="type"></param>
         /// <param name="typeToMatch"></param>
@@ -262,6 +262,55 @@ namespace Microsoft.Rest.Generator.Utilities
                 return primaryType.Type == typeToMatch;
             }
             return false;
+        }
+
+        /// <summary>
+        /// Returns true if the <paramref name="type"/> is a PrimaryType with KnownPrimaryType matching <paramref name="typeToMatch"/>
+        /// or a DictionaryType with ValueType matching <paramref name="typeToMatch"/> or a SequenceType matching <paramref name="typeToMatch"/>
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="typeToMatch"></param>
+        /// <returns></returns>
+        public static bool IsOrContainsPrimaryType(this IType type, KnownPrimaryType typeToMatch)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (type.IsPrimaryType(typeToMatch) ||
+                type.IsDictionaryContainingType(typeToMatch) ||
+                type.IsSequenceContainingType(typeToMatch))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if the <paramref name="type"/> is a DictionaryType with ValueType matching <paramref name="typeToMatch"/>
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="typeToMatch"></param>
+        /// <returns></returns>
+        public static bool IsDictionaryContainingType(this IType type, KnownPrimaryType typeToMatch)
+        {
+            DictionaryType dictionaryType = type as DictionaryType;
+            PrimaryType dictionaryPrimaryType = dictionaryType?.ValueType as PrimaryType;
+            return dictionaryPrimaryType != null && dictionaryPrimaryType.IsPrimaryType(typeToMatch);
+        }
+
+        /// <summary>
+        /// Returns true if the <paramref name="type"/>is a SequenceType matching <paramref name="typeToMatch"/>
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="typeToMatch"></param>
+        /// <returns></returns>
+        public static bool IsSequenceContainingType(this IType type, KnownPrimaryType typeToMatch)
+        {
+            SequenceType sequenceType = type as SequenceType;
+            PrimaryType sequencePrimaryType = sequenceType?.ElementType as PrimaryType;
+            return sequencePrimaryType != null && sequencePrimaryType.IsPrimaryType(typeToMatch);
         }
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/AcceptanceTests.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/AcceptanceTests.cs
@@ -198,12 +198,16 @@ namespace Microsoft.Rest.Generator.CSharp.Tests
             client.IntModel.PutMin32(Int32.MinValue);
             client.IntModel.PutMax64(Int64.MaxValue);
             client.IntModel.PutMin64(Int64.MinValue);
+            client.IntModel.PutUnixTimeDate(new DateTime(2016, 4, 13, 0, 0, 0));
             client.IntModel.GetNull();
             Assert.Throws<SerializationException>(() => client.IntModel.GetInvalid());
             Assert.Throws<SerializationException>(() => client.IntModel.GetOverflowInt32());
             Assert.Throws<SerializationException>(() => client.IntModel.GetOverflowInt64());
             Assert.Throws<SerializationException>(() => client.IntModel.GetUnderflowInt32());
             Assert.Throws<SerializationException>(() => client.IntModel.GetUnderflowInt64());
+            Assert.Throws<SerializationException>(() => client.IntModel.GetInvalidUnixTime());
+            Assert.Null(client.IntModel.GetNullUnixTime());
+            Assert.Equal(new DateTime(2016, 4, 13, 0, 0, 0), client.IntModel.GetUnixTime());
         }
 
         [Fact]

--- a/AutoRest/Generators/CSharp/CSharp.Tests/AcceptanceTests.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/AcceptanceTests.cs
@@ -1355,6 +1355,7 @@ namespace Microsoft.Rest.Generator.CSharp.Tests
                 client.Paths.Base64Url(Encoding.UTF8.GetBytes("lorem"));
                 var testArray = new List<string> { "ArrayPath1", @"begin!*'();:@ &=+$,/?#[]end", null, "" };
                 client.Paths.ArrayCsvInPath(testArray);
+                client.Paths.UnixTimeUrl(new DateTime(2016, 4, 13, 0, 0, 0));
             }
         }
 

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/IIntModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/IIntModel.cs
@@ -129,5 +129,47 @@ namespace Fixtures.AcceptanceTestsBodyInteger
         /// The cancellation token.
         /// </param>
         Task<HttpOperationResponse> PutMin64WithHttpMessagesAsync(long intBody, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Get datetime encoded as Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse<DateTime?>> GetUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Put datetime encoded as Unix time
+        /// </summary>
+        /// <param name='intBody'>
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse> PutUnixTimeDateWithHttpMessagesAsync(DateTime intBody, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Get invalid Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse<DateTime?>> GetInvalidUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Get null Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse<DateTime?>> GetNullUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/IntModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/IntModel.cs
@@ -1202,5 +1202,472 @@ namespace Fixtures.AcceptanceTestsBodyInteger
             return _result;
         }
 
+        /// <summary>
+        /// Get datetime encoded as Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse<DateTime?>> GetUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "GetUnixTime", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "int/unixtime").ToString();
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse<DateTime?>();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            // Deserialize Response
+            if ((int)_statusCode == 200)
+            {
+                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    _result.Body = SafeJsonConvert.DeserializeObject<DateTime?>(_responseContent, new UnixTimeJsonConverter());
+                }
+                catch (JsonException ex)
+                {
+                    _httpRequest.Dispose();
+                    if (_httpResponse != null)
+                    {
+                        _httpResponse.Dispose();
+                    }
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                }
+            }
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
+        /// Put datetime encoded as Unix time
+        /// </summary>
+        /// <param name='intBody'>
+        /// </param>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse> PutUnixTimeDateWithHttpMessagesAsync(DateTime intBody, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("intBody", intBody);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "PutUnixTimeDate", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "int/unixtime").ToString();
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("PUT");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            if(intBody != null)
+            {
+                _requestContent = SafeJsonConvert.SerializeObject(intBody, new UnixTimeJsonConverter());
+                _httpRequest.Content = new StringContent(_requestContent, Encoding.UTF8);
+                _httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+            }
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
+        /// Get invalid Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse<DateTime?>> GetInvalidUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "GetInvalidUnixTime", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "int/invalidunixtime").ToString();
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse<DateTime?>();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            // Deserialize Response
+            if ((int)_statusCode == 200)
+            {
+                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    _result.Body = SafeJsonConvert.DeserializeObject<DateTime?>(_responseContent, new UnixTimeJsonConverter());
+                }
+                catch (JsonException ex)
+                {
+                    _httpRequest.Dispose();
+                    if (_httpResponse != null)
+                    {
+                        _httpResponse.Dispose();
+                    }
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                }
+            }
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
+        /// Get null Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse<DateTime?>> GetNullUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "GetNullUnixTime", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "int/nullunixtime").ToString();
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse<DateTime?>();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            // Deserialize Response
+            if ((int)_statusCode == 200)
+            {
+                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    _result.Body = SafeJsonConvert.DeserializeObject<DateTime?>(_responseContent, new UnixTimeJsonConverter());
+                }
+                catch (JsonException ex)
+                {
+                    _httpRequest.Dispose();
+                    if (_httpResponse != null)
+                    {
+                        _httpResponse.Dispose();
+                    }
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                }
+            }
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/IntModelExtensions.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/IntModelExtensions.cs
@@ -305,5 +305,118 @@ namespace Fixtures.AcceptanceTestsBodyInteger
                 await operations.PutMin64WithHttpMessagesAsync(intBody, null, cancellationToken).ConfigureAwait(false);
             }
 
+            /// <summary>
+            /// Get datetime encoded as Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            public static DateTime? GetUnixTime(this IIntModel operations)
+            {
+                return Task.Factory.StartNew(s => ((IIntModel)s).GetUnixTimeAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get datetime encoded as Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task<DateTime?> GetUnixTimeAsync(this IIntModel operations, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                using (var _result = await operations.GetUnixTimeWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false))
+                {
+                    return _result.Body;
+                }
+            }
+
+            /// <summary>
+            /// Put datetime encoded as Unix time
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='intBody'>
+            /// </param>
+            public static void PutUnixTimeDate(this IIntModel operations, DateTime intBody)
+            {
+                Task.Factory.StartNew(s => ((IIntModel)s).PutUnixTimeDateAsync(intBody), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Put datetime encoded as Unix time
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='intBody'>
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task PutUnixTimeDateAsync(this IIntModel operations, DateTime intBody, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                await operations.PutUnixTimeDateWithHttpMessagesAsync(intBody, null, cancellationToken).ConfigureAwait(false);
+            }
+
+            /// <summary>
+            /// Get invalid Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            public static DateTime? GetInvalidUnixTime(this IIntModel operations)
+            {
+                return Task.Factory.StartNew(s => ((IIntModel)s).GetInvalidUnixTimeAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get invalid Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task<DateTime?> GetInvalidUnixTimeAsync(this IIntModel operations, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                using (var _result = await operations.GetInvalidUnixTimeWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false))
+                {
+                    return _result.Body;
+                }
+            }
+
+            /// <summary>
+            /// Get null Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            public static DateTime? GetNullUnixTime(this IIntModel operations)
+            {
+                return Task.Factory.StartNew(s => ((IIntModel)s).GetNullUnixTimeAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get null Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task<DateTime?> GetNullUnixTimeAsync(this IIntModel operations, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                using (var _result = await operations.GetNullUnixTimeWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false))
+                {
+                    return _result.Body;
+                }
+            }
+
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/IIntModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/IIntModel.cs
@@ -129,5 +129,47 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient
         /// The cancellation token.
         /// </param>
         Task<HttpOperationResponse> PutMin64WithHttpMessagesAsync(long intBody, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Get datetime encoded as Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse<DateTime?>> GetUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Put datetime encoded as Unix time
+        /// </summary>
+        /// <param name='intBody'>
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse> PutUnixTimeDateWithHttpMessagesAsync(DateTime intBody, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Get invalid Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse<DateTime?>> GetInvalidUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Get null Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse<DateTime?>> GetNullUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/IntModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/IntModel.cs
@@ -1202,5 +1202,472 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient
             return _result;
         }
 
+        /// <summary>
+        /// Get datetime encoded as Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse<DateTime?>> GetUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "GetUnixTime", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "int/unixtime").ToString();
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse<DateTime?>();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            // Deserialize Response
+            if ((int)_statusCode == 200)
+            {
+                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    _result.Body = SafeJsonConvert.DeserializeObject<DateTime?>(_responseContent, new UnixTimeJsonConverter());
+                }
+                catch (JsonException ex)
+                {
+                    _httpRequest.Dispose();
+                    if (_httpResponse != null)
+                    {
+                        _httpResponse.Dispose();
+                    }
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                }
+            }
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
+        /// Put datetime encoded as Unix time
+        /// </summary>
+        /// <param name='intBody'>
+        /// </param>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse> PutUnixTimeDateWithHttpMessagesAsync(DateTime intBody, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("intBody", intBody);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "PutUnixTimeDate", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "int/unixtime").ToString();
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("PUT");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            if(intBody != null)
+            {
+                _requestContent = SafeJsonConvert.SerializeObject(intBody, new UnixTimeJsonConverter());
+                _httpRequest.Content = new StringContent(_requestContent, Encoding.UTF8);
+                _httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+            }
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
+        /// Get invalid Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse<DateTime?>> GetInvalidUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "GetInvalidUnixTime", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "int/invalidunixtime").ToString();
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse<DateTime?>();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            // Deserialize Response
+            if ((int)_statusCode == 200)
+            {
+                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    _result.Body = SafeJsonConvert.DeserializeObject<DateTime?>(_responseContent, new UnixTimeJsonConverter());
+                }
+                catch (JsonException ex)
+                {
+                    _httpRequest.Dispose();
+                    if (_httpResponse != null)
+                    {
+                        _httpResponse.Dispose();
+                    }
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                }
+            }
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
+        /// Get null Unix time value
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse<DateTime?>> GetNullUnixTimeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "GetNullUnixTime", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "int/nullunixtime").ToString();
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse<DateTime?>();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            // Deserialize Response
+            if ((int)_statusCode == 200)
+            {
+                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    _result.Body = SafeJsonConvert.DeserializeObject<DateTime?>(_responseContent, new UnixTimeJsonConverter());
+                }
+                catch (JsonException ex)
+                {
+                    _httpRequest.Dispose();
+                    if (_httpResponse != null)
+                    {
+                        _httpResponse.Dispose();
+                    }
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                }
+            }
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/IntModelExtensions.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/IntModelExtensions.cs
@@ -305,5 +305,118 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient
                 await operations.PutMin64WithHttpMessagesAsync(intBody, null, cancellationToken).ConfigureAwait(false);
             }
 
+            /// <summary>
+            /// Get datetime encoded as Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            public static DateTime? GetUnixTime(this IIntModel operations)
+            {
+                return Task.Factory.StartNew(s => ((IIntModel)s).GetUnixTimeAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get datetime encoded as Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task<DateTime?> GetUnixTimeAsync(this IIntModel operations, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                using (var _result = await operations.GetUnixTimeWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false))
+                {
+                    return _result.Body;
+                }
+            }
+
+            /// <summary>
+            /// Put datetime encoded as Unix time
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='intBody'>
+            /// </param>
+            public static void PutUnixTimeDate(this IIntModel operations, DateTime intBody)
+            {
+                Task.Factory.StartNew(s => ((IIntModel)s).PutUnixTimeDateAsync(intBody), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Put datetime encoded as Unix time
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='intBody'>
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task PutUnixTimeDateAsync(this IIntModel operations, DateTime intBody, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                await operations.PutUnixTimeDateWithHttpMessagesAsync(intBody, null, cancellationToken).ConfigureAwait(false);
+            }
+
+            /// <summary>
+            /// Get invalid Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            public static DateTime? GetInvalidUnixTime(this IIntModel operations)
+            {
+                return Task.Factory.StartNew(s => ((IIntModel)s).GetInvalidUnixTimeAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get invalid Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task<DateTime?> GetInvalidUnixTimeAsync(this IIntModel operations, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                using (var _result = await operations.GetInvalidUnixTimeWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false))
+                {
+                    return _result.Body;
+                }
+            }
+
+            /// <summary>
+            /// Get null Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            public static DateTime? GetNullUnixTime(this IIntModel operations)
+            {
+                return Task.Factory.StartNew(s => ((IIntModel)s).GetNullUnixTimeAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get null Unix time value
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task<DateTime?> GetNullUnixTimeAsync(this IIntModel operations, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                using (var _result = await operations.GetNullUnixTimeWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false))
+                {
+                    return _result.Body;
+                }
+            }
+
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/IPaths.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/IPaths.cs
@@ -305,5 +305,18 @@ namespace Fixtures.AcceptanceTestsUrl
         /// The cancellation token.
         /// </param>
         Task<HttpOperationResponse> ArrayCsvInPathWithHttpMessagesAsync(IList<string> arrayPath, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
+        /// </summary>
+        /// <param name='unixTimeUrlPath'>
+        /// Unix time encoded value
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse> UnixTimeUrlWithHttpMessagesAsync(DateTime unixTimeUrlPath, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/Paths.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/Paths.cs
@@ -2692,5 +2692,111 @@ namespace Fixtures.AcceptanceTestsUrl
             return _result;
         }
 
+        /// <summary>
+        /// Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
+        /// </summary>
+        /// <param name='unixTimeUrlPath'>
+        /// Unix time encoded value
+        /// </param>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse> UnixTimeUrlWithHttpMessagesAsync(DateTime unixTimeUrlPath, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("unixTimeUrlPath", unixTimeUrlPath);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "UnixTimeUrl", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "paths/int/1460505600/{unixTimeUrlPath}").ToString();
+            _url = _url.Replace("{unixTimeUrlPath}", Uri.EscapeDataString(SafeJsonConvert.SerializeObject(unixTimeUrlPath, new UnixTimeJsonConverter()).Trim('"')));
+            // Create HTTP transport objects
+            HttpRequestMessage _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new Uri(_url);
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200)
+            {
+                var ex = new ErrorException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Error _errorBody = SafeJsonConvert.DeserializeObject<Error>(_responseContent, this.Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/PathsExtensions.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/PathsExtensions.cs
@@ -712,5 +712,36 @@ namespace Fixtures.AcceptanceTestsUrl
                 await operations.ArrayCsvInPathWithHttpMessagesAsync(arrayPath, null, cancellationToken).ConfigureAwait(false);
             }
 
+            /// <summary>
+            /// Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='unixTimeUrlPath'>
+            /// Unix time encoded value
+            /// </param>
+            public static void UnixTimeUrl(this IPaths operations, DateTime unixTimeUrlPath)
+            {
+                Task.Factory.StartNew(s => ((IPaths)s).UnixTimeUrlAsync(unixTimeUrlPath), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='unixTimeUrlPath'>
+            /// Unix time encoded value
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task UnixTimeUrlAsync(this IPaths operations, DateTime unixTimeUrlPath, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                await operations.UnixTimeUrlWithHttpMessagesAsync(unixTimeUrlPath, null, cancellationToken).ConfigureAwait(false);
+            }
+
     }
 }

--- a/AutoRest/Generators/CSharp/CSharp/CSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/CSharp/CSharpCodeNamer.cs
@@ -297,6 +297,10 @@ namespace Microsoft.Rest.Generator.CSharp
             {
                 primaryType.Name = "ServiceClientCredentials";
             }
+            else if (primaryType.Type == KnownPrimaryType.UnixTime)
+            {
+                primaryType.Name = "DateTime";
+            }
             else if (primaryType.Type == KnownPrimaryType.Uuid)
             {
                 primaryType.Name = "Guid";
@@ -401,7 +405,8 @@ namespace Microsoft.Rest.Generator.CSharp
                             primaryType.Type == KnownPrimaryType.DateTimeRfc1123 ||
                             primaryType.Type == KnownPrimaryType.TimeSpan ||
                             primaryType.Type == KnownPrimaryType.ByteArray ||
-                            primaryType.Type == KnownPrimaryType.Base64Url)
+                            primaryType.Type == KnownPrimaryType.Base64Url ||
+                            primaryType.Type == KnownPrimaryType.UnixTime)
                         {
 
                             return "SafeJsonConvert.DeserializeObject<" + primaryType.Name.TrimEnd('?') +

--- a/AutoRest/Generators/CSharp/CSharp/ClientModelExtensions.cs
+++ b/AutoRest/Generators/CSharp/CSharp/ClientModelExtensions.cs
@@ -225,6 +225,10 @@ namespace Microsoft.Rest.Generator.CSharp
                 {
                     serializationSettings = "new Base64UrlJsonConverter()";
                 }
+                else if (primaryType.Type == KnownPrimaryType.UnixTime)
+                {
+                    serializationSettings = "new UnixTimeJsonConverter()";
+                }
             }
 
             return string.Format(CultureInfo.InvariantCulture,
@@ -268,6 +272,7 @@ namespace Microsoft.Rest.Generator.CSharp
                 || primaryType.Type == KnownPrimaryType.Long 
                 || primaryType.Type == KnownPrimaryType.TimeSpan 
                 || primaryType.Type == KnownPrimaryType.DateTimeRfc1123
+                || primaryType.Type == KnownPrimaryType.UnixTime
                 || primaryType.Type == KnownPrimaryType.Uuid));
         }
 

--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/MethodTemplateModel.cs
@@ -351,6 +351,14 @@ namespace Microsoft.Rest.Generator.CSharp
             {
                 return "new Base64UrlJsonConverter()";
             }
+            else if (serializationType.IsPrimaryType(KnownPrimaryType.UnixTime) ||
+                (sequenceType != null && sequenceType.ElementType is PrimaryType
+                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.UnixTime) ||
+                (dictionaryType != null && dictionaryType.ValueType is PrimaryType
+                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.UnixTime))
+            {
+                return "new UnixTimeJsonConverter()";
+            }
             return ClientReference + ".SerializationSettings";
         }
 
@@ -371,13 +379,21 @@ namespace Microsoft.Rest.Generator.CSharp
             {
                 return "new DateJsonConverter()";
             }
-            if (deserializationType.IsPrimaryType(KnownPrimaryType.Base64Url) ||
+            else if (deserializationType.IsPrimaryType(KnownPrimaryType.Base64Url) ||
                 (sequenceType != null && sequenceType.ElementType is PrimaryType
                     && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.Base64Url) ||
                 (dictionaryType != null && dictionaryType.ValueType is PrimaryType
                     && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.Base64Url))
             {
                 return "new Base64UrlJsonConverter()";
+            }
+            else if (deserializationType.IsPrimaryType(KnownPrimaryType.UnixTime) ||
+                (sequenceType != null && sequenceType.ElementType is PrimaryType
+                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.UnixTime) ||
+                (dictionaryType != null && dictionaryType.ValueType is PrimaryType
+                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.UnixTime))
+            {
+                return "new UnixTimeJsonConverter()";
             }
 
             return ClientReference + ".DeserializationSettings";

--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/MethodTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/MethodTemplateModel.cs
@@ -325,37 +325,19 @@ namespace Microsoft.Rest.Generator.CSharp
         /// <returns></returns>
         public string GetSerializationSettingsReference(IType serializationType)
         {
-            SequenceType sequenceType = serializationType as SequenceType;
-            DictionaryType dictionaryType = serializationType as DictionaryType;
-            if (serializationType.IsPrimaryType(KnownPrimaryType.Date) ||
-                (sequenceType != null && sequenceType.ElementType is PrimaryType 
-                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.Date) ||
-                (dictionaryType != null && dictionaryType.ValueType is PrimaryType 
-                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.Date))
+            if (serializationType.IsOrContainsPrimaryType(KnownPrimaryType.Date))
             {
                 return "new DateJsonConverter()";
             }
-            else if (serializationType.IsPrimaryType(KnownPrimaryType.DateTimeRfc1123) ||
-                (sequenceType != null && sequenceType.ElementType is PrimaryType
-                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.DateTimeRfc1123) ||
-                (dictionaryType != null && dictionaryType.ValueType is PrimaryType
-                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.DateTimeRfc1123))
+            else if (serializationType.IsOrContainsPrimaryType(KnownPrimaryType.DateTimeRfc1123))
             {
                 return "new DateTimeRfc1123JsonConverter()";
             }
-            else if (serializationType.IsPrimaryType(KnownPrimaryType.Base64Url) ||
-                (sequenceType != null && sequenceType.ElementType is PrimaryType
-                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.Base64Url) ||
-                (dictionaryType != null && dictionaryType.ValueType is PrimaryType
-                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.Base64Url))
+            else if (serializationType.IsOrContainsPrimaryType(KnownPrimaryType.Base64Url))
             {
                 return "new Base64UrlJsonConverter()";
             }
-            else if (serializationType.IsPrimaryType(KnownPrimaryType.UnixTime) ||
-                (sequenceType != null && sequenceType.ElementType is PrimaryType
-                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.UnixTime) ||
-                (dictionaryType != null && dictionaryType.ValueType is PrimaryType
-                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.UnixTime))
+            else if (serializationType.IsOrContainsPrimaryType(KnownPrimaryType.UnixTime))
             {
                 return "new UnixTimeJsonConverter()";
             }
@@ -369,33 +351,18 @@ namespace Microsoft.Rest.Generator.CSharp
         /// <returns></returns>
         public string GetDeserializationSettingsReference(IType deserializationType)
         {
-            SequenceType sequenceType = deserializationType as SequenceType;
-            DictionaryType dictionaryType = deserializationType as DictionaryType;
-            if (deserializationType.IsPrimaryType(KnownPrimaryType.Date) ||
-                (sequenceType != null && sequenceType.ElementType is PrimaryType
-                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.Date) ||
-                (dictionaryType != null && dictionaryType.ValueType is PrimaryType
-                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.Date))
+            if (deserializationType.IsOrContainsPrimaryType(KnownPrimaryType.Date))
             {
                 return "new DateJsonConverter()";
             }
-            else if (deserializationType.IsPrimaryType(KnownPrimaryType.Base64Url) ||
-                (sequenceType != null && sequenceType.ElementType is PrimaryType
-                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.Base64Url) ||
-                (dictionaryType != null && dictionaryType.ValueType is PrimaryType
-                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.Base64Url))
+            else if (deserializationType.IsOrContainsPrimaryType(KnownPrimaryType.Base64Url))
             {
                 return "new Base64UrlJsonConverter()";
             }
-            else if (deserializationType.IsPrimaryType(KnownPrimaryType.UnixTime) ||
-                (sequenceType != null && sequenceType.ElementType is PrimaryType
-                    && ((PrimaryType)sequenceType.ElementType).Type == KnownPrimaryType.UnixTime) ||
-                (dictionaryType != null && dictionaryType.ValueType is PrimaryType
-                    && ((PrimaryType)dictionaryType.ValueType).Type == KnownPrimaryType.UnixTime))
+            else if (deserializationType.IsOrContainsPrimaryType(KnownPrimaryType.UnixTime))
             {
                 return "new UnixTimeJsonConverter()";
             }
-
             return ClientReference + ".DeserializationSettings";
         }
 

--- a/AutoRest/Generators/CSharp/CSharp/Templates/ModelTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/ModelTemplate.cshtml
@@ -123,6 +123,10 @@ namespace @(Settings.Namespace).Models
             {
         @:[JsonConverter(typeof(Base64UrlJsonConverter))]
             }
+            if (property.Type.IsPrimaryType(KnownPrimaryType.UnixTime))
+            {
+        @:[JsonConverter(typeof(UnixTimeJsonConverter))]
+            }
         @:[JsonProperty(PropertyName = "@property.SerializedName")]
         @:public @property.Type.Name @property.Name { get; @(property.IsReadOnly ? "private " : "")set; }
         @EmptyLine
@@ -144,6 +148,10 @@ namespace @(Settings.Namespace).Models
             if (property.Type.IsPrimaryType(KnownPrimaryType.Base64Url))
             {
         @:[JsonConverter(typeof(Base64UrlJsonConverter))]
+            }
+            if (property.Type.IsPrimaryType(KnownPrimaryType.UnixTime))
+            {
+        @:[JsonConverter(typeof(UnixTimeJsonConverter))]
             }
         @:[JsonProperty(PropertyName = "@property.SerializedName")]
         @:public static @property.Type.Name @property.Name { get; private set; }

--- a/AutoRest/Generators/Java/Java/TypeModels/PrimaryTypeModel.cs
+++ b/AutoRest/Generators/Java/Java/TypeModels/PrimaryTypeModel.cs
@@ -202,6 +202,10 @@ namespace Microsoft.Rest.Generator.Java
                 Name = "Period";
                 _imports.Add("org.joda.time.Period");
             }
+            else if (primaryType.Type == KnownPrimaryType.UnixTime)
+            {
+                Name = "long";
+            }
             else if (primaryType.Type == KnownPrimaryType.Uuid)
             {
                 Name = "UUID";

--- a/AutoRest/Generators/NodeJS/NodeJS/NodeJsCodeNamer.cs
+++ b/AutoRest/Generators/NodeJS/NodeJS/NodeJsCodeNamer.cs
@@ -393,6 +393,10 @@ namespace Microsoft.Rest.Generator.NodeJS
             {
                 primaryType.Name = "moment.duration"; 
             }
+            else if (primaryType.Type == KnownPrimaryType.UnixTime)
+            {
+                primaryType.Name = "Number";
+            }
             else if (primaryType.Type == KnownPrimaryType.Uuid)
             {
                 primaryType.Name = "Uuid";

--- a/AutoRest/Generators/Python/Python/PythonCodeNamer.cs
+++ b/AutoRest/Generators/Python/Python/PythonCodeNamer.cs
@@ -376,6 +376,10 @@ namespace Microsoft.Rest.Generator.Python
             {
                 primaryType.Name = "Decimal";
             }
+            else if (primaryType.Type == KnownPrimaryType.UnixTime)
+            {
+                primaryType.Name = "long"; 
+            }
             else if (primaryType.Type == KnownPrimaryType.Object)  // Revisit here
             {
                 primaryType.Name = "object";

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeNamer.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeNamer.cs
@@ -372,6 +372,10 @@ namespace Microsoft.Rest.Generator.Ruby
             {
                 primaryType.Name = "Duration";
             }
+            else if (primaryType.Type == KnownPrimaryType.UnixTime)
+            {
+                primaryType.Name = "Bignum";
+            }
             else if (primaryType.Type == KnownPrimaryType.Object)
             {
                 primaryType.Name = "Object";

--- a/AutoRest/Modelers/Swagger/Model/SwaggerObject.cs
+++ b/AutoRest/Modelers/Swagger/Model/SwaggerObject.cs
@@ -132,6 +132,10 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
                     {
                         return new PrimaryType(KnownPrimaryType.Long);
                     }
+                    if (string.Equals("unixtime", Format, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new PrimaryType(KnownPrimaryType.UnixTime);
+                    }
                     return new PrimaryType(KnownPrimaryType.Int);
                 case DataType.Boolean:
                     return new PrimaryType(KnownPrimaryType.Boolean);

--- a/AutoRest/TestServer/server/app.js
+++ b/AutoRest/TestServer/server/app.js
@@ -195,15 +195,6 @@ var coverage = {
   "getStringWithLeadingAndTrailingWhitespace" : 0,
   "putStringWithLeadingAndTrailingWhitespace" : 0,
   "getStringNotProvided": 0,
-  /* TODO: only C# and node.js support the base64url format currently. Exclude these tests from code coverage until it is implemented in other languages */
-  "getStringBase64Encoded": 1,
-  "getStringBase64UrlEncoded": 1,
-  "putStringBase64UrlEncoded": 1,
-  "getStringNullBase64UrlEncoding": 1,
-  "getArrayBase64Url": 1,
-  "getDictionaryBase64Url": 1,
-  "UrlPathsStringBase64Url": 1,
-  "UrlPathsArrayCSVInPath": 1,
   "getEnumNotExpandable": 0,
   "putEnumNotExpandable":0,
   "putComplexBasicValid": 0,
@@ -438,7 +429,22 @@ var coverage = {
   'putModelFlattenResourceCollection': 0,
   'putModelFlattenCustomBase': 0,
   'postModelFlattenCustomParameter': 0,
-  'putModelFlattenCustomGroupedParameter': 0
+  'putModelFlattenCustomGroupedParameter': 0,
+  /* TODO: only C# and node.js support the base64url format currently. Exclude these tests from code coverage until it is implemented in other languages */
+  "getStringBase64Encoded": 1,
+  "getStringBase64UrlEncoded": 1,
+  "putStringBase64UrlEncoded": 1,
+  "getStringNullBase64UrlEncoding": 1,
+  "getArrayBase64Url": 1,
+  "getDictionaryBase64Url": 1,
+  "UrlPathsStringBase64Url": 1,
+  "UrlPathsArrayCSVInPath": 1,
+  /* TODO: only C# supports the unixtime format currently. Exclude these tests from code coverage until it is implemented in other languages */
+  "getUnixTime": 1,
+  "getInvalidUnixTime": 1,
+  "getNullUnixTime": 1,
+  "putUnixTime": 1,
+  "UrlPathsIntUnixTime": 1
 };
 
 // view engine setup

--- a/AutoRest/TestServer/server/routes/int.js
+++ b/AutoRest/TestServer/server/routes/int.js
@@ -65,10 +65,27 @@ var integer = function(coverage) {
         } else if (req.params.scenario === 'underflowint64') {
             coverage['getLongUnderflow']++;
             res.status(200).end('-9223372036854775910');
+        } else if (req.params.scenario === 'unixtime') {
+            coverage['getUnixTime']++;
+            res.status(200).end('1460505600');
+        } else if (req.params.scenario === 'invalidunixtime') {
+            coverage['getInvalidUnixTime']++;
+            res.status(200).end('123jkl');
+        } else if (req.params.scenario === 'nullunixtime') {
+            coverage['getNullUnixTime']++;
+            res.status(200).end();
         } else {
             res.status(400).send('Request path must contain true or false');
         }
-
+    });
+    
+    router.put('/unixtime', function(req, res, next) {
+          if (req.body != 1460505600) {
+              utils.send400(res, next, "Did not like the value provided for unixtime in the req " + util.inspect(req.body));
+          } else {
+              coverage['putUnixTime']++;
+              res.status(200).end();
+          }
     });
 }
 

--- a/AutoRest/TestServer/server/routes/paths.js
+++ b/AutoRest/TestServer/server/routes/paths.js
@@ -23,6 +23,7 @@ var scenarioMap = {
   "2012-01-01T01:01:01Z": "Valid",
   "green color" : "Valid",
   "bG9yZW0" : "Base64Url",
+  "1460505600": "UnixTime",
   "ArrayPath1,begin!*'();:@ &=+$,/?#[]end,,": "CSVInPath"
 };
 

--- a/AutoRest/TestServer/swagger/body-integer.json
+++ b/AutoRest/TestServer/swagger/body-integer.json
@@ -251,6 +251,95 @@
           }
         }
       }
+    },
+    "/int/unixtime": {
+      "get": {
+        "operationId": "int_getUnixTime",
+        "description": "Get datetime encoded as Unix time value",
+        "responses": {
+          "200": {
+            "description": "The date value encoded as Unix time",
+            "schema": {
+              "type": "integer",
+              "format": "unixtime"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "int_putUnixTimeDate",
+        "description": "Put datetime encoded as Unix time",
+        "parameters": [
+          {
+            "name": "intBody",
+            "in": "body",
+            "schema": {
+              "type": "integer",
+              "format": "unixtime"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The datetime value encoded as Unix time"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/int/invalidunixtime": {
+      "get": {
+        "operationId": "int_getInvalidUnixTime",
+        "description": "Get invalid Unix time value",
+        "responses": {
+          "200": {
+            "description": "The invalid Unix time value",
+            "schema": {
+              "type": "integer",
+              "format": "unixtime"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/int/nullunixtime": {
+      "get": {
+        "operationId": "int_getNullUnixTime",
+        "description": "Get null Unix time value",
+        "responses": {
+          "200": {
+            "description": "The null Unix time value",
+            "schema": {
+              "type": "integer",
+              "format": "unixtime"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/AutoRest/TestServer/swagger/url.json
+++ b/AutoRest/TestServer/swagger/url.json
@@ -773,6 +773,36 @@
         }
       }
     },
+    "/paths/int/1460505600/{unixTimeUrlPath}": {
+      "get": {
+        "operationId": "paths_unixTimeUrl",
+        "description": "Get the date 2016-04-13 encoded value as '1460505600' (Unix time)",
+        "tags": [
+          "Path Operations"
+        ],
+        "parameters": [
+          {
+            "name": "unixTimeUrlPath",
+            "in": "path",
+            "description": "Unix time encoded value",
+            "type": "integer",
+            "format": "unixtime",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully Received date 2016-04-13 encoded value as '1460505600' (Unix time)"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/queries/bool/true": {
       "get": {
         "operationId": "queries_getBooleanTrue",

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime/Serialization/UnixTimeJsonConverter.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime/Serialization/UnixTimeJsonConverter.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Rest.Serialization
+{
+    public class UnixTimeJsonConverter : JsonConverter
+    {
+        public static readonly DateTime EpochDate = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// Converts a byte array to a Base64Url encoded string
+        /// </summary>
+        /// <param name="input">The byte array to convert</param>
+        /// <returns>The Base64Url encoded form of the input</returns>
+        private static long? ToUnixTime(DateTime dateTime)
+        {
+            return (long?)dateTime.Subtract(EpochDate).TotalSeconds;
+        }
+
+        /// <summary>
+        /// Converts a Base64Url encoded string to a byte array
+        /// </summary>
+        /// <param name="input">The Base64Url encoded string</param>
+        /// <returns>The byte array represented by the enconded string</returns>
+        private static DateTime FromUnixTime(long? seconds)
+        {
+            if (seconds.HasValue)
+            {
+                return EpochDate.AddSeconds(seconds.Value);
+            }
+            return EpochDate;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            if (objectType == typeof(DateTime))
+                return true;
+
+            return false;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (objectType != typeof(DateTime))
+            {
+                return serializer.Deserialize(reader, objectType);
+            }
+            else
+            {
+                var value = serializer.Deserialize<long?>(reader);
+                if (value.HasValue)
+                {
+                    return FromUnixTime(value);
+                }
+            }
+
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value.GetType() != typeof(DateTime))
+            {
+                JToken.FromObject(value).WriteTo(writer);
+            }
+            else
+            {
+                JToken.FromObject(ToUnixTime((DateTime)value)).WriteTo(writer);
+            }
+        }
+    }
+}

--- a/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime/Serialization/UnixTimeJsonConverter.cs
+++ b/ClientRuntimes/CSharp/Microsoft.Rest.ClientRuntime/Serialization/UnixTimeJsonConverter.cs
@@ -26,18 +26,18 @@ namespace Microsoft.Rest.Serialization
         /// </summary>
         /// <param name="input">The Base64Url encoded string</param>
         /// <returns>The byte array represented by the enconded string</returns>
-        private static DateTime FromUnixTime(long? seconds)
+        private static DateTime? FromUnixTime(long? seconds)
         {
             if (seconds.HasValue)
             {
                 return EpochDate.AddSeconds(seconds.Value);
             }
-            return EpochDate;
+            return null;
         }
 
         public override bool CanConvert(Type objectType)
         {
-            if (objectType == typeof(DateTime))
+            if (objectType == typeof(DateTime?) || objectType == typeof(DateTime))
                 return true;
 
             return false;
@@ -45,13 +45,14 @@ namespace Microsoft.Rest.Serialization
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            if (objectType != typeof(DateTime))
+            if (objectType != typeof(DateTime?))
             {
                 return serializer.Deserialize(reader, objectType);
             }
             else
             {
                 var value = serializer.Deserialize<long?>(reader);
+
                 if (value.HasValue)
                 {
                     return FromUnixTime(value);


### PR DESCRIPTION
Addressing issue #909
Adding a new known primary type for Unix time formatted dates (which is in seconds since Unix Epoch). Wiring up code namers to handle this primary type and set the correct.

Implementing the JsonConverter for C# and adding to templates for serializing/deserializing a DateTime object with the Unix time format. Adding path and body tests in C# to validate this functionality