### PR TITLE
[Java & Java.Azure] Create service once in each client

### DIFF
--- a/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/azureparametergrouping/implementation/api/AutoRestParameterGroupingTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/azureparametergrouping/implementation/api/AutoRestParameterGroupingTestServiceImpl.java
@@ -108,11 +108,16 @@ public final class AutoRestParameterGroupingTestServiceImpl extends AzureService
     }
 
     /**
+     * The ParameterGroupingsInner object to access its operations.
+     */
+    private ParameterGroupingsInner parameterGroupings;
+
+    /**
      * Gets the ParameterGroupingsInner object to access its operations.
      * @return the ParameterGroupingsInner object.
      */
     public ParameterGroupingsInner parameterGroupings() {
-        return new ParameterGroupingsInner(restClient().retrofit(), this);
+        return this.parameterGroupings;
     }
 
     /**
@@ -151,6 +156,7 @@ public final class AutoRestParameterGroupingTestServiceImpl extends AzureService
         this.acceptLanguage = "en-US";
         this.longRunningOperationRetryTimeout = 30;
         this.generateClientRequestId = true;
+        this.parameterGroupings = new ParameterGroupingsInner(restClient().retrofit(), this);
         restClient().headers().addHeader("x-ms-client-request-id", UUID.randomUUID().toString());
         this.azureClient = new AzureClient(restClient());
     }

--- a/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/azurespecials/implementation/api/AutoRestAzureSpecialParametersTestClientImpl.java
+++ b/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/azurespecials/implementation/api/AutoRestAzureSpecialParametersTestClientImpl.java
@@ -141,67 +141,107 @@ public final class AutoRestAzureSpecialParametersTestClientImpl extends AzureSer
     }
 
     /**
+     * The XMsClientRequestIdsInner object to access its operations.
+     */
+    private XMsClientRequestIdsInner xMsClientRequestIds;
+
+    /**
      * Gets the XMsClientRequestIdsInner object to access its operations.
      * @return the XMsClientRequestIdsInner object.
      */
     public XMsClientRequestIdsInner xMsClientRequestIds() {
-        return new XMsClientRequestIdsInner(restClient().retrofit(), this);
+        return this.xMsClientRequestIds;
     }
+
+    /**
+     * The SubscriptionInCredentialsInner object to access its operations.
+     */
+    private SubscriptionInCredentialsInner subscriptionInCredentials;
 
     /**
      * Gets the SubscriptionInCredentialsInner object to access its operations.
      * @return the SubscriptionInCredentialsInner object.
      */
     public SubscriptionInCredentialsInner subscriptionInCredentials() {
-        return new SubscriptionInCredentialsInner(restClient().retrofit(), this);
+        return this.subscriptionInCredentials;
     }
+
+    /**
+     * The SubscriptionInMethodsInner object to access its operations.
+     */
+    private SubscriptionInMethodsInner subscriptionInMethods;
 
     /**
      * Gets the SubscriptionInMethodsInner object to access its operations.
      * @return the SubscriptionInMethodsInner object.
      */
     public SubscriptionInMethodsInner subscriptionInMethods() {
-        return new SubscriptionInMethodsInner(restClient().retrofit(), this);
+        return this.subscriptionInMethods;
     }
+
+    /**
+     * The ApiVersionDefaultsInner object to access its operations.
+     */
+    private ApiVersionDefaultsInner apiVersionDefaults;
 
     /**
      * Gets the ApiVersionDefaultsInner object to access its operations.
      * @return the ApiVersionDefaultsInner object.
      */
     public ApiVersionDefaultsInner apiVersionDefaults() {
-        return new ApiVersionDefaultsInner(restClient().retrofit(), this);
+        return this.apiVersionDefaults;
     }
+
+    /**
+     * The ApiVersionLocalsInner object to access its operations.
+     */
+    private ApiVersionLocalsInner apiVersionLocals;
 
     /**
      * Gets the ApiVersionLocalsInner object to access its operations.
      * @return the ApiVersionLocalsInner object.
      */
     public ApiVersionLocalsInner apiVersionLocals() {
-        return new ApiVersionLocalsInner(restClient().retrofit(), this);
+        return this.apiVersionLocals;
     }
+
+    /**
+     * The SkipUrlEncodingsInner object to access its operations.
+     */
+    private SkipUrlEncodingsInner skipUrlEncodings;
 
     /**
      * Gets the SkipUrlEncodingsInner object to access its operations.
      * @return the SkipUrlEncodingsInner object.
      */
     public SkipUrlEncodingsInner skipUrlEncodings() {
-        return new SkipUrlEncodingsInner(restClient().retrofit(), this);
+        return this.skipUrlEncodings;
     }
+
+    /**
+     * The OdatasInner object to access its operations.
+     */
+    private OdatasInner odatas;
 
     /**
      * Gets the OdatasInner object to access its operations.
      * @return the OdatasInner object.
      */
     public OdatasInner odatas() {
-        return new OdatasInner(restClient().retrofit(), this);
+        return this.odatas;
     }
