### PR TITLE
Adding x-ms-client-flatten parameter to the body parameter swagger scehma

### DIFF
--- a/schema/swagger-extensions.json
+++ b/schema/swagger-extensions.json
@@ -544,6 +544,9 @@
         },
         "schema": {
           "$ref": "#/definitions/schema"
+        },
+        "x-ms-client-flatten": {
+          "$ref": "#/definitions/xmsClientFlatten"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
The AutoRest SDK defines that it is possible to add the x-ms-client-flatten extension to a request body:
[AutoRest Extensions for Swagger 2.0](https://github.com/Azure/autorest/blob/master/Documentation/swagger-extensions.md#x-ms-client-flatten)

`"post": {
  "operationId": "DeployTemplate",        
  "parameters": [
  {
     "name": "body",
     "in": "body",
     "x-ms-client-flatten": true,
     "schema": {
       "$ref": "#/definitions/template"
     }
    }
  ]
}`

and it was missing from the schema.
