### PR TITLE
Java: Use SNAPSHOT runtime as dependency

### DIFF
--- a/ClientRuntimes/Java/azure-android-client-authentication/build.gradle
+++ b/ClientRuntimes/Java/azure-android-client-authentication/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.microsoft.aad:adal:1.1.11'
-    compile 'com.microsoft.rest:client-runtime:1.0.0-beta1'
+    compile 'com.microsoft.rest:client-runtime:1.0.0-SNAPSHOT'
     testCompile 'junit:junit:4.12'
     testCompile 'junit:junit-dep:4.11'
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.10"

--- a/ClientRuntimes/Java/azure-client-authentication/build.gradle
+++ b/ClientRuntimes/Java/azure-client-authentication/build.gradle
@@ -20,7 +20,7 @@ checkstyle {
 
 dependencies {
     compile 'com.microsoft.azure:adal4j:1.1.2'
-    compile 'com.microsoft.rest:client-runtime:1.0.0-beta1'
+    compile 'com.microsoft.rest:client-runtime:1.0.0-SNAPSHOT'
     testCompile 'junit:junit:4.12'
     testCompile 'junit:junit-dep:4.11'
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.10"

--- a/ClientRuntimes/Java/azure-client-runtime/build.gradle
+++ b/ClientRuntimes/Java/azure-client-runtime/build.gradle
@@ -20,7 +20,7 @@ checkstyle {
 }
 
 dependencies {
-    compile 'com.microsoft.rest:client-runtime:1.0.0-beta1'
+    compile 'com.microsoft.rest:client-runtime:1.0.0-SNAPSHOT'
     testCompile 'junit:junit:4.12'
     testCompile 'junit:junit-dep:4.11'
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.10"


### PR DESCRIPTION
A tiny fix as beta1 is a bit outdated.
No need to merge in `release` branch as runtime releases are separate.