### PR TITLE
Http method get with status code 204 should be success in long-running operation

### DIFF
--- a/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_service_client.rb
+++ b/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_service_client.rb
@@ -36,7 +36,7 @@ module MsRestAzure
             elsif !polling_state.location_header_link.nil?
               update_state_from_location_header(polling_state.get_request(headers: request.headers, base_uri: request.base_uri), polling_state, custom_deserialization_block)
             elsif http_method === :put
-              get_request = MsRest::HttpOperationRequest.new(request.base_uri, request.build_path.to_s, 'get', query_params: request.query_params)
+              get_request = MsRest::HttpOperationRequest.new(request.base_uri, request.build_path.to_s, :get, query_params: request.query_params)
               update_state_from_get_resource_operation(get_request, polling_state, custom_deserialization_block)
             else
               task.shutdown
@@ -64,7 +64,7 @@ module MsRestAzure
       end
 
       if (http_method === :put || http_method === :patch) && AsyncOperationStatus.is_successful_status(polling_state.status) && polling_state.resource.nil?
-        get_request = MsRest::HttpOperationRequest.new(request.base_uri, request.build_path.to_s, 'get', query_params: request.query_params)
+        get_request = MsRest::HttpOperationRequest.new(request.base_uri, request.build_path.to_s, :get, query_params: request.query_params)
         update_state_from_get_resource_operation(get_request, polling_state, custom_deserialization_block)
       end
 
@@ -154,7 +154,7 @@ module MsRestAzure
       if status_code === 202
         polling_state.status = AsyncOperationStatus::IN_PROGRESS_STATUS
       elsif status_code === 200 || (status_code === 201 && http_method === :put) ||
-          (status_code === 204 && (http_method === :delete || http_method === :post))
+          (status_code === 204 && (http_method === :delete || http_method === :post || http_method === :get))
         polling_state.status = AsyncOperationStatus::SUCCESS_STATUS
 
         error_data = CloudErrorData.new
@@ -164,7 +164,7 @@ module MsRestAzure
         polling_state.error_data = error_data
         polling_state.resource = result.body
       else
-        fail AzureOperationError, 'The response from long running operation does not have a valid status code'
+        fail AzureOperationError, "The response from long running operation does not have a valid status code. Method: #{http_method}, Status Code: #{status_code}"
       end
     end
 

--- a/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
+++ b/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
@@ -94,7 +94,7 @@ module MsRestAzure
     
     def get_request(options = {})
       link = @azure_async_operation_header_link || @location_header_link
-      MsRest::HttpOperationRequest.new(nil, link, 'get', options)
+      MsRest::HttpOperationRequest.new(nil, link, :get, options)
     end
 
     private


### PR DESCRIPTION
1. Http Status code 204 with Get method in long running used to be a success. Refactoring in PR #1011 broke that scenario. This was caught by the VCR tests inside azure_mgmt_resources gem using method [move_resources](https://github.com/Azure/azure-sdk-ruby/blob/master/resource_management/azure_mgmt_resources/lib/azure_mgmt_resources/resources.rb#L34)

2. Using synbol as http method name instead of string