### PR TITLE
Fix for a null reference exception when not providing namespace

### DIFF
--- a/AutoRest/Generators/Java/Java/JavaCodeNamer.cs
+++ b/AutoRest/Generators/Java/Java/JavaCodeNamer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Rest.Generator.Java
         {
             // List retrieved from 
             // http://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
-            _package = nameSpace.ToLower(CultureInfo.InvariantCulture);
+            _package = nameSpace != null ? nameSpace.ToLower(CultureInfo.InvariantCulture) : string.Empty;
             new HashSet<string>
             {
                 "abstract", "assert",   "boolean",  "break",    "byte",


### PR DESCRIPTION
In JavaCodeNamer.cs, when the namespace parameter is not provided as a command line parameter, it throws a null reference exception when calling `ToLower()`. Even though namespace is necessary for Java code to be generated, this code path is still reached when calling AutoRest with no parameters (e.g. when viewing help).