### PR TITLE
Adding dnx folders and files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,8 @@ AutoRest/Generators/Ruby/*/RspecTests/Generated/*
 #netcore 
 /NetCore
 *.lock.json
+
+#dnx installation
+dnx-clr-win-x86*/
+dnx-coreclr-win-x86*/
+/dnx


### PR DESCRIPTION
Since developers might still have them in their working copy after upgrading to CoreCLR RC2