+
+    /**
+     * The HeadersInner object to access its operations.
+     */
+    private HeadersInner headers;
 
     /**
      * Gets the HeadersInner object to access its operations.
      * @return the HeadersInner object.
      */
     public HeadersInner headers() {
-        return new HeadersInner(restClient().retrofit(), this);
+        return this.headers;
     }
 
     /**
@@ -241,6 +281,14 @@ public final class AutoRestAzureSpecialParametersTestClientImpl extends AzureSer
         this.acceptLanguage = "en-US";
         this.longRunningOperationRetryTimeout = 30;
         this.generateClientRequestId = true;
+        this.xMsClientRequestIds = new XMsClientRequestIdsInner(restClient().retrofit(), this);
+        this.subscriptionInCredentials = new SubscriptionInCredentialsInner(restClient().retrofit(), this);
+        this.subscriptionInMethods = new SubscriptionInMethodsInner(restClient().retrofit(), this);
+        this.apiVersionDefaults = new ApiVersionDefaultsInner(restClient().retrofit(), this);
+        this.apiVersionLocals = new ApiVersionLocalsInner(restClient().retrofit(), this);
+        this.skipUrlEncodings = new SkipUrlEncodingsInner(restClient().retrofit(), this);
+        this.odatas = new OdatasInner(restClient().retrofit(), this);
+        this.headers = new HeadersInner(restClient().retrofit(), this);
         restClient().headers().addHeader("x-ms-client-request-id", UUID.randomUUID().toString());
         this.azureClient = new AzureClient(restClient());
     }

--- a/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/custombaseuri/implementation/api/AutoRestParameterizedHostTestClientImpl.java
+++ b/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/custombaseuri/implementation/api/AutoRestParameterizedHostTestClientImpl.java
@@ -129,11 +129,16 @@ public final class AutoRestParameterizedHostTestClientImpl extends AzureServiceC
     }
 
     /**
+     * The PathsInner object to access its operations.
+     */
+    private PathsInner paths;
+
+    /**
      * Gets the PathsInner object to access its operations.
      * @return the PathsInner object.
      */
     public PathsInner paths() {
-        return new PathsInner(restClient().retrofit(), this);
+        return this.paths;
     }
 
     /**
@@ -173,6 +178,7 @@ public final class AutoRestParameterizedHostTestClientImpl extends AzureServiceC
         this.acceptLanguage = "en-US";
         this.longRunningOperationRetryTimeout = 30;
         this.generateClientRequestId = true;
+        this.paths = new PathsInner(restClient().retrofit(), this);
         restClient().headers().addHeader("x-ms-client-request-id", UUID.randomUUID().toString());
         this.azureClient = new AzureClient(restClient());
     }

--- a/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/head/implementation/api/AutoRestHeadTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/head/implementation/api/AutoRestHeadTestServiceImpl.java
@@ -108,11 +108,16 @@ public final class AutoRestHeadTestServiceImpl extends AzureServiceClient {
     }
 
     /**
+     * The HttpSuccessInner object to access its operations.
+     */
+    private HttpSuccessInner httpSuccess;
+
+    /**
      * Gets the HttpSuccessInner object to access its operations.
      * @return the HttpSuccessInner object.
      */
     public HttpSuccessInner httpSuccess() {
-        return new HttpSuccessInner(restClient().retrofit(), this);
+        return this.httpSuccess;
     }
 
     /**
@@ -151,6 +156,7 @@ public final class AutoRestHeadTestServiceImpl extends AzureServiceClient {
         this.acceptLanguage = "en-US";
         this.longRunningOperationRetryTimeout = 30;
         this.generateClientRequestId = true;
+        this.httpSuccess = new HttpSuccessInner(restClient().retrofit(), this);
         restClient().headers().addHeader("x-ms-client-request-id", UUID.randomUUID().toString());
         this.azureClient = new AzureClient(restClient());
     }

--- a/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/headexceptions/implementation/api/AutoRestHeadExceptionTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/headexceptions/implementation/api/AutoRestHeadExceptionTestServiceImpl.java
@@ -108,11 +108,16 @@ public final class AutoRestHeadExceptionTestServiceImpl extends AzureServiceClie
     }
 
     /**
+     * The HeadExceptionsInner object to access its operations.
+     */
+    private HeadExceptionsInner headExceptions;
+
+    /**
      * Gets the HeadExceptionsInner object to access its operations.
      * @return the HeadExceptionsInner object.
      */
     public HeadExceptionsInner headExceptions() {
-        return new HeadExceptionsInner(restClient().retrofit(), this);
+        return this.headExceptions;
     }
 
     /**
@@ -151,6 +156,7 @@ public final class AutoRestHeadExceptionTestServiceImpl extends AzureServiceClie
         this.acceptLanguage = "en-US";
         this.longRunningOperationRetryTimeout = 30;
         this.generateClientRequestId = true;
+        this.headExceptions = new HeadExceptionsInner(restClient().retrofit(), this);
         restClient().headers().addHeader("x-ms-client-request-id", UUID.randomUUID().toString());
         this.azureClient = new AzureClient(restClient());
     }

--- a/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/lro/implementation/api/AutoRestLongRunningOperationTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/lro/implementation/api/AutoRestLongRunningOperationTestServiceImpl.java
@@ -108,35 +108,55 @@ public final class AutoRestLongRunningOperationTestServiceImpl extends AzureServ
     }
 
     /**
+     * The LROsInner object to access its operations.
+     */
+    private LROsInner lROs;
+
+    /**
      * Gets the LROsInner object to access its operations.
      * @return the LROsInner object.
      */
     public LROsInner lROs() {
-        return new LROsInner(restClient().retrofit(), this);
+        return this.lROs;
     }
+
+    /**
+     * The LRORetrysInner object to access its operations.
+     */
+    private LRORetrysInner lRORetrys;
 
     /**
      * Gets the LRORetrysInner object to access its operations.
      * @return the LRORetrysInner object.
      */
     public LRORetrysInner lRORetrys() {
-        return new LRORetrysInner(restClient().retrofit(), this);
+        return this.lRORetrys;
     }
+
+    /**
+     * The LROSADsInner object to access its operations.
+     */
+    private LROSADsInner lROSADs;
 
     /**
      * Gets the LROSADsInner object to access its operations.
      * @return the LROSADsInner object.
      */
     public LROSADsInner lROSADs() {
-        return new LROSADsInner(restClient().retrofit(), this);
+        return this.lROSADs;
     }
