### PR TITLE
Add platform in Python UserAgent

### DIFF
--- a/ClientRuntimes/Python/msrest/msrest/configuration.py
+++ b/ClientRuntimes/Python/msrest/msrest/configuration.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     import ConfigParser as configparser
     from ConfigParser import NoOptionError
-import sys
+import platform
 
 import requests
 
@@ -68,8 +68,9 @@ class Configuration(object):
         self.redirect_policy = ClientRedirectPolicy()
 
         # User-Agent Header
-        self._user_agent = "python/{} requests/{} msrest/{}".format(
-            sys.version.split(' ')[0],
+        self._user_agent = "python/{} ({}) requests/{} msrest/{}".format(
+            platform.python_version(),
+            platform.platform(),
             requests.__version__,
             msrest_version)
 


### PR DESCRIPTION
Adding platform information in UserAgent for good metrics.

User-Agent looks like:
Python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 .............
Python/2.7.10 (Linux-4.2.0-30-generic-x86_64-with-Ubuntu-15.10-wily)  requests/2.10.0 .......
