### PR TITLE
CSharp: add support for excluding models from a proxy by referencing …

### DIFF
--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/AutoRestDurationTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/AutoRestDurationTestService.cs
@@ -265,6 +265,10 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationAllSync
         }
 
         /// <summary>
+        /// An optional partial-method to perform custom initialization.
+        /// </summary>
+        partial void CustomInitialize();
+        /// <summary>
         /// Initializes client properties.
         /// </summary>
         private void Initialize()
@@ -299,6 +303,7 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationAllSync
                         new Iso8601TimeSpanConverter()
                     }
             };
+            CustomInitialize();
             DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
         }    
     }

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/AutoRestDurationTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/AutoRestDurationTestService.cs
@@ -265,6 +265,10 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationNoSync
         }
 
         /// <summary>
+        /// An optional partial-method to perform custom initialization.
+        /// </summary>
+        partial void CustomInitialize();
+        /// <summary>
         /// Initializes client properties.
         /// </summary>
         private void Initialize()
@@ -299,6 +303,7 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationNoSync
                         new Iso8601TimeSpanConverter()
                     }
             };
+            CustomInitialize();
             DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
         }    
     }

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/HeaderOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/HeaderOperations.cs
@@ -229,6 +229,12 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="ErrorException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/IHeaderOperations.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/IHeaderOperations.cs
@@ -55,6 +55,12 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="ErrorException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationHeaderResponse<HeaderCustomNamedRequestIdParamGroupingHeaders>> CustomNamedRequestIdParamGroupingWithHttpMessagesAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingParameters.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingParameters.cs
@@ -44,8 +44,11 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
         public string FooClientRequestId { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (FooClientRequestId == null)

--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeGenerator.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeGenerator.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
             // Service client
             var serviceClientTemplate = new AzureServiceClientTemplate
             {
-                Model = new AzureServiceClientTemplateModel(serviceClient, InternalConstructors),
+                Model = new AzureServiceClientTemplateModel(serviceClient, InternalConstructors, ReferencedNamespaces),
             };
             await Write(serviceClientTemplate, serviceClient.Name + ".cs");
 
@@ -99,7 +99,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
             {
                 var extensionsTemplate = new ExtensionsTemplate
                 {
-                    Model = new AzureExtensionsTemplateModel(serviceClient, null, SyncMethods),
+                    Model = new AzureExtensionsTemplateModel(serviceClient, null, SyncMethods, ReferencedNamespaces),
                 };
                 await Write(extensionsTemplate, serviceClient.Name + "Extensions.cs");
             }
@@ -107,7 +107,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
             // Service client interface
             var serviceClientInterfaceTemplate = new ServiceClientInterfaceTemplate
             {
-                Model = new AzureServiceClientTemplateModel(serviceClient, InternalConstructors),
+                Model = new AzureServiceClientTemplateModel(serviceClient, InternalConstructors, ReferencedNamespaces),
             };
             await Write(serviceClientInterfaceTemplate, "I" + serviceClient.Name + ".cs");
 
@@ -117,21 +117,21 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
                 // Operation
                 var operationsTemplate = new AzureMethodGroupTemplate
                 {
-                    Model = new AzureMethodGroupTemplateModel(serviceClient, group),
+                    Model = new AzureMethodGroupTemplateModel(serviceClient, group, ReferencedNamespaces),
                 };
                 await Write(operationsTemplate, operationsTemplate.Model.MethodGroupType + ".cs");
 
                 // Service client extensions
                 var operationExtensionsTemplate = new ExtensionsTemplate
                 {
-                    Model = new AzureExtensionsTemplateModel(serviceClient, group, SyncMethods),
+                    Model = new AzureExtensionsTemplateModel(serviceClient, group, SyncMethods, ReferencedNamespaces),
                 };
                 await Write(operationExtensionsTemplate, operationExtensionsTemplate.Model.ExtensionName + "Extensions.cs");
 
                 // Operation interface
                 var operationsInterfaceTemplate = new MethodGroupInterfaceTemplate
                 {
-                    Model = new AzureMethodGroupTemplateModel(serviceClient, group),
+                    Model = new AzureMethodGroupTemplateModel(serviceClient, group, ReferencedNamespaces),
                 };
                 await Write(operationsInterfaceTemplate, "I" + operationsInterfaceTemplate.Model.MethodGroupType + ".cs");
             }