+
+    /**
+     * The LROsCustomHeadersInner object to access its operations.
+     */
+    private LROsCustomHeadersInner lROsCustomHeaders;
 
     /**
      * Gets the LROsCustomHeadersInner object to access its operations.
      * @return the LROsCustomHeadersInner object.
      */
     public LROsCustomHeadersInner lROsCustomHeaders() {
-        return new LROsCustomHeadersInner(restClient().retrofit(), this);
+        return this.lROsCustomHeaders;
     }
 
     /**
@@ -175,6 +195,10 @@ public final class AutoRestLongRunningOperationTestServiceImpl extends AzureServ
         this.acceptLanguage = "en-US";
         this.longRunningOperationRetryTimeout = 30;
         this.generateClientRequestId = true;
+        this.lROs = new LROsInner(restClient().retrofit(), this);
+        this.lRORetrys = new LRORetrysInner(restClient().retrofit(), this);
+        this.lROSADs = new LROSADsInner(restClient().retrofit(), this);
+        this.lROsCustomHeaders = new LROsCustomHeadersInner(restClient().retrofit(), this);
         restClient().headers().addHeader("x-ms-client-request-id", UUID.randomUUID().toString());
         this.azureClient = new AzureClient(restClient());
     }

--- a/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/paging/implementation/api/AutoRestPagingTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/paging/implementation/api/AutoRestPagingTestServiceImpl.java
@@ -108,11 +108,16 @@ public final class AutoRestPagingTestServiceImpl extends AzureServiceClient {
     }
 
     /**
+     * The PagingsInner object to access its operations.
+     */
+    private PagingsInner pagings;
+
+    /**
      * Gets the PagingsInner object to access its operations.
      * @return the PagingsInner object.
      */
     public PagingsInner pagings() {
-        return new PagingsInner(restClient().retrofit(), this);
+        return this.pagings;
     }
 
     /**
@@ -151,6 +156,7 @@ public final class AutoRestPagingTestServiceImpl extends AzureServiceClient {
         this.acceptLanguage = "en-US";
         this.longRunningOperationRetryTimeout = 30;
         this.generateClientRequestId = true;
+        this.pagings = new PagingsInner(restClient().retrofit(), this);
         restClient().headers().addHeader("x-ms-client-request-id", UUID.randomUUID().toString());
         this.azureClient = new AzureClient(restClient());
     }

--- a/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/api/MicrosoftAzureTestUrlImpl.java
+++ b/AutoRest/Generators/Java/Azure.Java.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/api/MicrosoftAzureTestUrlImpl.java
@@ -141,11 +141,16 @@ public final class MicrosoftAzureTestUrlImpl extends AzureServiceClient {
     }
 
     /**
+     * The GroupsInner object to access its operations.
+     */
+    private GroupsInner groups;
+
+    /**
      * Gets the GroupsInner object to access its operations.
      * @return the GroupsInner object.
      */
     public GroupsInner groups() {
-        return new GroupsInner(restClient().retrofit(), this);
+        return this.groups;
     }
 
     /**
@@ -185,6 +190,7 @@ public final class MicrosoftAzureTestUrlImpl extends AzureServiceClient {
         this.acceptLanguage = "en-US";
         this.longRunningOperationRetryTimeout = 30;
         this.generateClientRequestId = true;
+        this.groups = new GroupsInner(restClient().retrofit(), this);
         restClient().headers().addHeader("x-ms-client-request-id", UUID.randomUUID().toString());
         this.azureClient = new AzureClient(restClient());
     }

--- a/AutoRest/Generators/Java/Azure.Java/Templates/AzureServiceClientTemplate.cshtml
+++ b/AutoRest/Generators/Java/Azure.Java/Templates/AzureServiceClientTemplate.cshtml
@@ -71,11 +71,16 @@ if(!property.IsReadOnly)
 {
 @EmptyLine
 @:    /**
+@:     * The @(operation.MethodGroupType)Inner object to access its operations.
+@:     */
+@:    private @(operation.MethodGroupType)Inner @(operation.MethodGroupName);
+@EmptyLine
+@:    /**
 @:     * Gets the @(operation.MethodGroupType)Inner object to access its operations.
 @:     * @@return the @(operation.MethodGroupType)Inner object.
 @:     */
 @:    public @(operation.MethodGroupType)Inner @(operation.MethodGroupName)() {
-@:        return new @(operation.MethodGroupType)Inner(restClient().retrofit(), this);
+@:        return this.@(operation.MethodGroupName);
 @:    }
 }
 @EmptyLine
