### PR TITLE
Adding support for unix datetime in ruby

### DIFF
--- a/AutoRest/Generators/Ruby/Azure.Ruby/AzureClientModelExtensions.cs
+++ b/AutoRest/Generators/Ruby/Azure.Ruby/AzureClientModelExtensions.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Rest.Generator.Azure.Ruby.Templates
                 {
                     return builder.AppendLine("{0} = DateTime.parse({0}) unless {0}.to_s.empty?", valueReference).ToString();
                 }
+
+                if (primary.Type == KnownPrimaryType.UnixTime)
+                {
+                    return builder.AppendLine("{0} = DateTime.strptime({0}.to_s, '%s') unless {0}.to_s.empty?", valueReference).ToString();
+                }
             }
             else if (enumType != null && !string.IsNullOrEmpty(enumType.Name))
             {
@@ -174,6 +179,11 @@ namespace Microsoft.Rest.Generator.Azure.Ruby.Templates
                 if (primary.Type == KnownPrimaryType.DateTimeRfc1123)
                 {
                     return builder.AppendLine("{0} = {0}.new_offset(0).strftime('%a, %d %b %Y %H:%M:%S GMT')", valueReference).ToString();
+                }
+
+                if (primary.Type == KnownPrimaryType.UnixTime)
+                {
+                    return builder.AppendLine("{0} = {0}.new_offset(0).strftime('%s')", valueReference).ToString();
                 }
             }
             else if (sequence != null)

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/integer_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/integer_spec.rb
@@ -94,6 +94,6 @@ describe Int do
   end
 
   it 'should get invalid unix time' do
-    expect{ @int_client.get_invalid_async().value! }.to raise_error(MsRest::DeserializationError)
+    expect{ @int_client.get_invalid_unix_time_async().value! }.to raise_error(MsRest::DeserializationError)
   end
 end

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/integer_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/integer_spec.rb
@@ -67,11 +67,33 @@ describe Int do
 
   it 'should get null' do
     result = @int_client.get_null_async().value!
-	  expect(result.response.status).to eq(200)
-	  expect(result.body).to eq(nil)
+    expect(result.response.status).to eq(200)
+    expect(result.body).to eq(nil)
   end
 
   it 'should get invalid' do
+    expect{ @int_client.get_invalid_async().value! }.to raise_error(MsRest::DeserializationError)
+  end
+
+  it 'should put unix time' do
+    result = @int_client.put_unix_time_date_async(DateTime.new(2016, 4, 13, 0, 0, 0, 'Z')).value!
+    expect(result.response.status).to eq(200)
+    expect(result.body).to eq(nil)
+  end
+
+  it 'should get unix time' do
+    result = @int_client.get_unix_time_async().value!
+    expect(result.response.status).to eq(200)
+    expect(result.body).to eq(DateTime.new(2016, 4, 13, 0, 0, 0, 'Z'))
+  end
+
+  it 'should get null unix time' do
+    result = @int_client.get_null_unix_time_async().value!
+    expect(result.response.status).to eq(200)
+    expect(result.body).to eq(nil)
+  end
+
+  it 'should get invalid unix time' do
     expect{ @int_client.get_invalid_async().value! }.to raise_error(MsRest::DeserializationError)
   end
 end

--- a/AutoRest/Generators/Ruby/Ruby/ClientModelExtensions.cs
+++ b/AutoRest/Generators/Ruby/Ruby/ClientModelExtensions.cs
@@ -313,6 +313,11 @@ namespace Microsoft.Rest.Generator.Ruby.TemplateModels
                 {
                     return builder.AppendLine("{0} = DateTime.parse({0}) unless {0}.to_s.empty?", valueReference).ToString();
                 }
+
+                if (primary.Type == KnownPrimaryType.UnixTime)
+                {
+                    return builder.AppendLine("{0} = DateTime.strptime({0}.to_s, '%s') unless {0}.to_s.empty?", valueReference).ToString();
+                }
             }
             else if (enumType != null && !string.IsNullOrEmpty(enumType.Name))
             {
@@ -414,6 +419,11 @@ namespace Microsoft.Rest.Generator.Ruby.TemplateModels
                 if (primary.Type == KnownPrimaryType.DateTimeRfc1123)
                 {
                     return builder.AppendLine("{0} = {0}.new_offset(0).strftime('%a, %d %b %Y %H:%M:%S GMT')", valueReference).ToString();
+                }
+
+                if (primary.Type == KnownPrimaryType.UnixTime)
+                {
+                    return builder.AppendLine("{0} = {0}.new_offset(0).strftime('%s')", valueReference).ToString();
                 }
             }
             else if (sequence != null)

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeNamer.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeNamer.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Rest.Generator.Ruby
             }
             else if (primaryType.Type == KnownPrimaryType.UnixTime)
             {
-                primaryType.Name = "Bignum";
+                primaryType.Name = "DateTime";
             }
             else if (primaryType.Type == KnownPrimaryType.Object)
             {


### PR DESCRIPTION
Addressing issue #909 for ruby
Adding a new known primary type for Unix time formatted dates (which is in seconds since Unix Epoch). Updating Ruby & AzureRuby client extensions to support conversion between DateTime and UnixTime.