### PR TITLE
Generate a constructor which includes all required properties.

### DIFF
--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/ServiceClientTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/ServiceClientTemplateModel.cs
@@ -67,6 +67,20 @@ namespace Microsoft.Rest.Generator.CSharp
                 return string.Join(", ", requireParams);
             }
         }
+        
+        public string RequiredConstructorParametersExtended
+        {
+            get
+            {
+                var requireParams = new List<string>();
+                this.Properties.Where(p => p.IsRequired && !(p.IsReadOnly))
+                    .ForEach(p => requireParams.Add(string.Format(CultureInfo.InvariantCulture, 
+                        "{0} {1}", 
+                        p.Type.Name, 
+                        p.Name.ToCamelCase())));
+                return string.Join(", ", requireParams);
+            }
+        }
 
         public bool NeedsTransformationConverter
         {


### PR DESCRIPTION
In the field 'RequiredConstructorParameters', a parameter which is merely IsRequired will not be included in the constructor because p.IsReadOnly returns false. The fields which are required but not read-only are not included. So another constructor 'RequiredConstructorParametersExtended' is added to make sure all required properties are returned.