@@ -155,6 +160,10 @@ else
 @foreach (var property in Model.Properties.Where(p => p.DefaultValue != null))
 {
         @:this.@(property.Name) = @(property.DefaultValue);
+}
+@foreach (var operation in Model.Operations)
+{
+@:        this.@(operation.MethodGroupName) = new @(operation.MethodGroupType)Inner(restClient().retrofit(), this);
 }
         @Model.SetDefaultHeaders
         this.azureClient = new AzureClient(restClient());

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyarray/implementation/AutoRestSwaggerBATArrayServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyarray/implementation/AutoRestSwaggerBATArrayServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestSwaggerBATArrayServiceImpl extends ServiceClient implements AutoRestSwaggerBATArrayService {
 
     /**
+     * The Arrays object to access its operations.
+     */
+    private Arrays arrays;
+
+    /**
      * Gets the Arrays object to access its operations.
      * @return the Arrays object.
      */
     public Arrays arrays() {
-        return new ArraysImpl(restClient().retrofit(), this);
+        return this.arrays;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestSwaggerBATArrayServiceImpl extends ServiceClient impl
      */
     public AutoRestSwaggerBATArrayServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestSwaggerBATArrayServiceImpl extends ServiceClient impl
      */
     public AutoRestSwaggerBATArrayServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.arrays = new ArraysImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyboolean/implementation/AutoRestBoolTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyboolean/implementation/AutoRestBoolTestServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestBoolTestServiceImpl extends ServiceClient implements AutoRestBoolTestService {
 
     /**
+     * The Bools object to access its operations.
+     */
+    private Bools bools;
+
+    /**
      * Gets the Bools object to access its operations.
      * @return the Bools object.
      */
     public Bools bools() {
-        return new BoolsImpl(restClient().retrofit(), this);
+        return this.bools;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestBoolTestServiceImpl extends ServiceClient implements 
      */
     public AutoRestBoolTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestBoolTestServiceImpl extends ServiceClient implements 
      */
     public AutoRestBoolTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.bools = new BoolsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodybyte/implementation/AutoRestSwaggerBATByteServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodybyte/implementation/AutoRestSwaggerBATByteServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestSwaggerBATByteServiceImpl extends ServiceClient implements AutoRestSwaggerBATByteService {
 
     /**
+     * The Bytes object to access its operations.
+     */
+    private Bytes bytes;
+
+    /**
      * Gets the Bytes object to access its operations.
      * @return the Bytes object.
      */
     public Bytes bytes() {
-        return new BytesImpl(restClient().retrofit(), this);
+        return this.bytes;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestSwaggerBATByteServiceImpl extends ServiceClient imple
      */
     public AutoRestSwaggerBATByteServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestSwaggerBATByteServiceImpl extends ServiceClient imple
      */
     public AutoRestSwaggerBATByteServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.bytes = new BytesImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/implementation/AutoRestComplexTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodycomplex/implementation/AutoRestComplexTestServiceImpl.java
@@ -49,67 +49,107 @@ public final class AutoRestComplexTestServiceImpl extends ServiceClient implemen
     }
 
     /**
+     * The Basics object to access its operations.
+     */
+    private Basics basics;
+
+    /**
      * Gets the Basics object to access its operations.
      * @return the Basics object.
      */
     public Basics basics() {
-        return new BasicsImpl(restClient().retrofit(), this);
+        return this.basics;
     }
+
+    /**
+     * The Primitives object to access its operations.
+     */
+    private Primitives primitives;
 
     /**
      * Gets the Primitives object to access its operations.
      * @return the Primitives object.
      */
     public Primitives primitives() {
-        return new PrimitivesImpl(restClient().retrofit(), this);
+        return this.primitives;
     }
+
+    /**
+     * The Arrays object to access its operations.
+     */
+    private Arrays arrays;
 
     /**
      * Gets the Arrays object to access its operations.
      * @return the Arrays object.
      */
     public Arrays arrays() {
-        return new ArraysImpl(restClient().retrofit(), this);
+        return this.arrays;
     }
+
+    /**
+     * The Dictionarys object to access its operations.
+     */
+    private Dictionarys dictionarys;
 
     /**
      * Gets the Dictionarys object to access its operations.
      * @return the Dictionarys object.
      */
     public Dictionarys dictionarys() {
-        return new DictionarysImpl(restClient().retrofit(), this);
+        return this.dictionarys;
     }
+
+    /**
+     * The Inheritances object to access its operations.
+     */
+    private Inheritances inheritances;
 
     /**
      * Gets the Inheritances object to access its operations.
      * @return the Inheritances object.
      */
     public Inheritances inheritances() {
-        return new InheritancesImpl(restClient().retrofit(), this);
+        return this.inheritances;
     }
+
+    /**
+     * The Polymorphisms object to access its operations.
+     */
+    private Polymorphisms polymorphisms;
 
     /**
      * Gets the Polymorphisms object to access its operations.
      * @return the Polymorphisms object.
      */
     public Polymorphisms polymorphisms() {
-        return new PolymorphismsImpl(restClient().retrofit(), this);
+        return this.polymorphisms;
     }
+
+    /**
+     * The Polymorphicrecursives object to access its operations.
+     */
+    private Polymorphicrecursives polymorphicrecursives;
 
     /**
      * Gets the Polymorphicrecursives object to access its operations.
      * @return the Polymorphicrecursives object.
      */
     public Polymorphicrecursives polymorphicrecursives() {
-        return new PolymorphicrecursivesImpl(restClient().retrofit(), this);
+        return this.polymorphicrecursives;
     }
+
+    /**
+     * The Readonlypropertys object to access its operations.
+     */
+    private Readonlypropertys readonlypropertys;
 
     /**
      * Gets the Readonlypropertys object to access its operations.
      * @return the Readonlypropertys object.
      */
     public Readonlypropertys readonlypropertys() {
-        return new ReadonlypropertysImpl(restClient().retrofit(), this);
+        return this.readonlypropertys;
     }
 
     /**
@@ -126,6 +166,7 @@ public final class AutoRestComplexTestServiceImpl extends ServiceClient implemen
      */
     public AutoRestComplexTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -135,5 +176,18 @@ public final class AutoRestComplexTestServiceImpl extends ServiceClient implemen
      */
     public AutoRestComplexTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.apiVersion = "2014-04-01-preview";
+        this.basics = new BasicsImpl(restClient().retrofit(), this);
+        this.primitives = new PrimitivesImpl(restClient().retrofit(), this);
+        this.arrays = new ArraysImpl(restClient().retrofit(), this);
+        this.dictionarys = new DictionarysImpl(restClient().retrofit(), this);
+        this.inheritances = new InheritancesImpl(restClient().retrofit(), this);
+        this.polymorphisms = new PolymorphismsImpl(restClient().retrofit(), this);
+        this.polymorphicrecursives = new PolymorphicrecursivesImpl(restClient().retrofit(), this);
+        this.readonlypropertys = new ReadonlypropertysImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydate/implementation/AutoRestDateTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydate/implementation/AutoRestDateTestServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestDateTestServiceImpl extends ServiceClient implements AutoRestDateTestService {
 
     /**
+     * The Dates object to access its operations.
+     */
+    private Dates dates;
+
+    /**
      * Gets the Dates object to access its operations.
      * @return the Dates object.
      */
     public Dates dates() {
-        return new DatesImpl(restClient().retrofit(), this);
+        return this.dates;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestDateTestServiceImpl extends ServiceClient implements 
      */
     public AutoRestDateTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestDateTestServiceImpl extends ServiceClient implements 
      */
     public AutoRestDateTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.dates = new DatesImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydatetime/implementation/AutoRestDateTimeTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydatetime/implementation/AutoRestDateTimeTestServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestDateTimeTestServiceImpl extends ServiceClient implements AutoRestDateTimeTestService {
 
     /**
+     * The Datetimes object to access its operations.
+     */
+    private Datetimes datetimes;
+
+    /**
      * Gets the Datetimes object to access its operations.
      * @return the Datetimes object.
      */
     public Datetimes datetimes() {
-        return new DatetimesImpl(restClient().retrofit(), this);
+        return this.datetimes;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestDateTimeTestServiceImpl extends ServiceClient impleme
      */
     public AutoRestDateTimeTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestDateTimeTestServiceImpl extends ServiceClient impleme
      */
     public AutoRestDateTimeTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.datetimes = new DatetimesImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/implementation/AutoRestRFC1123DateTimeTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/implementation/AutoRestRFC1123DateTimeTestServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestRFC1123DateTimeTestServiceImpl extends ServiceClient implements AutoRestRFC1123DateTimeTestService {
 
     /**
+     * The Datetimerfc1123s object to access its operations.
+     */
+    private Datetimerfc1123s datetimerfc1123s;
+
+    /**
      * Gets the Datetimerfc1123s object to access its operations.
      * @return the Datetimerfc1123s object.
      */
     public Datetimerfc1123s datetimerfc1123s() {
-        return new Datetimerfc1123sImpl(restClient().retrofit(), this);
+        return this.datetimerfc1123s;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestRFC1123DateTimeTestServiceImpl extends ServiceClient 
      */
     public AutoRestRFC1123DateTimeTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestRFC1123DateTimeTestServiceImpl extends ServiceClient 
      */
     public AutoRestRFC1123DateTimeTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.datetimerfc1123s = new Datetimerfc1123sImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATdictionaryServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATdictionaryServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestSwaggerBATdictionaryServiceImpl extends ServiceClient implements AutoRestSwaggerBATdictionaryService {
 
     /**
+     * The Dictionarys object to access its operations.
+     */
+    private Dictionarys dictionarys;
+
+    /**
      * Gets the Dictionarys object to access its operations.
      * @return the Dictionarys object.
      */
     public Dictionarys dictionarys() {
-        return new DictionarysImpl(restClient().retrofit(), this);
+        return this.dictionarys;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestSwaggerBATdictionaryServiceImpl extends ServiceClient
      */
     public AutoRestSwaggerBATdictionaryServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestSwaggerBATdictionaryServiceImpl extends ServiceClient
      */
     public AutoRestSwaggerBATdictionaryServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.dictionarys = new DictionarysImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyduration/implementation/AutoRestDurationTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyduration/implementation/AutoRestDurationTestServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestDurationTestServiceImpl extends ServiceClient implements AutoRestDurationTestService {
 
     /**
+     * The Durations object to access its operations.
+     */
+    private Durations durations;
+
+    /**
      * Gets the Durations object to access its operations.
      * @return the Durations object.
      */
     public Durations durations() {
-        return new DurationsImpl(restClient().retrofit(), this);
+        return this.durations;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestDurationTestServiceImpl extends ServiceClient impleme
      */
     public AutoRestDurationTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestDurationTestServiceImpl extends ServiceClient impleme
      */
     public AutoRestDurationTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.durations = new DurationsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyfile/implementation/AutoRestSwaggerBATFileServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyfile/implementation/AutoRestSwaggerBATFileServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestSwaggerBATFileServiceImpl extends ServiceClient implements AutoRestSwaggerBATFileService {
 
     /**
+     * The Files object to access its operations.
+     */
+    private Files files;
+
+    /**
      * Gets the Files object to access its operations.
      * @return the Files object.
      */
     public Files files() {
-        return new FilesImpl(restClient().retrofit(), this);
+        return this.files;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestSwaggerBATFileServiceImpl extends ServiceClient imple
      */
     public AutoRestSwaggerBATFileServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestSwaggerBATFileServiceImpl extends ServiceClient imple
      */
     public AutoRestSwaggerBATFileServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.files = new FilesImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/implementation/AutoRestSwaggerBATFormDataServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyformdata/implementation/AutoRestSwaggerBATFormDataServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestSwaggerBATFormDataServiceImpl extends ServiceClient implements AutoRestSwaggerBATFormDataService {
 
     /**
+     * The Formdatas object to access its operations.
+     */
+    private Formdatas formdatas;
+
+    /**
      * Gets the Formdatas object to access its operations.
      * @return the Formdatas object.
      */
     public Formdatas formdatas() {
-        return new FormdatasImpl(restClient().retrofit(), this);
+        return this.formdatas;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestSwaggerBATFormDataServiceImpl extends ServiceClient i
      */
     public AutoRestSwaggerBATFormDataServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestSwaggerBATFormDataServiceImpl extends ServiceClient i
      */
     public AutoRestSwaggerBATFormDataServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.formdatas = new FormdatasImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyinteger/implementation/AutoRestIntegerTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodyinteger/implementation/AutoRestIntegerTestServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestIntegerTestServiceImpl extends ServiceClient implements AutoRestIntegerTestService {
 
     /**
+     * The Ints object to access its operations.
+     */
+    private Ints ints;
+
+    /**
      * Gets the Ints object to access its operations.
      * @return the Ints object.
      */
     public Ints ints() {
-        return new IntsImpl(restClient().retrofit(), this);
+        return this.ints;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestIntegerTestServiceImpl extends ServiceClient implemen
      */
     public AutoRestIntegerTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestIntegerTestServiceImpl extends ServiceClient implemen
      */
     public AutoRestIntegerTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.ints = new IntsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodynumber/implementation/AutoRestNumberTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodynumber/implementation/AutoRestNumberTestServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestNumberTestServiceImpl extends ServiceClient implements AutoRestNumberTestService {
 
     /**
+     * The Numbers object to access its operations.
+     */
+    private Numbers numbers;
+
+    /**
      * Gets the Numbers object to access its operations.
      * @return the Numbers object.
      */
     public Numbers numbers() {
-        return new NumbersImpl(restClient().retrofit(), this);
+        return this.numbers;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestNumberTestServiceImpl extends ServiceClient implement
      */
     public AutoRestNumberTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestNumberTestServiceImpl extends ServiceClient implement
      */
     public AutoRestNumberTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.numbers = new NumbersImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImpl.java
@@ -22,19 +22,29 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestSwaggerBATServiceImpl extends ServiceClient implements AutoRestSwaggerBATService {
 
     /**
+     * The Strings object to access its operations.
+     */
+    private Strings strings;
+
+    /**
      * Gets the Strings object to access its operations.
      * @return the Strings object.
      */
     public Strings strings() {
-        return new StringsImpl(restClient().retrofit(), this);
+        return this.strings;
     }
+
+    /**
+     * The Enums object to access its operations.
+     */
+    private Enums enums;
 
     /**
      * Gets the Enums object to access its operations.
      * @return the Enums object.
      */
     public Enums enums() {
-        return new EnumsImpl(restClient().retrofit(), this);
+        return this.enums;
     }
 
     /**
@@ -51,6 +61,7 @@ public final class AutoRestSwaggerBATServiceImpl extends ServiceClient implement
      */
     public AutoRestSwaggerBATServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -60,5 +71,11 @@ public final class AutoRestSwaggerBATServiceImpl extends ServiceClient implement
      */
     public AutoRestSwaggerBATServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.strings = new StringsImpl(restClient().retrofit(), this);
+        this.enums = new EnumsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/custombaseuri/implementation/AutoRestParameterizedHostTestClientImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/custombaseuri/implementation/AutoRestParameterizedHostTestClientImpl.java
@@ -42,11 +42,16 @@ public final class AutoRestParameterizedHostTestClientImpl extends ServiceClient
     }
 
     /**
+     * The Paths object to access its operations.
+     */
+    private Paths paths;
+
+    /**
      * Gets the Paths object to access its operations.
      * @return the Paths object.
      */
     public Paths paths() {
-        return new PathsImpl(restClient().retrofit(), this);
+        return this.paths;
     }
 
     /**
@@ -63,6 +68,7 @@ public final class AutoRestParameterizedHostTestClientImpl extends ServiceClient
      */
     private AutoRestParameterizedHostTestClientImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -72,5 +78,11 @@ public final class AutoRestParameterizedHostTestClientImpl extends ServiceClient
      */
     public AutoRestParameterizedHostTestClientImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.host = "host";
+        this.paths = new PathsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/implementation/AutoRestParameterizedCustomHostTestClientImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/implementation/AutoRestParameterizedCustomHostTestClientImpl.java
@@ -63,11 +63,16 @@ public final class AutoRestParameterizedCustomHostTestClientImpl extends Service
     }
 
     /**
+     * The Paths object to access its operations.
+     */
+    private Paths paths;
+
+    /**
      * Gets the Paths object to access its operations.
      * @return the Paths object.
      */
     public Paths paths() {
-        return new PathsImpl(restClient().retrofit(), this);
+        return this.paths;
     }
 
     /**
@@ -84,6 +89,7 @@ public final class AutoRestParameterizedCustomHostTestClientImpl extends Service
      */
     private AutoRestParameterizedCustomHostTestClientImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -93,5 +99,11 @@ public final class AutoRestParameterizedCustomHostTestClientImpl extends Service
      */
     public AutoRestParameterizedCustomHostTestClientImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.dnsSuffix = "host";
+        this.paths = new PathsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/header/implementation/AutoRestSwaggerBATHeaderServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/header/implementation/AutoRestSwaggerBATHeaderServiceImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestSwaggerBATHeaderServiceImpl extends ServiceClient implements AutoRestSwaggerBATHeaderService {
 
     /**
+     * The Headers object to access its operations.
+     */
+    private Headers headers;
+
+    /**
      * Gets the Headers object to access its operations.
      * @return the Headers object.
      */
     public Headers headers() {
-        return new HeadersImpl(restClient().retrofit(), this);
+        return this.headers;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestSwaggerBATHeaderServiceImpl extends ServiceClient imp
      */
     public AutoRestSwaggerBATHeaderServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestSwaggerBATHeaderServiceImpl extends ServiceClient imp
      */
     public AutoRestSwaggerBATHeaderServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.headers = new HeadersImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/http/implementation/AutoRestHttpInfrastructureTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/http/implementation/AutoRestHttpInfrastructureTestServiceImpl.java
@@ -27,59 +27,94 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestHttpInfrastructureTestServiceImpl extends ServiceClient implements AutoRestHttpInfrastructureTestService {
 
     /**
+     * The HttpFailures object to access its operations.
+     */
+    private HttpFailures httpFailures;
+
+    /**
      * Gets the HttpFailures object to access its operations.
      * @return the HttpFailures object.
      */
     public HttpFailures httpFailures() {
-        return new HttpFailuresImpl(restClient().retrofit(), this);
+        return this.httpFailures;
     }
+
+    /**
+     * The HttpSuccess object to access its operations.
+     */
+    private HttpSuccess httpSuccess;
 
     /**
      * Gets the HttpSuccess object to access its operations.
      * @return the HttpSuccess object.
      */
     public HttpSuccess httpSuccess() {
-        return new HttpSuccessImpl(restClient().retrofit(), this);
+        return this.httpSuccess;
     }
+
+    /**
+     * The HttpRedirects object to access its operations.
+     */
+    private HttpRedirects httpRedirects;
 
     /**
      * Gets the HttpRedirects object to access its operations.
      * @return the HttpRedirects object.
      */
     public HttpRedirects httpRedirects() {
-        return new HttpRedirectsImpl(restClient().retrofit(), this);
+        return this.httpRedirects;
     }
+
+    /**
+     * The HttpClientFailures object to access its operations.
+     */
+    private HttpClientFailures httpClientFailures;
 
     /**
      * Gets the HttpClientFailures object to access its operations.
      * @return the HttpClientFailures object.
      */
     public HttpClientFailures httpClientFailures() {
-        return new HttpClientFailuresImpl(restClient().retrofit(), this);
+        return this.httpClientFailures;
     }
+
+    /**
+     * The HttpServerFailures object to access its operations.
+     */
+    private HttpServerFailures httpServerFailures;
 
     /**
      * Gets the HttpServerFailures object to access its operations.
      * @return the HttpServerFailures object.
      */
     public HttpServerFailures httpServerFailures() {
-        return new HttpServerFailuresImpl(restClient().retrofit(), this);
+        return this.httpServerFailures;
     }
+
+    /**
+     * The HttpRetrys object to access its operations.
+     */
+    private HttpRetrys httpRetrys;
 
     /**
      * Gets the HttpRetrys object to access its operations.
      * @return the HttpRetrys object.
      */
     public HttpRetrys httpRetrys() {
-        return new HttpRetrysImpl(restClient().retrofit(), this);
+        return this.httpRetrys;
     }
+
+    /**
+     * The MultipleResponses object to access its operations.
+     */
+    private MultipleResponses multipleResponses;
 
     /**
      * Gets the MultipleResponses object to access its operations.
      * @return the MultipleResponses object.
      */
     public MultipleResponses multipleResponses() {
-        return new MultipleResponsesImpl(restClient().retrofit(), this);
+        return this.multipleResponses;
     }
 
     /**
@@ -96,6 +131,7 @@ public final class AutoRestHttpInfrastructureTestServiceImpl extends ServiceClie
      */
     public AutoRestHttpInfrastructureTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -105,5 +141,16 @@ public final class AutoRestHttpInfrastructureTestServiceImpl extends ServiceClie
      */
     public AutoRestHttpInfrastructureTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.httpFailures = new HttpFailuresImpl(restClient().retrofit(), this);
+        this.httpSuccess = new HttpSuccessImpl(restClient().retrofit(), this);
+        this.httpRedirects = new HttpRedirectsImpl(restClient().retrofit(), this);
+        this.httpClientFailures = new HttpClientFailuresImpl(restClient().retrofit(), this);
+        this.httpServerFailures = new HttpServerFailuresImpl(restClient().retrofit(), this);
+        this.httpRetrys = new HttpRetrysImpl(restClient().retrofit(), this);
+        this.multipleResponses = new MultipleResponsesImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -62,7 +62,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      */
     public AutoRestResourceFlatteningTestServiceImpl(String baseUrl) {
         super(baseUrl);
-        initializeService();
+        initialize();
     }
 
     /**
@@ -72,6 +72,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      */
     public AutoRestResourceFlatteningTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
         initializeService();
     }
 

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/parameterflattening/implementation/AutoRestParameterFlatteningImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/parameterflattening/implementation/AutoRestParameterFlatteningImpl.java
@@ -21,11 +21,16 @@ import com.microsoft.rest.RestClient;
 public final class AutoRestParameterFlatteningImpl extends ServiceClient implements AutoRestParameterFlattening {
 
     /**
+     * The AvailabilitySets object to access its operations.
+     */
+    private AvailabilitySets availabilitySets;
+
+    /**
      * Gets the AvailabilitySets object to access its operations.
      * @return the AvailabilitySets object.
      */
     public AvailabilitySets availabilitySets() {
-        return new AvailabilitySetsImpl(restClient().retrofit(), this);
+        return this.availabilitySets;
     }
 
     /**
@@ -42,6 +47,7 @@ public final class AutoRestParameterFlatteningImpl extends ServiceClient impleme
      */
     public AutoRestParameterFlatteningImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -51,5 +57,10 @@ public final class AutoRestParameterFlatteningImpl extends ServiceClient impleme
      */
     public AutoRestParameterFlatteningImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.availabilitySets = new AvailabilitySetsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
@@ -51,7 +51,7 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      */
     public AutoRestReportServiceImpl(String baseUrl) {
         super(baseUrl);
-        initializeService();
+        initialize();
     }
 
     /**
@@ -61,6 +61,10 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      */
     public AutoRestReportServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
         initializeService();
     }
 

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/requiredoptional/implementation/AutoRestRequiredOptionalTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/requiredoptional/implementation/AutoRestRequiredOptionalTestServiceImpl.java
@@ -85,19 +85,29 @@ public final class AutoRestRequiredOptionalTestServiceImpl extends ServiceClient
     }
 
     /**
+     * The Implicits object to access its operations.
+     */
+    private Implicits implicits;
+
+    /**
      * Gets the Implicits object to access its operations.
      * @return the Implicits object.
      */
     public Implicits implicits() {
-        return new ImplicitsImpl(restClient().retrofit(), this);
+        return this.implicits;
     }
+
+    /**
+     * The Explicits object to access its operations.
+     */
+    private Explicits explicits;
 
     /**
      * Gets the Explicits object to access its operations.
      * @return the Explicits object.
      */
     public Explicits explicits() {
-        return new ExplicitsImpl(restClient().retrofit(), this);
+        return this.explicits;
     }
 
     /**
@@ -114,6 +124,7 @@ public final class AutoRestRequiredOptionalTestServiceImpl extends ServiceClient
      */
     public AutoRestRequiredOptionalTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -123,5 +134,11 @@ public final class AutoRestRequiredOptionalTestServiceImpl extends ServiceClient
      */
     public AutoRestRequiredOptionalTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.implicits = new ImplicitsImpl(restClient().retrofit(), this);
+        this.explicits = new ExplicitsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/url/implementation/AutoRestUrlTestServiceImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/url/implementation/AutoRestUrlTestServiceImpl.java
@@ -65,27 +65,42 @@ public final class AutoRestUrlTestServiceImpl extends ServiceClient implements A
     }
 
     /**
+     * The Paths object to access its operations.
+     */
+    private Paths paths;
+
+    /**
      * Gets the Paths object to access its operations.
      * @return the Paths object.
      */
     public Paths paths() {
-        return new PathsImpl(restClient().retrofit(), this);
+        return this.paths;
     }
+
+    /**
+     * The Queries object to access its operations.
+     */
+    private Queries queries;
 
     /**
      * Gets the Queries object to access its operations.
      * @return the Queries object.
      */
     public Queries queries() {
-        return new QueriesImpl(restClient().retrofit(), this);
+        return this.queries;
     }
+
+    /**
+     * The PathItems object to access its operations.
+     */
+    private PathItems pathItems;
 
     /**
      * Gets the PathItems object to access its operations.
      * @return the PathItems object.
      */
     public PathItems pathItems() {
-        return new PathItemsImpl(restClient().retrofit(), this);
+        return this.pathItems;
     }
 
     /**
@@ -102,6 +117,7 @@ public final class AutoRestUrlTestServiceImpl extends ServiceClient implements A
      */
     public AutoRestUrlTestServiceImpl(String baseUrl) {
         super(baseUrl);
+        initialize();
     }
 
     /**
@@ -111,5 +127,12 @@ public final class AutoRestUrlTestServiceImpl extends ServiceClient implements A
      */
     public AutoRestUrlTestServiceImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
+        this.paths = new PathsImpl(restClient().retrofit(), this);
+        this.queries = new QueriesImpl(restClient().retrofit(), this);
+        this.pathItems = new PathItemsImpl(restClient().retrofit(), this);
     }
 }

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
@@ -100,7 +100,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      */
     public AutoRestValidationTestImpl(String baseUrl) {
         super(baseUrl);
-        initializeService();
+        initialize();
     }
 
     /**
@@ -110,6 +110,10 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      */
     public AutoRestValidationTestImpl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
+
+    private void initialize() {
         initializeService();
     }
 

--- a/AutoRest/Generators/Java/Java/Templates/ServiceClientTemplate.cshtml
+++ b/AutoRest/Generators/Java/Java/Templates/ServiceClientTemplate.cshtml
@@ -62,11 +62,16 @@ if(!property.IsReadOnly)
 {
 @EmptyLine
 @:    /**
+@:     * The @(operation.MethodGroupType) object to access its operations.
+@:     */
+@:    private @(operation.MethodGroupType) @(operation.MethodGroupName);
+@EmptyLine
+@:    /**
 @:     * Gets the @(operation.MethodGroupType) object to access its operations.
 @:     * @@return the @(operation.MethodGroupType) object.
 @:     */
 @:    public @(operation.MethodGroupType) @(operation.MethodGroupName)() {
-@:        return new @(operation.MethodGroupType)Impl(restClient().retrofit(), this);
+@:        return this.@(operation.MethodGroupName);
 @:    }
 }
 @EmptyLine
@@ -84,10 +89,7 @@ if(!property.IsReadOnly)
      */
     @(Model.IsCustomBaseUri ? "private" : "public") @(Model.Name)Impl(String baseUrl) {
         super(baseUrl);
-@if (Model.MethodTemplateModels.Any())
-{
-@:        initializeService();
-}
+        initialize();
     }
 
 @EmptyLine
@@ -98,7 +100,19 @@ if(!property.IsReadOnly)
      */
     public @(Model.Name)Impl(RestClient restClient) {
         super(restClient);
+        initialize();
+    }
 
+@EmptyLine
+    private void initialize() {
+@foreach (var property in Model.Properties.Where(p => p.DefaultValue != null))
+{
+@:        this.@(property.Name) = @(property.DefaultValue);
+}
+@foreach (var operation in Model.Operations)
+{
+@:        this.@(operation.MethodGroupName) = new @(operation.MethodGroupType)Impl(restClient().retrofit(), this);
+}
 @if (Model.MethodTemplateModels.Any())
 {
 @:        initializeService();


### PR DESCRIPTION
To avoid the overhead of calling `someClient.someOps()`.