### PR TITLE
Added support for required parameters constructors

### DIFF
--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/AcceptanceTests.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/AcceptanceTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
         {
             SwaggerSpecRunner.RunTests(
                 SwaggerPath("custom-baseUrl.json"), ExpectedPath("CustomBaseUri"), generator: "Azure.CSharp");
-            using (var client = new AutoRestParameterizedHostTestClient(new TokenCredentials(Guid.NewGuid().ToString())))
+            using (var client = new AutoRestParameterizedHostTestClient(new TokenCredentials(Guid.NewGuid().ToString()), "host"))
             {
                 // small modification to the "host" portion to include the port and the '.'
                 client.Host = string.Format(CultureInfo.InvariantCulture, "{0}.:{1}", client.Host, Fixture.Port);
@@ -81,7 +81,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
         {
             SwaggerSpecRunner.RunTests(
                 SwaggerPath("custom-baseUrl.json"), ExpectedPath("CustomBaseUri"), generator: "Azure.CSharp");
-            using (var client = new AutoRestParameterizedHostTestClient(new TokenCredentials(Guid.NewGuid().ToString())))
+            using (var client = new AutoRestParameterizedHostTestClient(new TokenCredentials(Guid.NewGuid().ToString()), "host"))
             {
                 // use a bad acct name
                 Assert.Throws<HttpRequestException>(() =>
@@ -106,7 +106,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
             using (
                 var client =
                     new MicrosoftAzureTestUrl(Fixture.Uri,
-                        new TokenCredentials(Guid.NewGuid().ToString())))
+                        new TokenCredentials(Guid.NewGuid().ToString()), Guid.NewGuid().ToString()))
             {
                 client.SubscriptionId = Guid.NewGuid().ToString();
                 var group = client.Group.GetSampleResourceGroup("testgroup101");
@@ -480,8 +480,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
                 SwaggerPath("azure-special-properties.json"), ExpectedPath("AzureSpecials"), generator: "Azure.CSharp");
             using (
                 var client = new AutoRestAzureSpecialParametersTestClient(Fixture.Uri,
-                    new TokenCredentials(Guid.NewGuid().ToString()))
-                    { SubscriptionId = validSubscription })
+                    new TokenCredentials(Guid.NewGuid().ToString()), validSubscription))
             {
                 client.SubscriptionInCredentials.PostMethodGlobalNotProvidedValid();
                 client.SubscriptionInCredentials.PostMethodGlobalValid();
@@ -518,9 +517,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
             var validSubscription = "1234-5678-9012-3456";
             SwaggerSpecRunner.RunTests(
                 SwaggerPath("azure-special-properties.json"), ExpectedPath("AzureSpecials"), generator: "Azure.CSharp");
-            using (var client = new AutoRestAzureSpecialParametersTestClient(Fixture.Uri,
-                    new TokenCredentials(Guid.NewGuid().ToString()))
-                { SubscriptionId = validSubscription })
+            using (var client = new AutoRestAzureSpecialParametersTestClient(
+                    Fixture.Uri, new TokenCredentials(Guid.NewGuid().ToString()), validSubscription))
             {
                 var filter = new ODataQuery<OdataFilter>(f => f.Id > 5 && f.Name == "foo")
                 {
@@ -538,9 +536,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
         {
             var validSubscription = "1234-5678-9012-3456";
             var validClientId = "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0";
-            using (var client = new AutoRestAzureSpecialParametersTestClient(Fixture.Uri,
-                    new TokenCredentials(validSubscription, Guid.NewGuid().ToString()))
-                    { SubscriptionId = validSubscription })
+            using (var client = new AutoRestAzureSpecialParametersTestClient(
+                    Fixture.Uri, new TokenCredentials(validSubscription, Guid.NewGuid().ToString()), validSubscription))
             {
                 Dictionary<string, List<string>> customHeaders = new Dictionary<string, List<string>>();
                 customHeaders["x-ms-client-request-id"] = new List<string> { validClientId };
@@ -559,8 +556,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
         {
             var validSubscription = "1234-5678-9012-3456";
             using (var client = new AutoRestAzureSpecialParametersTestClient(Fixture.Uri,
-                    new TokenCredentials(validSubscription, Guid.NewGuid().ToString()))
-            { SubscriptionId = validSubscription })
+                    new TokenCredentials(validSubscription, Guid.NewGuid().ToString()), validSubscription))
             {
                 client.GenerateClientRequestId = false;
                 client.XMsClientRequestId.Get();
@@ -572,12 +568,11 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
         {
             var validSubscription = "1234-5678-9012-3456";
             using (var client = new AutoRestAzureSpecialParametersTestClient(Fixture.Uri,
-                    new TokenCredentials(validSubscription, Guid.NewGuid().ToString()))
-            { SubscriptionId = validSubscription })
+                    new TokenCredentials(validSubscription, Guid.NewGuid().ToString()), validSubscription))
             {
                 Dictionary<string, List<string>> customHeaders = new Dictionary<string, List<string>>();
                 var exception = Assert.Throws<CloudException>(() => client.XMsClientRequestId.Get());
-                Assert.Equal("123", exception.RequestId);                
+                Assert.Equal("123", exception.RequestId);
             }
         }
 
@@ -586,12 +581,12 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
         {
             SwaggerSpecRunner.RunTests(
                 SwaggerPath("azure-special-properties.json"), ExpectedPath("AzureSpecials"), generator: "Azure.CSharp");
-            
+
             const string validSubscription = "1234-5678-9012-3456";
             const string expectedRequestId = "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0";
 
             using (var client = new AutoRestAzureSpecialParametersTestClient(Fixture.Uri,
-                new TokenCredentials(validSubscription, Guid.NewGuid().ToString())))
+                new TokenCredentials(validSubscription, Guid.NewGuid().ToString()), validSubscription))
             {
                 IAzureOperationResponse response = client.Header.CustomNamedRequestIdWithHttpMessagesAsync(expectedRequestId).Result;
 
@@ -616,7 +611,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure.Tests
                 client.Duration.PutPositiveDuration(new TimeSpan(123, 22, 14, 12, 11));
             }
         }
-        
+
         [Fact]
         public void ParameterGroupingTests()
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDuration/AutoRestDurationTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDuration/AutoRestDurationTestService.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -76,7 +76,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         /// Initializes a new instance of the AutoRestDurationTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestDurationTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -87,10 +87,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         /// Initializes a new instance of the AutoRestDurationTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestDurationTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -104,7 +104,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestDurationTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -122,10 +122,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestDurationTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -143,7 +143,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDurationTestService(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -165,10 +165,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDurationTestService(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -193,7 +193,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDurationTestService(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -223,10 +223,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDurationTestService(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/AzureCompositeModel.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/AzureCompositeModel.cs
@@ -37,14 +37,14 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -117,7 +117,7 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// Initializes a new instance of the AzureCompositeModel class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AzureCompositeModel(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -128,10 +128,10 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// Initializes a new instance of the AzureCompositeModel class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AzureCompositeModel(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -145,7 +145,7 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AzureCompositeModel(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -163,10 +163,10 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AzureCompositeModel(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -183,20 +183,28 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='subscriptionId'>
+        /// Required. Subscription ID.
         /// </param>
-        public AzureCompositeModel(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AzureCompositeModel(ServiceClientCredentials credentials, string subscriptionId, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -205,23 +213,31 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. Subscription ID.
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public AzureCompositeModel(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public AzureCompositeModel(ServiceClientCredentials credentials, string subscriptionId, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -233,10 +249,13 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='subscriptionId'>
+        /// Required. Subscription ID.
         /// </param>
-        public AzureCompositeModel(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AzureCompositeModel(Uri baseUri, ServiceClientCredentials credentials, string subscriptionId, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
             {
@@ -246,12 +265,17 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
             {
                 throw new ArgumentNullException("credentials");
             }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -263,13 +287,16 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. Subscription ID.
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public AzureCompositeModel(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public AzureCompositeModel(Uri baseUri, ServiceClientCredentials credentials, string subscriptionId, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
             {
@@ -279,12 +306,17 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
             {
                 throw new ArgumentNullException("credentials");
             }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureParameterGrouping/AutoRestParameterGroupingTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureParameterGrouping/AutoRestParameterGroupingTestService.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -76,7 +76,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         /// Initializes a new instance of the AutoRestParameterGroupingTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestParameterGroupingTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -87,10 +87,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         /// Initializes a new instance of the AutoRestParameterGroupingTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestParameterGroupingTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -104,7 +104,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestParameterGroupingTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -122,10 +122,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestParameterGroupingTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -143,7 +143,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterGroupingTestService(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -165,10 +165,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterGroupingTestService(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -193,7 +193,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterGroupingTestService(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -223,10 +223,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterGroupingTestService(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureReport/AutoRestReportServiceForAzure.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureReport/AutoRestReportServiceForAzure.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -71,7 +71,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         /// Initializes a new instance of the AutoRestReportServiceForAzure class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestReportServiceForAzure(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -82,10 +82,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         /// Initializes a new instance of the AutoRestReportServiceForAzure class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestReportServiceForAzure(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -99,7 +99,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestReportServiceForAzure(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -117,10 +117,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestReportServiceForAzure(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -138,7 +138,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestReportServiceForAzure(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -160,10 +160,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestReportServiceForAzure(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -188,7 +188,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestReportServiceForAzure(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -218,10 +218,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestReportServiceForAzure(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureResource/AutoRestResourceFlatteningTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureResource/AutoRestResourceFlatteningTestService.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -71,7 +71,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         /// Initializes a new instance of the AutoRestResourceFlatteningTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestResourceFlatteningTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -82,10 +82,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         /// Initializes a new instance of the AutoRestResourceFlatteningTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestResourceFlatteningTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -99,7 +99,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestResourceFlatteningTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -117,10 +117,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestResourceFlatteningTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -138,7 +138,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestResourceFlatteningTestService(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -160,10 +160,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestResourceFlatteningTestService(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -188,7 +188,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestResourceFlatteningTestService(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -218,10 +218,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestResourceFlatteningTestService(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/AutoRestAzureSpecialParametersTestClient.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/AutoRestAzureSpecialParametersTestClient.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -123,7 +123,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// Initializes a new instance of the AutoRestAzureSpecialParametersTestClient class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestAzureSpecialParametersTestClient(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -134,10 +134,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// Initializes a new instance of the AutoRestAzureSpecialParametersTestClient class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestAzureSpecialParametersTestClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -151,7 +151,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestAzureSpecialParametersTestClient(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -169,10 +169,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestAzureSpecialParametersTestClient(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -189,20 +189,28 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='subscriptionId'>
+        /// Required. The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'
         /// </param>
-        public AutoRestAzureSpecialParametersTestClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestAzureSpecialParametersTestClient(ServiceClientCredentials credentials, string subscriptionId, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -211,23 +219,31 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public AutoRestAzureSpecialParametersTestClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public AutoRestAzureSpecialParametersTestClient(ServiceClientCredentials credentials, string subscriptionId, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -239,10 +255,13 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='subscriptionId'>
+        /// Required. The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'
         /// </param>
-        public AutoRestAzureSpecialParametersTestClient(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestAzureSpecialParametersTestClient(Uri baseUri, ServiceClientCredentials credentials, string subscriptionId, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
             {
@@ -252,12 +271,17 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             {
                 throw new ArgumentNullException("credentials");
             }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -269,13 +293,16 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public AutoRestAzureSpecialParametersTestClient(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public AutoRestAzureSpecialParametersTestClient(Uri baseUri, ServiceClientCredentials credentials, string subscriptionId, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
             {
@@ -285,12 +312,17 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             {
                 throw new ArgumentNullException("credentials");
             }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/CustomBaseUri/AutoRestParameterizedHostTestClient.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/CustomBaseUri/AutoRestParameterizedHostTestClient.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri
         internal string BaseUri {get; set;}
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -81,7 +81,7 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri
         /// Initializes a new instance of the AutoRestParameterizedHostTestClient class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestParameterizedHostTestClient(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -92,10 +92,10 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri
         /// Initializes a new instance of the AutoRestParameterizedHostTestClient class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestParameterizedHostTestClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -108,20 +108,28 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='host'>
+        /// Required. A string value that is used as a global part of the parameterized host
         /// </param>
-        public AutoRestParameterizedHostTestClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestParameterizedHostTestClient(ServiceClientCredentials credentials, string host, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (host == null)
+            {
+                throw new ArgumentNullException("host");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.Host = host;
         }
 
         /// <summary>
@@ -130,23 +138,31 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='host'>
+        /// Required. A string value that is used as a global part of the parameterized host
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public AutoRestParameterizedHostTestClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public AutoRestParameterizedHostTestClient(ServiceClientCredentials credentials, string host, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (host == null)
+            {
+                throw new ArgumentNullException("host");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.Host = host;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Head/AutoRestHeadTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Head/AutoRestHeadTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -75,7 +75,7 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         /// Initializes a new instance of the AutoRestHeadTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestHeadTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -86,10 +86,10 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         /// Initializes a new instance of the AutoRestHeadTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestHeadTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -103,7 +103,7 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestHeadTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -121,10 +121,10 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestHeadTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -142,7 +142,7 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHeadTestService(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -164,10 +164,10 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHeadTestService(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -192,7 +192,7 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHeadTestService(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -222,10 +222,10 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHeadTestService(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/HeadExceptions/AutoRestHeadExceptionTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/HeadExceptions/AutoRestHeadExceptionTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -75,7 +75,7 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         /// Initializes a new instance of the AutoRestHeadExceptionTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestHeadExceptionTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -86,10 +86,10 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         /// Initializes a new instance of the AutoRestHeadExceptionTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestHeadExceptionTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -103,7 +103,7 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestHeadExceptionTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -121,10 +121,10 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestHeadExceptionTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -142,7 +142,7 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHeadExceptionTestService(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -164,10 +164,10 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHeadExceptionTestService(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -192,7 +192,7 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHeadExceptionTestService(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -222,10 +222,10 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHeadExceptionTestService(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/AutoRestLongRunningOperationTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Lro/AutoRestLongRunningOperationTestService.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -91,7 +91,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// Initializes a new instance of the AutoRestLongRunningOperationTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestLongRunningOperationTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -102,10 +102,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// Initializes a new instance of the AutoRestLongRunningOperationTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestLongRunningOperationTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -119,7 +119,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestLongRunningOperationTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -137,10 +137,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestLongRunningOperationTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -158,7 +158,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestLongRunningOperationTestService(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -180,10 +180,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestLongRunningOperationTestService(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -208,7 +208,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestLongRunningOperationTestService(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -238,10 +238,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestLongRunningOperationTestService(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Paging/AutoRestPagingTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/Paging/AutoRestPagingTestService.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -76,7 +76,7 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         /// Initializes a new instance of the AutoRestPagingTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestPagingTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -87,10 +87,10 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         /// Initializes a new instance of the AutoRestPagingTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestPagingTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -104,7 +104,7 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestPagingTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -122,10 +122,10 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected AutoRestPagingTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -143,7 +143,7 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestPagingTestService(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -165,10 +165,10 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestPagingTestService(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -193,7 +193,7 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestPagingTestService(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -223,10 +223,10 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         /// Required. Gets Azure subscription credentials.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestPagingTestService(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/MicrosoftAzureTestUrl.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/MicrosoftAzureTestUrl.cs
@@ -36,14 +36,14 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -86,7 +86,7 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         /// Initializes a new instance of the MicrosoftAzureTestUrl class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected MicrosoftAzureTestUrl(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -97,10 +97,10 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         /// Initializes a new instance of the MicrosoftAzureTestUrl class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected MicrosoftAzureTestUrl(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -114,7 +114,7 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected MicrosoftAzureTestUrl(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -132,10 +132,10 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected MicrosoftAzureTestUrl(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -152,20 +152,28 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='subscriptionId'>
+        /// Required. Subscription Id.
         /// </param>
-        public MicrosoftAzureTestUrl(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public MicrosoftAzureTestUrl(ServiceClientCredentials credentials, string subscriptionId, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -174,23 +182,31 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. Subscription Id.
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public MicrosoftAzureTestUrl(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public MicrosoftAzureTestUrl(ServiceClientCredentials credentials, string subscriptionId, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -202,10 +218,13 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='subscriptionId'>
+        /// Required. Subscription Id.
         /// </param>
-        public MicrosoftAzureTestUrl(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public MicrosoftAzureTestUrl(Uri baseUri, ServiceClientCredentials credentials, string subscriptionId, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
             {
@@ -215,12 +234,17 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
             {
                 throw new ArgumentNullException("credentials");
             }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -232,13 +256,16 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. Subscription Id.
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public MicrosoftAzureTestUrl(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public MicrosoftAzureTestUrl(Uri baseUri, ServiceClientCredentials credentials, string subscriptionId, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
             {
@@ -248,12 +275,17 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
             {
                 throw new ArgumentNullException("credentials");
             }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyArray/AutoRestSwaggerBATArrayService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyArray/AutoRestSwaggerBATArrayService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyArray
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IArray.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// Initializes a new instance of the AutoRestSwaggerBATArrayService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATArrayService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// Initializes a new instance of the AutoRestSwaggerBATArrayService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATArrayService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATArrayService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATArrayService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyBoolean/AutoRestBoolTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyBoolean/AutoRestBoolTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IBoolModel.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
         /// Initializes a new instance of the AutoRestBoolTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestBoolTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
         /// Initializes a new instance of the AutoRestBoolTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestBoolTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestBoolTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyBoolean
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestBoolTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyByte/AutoRestSwaggerBATByteService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyByte/AutoRestSwaggerBATByteService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyByte
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IByteModel.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyByte
         /// Initializes a new instance of the AutoRestSwaggerBATByteService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATByteService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyByte
         /// Initializes a new instance of the AutoRestSwaggerBATByteService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATByteService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyByte
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATByteService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyByte
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATByteService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/AutoRestComplexTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyComplex/AutoRestComplexTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// API ID.
@@ -93,7 +93,7 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         /// Initializes a new instance of the AutoRestComplexTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestComplexTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -104,10 +104,10 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         /// Initializes a new instance of the AutoRestComplexTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestComplexTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -121,7 +121,7 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestComplexTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -139,10 +139,10 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestComplexTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -151,6 +151,100 @@ namespace Fixtures.AcceptanceTestsBodyComplex
                 throw new ArgumentNullException("baseUri");
             }
             this.BaseUri = baseUri;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestComplexTestService class.
+        /// </summary>
+        /// <param name='apiVersion'>
+        /// Required. API ID.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestComplexTestService(string apiVersion, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException("apiVersion");
+            }
+            this.ApiVersion = apiVersion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestComplexTestService class.
+        /// </summary>
+        /// <param name='apiVersion'>
+        /// Required. API ID.
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestComplexTestService(string apiVersion, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException("apiVersion");
+            }
+            this.ApiVersion = apiVersion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestComplexTestService class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='apiVersion'>
+        /// Required. API ID.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestComplexTestService(Uri baseUri, string apiVersion, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new ArgumentNullException("baseUri");
+            }
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException("apiVersion");
+            }
+            this.BaseUri = baseUri;
+            this.ApiVersion = apiVersion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestComplexTestService class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='apiVersion'>
+        /// Required. API ID.
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestComplexTestService(Uri baseUri, string apiVersion, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new ArgumentNullException("baseUri");
+            }
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException("apiVersion");
+            }
+            this.BaseUri = baseUri;
+            this.ApiVersion = apiVersion;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDate/AutoRestDateTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDate/AutoRestDateTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyDate
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IDate.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyDate
         /// Initializes a new instance of the AutoRestDateTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDateTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyDate
         /// Initializes a new instance of the AutoRestDateTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDateTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyDate
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDateTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyDate
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDateTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDateTime/AutoRestDateTimeTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDateTime/AutoRestDateTimeTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IDatetime.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
         /// Initializes a new instance of the AutoRestDateTimeTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDateTimeTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
         /// Initializes a new instance of the AutoRestDateTimeTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDateTimeTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDateTimeTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyDateTime
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDateTimeTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/AutoRestRFC1123DateTimeTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/AutoRestRFC1123DateTimeTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyDateTimeRfc1123
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IDatetimerfc1123.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyDateTimeRfc1123
         /// Initializes a new instance of the AutoRestRFC1123DateTimeTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestRFC1123DateTimeTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyDateTimeRfc1123
         /// Initializes a new instance of the AutoRestRFC1123DateTimeTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestRFC1123DateTimeTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyDateTimeRfc1123
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestRFC1123DateTimeTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyDateTimeRfc1123
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestRFC1123DateTimeTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/AutoRestSwaggerBATdictionaryService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/AutoRestSwaggerBATdictionaryService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IDictionary.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         /// Initializes a new instance of the AutoRestSwaggerBATdictionaryService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATdictionaryService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         /// Initializes a new instance of the AutoRestSwaggerBATdictionaryService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATdictionaryService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATdictionaryService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATdictionaryService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDuration/AutoRestDurationTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyDuration/AutoRestDurationTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyDuration
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IDuration.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyDuration
         /// Initializes a new instance of the AutoRestDurationTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDurationTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyDuration
         /// Initializes a new instance of the AutoRestDurationTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDurationTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyDuration
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDurationTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyDuration
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestDurationTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFile/AutoRestSwaggerBATFileService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFile/AutoRestSwaggerBATFileService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyFile
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IFiles.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyFile
         /// Initializes a new instance of the AutoRestSwaggerBATFileService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATFileService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyFile
         /// Initializes a new instance of the AutoRestSwaggerBATFileService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATFileService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyFile
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATFileService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyFile
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATFileService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFormData/AutoRestSwaggerBATFormDataService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyFormData/AutoRestSwaggerBATFormDataService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyFormData
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IFormdata.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyFormData
         /// Initializes a new instance of the AutoRestSwaggerBATFormDataService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATFormDataService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyFormData
         /// Initializes a new instance of the AutoRestSwaggerBATFormDataService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATFormDataService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyFormData
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATFormDataService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyFormData
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATFormDataService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/AutoRestIntegerTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyInteger/AutoRestIntegerTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyInteger
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IIntModel.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyInteger
         /// Initializes a new instance of the AutoRestIntegerTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestIntegerTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyInteger
         /// Initializes a new instance of the AutoRestIntegerTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestIntegerTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyInteger
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestIntegerTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyInteger
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestIntegerTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyNumber/AutoRestNumberTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyNumber/AutoRestNumberTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyNumber
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the INumber.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsBodyNumber
         /// Initializes a new instance of the AutoRestNumberTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestNumberTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsBodyNumber
         /// Initializes a new instance of the AutoRestNumberTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestNumberTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsBodyNumber
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestNumberTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsBodyNumber
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestNumberTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyString/AutoRestSwaggerBATService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/BodyString/AutoRestSwaggerBATService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsBodyString
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IStringModel.
@@ -58,7 +58,7 @@ namespace Fixtures.AcceptanceTestsBodyString
         /// Initializes a new instance of the AutoRestSwaggerBATService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -69,10 +69,10 @@ namespace Fixtures.AcceptanceTestsBodyString
         /// Initializes a new instance of the AutoRestSwaggerBATService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -86,7 +86,7 @@ namespace Fixtures.AcceptanceTestsBodyString
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -104,10 +104,10 @@ namespace Fixtures.AcceptanceTestsBodyString
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/CompositeBoolInt.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/CompositeBoolInt.cs
@@ -36,14 +36,14 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IBoolModel.
@@ -59,7 +59,7 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient
         /// Initializes a new instance of the CompositeBoolInt class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public CompositeBoolInt(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -70,10 +70,10 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient
         /// Initializes a new instance of the CompositeBoolInt class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public CompositeBoolInt(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -87,7 +87,7 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public CompositeBoolInt(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -105,10 +105,10 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public CompositeBoolInt(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CustomBaseUri/AutoRestParameterizedHostTestClient.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CustomBaseUri/AutoRestParameterizedHostTestClient.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsCustomBaseUri
         internal string BaseUri {get; set;}
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// A string value that is used as a global part of the parameterized host
@@ -58,7 +58,7 @@ namespace Fixtures.AcceptanceTestsCustomBaseUri
         /// Initializes a new instance of the AutoRestParameterizedHostTestClient class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterizedHostTestClient(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -69,14 +69,53 @@ namespace Fixtures.AcceptanceTestsCustomBaseUri
         /// Initializes a new instance of the AutoRestParameterizedHostTestClient class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterizedHostTestClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
             this.Initialize();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestParameterizedHostTestClient class.
+        /// </summary>
+        /// <param name='host'>
+        /// Required. A string value that is used as a global part of the parameterized host
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestParameterizedHostTestClient(string host, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (host == null)
+            {
+                throw new ArgumentNullException("host");
+            }
+            this.Host = host;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestParameterizedHostTestClient class.
+        /// </summary>
+        /// <param name='host'>
+        /// Required. A string value that is used as a global part of the parameterized host
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestParameterizedHostTestClient(string host, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (host == null)
+            {
+                throw new ArgumentNullException("host");
+            }
+            this.Host = host;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/AutoRestParameterizedCustomHostTestClient.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/AutoRestParameterizedCustomHostTestClient.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsCustomBaseUriMoreOptions
         internal string BaseUri {get; set;}
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// The subscription id with value 'test12'.
@@ -64,7 +64,7 @@ namespace Fixtures.AcceptanceTestsCustomBaseUriMoreOptions
         /// Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterizedCustomHostTestClient(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -75,14 +75,69 @@ namespace Fixtures.AcceptanceTestsCustomBaseUriMoreOptions
         /// Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterizedCustomHostTestClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
             this.Initialize();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
+        /// </summary>
+        /// <param name='subscriptionId'>
+        /// Required. The subscription id with value 'test12'.
+        /// </param>
+        /// <param name='dnsSuffix'>
+        /// Required. A string value that is used as a global part of the parameterized host. Default value 'host'.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestParameterizedCustomHostTestClient(string subscriptionId, string dnsSuffix, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
+            if (dnsSuffix == null)
+            {
+                throw new ArgumentNullException("dnsSuffix");
+            }
+            this.SubscriptionId = subscriptionId;
+            this.DnsSuffix = dnsSuffix;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
+        /// </summary>
+        /// <param name='subscriptionId'>
+        /// Required. The subscription id with value 'test12'.
+        /// </param>
+        /// <param name='dnsSuffix'>
+        /// Required. A string value that is used as a global part of the parameterized host. Default value 'host'.
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestParameterizedCustomHostTestClient(string subscriptionId, string dnsSuffix, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
+            if (dnsSuffix == null)
+            {
+                throw new ArgumentNullException("dnsSuffix");
+            }
+            this.SubscriptionId = subscriptionId;
+            this.DnsSuffix = dnsSuffix;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Header/AutoRestSwaggerBATHeaderService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Header/AutoRestSwaggerBATHeaderService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsHeader
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IHeader.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsHeader
         /// Initializes a new instance of the AutoRestSwaggerBATHeaderService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATHeaderService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsHeader
         /// Initializes a new instance of the AutoRestSwaggerBATHeaderService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATHeaderService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsHeader
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATHeaderService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsHeader
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestSwaggerBATHeaderService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/AutoRestHttpInfrastructureTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Http/AutoRestHttpInfrastructureTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsHttp
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IHttpFailure.
@@ -83,7 +83,7 @@ namespace Fixtures.AcceptanceTestsHttp
         /// Initializes a new instance of the AutoRestHttpInfrastructureTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHttpInfrastructureTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -94,10 +94,10 @@ namespace Fixtures.AcceptanceTestsHttp
         /// Initializes a new instance of the AutoRestHttpInfrastructureTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHttpInfrastructureTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -111,7 +111,7 @@ namespace Fixtures.AcceptanceTestsHttp
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHttpInfrastructureTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -129,10 +129,10 @@ namespace Fixtures.AcceptanceTestsHttp
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestHttpInfrastructureTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestService.cs
@@ -35,20 +35,20 @@ namespace Fixtures.AcceptanceTestsModelFlattening
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the AutoRestResourceFlatteningTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestResourceFlatteningTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -59,10 +59,10 @@ namespace Fixtures.AcceptanceTestsModelFlattening
         /// Initializes a new instance of the AutoRestResourceFlatteningTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestResourceFlatteningTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -76,7 +76,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestResourceFlatteningTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -94,10 +94,10 @@ namespace Fixtures.AcceptanceTestsModelFlattening
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestResourceFlatteningTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ParameterFlattening/AutoRestParameterFlattening.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ParameterFlattening/AutoRestParameterFlattening.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsParameterFlattening
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IAvailabilitySets.
@@ -53,7 +53,7 @@ namespace Fixtures.AcceptanceTestsParameterFlattening
         /// Initializes a new instance of the AutoRestParameterFlattening class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterFlattening(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.AcceptanceTestsParameterFlattening
         /// Initializes a new instance of the AutoRestParameterFlattening class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterFlattening(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.AcceptanceTestsParameterFlattening
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterFlattening(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.AcceptanceTestsParameterFlattening
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestParameterFlattening(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Report/AutoRestReportService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Report/AutoRestReportService.cs
@@ -35,20 +35,20 @@ namespace Fixtures.AcceptanceTestsReport
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the AutoRestReportService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestReportService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -59,10 +59,10 @@ namespace Fixtures.AcceptanceTestsReport
         /// Initializes a new instance of the AutoRestReportService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestReportService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -76,7 +76,7 @@ namespace Fixtures.AcceptanceTestsReport
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestReportService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -94,10 +94,10 @@ namespace Fixtures.AcceptanceTestsReport
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestReportService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/AutoRestRequiredOptionalTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/AutoRestRequiredOptionalTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// number of items to skip
@@ -73,7 +73,7 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         /// Initializes a new instance of the AutoRestRequiredOptionalTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestRequiredOptionalTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -84,10 +84,10 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         /// Initializes a new instance of the AutoRestRequiredOptionalTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestRequiredOptionalTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -101,7 +101,7 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestRequiredOptionalTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -119,10 +119,10 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestRequiredOptionalTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -131,6 +131,132 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
                 throw new ArgumentNullException("baseUri");
             }
             this.BaseUri = baseUri;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestRequiredOptionalTestService class.
+        /// </summary>
+        /// <param name='requiredGlobalPath'>
+        /// Required. number of items to skip
+        /// </param>
+        /// <param name='requiredGlobalQuery'>
+        /// Required. number of items to skip
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestRequiredOptionalTestService(string requiredGlobalPath, string requiredGlobalQuery, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (requiredGlobalPath == null)
+            {
+                throw new ArgumentNullException("requiredGlobalPath");
+            }
+            if (requiredGlobalQuery == null)
+            {
+                throw new ArgumentNullException("requiredGlobalQuery");
+            }
+            this.RequiredGlobalPath = requiredGlobalPath;
+            this.RequiredGlobalQuery = requiredGlobalQuery;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestRequiredOptionalTestService class.
+        /// </summary>
+        /// <param name='requiredGlobalPath'>
+        /// Required. number of items to skip
+        /// </param>
+        /// <param name='requiredGlobalQuery'>
+        /// Required. number of items to skip
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestRequiredOptionalTestService(string requiredGlobalPath, string requiredGlobalQuery, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (requiredGlobalPath == null)
+            {
+                throw new ArgumentNullException("requiredGlobalPath");
+            }
+            if (requiredGlobalQuery == null)
+            {
+                throw new ArgumentNullException("requiredGlobalQuery");
+            }
+            this.RequiredGlobalPath = requiredGlobalPath;
+            this.RequiredGlobalQuery = requiredGlobalQuery;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestRequiredOptionalTestService class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='requiredGlobalPath'>
+        /// Required. number of items to skip
+        /// </param>
+        /// <param name='requiredGlobalQuery'>
+        /// Required. number of items to skip
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestRequiredOptionalTestService(Uri baseUri, string requiredGlobalPath, string requiredGlobalQuery, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new ArgumentNullException("baseUri");
+            }
+            if (requiredGlobalPath == null)
+            {
+                throw new ArgumentNullException("requiredGlobalPath");
+            }
+            if (requiredGlobalQuery == null)
+            {
+                throw new ArgumentNullException("requiredGlobalQuery");
+            }
+            this.BaseUri = baseUri;
+            this.RequiredGlobalPath = requiredGlobalPath;
+            this.RequiredGlobalQuery = requiredGlobalQuery;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestRequiredOptionalTestService class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='requiredGlobalPath'>
+        /// Required. number of items to skip
+        /// </param>
+        /// <param name='requiredGlobalQuery'>
+        /// Required. number of items to skip
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestRequiredOptionalTestService(Uri baseUri, string requiredGlobalPath, string requiredGlobalQuery, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new ArgumentNullException("baseUri");
+            }
+            if (requiredGlobalPath == null)
+            {
+                throw new ArgumentNullException("requiredGlobalPath");
+            }
+            if (requiredGlobalQuery == null)
+            {
+                throw new ArgumentNullException("requiredGlobalQuery");
+            }
+            this.BaseUri = baseUri;
+            this.RequiredGlobalPath = requiredGlobalPath;
+            this.RequiredGlobalQuery = requiredGlobalQuery;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/AutoRestUrlTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Url/AutoRestUrlTestService.cs
@@ -35,14 +35,14 @@ namespace Fixtures.AcceptanceTestsUrl
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// A string value 'globalItemStringPath' that appears in the path
@@ -73,7 +73,7 @@ namespace Fixtures.AcceptanceTestsUrl
         /// Initializes a new instance of the AutoRestUrlTestService class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestUrlTestService(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -84,10 +84,10 @@ namespace Fixtures.AcceptanceTestsUrl
         /// Initializes a new instance of the AutoRestUrlTestService class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestUrlTestService(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -101,7 +101,7 @@ namespace Fixtures.AcceptanceTestsUrl
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestUrlTestService(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -119,10 +119,10 @@ namespace Fixtures.AcceptanceTestsUrl
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestUrlTestService(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -131,6 +131,100 @@ namespace Fixtures.AcceptanceTestsUrl
                 throw new ArgumentNullException("baseUri");
             }
             this.BaseUri = baseUri;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestUrlTestService class.
+        /// </summary>
+        /// <param name='globalStringPath'>
+        /// Required. A string value 'globalItemStringPath' that appears in the path
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestUrlTestService(string globalStringPath, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (globalStringPath == null)
+            {
+                throw new ArgumentNullException("globalStringPath");
+            }
+            this.GlobalStringPath = globalStringPath;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestUrlTestService class.
+        /// </summary>
+        /// <param name='globalStringPath'>
+        /// Required. A string value 'globalItemStringPath' that appears in the path
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestUrlTestService(string globalStringPath, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (globalStringPath == null)
+            {
+                throw new ArgumentNullException("globalStringPath");
+            }
+            this.GlobalStringPath = globalStringPath;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestUrlTestService class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='globalStringPath'>
+        /// Required. A string value 'globalItemStringPath' that appears in the path
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestUrlTestService(Uri baseUri, string globalStringPath, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new ArgumentNullException("baseUri");
+            }
+            if (globalStringPath == null)
+            {
+                throw new ArgumentNullException("globalStringPath");
+            }
+            this.BaseUri = baseUri;
+            this.GlobalStringPath = globalStringPath;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestUrlTestService class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='globalStringPath'>
+        /// Required. A string value 'globalItemStringPath' that appears in the path
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestUrlTestService(Uri baseUri, string globalStringPath, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new ArgumentNullException("baseUri");
+            }
+            if (globalStringPath == null)
+            {
+                throw new ArgumentNullException("globalStringPath");
+            }
+            this.BaseUri = baseUri;
+            this.GlobalStringPath = globalStringPath;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Validation/AutoRestValidationTest.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/Validation/AutoRestValidationTest.cs
@@ -36,14 +36,14 @@ namespace Fixtures.AcceptanceTestsValidation
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Subscription ID.
@@ -59,7 +59,7 @@ namespace Fixtures.AcceptanceTestsValidation
         /// Initializes a new instance of the AutoRestValidationTest class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestValidationTest(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -70,10 +70,10 @@ namespace Fixtures.AcceptanceTestsValidation
         /// Initializes a new instance of the AutoRestValidationTest class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestValidationTest(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -87,7 +87,7 @@ namespace Fixtures.AcceptanceTestsValidation
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestValidationTest(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -105,10 +105,10 @@ namespace Fixtures.AcceptanceTestsValidation
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public AutoRestValidationTest(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -117,6 +117,132 @@ namespace Fixtures.AcceptanceTestsValidation
                 throw new ArgumentNullException("baseUri");
             }
             this.BaseUri = baseUri;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestValidationTest class.
+        /// </summary>
+        /// <param name='subscriptionId'>
+        /// Required. Subscription ID.
+        /// </param>
+        /// <param name='apiVersion'>
+        /// Required. Required string following pattern \d{2}-\d{2}-\d{4}
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestValidationTest(string subscriptionId, string apiVersion, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException("apiVersion");
+            }
+            this.SubscriptionId = subscriptionId;
+            this.ApiVersion = apiVersion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestValidationTest class.
+        /// </summary>
+        /// <param name='subscriptionId'>
+        /// Required. Subscription ID.
+        /// </param>
+        /// <param name='apiVersion'>
+        /// Required. Required string following pattern \d{2}-\d{2}-\d{4}
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestValidationTest(string subscriptionId, string apiVersion, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException("apiVersion");
+            }
+            this.SubscriptionId = subscriptionId;
+            this.ApiVersion = apiVersion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestValidationTest class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. Subscription ID.
+        /// </param>
+        /// <param name='apiVersion'>
+        /// Required. Required string following pattern \d{2}-\d{2}-\d{4}
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestValidationTest(Uri baseUri, string subscriptionId, string apiVersion, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new ArgumentNullException("baseUri");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException("apiVersion");
+            }
+            this.BaseUri = baseUri;
+            this.SubscriptionId = subscriptionId;
+            this.ApiVersion = apiVersion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AutoRestValidationTest class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. Subscription ID.
+        /// </param>
+        /// <param name='apiVersion'>
+        /// Required. Required string following pattern \d{2}-\d{2}-\d{4}
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The HTTP client handler used to handle HTTP transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public AutoRestValidationTest(Uri baseUri, string subscriptionId, string apiVersion, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new ArgumentNullException("baseUri");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
+            if (apiVersion == null)
+            {
+                throw new ArgumentNullException("apiVersion");
+            }
+            this.BaseUri = baseUri;
+            this.SubscriptionId = subscriptionId;
+            this.ApiVersion = apiVersion;
         }
 
         /// <summary>

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/DateTimeOffset/SwaggerDateTimeOffsetClient.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/DateTimeOffset/SwaggerDateTimeOffsetClient.cs
@@ -35,20 +35,20 @@ namespace Fixtures.DateTimeOffset
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the SwaggerDateTimeOffsetClient class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerDateTimeOffsetClient(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -59,10 +59,10 @@ namespace Fixtures.DateTimeOffset
         /// Initializes a new instance of the SwaggerDateTimeOffsetClient class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerDateTimeOffsetClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -76,7 +76,7 @@ namespace Fixtures.DateTimeOffset
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerDateTimeOffsetClient(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -94,10 +94,10 @@ namespace Fixtures.DateTimeOffset
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerDateTimeOffsetClient(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Internal.Ctors/InternalClient.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Internal.Ctors/InternalClient.cs
@@ -35,14 +35,14 @@ namespace Fixtures.InternalCtors
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets the IPets.
@@ -53,7 +53,7 @@ namespace Fixtures.InternalCtors
         /// Initializes a new instance of the InternalClient class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         internal InternalClient(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -64,10 +64,10 @@ namespace Fixtures.InternalCtors
         /// Initializes a new instance of the InternalClient class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         internal InternalClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -81,7 +81,7 @@ namespace Fixtures.InternalCtors
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         internal InternalClient(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -99,10 +99,10 @@ namespace Fixtures.InternalCtors
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         internal InternalClient(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Polymorphic/PolymorphicAnimalStore.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Polymorphic/PolymorphicAnimalStore.cs
@@ -35,20 +35,20 @@ namespace Fixtures.MirrorPolymorphic
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the PolymorphicAnimalStore class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public PolymorphicAnimalStore(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -59,10 +59,10 @@ namespace Fixtures.MirrorPolymorphic
         /// Initializes a new instance of the PolymorphicAnimalStore class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public PolymorphicAnimalStore(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -76,7 +76,7 @@ namespace Fixtures.MirrorPolymorphic
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public PolymorphicAnimalStore(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -94,10 +94,10 @@ namespace Fixtures.MirrorPolymorphic
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public PolymorphicAnimalStore(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Primitives/SwaggerDataTypesClient.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Primitives/SwaggerDataTypesClient.cs
@@ -35,20 +35,20 @@ namespace Fixtures.MirrorPrimitives
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the SwaggerDataTypesClient class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerDataTypesClient(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -59,10 +59,10 @@ namespace Fixtures.MirrorPrimitives
         /// Initializes a new instance of the SwaggerDataTypesClient class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerDataTypesClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -76,7 +76,7 @@ namespace Fixtures.MirrorPrimitives
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerDataTypesClient(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -94,10 +94,10 @@ namespace Fixtures.MirrorPrimitives
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerDataTypesClient(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.RecursiveTypes/RecursiveTypesAPI.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.RecursiveTypes/RecursiveTypesAPI.cs
@@ -35,20 +35,20 @@ namespace Fixtures.MirrorRecursiveTypes
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the RecursiveTypesAPI class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public RecursiveTypesAPI(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -59,10 +59,10 @@ namespace Fixtures.MirrorRecursiveTypes
         /// Initializes a new instance of the RecursiveTypesAPI class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public RecursiveTypesAPI(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -76,7 +76,7 @@ namespace Fixtures.MirrorRecursiveTypes
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public RecursiveTypesAPI(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -94,10 +94,10 @@ namespace Fixtures.MirrorRecursiveTypes
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public RecursiveTypesAPI(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Sequences/SequenceRequestResponseTest.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/Mirror.Sequences/SequenceRequestResponseTest.cs
@@ -36,20 +36,20 @@ namespace Fixtures.MirrorSequences
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the SequenceRequestResponseTest class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SequenceRequestResponseTest(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -60,10 +60,10 @@ namespace Fixtures.MirrorSequences
         /// Initializes a new instance of the SequenceRequestResponseTest class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SequenceRequestResponseTest(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -77,7 +77,7 @@ namespace Fixtures.MirrorSequences
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SequenceRequestResponseTest(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -95,10 +95,10 @@ namespace Fixtures.MirrorSequences
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SequenceRequestResponseTest(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/PetstoreV2/SwaggerPetstoreV2.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/PetstoreV2/SwaggerPetstoreV2.cs
@@ -39,14 +39,14 @@ namespace Fixtures.PetstoreV2
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Subscription credentials which uniquely identify client subscription.
@@ -57,7 +57,7 @@ namespace Fixtures.PetstoreV2
         /// Initializes a new instance of the SwaggerPetstoreV2 class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected SwaggerPetstoreV2(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -68,10 +68,10 @@ namespace Fixtures.PetstoreV2
         /// Initializes a new instance of the SwaggerPetstoreV2 class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected SwaggerPetstoreV2(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -85,7 +85,7 @@ namespace Fixtures.PetstoreV2
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected SwaggerPetstoreV2(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -103,10 +103,10 @@ namespace Fixtures.PetstoreV2
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected SwaggerPetstoreV2(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -124,7 +124,7 @@ namespace Fixtures.PetstoreV2
         /// Required. Subscription credentials which uniquely identify client subscription.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerPetstoreV2(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -146,10 +146,10 @@ namespace Fixtures.PetstoreV2
         /// Required. Subscription credentials which uniquely identify client subscription.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerPetstoreV2(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -174,7 +174,7 @@ namespace Fixtures.PetstoreV2
         /// Required. Subscription credentials which uniquely identify client subscription.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerPetstoreV2(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -204,10 +204,10 @@ namespace Fixtures.PetstoreV2
         /// Required. Subscription credentials which uniquely identify client subscription.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerPetstoreV2(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {

--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/ServiceClientTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/ServiceClientTemplateModel.cs
@@ -59,10 +59,10 @@ namespace Microsoft.Rest.Generator.CSharp
             get
             {
                 var requireParams = new List<string>();
-                this.Properties.Where(p => p.IsRequired && p.IsReadOnly)
-                    .ForEach(p => requireParams.Add(string.Format(CultureInfo.InvariantCulture, 
-                        "{0} {1}", 
-                        p.Type.Name, 
+                this.Properties.Where(p => p.IsRequired)
+                    .ForEach(p => requireParams.Add(string.Format(CultureInfo.InvariantCulture,
+                        "{0} {1}",
+                        p.Type.Name,
                         p.Name.ToCamelCase())));
                 return string.Join(", ", requireParams);
             }

--- a/AutoRest/Generators/CSharp/CSharp/Templates/ServiceClientBodyTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/ServiceClientBodyTemplate.cshtml
@@ -21,13 +21,13 @@ else
 @EmptyLine
 
 /// <summary>
-/// Gets or sets json serialization settings.
+/// Gets JSON serialization settings.
 /// </summary>
 public JsonSerializerSettings SerializationSettings { get; private set; }
 @EmptyLine
 
 /// <summary>
-/// Gets or sets json deserialization settings.
+/// Gets JSON deserialization settings.
 /// </summary>
 public JsonSerializerSettings DeserializationSettings { get; private set; }        
 @EmptyLine
@@ -54,7 +54,7 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 /// Initializes a new instance of the @Model.Name class.
 /// </summary>
 /// <param name='handlers'>
-/// Optional. The delegating handlers to add to the http client pipeline.
+/// Optional. The delegating handlers to add to the HTTP pipeline.
 /// </param>
 @(Model.ContainsCredentials ? "protected" : Model.ConstructorVisibility) @(Model.Name)(params DelegatingHandler[] handlers) : base(handlers)
 {
@@ -66,10 +66,10 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 /// Initializes a new instance of the @Model.Name class.
 /// </summary>
 /// <param name='rootHandler'>
-/// Optional. The http client handler used to handle http transport.
+/// Optional. The http client handler used to handle HTTP transport.
 /// </param>
 /// <param name='handlers'>
-/// Optional. The delegating handlers to add to the http client pipeline.
+/// Optional. The delegating handlers to add to the HTTP pipeline.
 /// </param>
 @(Model.ContainsCredentials ? "protected" : Model.ConstructorVisibility) @(Model.Name)(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
 {
@@ -86,7 +86,7 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 @:/// Optional. The base URI of the service.
 @:/// </param>
 @:/// <param name='handlers'>
-@:/// Optional. The delegating handlers to add to the http client pipeline.
+@:/// Optional. The delegating handlers to add to the HTTP pipeline.
 @:/// </param>
 @:@(Model.ContainsCredentials ? "protected" : Model.ConstructorVisibility) @(Model.Name)(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
 @:{
@@ -106,10 +106,10 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 @:/// Optional. The base URI of the service.
 @:/// </param>
 @:/// <param name='rootHandler'>
-@:/// Optional. The http client handler used to handle http transport.
+@:/// Optional. The http client handler used to handle HTTP transport.
 @:/// </param>
 @:/// <param name='handlers'>
-@:/// Optional. The delegating handlers to add to the http client pipeline.
+@:/// Optional. The delegating handlers to add to the HTTP pipeline.
 @:/// </param>
 @:@(Model.ContainsCredentials ? "protected" : Model.ConstructorVisibility) @(Model.Name)(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
 @:{
@@ -123,7 +123,7 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 @:@EmptyLine
 }
 
-@{var parameters = Model.Properties.Where(p => p.IsRequired && p.IsReadOnly);}
+@{var parameters = Model.Properties.Where(p => p.IsRequired);}
 @if (parameters.Any())
 {
 @:/// <summary>
@@ -136,7 +136,7 @@ foreach (var param in parameters)
 @:/// </param>
 }
 @:/// <param name='handlers'>
-@:/// Optional. The delegating handlers to add to the http client pipeline.
+@:/// Optional. The delegating handlers to add to the HTTP pipeline.
 @:/// </param>
 @:@(Model.ConstructorVisibility) @(Model.Name)(@(Model.RequiredConstructorParameters), params DelegatingHandler[] handlers) : this(handlers)
 @:{
@@ -171,10 +171,10 @@ foreach (var param in parameters)
 @:/// </param>
 }
 @:/// <param name='rootHandler'>
-@:/// Optional. The http client handler used to handle http transport.
+@:/// Optional. The http client handler used to handle HTTP transport.
 @:/// </param>
 @:/// <param name='handlers'>
-@:/// Optional. The delegating handlers to add to the http client pipeline.
+@:/// Optional. The delegating handlers to add to the HTTP pipeline.
 @:/// </param>
 @:@(Model.ConstructorVisibility) @(Model.Name)(@(Model.RequiredConstructorParameters), HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
 @:{
@@ -214,7 +214,7 @@ foreach (var param in parameters)
 @:/// </param>
 }
 @:/// <param name='handlers'>
-@:/// Optional. The delegating handlers to add to the http client pipeline.
+@:/// Optional. The delegating handlers to add to the HTTP pipeline.
 @:/// </param>
 @:@(Model.ConstructorVisibility) @(Model.Name)(Uri baseUri, @(Model.RequiredConstructorParameters), params DelegatingHandler[] handlers) : this(handlers)
 @:{
@@ -260,10 +260,10 @@ foreach (var param in parameters)
 @:/// </param>
 }
 @:/// <param name='rootHandler'>
-@:/// Optional. The http client handler used to handle http transport.
+@:/// Optional. The HTTP client handler used to handle HTTP transport.
 @:/// </param>
 @:/// <param name='handlers'>
-@:/// Optional. The delegating handlers to add to the http client pipeline.
+@:/// Optional. The delegating handlers to add to the HTTP pipeline.
 @:/// </param>
 @:@(Model.ConstructorVisibility) @(Model.Name)(Uri baseUri, @(Model.RequiredConstructorParameters), HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
 @:{

--- a/AutoRest/Generators/CSharp/CSharp/Templates/ServiceClientBodyTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/ServiceClientBodyTemplate.cshtml
@@ -29,9 +29,9 @@ public JsonSerializerSettings SerializationSettings { get; private set; }
 /// <summary>
 /// Gets JSON deserialization settings.
 /// </summary>
-public JsonSerializerSettings DeserializationSettings { get; private set; }        
+public JsonSerializerSettings DeserializationSettings { get; private set; }
 @EmptyLine
-        
+
 @foreach (var property in Model.Properties)
 {
 @:/// <summary>
@@ -40,8 +40,8 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 @:public @property.Type @property.Name { get; @(property.IsReadOnly || property.IsConstant ? "private " : "")set; }
 @EmptyLine
 }
-        
-@foreach (var operation in Model.Operations) 
+
+@foreach (var operation in Model.Operations)
 {
 @:/// <summary>
 @:/// Gets the I@(operation.MethodGroupType).
@@ -49,7 +49,7 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 @:public virtual I@(operation.MethodGroupType) @(operation.MethodGroupName) { get; private set; }
 @EmptyLine
 }
-       
+
 /// <summary>
 /// Initializes a new instance of the @Model.Name class.
 /// </summary>
@@ -66,7 +66,7 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 /// Initializes a new instance of the @Model.Name class.
 /// </summary>
 /// <param name='rootHandler'>
-/// Optional. The http client handler used to handle HTTP transport.
+/// Optional. The HTTP client handler used to handle HTTP transport.
 /// </param>
 /// <param name='handlers'>
 /// Optional. The delegating handlers to add to the HTTP pipeline.
@@ -78,7 +78,7 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 @EmptyLine
 
 @if(!Model.IsCustomBaseUri)
-{ 
+{
 @:/// <summary>
 @:/// Initializes a new instance of the @Model.Name class.
 @:/// </summary>
@@ -97,7 +97,7 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 @:
 @:    this.BaseUri = baseUri;
 @:}
-@:@EmptyLine 
+@:@EmptyLine
 
 @:/// <summary>
 @:/// Initializes a new instance of the @Model.Name class.
@@ -106,7 +106,7 @@ public JsonSerializerSettings DeserializationSettings { get; private set; }
 @:/// Optional. The base URI of the service.
 @:/// </param>
 @:/// <param name='rootHandler'>
-@:/// Optional. The http client handler used to handle HTTP transport.
+@:/// Optional. The HTTP client handler used to handle HTTP transport.
 @:/// </param>
 @:/// <param name='handlers'>
 @:/// Optional. The delegating handlers to add to the HTTP pipeline.
@@ -160,7 +160,7 @@ foreach (var param in parameters)
 }
 @:}
 @:@EmptyLine
-        
+
 @:/// <summary>
 @:/// Initializes a new instance of the @Model.Name class.
 @:/// </summary>
@@ -171,7 +171,7 @@ foreach (var param in parameters)
 @:/// </param>
 }
 @:/// <param name='rootHandler'>
-@:/// Optional. The http client handler used to handle HTTP transport.
+@:/// Optional. The HTTP client handler used to handle HTTP transport.
 @:/// </param>
 @:/// <param name='handlers'>
 @:/// Optional. The delegating handlers to add to the HTTP pipeline.
@@ -200,7 +200,7 @@ foreach (var param in parameters)
 @:@EmptyLine
 
 if(!Model.IsCustomBaseUri)
-{ 
+{
 @:/// <summary>
 @:/// Initializes a new instance of the @Model.Name class.
 @:/// </summary>
@@ -246,7 +246,7 @@ foreach (var param in parameters)
 }
 @:}
 @:@EmptyLine
-        
+
 @:/// <summary>
 @:/// Initializes a new instance of the @Model.Name class.
 @:/// </summary>

--- a/AutoRest/Generators/Python/Python.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/autorestparameterizedcustomhosttestclient/auto_rest_parameterized_custom_host_test_client.py
+++ b/AutoRest/Generators/Python/Python.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/autorestparameterizedcustomhosttestclient/auto_rest_parameterized_custom_host_test_client.py
@@ -33,9 +33,13 @@ class AutoRestParameterizedCustomHostTestClientConfiguration(Configuration):
             self, subscription_id, dns_suffix, filepath=None):
 
         if subscription_id is None:
-            raise ValueError('subscription_id must not be None.')
+            raise ValueError("Parameter 'subscription_id' must not be None.")
+        if not isinstance(subscription_id, str):
+            raise TypeError("Parameter 'subscription_id' must be str.")
         if dns_suffix is None:
-            raise ValueError('dns_suffix must not be None.')
+            raise ValueError("Parameter 'dns_suffix' must not be None.")
+        if not isinstance(dns_suffix, str):
+            raise TypeError("Parameter 'dns_suffix' must be str.")
         base_url = '{vault}{secret}{dnsSuffix}'
 
         super(AutoRestParameterizedCustomHostTestClientConfiguration, self).__init__(base_url, filepath)

--- a/Samples/azure-storage/Azure.CSharp/StorageManagementClient.cs
+++ b/Samples/azure-storage/Azure.CSharp/StorageManagementClient.cs
@@ -29,14 +29,14 @@ namespace Petstore
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Gets Azure subscription credentials.
@@ -86,7 +86,7 @@ namespace Petstore
         /// Initializes a new instance of the StorageManagementClient class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected StorageManagementClient(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -97,10 +97,10 @@ namespace Petstore
         /// Initializes a new instance of the StorageManagementClient class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected StorageManagementClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -114,7 +114,7 @@ namespace Petstore
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected StorageManagementClient(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -132,10 +132,10 @@ namespace Petstore
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         protected StorageManagementClient(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
@@ -152,20 +152,28 @@ namespace Petstore
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='subscriptionId'>
+        /// Required. Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.
         /// </param>
-        public StorageManagementClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public StorageManagementClient(ServiceClientCredentials credentials, string subscriptionId, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -174,23 +182,31 @@ namespace Petstore
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public StorageManagementClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public StorageManagementClient(ServiceClientCredentials credentials, string subscriptionId, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
             {
                 throw new ArgumentNullException("credentials");
+            }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
             }
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -202,10 +218,13 @@ namespace Petstore
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// <param name='subscriptionId'>
+        /// Required. Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.
         /// </param>
-        public StorageManagementClient(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
+        /// </param>
+        public StorageManagementClient(Uri baseUri, ServiceClientCredentials credentials, string subscriptionId, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
             {
@@ -215,12 +234,17 @@ namespace Petstore
             {
                 throw new ArgumentNullException("credentials");
             }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>
@@ -232,13 +256,16 @@ namespace Petstore
         /// <param name='credentials'>
         /// Required. Gets Azure subscription credentials.
         /// </param>
+        /// <param name='subscriptionId'>
+        /// Required. Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.
+        /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
-        public StorageManagementClient(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public StorageManagementClient(Uri baseUri, ServiceClientCredentials credentials, string subscriptionId, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
             {
@@ -248,12 +275,17 @@ namespace Petstore
             {
                 throw new ArgumentNullException("credentials");
             }
+            if (subscriptionId == null)
+            {
+                throw new ArgumentNullException("subscriptionId");
+            }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
             if (this.Credentials != null)
             {
                 this.Credentials.InitializeServiceClient(this);
             }
+            this.SubscriptionId = subscriptionId;
         }
 
         /// <summary>

--- a/Samples/petstore/CSharp/SwaggerPetstore.cs
+++ b/Samples/petstore/CSharp/SwaggerPetstore.cs
@@ -32,20 +32,20 @@ namespace Petstore
         public Uri BaseUri { get; set; }
 
         /// <summary>
-        /// Gets or sets json serialization settings.
+        /// Gets JSON serialization settings.
         /// </summary>
         public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets json deserialization settings.
+        /// Gets JSON deserialization settings.
         /// </summary>
-        public JsonSerializerSettings DeserializationSettings { get; private set; }        
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the SwaggerPetstore class.
         /// </summary>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerPetstore(params DelegatingHandler[] handlers) : base(handlers)
         {
@@ -56,10 +56,10 @@ namespace Petstore
         /// Initializes a new instance of the SwaggerPetstore class.
         /// </summary>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerPetstore(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
@@ -73,7 +73,7 @@ namespace Petstore
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerPetstore(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
@@ -91,10 +91,10 @@ namespace Petstore
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
+        /// Optional. The HTTP client handler used to handle HTTP transport.
         /// </param>
         /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// Optional. The delegating handlers to add to the HTTP pipeline.
         /// </param>
         public SwaggerPetstore(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {


### PR DESCRIPTION
Proposal:
Currently, there are already static constructors that the user can use without the required parameters in the service client templates. By removing the readOnly attribute for parameters, the user can simply note the parameter to be required. This will then be added to the required parameter constructors. As of right now, setting a parameter to be readOnly and required to be true does not work.

Changes:
- Removed the readOnly extension
- Regenerated the CSharp/Azure CSharp tests
- Minor: Made doc strings in the Service Client template to be more accurate

 

