### PR TITLE
Get formatted reference value for only sequence type or return name

### DIFF
--- a/AutoRest/Generators/Ruby/Ruby/ClientModelExtensions.cs
+++ b/AutoRest/Generators/Ruby/Ruby/ClientModelExtensions.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Rest.Generator.Ruby.TemplateModels
             SequenceType sequence = parameter.Type as SequenceType;
             if (sequence == null)
             {
-                return parameter.Type.ToString(parameter.Name);
+                return parameter.Name;
             }
 
             PrimaryType primaryType = sequence.ElementType as PrimaryType;


### PR DESCRIPTION
Ruby MethodTemplateModel used to have conditions like 
```
if (param.Type is SequenceType)  
{  
    encodedParameters.Add(string.Format("'{0}' => {1}", urlPathName, param.GetFormattedReferenceValue()));  
}  
else  
{  
    encodedParameters.Add(string.Format("'{0}' => {1}", urlPathName, variableName));  
}  

```
As part of the refactoring code in PR #992 that was removed and delegated to the method [GetFormattedReferenceValue](https://github.com/Azure/autorest/blob/master/AutoRest/Generators/Ruby/Ruby/ClientModelExtensions.cs#L178). That code was applying the ToString method on all the type that is not sequence type but it should supposed to return that parameter name as it.

Due to this change the URL request got changed in such a way that for nil values it did type conversion to ToString() and started constructing url with empty value of the key when key was nil causing the VCR tests to break. 