--- a/AutoRest/Generators/CSharp/Azure.CSharp/TemplateModels/AzureExtensionsTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/TemplateModels/AzureExtensionsTemplateModel.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
 {
     public class AzureExtensionsTemplateModel : ExtensionsTemplateModel
     {
-        public AzureExtensionsTemplateModel(ServiceClient serviceClient, string operationName, SyncMethodsGenerationMode syncWrappers)
-            : base(serviceClient, operationName, syncWrappers)
+        public AzureExtensionsTemplateModel(ServiceClient serviceClient, string operationName, SyncMethodsGenerationMode syncWrappers, IEnumerable<string> additionalNamespaces)
+            : base(serviceClient, operationName, syncWrappers, additionalNamespaces)
         {
             MethodTemplateModels.Clear();
             Methods.Where(m => m.Group == operationName)

--- a/AutoRest/Generators/CSharp/Azure.CSharp/TemplateModels/AzureMethodGroupTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/TemplateModels/AzureMethodGroupTemplateModel.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
 {
     public class AzureMethodGroupTemplateModel : MethodGroupTemplateModel
     {
-        public AzureMethodGroupTemplateModel(ServiceClient serviceClient, string methodGroupName)
-            : base(serviceClient, methodGroupName)
+        public AzureMethodGroupTemplateModel(ServiceClient serviceClient, string methodGroupName, IEnumerable<string> additionalNamespaces)
+            : base(serviceClient, methodGroupName, additionalNamespaces)
         {
             MethodGroupType = MethodGroupName + "Operations";
             // Clear base initialized MethodTemplateModels and re-populate with
@@ -41,6 +41,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
                 {
                     yield return "Models";
                 }
+                foreach (var ns in AdditionalNamespaces)
+                    yield return ns;
             }
         }
     }

--- a/AutoRest/Generators/CSharp/Azure.CSharp/TemplateModels/AzureServiceClientTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/TemplateModels/AzureServiceClientTemplateModel.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
 {
     public class AzureServiceClientTemplateModel : ServiceClientTemplateModel
     {
-        public AzureServiceClientTemplateModel(ServiceClient serviceClient, bool internalConstructors)
-            : base(serviceClient, internalConstructors)
+        public AzureServiceClientTemplateModel(ServiceClient serviceClient, bool internalConstructors, IEnumerable<string> additionalNamespaces)
+            : base(serviceClient, internalConstructors, additionalNamespaces)
         {
             // TODO: Initialized in the base constructor. Why Clear it?
             MethodTemplateModels.Clear();
@@ -28,7 +28,7 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
         {
             get
             {
-                return MethodGroups.Select(mg => new AzureMethodGroupTemplateModel(this, mg));
+                return MethodGroups.Select(mg => new AzureMethodGroupTemplateModel(this, mg, AdditionalNamespaces));
             }
         }
 
@@ -50,6 +50,8 @@ namespace Microsoft.Rest.Generator.CSharp.Azure
                 {
                     yield return "Models";
                 }
+                foreach (var ns in AdditionalNamespaces)
+                    yield return ns;
             }
         }
     }

--- a/AutoRest/Generators/CSharp/CSharp/CSharpCodeGenerator.cs
+++ b/AutoRest/Generators/CSharp/CSharp/CSharpCodeGenerator.cs
@@ -1,13 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Rest.Generator.ClientModel;
 using Microsoft.Rest.Generator.CSharp.Templates;
 using System.Linq;
+using System.Reflection;
+using Microsoft.Rest.Generator.CSharp.Properties;
+using Microsoft.Rest.Generator.Logging;
 
 namespace Microsoft.Rest.Generator.CSharp
 {
@@ -19,6 +24,7 @@ namespace Microsoft.Rest.Generator.CSharp
         public CSharpCodeGenerator(Settings settings) : base(settings)
         {
             _namer = new CSharpCodeNamer();
+            ReferencedNamespaces = new HashSet<string>();
             IsSingleFileGenerationSupported = true;
         }
 
@@ -36,6 +42,18 @@ namespace Microsoft.Rest.Generator.CSharp
         [SettingsAlias("syncMethods")]
         public SyncMethodsGenerationMode SyncMethods { get; set; }
 
+        /// <summary>
+        /// Allows a client to reference models from another assembly instead of generating new models
+        /// </summary>
+        [SettingsInfo("ExternalModelAssemblies")]
+        [SettingsAlias("modelAssemblies")]
+        public string[] ExternalModelAssemblies { get; set; }
+
+        /// <summary>
+        /// Referenced namespaces
+        /// </summary>
+        public HashSet<string> ReferencedNamespaces { get; private set; }
+
         public override string Name
         {
             get { return "CSharp"; }
@@ -49,7 +67,8 @@ namespace Microsoft.Rest.Generator.CSharp
 
         public override string UsageInstructions
         {
-            get {
+            get
+            {
                 return string.Format(CultureInfo.InvariantCulture,
                     Properties.Resources.UsageInformation, ClientRuntimePackage);
             }
@@ -72,12 +91,14 @@ namespace Microsoft.Rest.Generator.CSharp
         /// <param name="serviceClient"></param>
         public override void NormalizeClientModel(ServiceClient serviceClient)
         {
+            ReferencedNamespaces.UnionWith(ResolveExternalReferences(serviceClient));
             PopulateAdditionalProperties(serviceClient);
             Extensions.NormalizeClientModel(serviceClient, Settings);
             _namer.NormalizeClientModel(serviceClient);
             _namer.ResolveNameCollisions(serviceClient, Settings.Namespace,
                 Settings.Namespace + ".Models");
         }
+
 
         private void PopulateAdditionalProperties(ServiceClient serviceClient)
         {
@@ -94,6 +115,65 @@ namespace Microsoft.Rest.Generator.CSharp
             }
         }
 
+        [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFrom")]
+        private HashSet<string> ResolveExternalReferences(ServiceClient serviceClient)
+        {
+            List<Assembly> referenceAssemblies = new List<Assembly>();
+            if (ExternalModelAssemblies == null)
+                return new HashSet<string>();
+            foreach (var assemblyPath in ExternalModelAssemblies)
+            {
+                var a = Assembly.LoadFrom(assemblyPath);
+                if (a != null)
+                {
+                    referenceAssemblies.Add(a);
+                }
+                else
+                {
+                    Logger.LogError(new ArgumentException("ExternalModelAssemblies"),
+                        Properties.Resources.ReferenceAssemblyFailure, assemblyPath);
+                }
+            }
+            return ResolveExternalReferences(serviceClient, referenceAssemblies);
+        }
+
+        /// <summary>
+        /// Looks for model types in external assemblies. When found, the model is removed from the serviceClient ModelTypes
+        /// and the external namespace is added to the returned hashset.
+        /// This method could potentially be moved to Extensions.cs
+        /// </summary>
+        /// <param name="serviceClient"></param>
+        /// <param name="referenceAssemblies"></param>
+        /// <returns></returns>
+        private static HashSet<string> ResolveExternalReferences(ServiceClient serviceClient, ICollection<Assembly> referenceAssemblies)
+        {
+            HashSet<string> modelTypesToRemove = new HashSet<string>();
+            HashSet<string> modelNamespaces = new HashSet<string>();
+            HashSet<string> modelNames = new HashSet<string>(serviceClient.ModelTypes.Select(m => m.Name));
+
+            var matchingExportedTypes =
+                referenceAssemblies.SelectMany(t => t.ExportedTypes).Where(t => modelNames.Contains(t.Name)).ToList();
+            foreach(var typeGroup in matchingExportedTypes.GroupBy(t => t.Name))
+            {
+                if (typeGroup.Count() == 1)
+                {
+                    modelTypesToRemove.Add(typeGroup.Key);
+                    modelNamespaces.Add(matchingExportedTypes[0].Namespace);
+                }
+                else if (matchingExportedTypes.Count > 1)
+                {
+                    Logger.LogError(new ArgumentException("ExternalModelAssemblies"),
+                            Properties.Resources.ConflictingTypesError, typeGroup.Key,
+                            string.Join(", ", referenceAssemblies.Select(a => a.GetName())));
+                }
+            }
+            foreach (var model in modelTypesToRemove)
+            {
+                serviceClient.ModelTypes.RemoveWhere(t => t.Name.Equals(model));
+            }
+            return modelNamespaces;
+        }
+
         /// <summary>
         /// Generates C# code for service client.
         /// </summary>
@@ -104,7 +184,7 @@ namespace Microsoft.Rest.Generator.CSharp
             // Service client
             var serviceClientTemplate = new ServiceClientTemplate
             {
-                Model = new ServiceClientTemplateModel(serviceClient, InternalConstructors),
+                Model = new ServiceClientTemplateModel(serviceClient, InternalConstructors, ReferencedNamespaces)
             };
             await Write(serviceClientTemplate, serviceClient.Name + ".cs");
 
@@ -113,7 +193,7 @@ namespace Microsoft.Rest.Generator.CSharp
             {
                 var extensionsTemplate = new ExtensionsTemplate
                 {
-                    Model = new ExtensionsTemplateModel(serviceClient, null, SyncMethods),
+                    Model = new ExtensionsTemplateModel(serviceClient, null, SyncMethods, ReferencedNamespaces),
                 };
                 await Write(extensionsTemplate, serviceClient.Name + "Extensions.cs");
             }
@@ -121,7 +201,7 @@ namespace Microsoft.Rest.Generator.CSharp
             // Service client interface
             var serviceClientInterfaceTemplate = new ServiceClientInterfaceTemplate
             {
-                Model = new ServiceClientTemplateModel(serviceClient, InternalConstructors),
+                Model = new ServiceClientTemplateModel(serviceClient, InternalConstructors, ReferencedNamespaces),
             };
             await Write(serviceClientInterfaceTemplate, "I" + serviceClient.Name + ".cs");
 
@@ -131,21 +211,21 @@ namespace Microsoft.Rest.Generator.CSharp
                 // Operation
                 var operationsTemplate = new MethodGroupTemplate
                 {
-                    Model = new MethodGroupTemplateModel(serviceClient, group),
+                    Model = new MethodGroupTemplateModel(serviceClient, group, ReferencedNamespaces),
                 };
                 await Write(operationsTemplate, operationsTemplate.Model.MethodGroupType + ".cs");
 
                 // Service client extensions
                 var operationExtensionsTemplate = new ExtensionsTemplate
                 {
-                    Model = new ExtensionsTemplateModel(serviceClient, group, SyncMethods),
+                    Model = new ExtensionsTemplateModel(serviceClient, group, SyncMethods, ReferencedNamespaces),
                 };
                 await Write(operationExtensionsTemplate, group + "Extensions.cs");
 
                 // Operation interface
                 var operationsInterfaceTemplate = new MethodGroupInterfaceTemplate
                 {
-                    Model = new MethodGroupTemplateModel(serviceClient, group),
+                    Model = new MethodGroupTemplateModel(serviceClient, group, ReferencedNamespaces),
                 };
                 await Write(operationsInterfaceTemplate, "I" + operationsInterfaceTemplate.Model.MethodGroupType + ".cs");
             }

--- a/AutoRest/Generators/CSharp/CSharp/GlobalSuppressions.cs
+++ b/AutoRest/Generators/CSharp/CSharp/GlobalSuppressions.cs
@@ -77,4 +77,6 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0", Scope = "member", Target = "Microsoft.Rest.Generator.CSharp.MethodTemplateModel.#.ctor(Microsoft.Rest.Generator.ClientModel.Method,Microsoft.Rest.Generator.ClientModel.ServiceClient,Microsoft.Rest.Generator.CSharp.SyncMethodsGenerationMode)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "1", Scope = "member", Target = "Microsoft.Rest.Generator.CSharp.MethodTemplateModel.#.ctor(Microsoft.Rest.Generator.ClientModel.Method,Microsoft.Rest.Generator.ClientModel.ServiceClient,Microsoft.Rest.Generator.CSharp.SyncMethodsGenerationMode)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Rest.Generator.CSharp.MethodTemplateModel.#GetAsyncMethodInvocationArgs(System.String,System.String)")]
-
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:Properties should not return arrays", Scope = "member",
+    Target = "Microsoft.Rest.Generator.CSharp.CSharpCodeGenerator.ExternalModelAssemblies",
+    Justification = "The array type is used only for a setting from the command-line and is not used in performance-sensitive code")]

--- a/AutoRest/Generators/CSharp/CSharp/Properties/Resources.Designer.cs
+++ b/AutoRest/Generators/CSharp/CSharp/Properties/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace Microsoft.Rest.Generator.CSharp.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Found multiple types that match the model name {0} in assemblies: {1}.
+        /// </summary>
+        internal static string ConflictingTypesError {
+            get {
+                return ResourceManager.GetString("ConflictingTypesError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not load assembly {0}..
+        /// </summary>
+        internal static string ReferenceAssemblyFailure {
+            get {
+                return ResourceManager.GetString("ReferenceAssemblyFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} nuget package is required to compile the generated code..
         /// </summary>
         internal static string UsageInformation {

--- a/AutoRest/Generators/CSharp/CSharp/Properties/Resources.resx
+++ b/AutoRest/Generators/CSharp/CSharp/Properties/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ConflictingTypesError" xml:space="preserve">
+    <value>Found multiple types that match the model name {0} in assemblies: {1}</value>
+  </data>
+  <data name="ReferenceAssemblyFailure" xml:space="preserve">
+    <value>Could not load assembly {0}.</value>
+  </data>
   <data name="UsageInformation" xml:space="preserve">
     <value>The {0} nuget package is required to compile the generated code.</value>
   </data>

--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/ExtensionsTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/ExtensionsTemplateModel.cs
@@ -10,19 +10,22 @@ namespace Microsoft.Rest.Generator.CSharp
 {
     public class ExtensionsTemplateModel : ServiceClient
     {
-        public ExtensionsTemplateModel(ServiceClient serviceClient, string operationName, SyncMethodsGenerationMode syncWrappers)
+        public ExtensionsTemplateModel(ServiceClient serviceClient, string operationName, SyncMethodsGenerationMode syncWrappers, IEnumerable<string> additionalNamespaces)
         {
             this.LoadFrom(serviceClient);
             MethodTemplateModels = new List<MethodTemplateModel>();
             ExtensionName = operationName ?? this.Name;
             this.Methods.Where(m => m.Group == operationName)
                 .ForEach(m => MethodTemplateModels.Add(new MethodTemplateModel(m, serviceClient, syncWrappers)));
+            AdditionalNamespaces = new HashSet<string>(additionalNamespaces);
         }
 
 
         public List<MethodTemplateModel> MethodTemplateModels { get; private set; }
 
         public string ExtensionName { get; set; }
+
+        protected HashSet<string> AdditionalNamespaces { get; private set; }
 
         public virtual IEnumerable<string> Usings
         {
@@ -32,6 +35,8 @@ namespace Microsoft.Rest.Generator.CSharp
                 {
                     yield return "Models";
                 }
+                foreach (var ns in AdditionalNamespaces)
+                    yield return ns;
             }
         }
     }

--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/MethodGroupTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/MethodGroupTemplateModel.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Rest.Generator.CSharp
 {
     public class MethodGroupTemplateModel : ServiceClient
     {
-        public MethodGroupTemplateModel(ServiceClient serviceClient, string methodGroupName)
+        public MethodGroupTemplateModel(ServiceClient serviceClient, string methodGroupName, IEnumerable<string> additionalNamespaces)
         {
             this.LoadFrom(serviceClient);
             MethodTemplateModels = new List<MethodTemplateModel>();
@@ -20,6 +20,7 @@ namespace Microsoft.Rest.Generator.CSharp
             MethodGroupType = methodGroupName;
             Methods.Where(m => m.Group == MethodGroupName)
                 .ForEach(m => MethodTemplateModels.Add(new MethodTemplateModel(m, serviceClient, SyncMethodsGenerationMode.None)));
+            AdditionalNamespaces = new HashSet<string>(additionalNamespaces);
         }
 
         public List<MethodTemplateModel> MethodTemplateModels { get; private set; }
@@ -27,6 +28,8 @@ namespace Microsoft.Rest.Generator.CSharp
         public string MethodGroupName { get; set; }
 
         public string MethodGroupType { get; set; }
+
+        protected HashSet<string> AdditionalNamespaces { get; private set; }
 
         public virtual IEnumerable<string> Usings
         {
@@ -36,6 +39,8 @@ namespace Microsoft.Rest.Generator.CSharp
                 {
                     yield return "Models";
                 }
+                foreach (var ns in AdditionalNamespaces)
+                    yield return ns;
             }
         }
     }

--- a/AutoRest/Generators/CSharp/CSharp/TemplateModels/ServiceClientTemplateModel.cs
+++ b/AutoRest/Generators/CSharp/CSharp/TemplateModels/ServiceClientTemplateModel.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Rest.Generator.CSharp
 {
     public class ServiceClientTemplateModel : ServiceClient
     {
-        public ServiceClientTemplateModel(ServiceClient serviceClient, bool internalConstructors)
+        public ServiceClientTemplateModel(ServiceClient serviceClient, bool internalConstructors, IEnumerable<string> additionalNamespaces)
         {
             this.LoadFrom(serviceClient);
             MethodTemplateModels = new List<MethodTemplateModel>();
@@ -19,6 +19,7 @@ namespace Microsoft.Rest.Generator.CSharp
                 .ForEach(m => MethodTemplateModels.Add(new MethodTemplateModel(m, serviceClient, SyncMethodsGenerationMode.None)));
             ConstructorVisibility = internalConstructors ? "internal" : "public";
             this.IsCustomBaseUri = serviceClient.Extensions.ContainsKey(Microsoft.Rest.Generator.Extensions.ParameterizedHostExtension);
+            AdditionalNamespaces = new HashSet<string>(additionalNamespaces);
         }
 
         public bool IsCustomBaseUri { get; private set; }
@@ -29,10 +30,12 @@ namespace Microsoft.Rest.Generator.CSharp
         {
             get
             {
-                return MethodGroups.Select(mg => new MethodGroupTemplateModel(this, mg));
+                return MethodGroups.Select(mg => new MethodGroupTemplateModel(this, mg, AdditionalNamespaces));
             }
         }
 
+        protected HashSet<string> AdditionalNamespaces { get; private set; }
+         
         public virtual IEnumerable<string> Usings
         {
             get
@@ -41,6 +44,8 @@ namespace Microsoft.Rest.Generator.CSharp
                 {
                     yield return "Models";
                 }
+                foreach (var ns in AdditionalNamespaces)
+                    yield return ns;
             }
         }
 

--- a/AutoRest/Generators/Extensions/Extensions.Tests/AutoRest.Generator.Extensions.Tests.csproj
+++ b/AutoRest/Generators/Extensions/Extensions.Tests/AutoRest.Generator.Extensions.Tests.csproj
@@ -30,6 +30,7 @@
       <Link>AutoRest.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Compile Include="ExternalTestModel.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="MappingTests.cs" />
     <Compile Include="ExtensionsTests.cs" />
@@ -37,6 +38,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
+    </None>
+    <None Include="Swagger\swagger-externalmodels.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Swagger\swagger-x-ms-client-name.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/AutoRest/Generators/Extensions/Extensions.Tests/ExtensionsTests.cs
+++ b/AutoRest/Generators/Extensions/Extensions.Tests/ExtensionsTests.cs
@@ -340,5 +340,6 @@ namespace Microsoft.Rest.Generator.Tests
             Assert.Equal("error_message", type.Properties[1].Name);
             Assert.Equal("parent_error", type.Properties[2].Name);
         }
+
     }
 }

--- a/AutoRest/Generators/Extensions/Extensions.Tests/ExternalTestModel.cs
+++ b/AutoRest/Generators/Extensions/Extensions.Tests/ExternalTestModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Microsoft.Rest.Generator.Tests.ExternalModels
+{
+    [JsonObject()]
+    public class ExternalTestModel
+    {
+        public string Id { get; set; }
+
+        public DateTime? DateTime { get; set; }
+    }
+}

--- a/AutoRest/Generators/Extensions/Extensions.Tests/GlobalSuppressions.cs
+++ b/AutoRest/Generators/Extensions/Extensions.Tests/GlobalSuppressions.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.Rest.Generator.Tests.MappingExtensionsTests.#TestCSharpExternalModelReferences()")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Scope = "member", Target = "Microsoft.Rest.Generator.Tests.ExtensionsTests.#TestClientModelWithPayloadFlatteningViaXMSClientFlatten()")]

--- a/AutoRest/Generators/Extensions/Extensions.Tests/MappingTests.cs
+++ b/AutoRest/Generators/Extensions/Extensions.Tests/MappingTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.Rest.Generator.CSharp;
 using Microsoft.Rest.Generator.Utilities;
@@ -40,6 +41,40 @@ namespace Microsoft.Rest.Generator.Tests
                     minProduct.BaseProductDescription = baseProductDescription;
                     minProduct.MaxProductReference = maxProductReference;
                 }"));
+        }
+
+        [Fact]
+        public void TestCSharpExternalModelReferences()
+        {
+            var settings = new Settings
+            {
+                Namespace = "Test",
+                Input = Path.Combine("Swagger", "swagger-externalmodels.json"),
+                OutputDirectory = "X:\\"
+            };
+            settings.FileSystem = new MemoryFileSystem();
+            settings.FileSystem.WriteFile("AutoRest.json", File.ReadAllText("AutoRest.json"));
+            settings.FileSystem.CreateDirectory(Path.GetDirectoryName(settings.Input));
+            settings.FileSystem.WriteFile(settings.Input, File.ReadAllText(settings.Input));
+
+            var modeler = new SwaggerModeler(settings);
+            var clientModel = modeler.Build();
+            Assert.NotNull(clientModel);
+
+            var generator = new Microsoft.Rest.Generator.CSharp.CSharpCodeGenerator(settings);
+            generator.PopulateSettings(settings.CustomSettings);
+            generator.NormalizeClientModel(clientModel);
+            Assert.Contains("Microsoft.Rest.Generator.Tests.ExternalModels", generator.ReferencedNamespaces);
+            generator.Generate(clientModel).GetAwaiter().GetResult();
+
+            //Ensure the model was found and that the client references the namespace of the ExternalTestModel
+            string clientBody = settings.FileSystem.ReadFileAsText("X:\\SwaggerExternalModelClient.cs");
+            Assert.Contains("using Microsoft.Rest.Generator.Tests.ExternalModels", clientBody, StringComparison.Ordinal);
+            Assert.Contains("ExternalTestModel", clientBody, StringComparison.Ordinal);
+            Assert.True(settings.FileSystem.FileExists("X:\\Models\\Order.cs"));
+
+            //The generator should NOT have created a model file for ExternalTestModel
+            Assert.False(settings.FileSystem.FileExists("X:\\Models\\ExternalTestModel.cs"));
         }
     }
 }

--- a/AutoRest/Generators/Extensions/Extensions.Tests/MappingTests.cs
+++ b/AutoRest/Generators/Extensions/Extensions.Tests/MappingTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Rest.Generator.Tests
             {
                 Namespace = "Test",
                 Input = Path.Combine("Swagger", "swagger-externalmodels.json"),
-                OutputDirectory = "X:\\"
+                OutputDirectory = "X:"
             };
             settings.FileSystem = new MemoryFileSystem();
             settings.FileSystem.WriteFile("AutoRest.json", File.ReadAllText("AutoRest.json"));
@@ -68,13 +68,13 @@ namespace Microsoft.Rest.Generator.Tests
             generator.Generate(clientModel).GetAwaiter().GetResult();
 
             //Ensure the model was found and that the client references the namespace of the ExternalTestModel
-            string clientBody = settings.FileSystem.ReadFileAsText("X:\\SwaggerExternalModelClient.cs");
+            string clientBody = settings.FileSystem.ReadFileAsText(Path.Combine("X:", "SwaggerExternalModelClient.cs"));
             Assert.Contains("using Microsoft.Rest.Generator.Tests.ExternalModels", clientBody, StringComparison.Ordinal);
             Assert.Contains("ExternalTestModel", clientBody, StringComparison.Ordinal);
-            Assert.True(settings.FileSystem.FileExists("X:\\Models\\Order.cs"));
+            Assert.True(settings.FileSystem.FileExists(Path.Combine("X:", "Models", "Order.cs")));
 
             //The generator should NOT have created a model file for ExternalTestModel
-            Assert.False(settings.FileSystem.FileExists("X:\\Models\\ExternalTestModel.cs"));
+            Assert.False(settings.FileSystem.FileExists(Path.Combine("X:", "Models", "ExternalTestModel.cs")));
         }
     }
 }

--- a/AutoRest/Generators/Extensions/Extensions.Tests/Swagger/swagger-externalmodels.json
+++ b/AutoRest/Generators/Extensions/Extensions.Tests/Swagger/swagger-externalmodels.json
@@ -1,0 +1,181 @@
+﻿{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "SwaggerExternalModelClient",
+        "description": "A sample API that tests datetimeoffset usage for date-time",
+        "termsOfService": "n/a",
+        "license": {
+            "name": "MIT",
+            "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+        },
+        "x-ms-code-generation-settings": {
+            "modelAssemblies": [ "AutoRest.Generator.Extensions.Tests.dll" ]
+        }
+    },
+    "host": "localhost:3000",
+    "basePath": "/api",
+    "schemes": [ "http" ],
+    "consumes": [ "application/json" ],
+    "produces": [ "application/json" ],
+    "paths": {
+        "/testmodel": {
+            "post": {
+                "operationId": "postTestModel",
+                "summary": "Post an externally defined model",
+                "parameters": [
+                    {
+                        "name": "model",
+                        "in": "body",
+                        "description": "The model",
+                        "schema": {
+                            "$ref": "#/definitions/ExternalTestModel"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The model we created",
+                        "schema": {
+                            "$ref": "#/definitions/ExternalTestModel"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/testmodel/{id}": {
+            "get": {
+                "operationId": "getTestModel",
+                "summary": "Gets a model defined by an external DLL",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "header",
+                        "type": "string",
+                        "description": "The desired id"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The product we are creating",
+                        "schema": {
+                            "$ref": "#/definitions/ExternalTestModel"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/store/order": {
+            "post": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Place an order for a pet",
+                "description": "",
+                "operationId": "placeOrder",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "order placed for purchasing the pet",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Order"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Order": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "petId": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "quantity": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "shipDate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Order Status",
+                    "enum": [
+                        "placed",
+                        "approved",
+                        "delivered"
+                    ]
+                },
+                "complete": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "xml": {
+                "name": "Order"
+            }
+        },
+        "ExternalTestModel": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "dateTime": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "Error": {
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "fields": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…external assembly

- Change CustomSettings to be dictionary of object to allow for some settings to be arrays (this is used for referencing one or more external assemblies)
- Allow CodeGenSettings to be passed in as a json file on the commandline rather than the settings in the original swagger document (better for this to be a decision by the person generating the proxy than the service provider)
- Change CSharpGenerator to be able to reference external assemblies and
namespaces when assembly is passed in on commandline (like WCF svcutil). Namespaces of the matching types are automatically referenced in the proxy so the proxy does not need to be hand-edited. 