### PR TITLE
Adding YAML support to Autorest.

### DIFF
--- a/AutoRest/AutoRest.Core/AutoRest.nuspec
+++ b/AutoRest/AutoRest.Core/AutoRest.nuspec
@@ -35,5 +35,6 @@
     <file src="binaries/net45/AutoRest.Modeler.Swagger.dll" target="tools" />
     <file src="binaries/net45/AutoRest.Modeler.CompositeSwagger.dll" target="tools" />
     <file src="binaries/net45/Newtonsoft.Json.dll" target="tools" />
+    <file src="binaries/net45/YamlDotNet.dll" target="tools" />
   </files>
 </package>

--- a/AutoRest/Generators/AzureResourceSchema/AzureResourceSchema.Tests/AcceptanceTests.cs
+++ b/AutoRest/Generators/AzureResourceSchema/AzureResourceSchema.Tests/AcceptanceTests.cs
@@ -47,6 +47,13 @@ namespace AutoRest.Generator.AzureResourceSchema.Tests
             RunSwaggerTest("web.json", "Web");
         }
 
+        [Fact]
+        public static void WebYaml()
+        {
+            // same test as Web(), but converted to YAML
+            RunSwaggerTest("web.yaml", "Web");
+        }
+
         private static void RunSwaggerTest(string swaggerFileName, string expectedFolderName)
         {
             SwaggerSpecHelper.RunTests<AzureResourceSchemaCodeGenerator>(

--- a/AutoRest/Generators/AzureResourceSchema/AzureResourceSchema.Tests/AutoRest.Generator.AzureResourceSchema.Tests.csproj
+++ b/AutoRest/Generators/AzureResourceSchema/AzureResourceSchema.Tests/AutoRest.Generator.AzureResourceSchema.Tests.csproj
@@ -123,6 +123,9 @@
     <Content Include="Swagger\web.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Swagger\web.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Modelers\Swagger.Tests\AutoRest.Modeler.Swagger.Tests.csproj">

--- a/AutoRest/Generators/AzureResourceSchema/AzureResourceSchema.Tests/Swagger/web.yaml
+++ b/AutoRest/Generators/AzureResourceSchema/AzureResourceSchema.Tests/Swagger/web.yaml
@@ -1,0 +1,15193 @@
+﻿swagger: '2.0'
+info:
+  version: '2015-08-01'
+  title: WebSite Management Client
+  description: >-
+    Use these APIs to manage Azure Websites resources through the Azure Resource
+    Manager. All task operations conform to the HTTP/1.1 protocol specification
+    and each operation returns an x-ms-request-id header that can be used to
+    obtain information about the request. You must make sure that requests made
+    to these resources are secure. For more information, see <a
+    href="https://msdn.microsoft.com/en-us/library/azure/dn790557.aspx">Authenticating
+    Azure Resource Manager requests.</a>
+host: management.azure.com
+schemes:
+  - https
+paths:
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{certificateOrderName}/certificates/{name}':
+    get:
+      tags:
+        - CertificateOrders
+      summary: Get certificate associated with the certificate order
+      operationId: CertificateOrders_GetCertificate
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: "true"
+          type: string
+        - name: certificateOrderName
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrderCertificate'
+      deprecated: false
+    put:
+      tags:
+        - CertificateOrders
+      summary: >-
+        Associates a Key Vault secret to a certificate store that will be used
+        for storing the certificate once it's ready
+      operationId: CertificateOrders_CreateOrUpdateCertificate
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: certificateOrderName
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: keyVaultCertificate
+          in: body
+          description: Key Vault secret csm Id
+          required: true
+          schema:
+            $ref: '#/definitions/CertificateOrderCertificate'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrderCertificate'
+      deprecated: false
+    delete:
+      tags:
+        - CertificateOrders
+      summary: Deletes the certificate associated with the certificate order
+      operationId: CertificateOrders_DeleteCertificate
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: certificateOrderName
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - CertificateOrders
+      summary: >-
+        Associates a Key Vault secret to a certificate store that will be used
+        for storing the certificate once it's ready
+      operationId: CertificateOrders_UpdateCertificate
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: certificateOrderName
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: keyVaultCertificate
+          in: body
+          description: Key Vault secret csm Id
+          required: true
+          schema:
+            $ref: '#/definitions/CertificateOrderCertificate'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrderCertificate'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{name}':
+    get:
+      tags:
+        - CertificateOrders
+      summary: Get a certificate order
+      operationId: CertificateOrders_GetCertificateOrder
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrder'
+      deprecated: false
+    put:
+      tags:
+        - CertificateOrders
+      summary: Create or update a certificate purchase order
+      operationId: CertificateOrders_CreateOrUpdateCertificateOrder
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: certificateDistinguishedName
+          in: body
+          description: Distinguished name to be used for purchasing certificate
+          required: true
+          schema:
+            $ref: '#/definitions/CertificateOrder'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrder'
+      deprecated: false
+    delete:
+      tags:
+        - CertificateOrders
+      summary: Delete an existing certificate order
+      operationId: CertificateOrders_DeleteCertificateOrder
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - CertificateOrders
+      summary: Create or update a certificate purchase order
+      operationId: CertificateOrders_UpdateCertificateOrder
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: certificateDistinguishedName
+          in: body
+          description: Distinguished name to be used for purchasing certificate
+          required: true
+          schema:
+            $ref: '#/definitions/CertificateOrder'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrder'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders':
+    get:
+      tags:
+        - CertificateOrders
+      summary: Get certificate orders in a resource group
+      operationId: CertificateOrders_GetCertificateOrders
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrderCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{certificateOrderName}/certificates':
+    get:
+      tags:
+        - CertificateOrders
+      summary: >-
+        List all certificates associated with a certificate order (only one
+        certificate can be associated with an order at a time)
+      operationId: CertificateOrders_GetCertificates
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: certificateOrderName
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrderCertificateCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{name}/reissue':
+    post:
+      tags:
+        - CertificateOrders
+      summary: Reissue an existing certificate order
+      operationId: CertificateOrders_ReissueCertificateOrder
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: reissueCertificateOrderRequest
+          in: body
+          description: Reissue parameters
+          required: true
+          schema:
+            $ref: '#/definitions/ReissueCertificateOrderRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{name}/renew':
+    post:
+      tags:
+        - CertificateOrders
+      summary: Renew an existing certificate order
+      operationId: CertificateOrders_RenewCertificateOrder
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate name
+          required: true
+          type: string
+        - name: renewCertificateOrderRequest
+          in: body
+          description: Renew parameters
+          required: true
+          schema:
+            $ref: '#/definitions/RenewCertificateOrderRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{name}/retrieveCertificateActions':
+    post:
+      tags:
+        - CertificateOrders
+      summary: Retrieve the list of certificate actions
+      operationId: CertificateOrders_RetrieveCertificateActions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate order name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/CertificateOrderAction'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{name}/retrieveEmailHistory':
+    post:
+      tags:
+        - CertificateOrders
+      summary: Retrive email history
+      operationId: CertificateOrders_RetrieveCertificateEmailHistory
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate order name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/CertificateEmail'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{name}/resendEmail':
+    post:
+      tags:
+        - CertificateOrders
+      summary: Resend certificate email
+      operationId: CertificateOrders_ResendCertificateEmail
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate order name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{name}/verifyDomainOwnership':
+    post:
+      tags:
+        - CertificateOrders
+      summary: Verify domain ownership for this certificate order
+      operationId: CertificateOrders_VerifyDomainOwnership
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Azure resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Certificate order name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/certificates':
+    get:
+      tags:
+        - Certificates
+      summary: Get certificates for a subscription in the specified resource group.
+      operationId: Certificates_GetCertificates
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/certificates/{name}':
+    get:
+      tags:
+        - Certificates
+      summary: >-
+        Get a certificate by certificate name for a subscription in the
+        specified resource group.
+      operationId: Certificates_GetCertificate
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the certificate.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Certificate'
+      deprecated: false
+    put:
+      tags:
+        - Certificates
+      summary: Creates or modifies an existing certificate.
+      operationId: Certificates_CreateOrUpdateCertificate
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the certificate.
+          required: true
+          type: string
+        - name: certificateEnvelope
+          in: body
+          description: Details of certificate if it exists already.
+          required: true
+          schema:
+            $ref: '#/definitions/Certificate'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Certificate'
+      deprecated: false
+    delete:
+      tags:
+        - Certificates
+      summary: >-
+        Delete a certificate by name in a specificed subscription and
+        resourcegroup.
+      operationId: Certificates_DeleteCertificate
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the certificate to be deleted.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Certificates
+      summary: Creates or modifies an existing certificate.
+      operationId: Certificates_UpdateCertificate
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the certificate.
+          required: true
+          type: string
+        - name: certificateEnvelope
+          in: body
+          description: Details of certificate if it exists already.
+          required: true
+          schema:
+            $ref: '#/definitions/Certificate'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Certificate'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/csrs':
+    get:
+      tags:
+        - Certificates
+      summary: >-
+        Gets the certificate signing requests for a subscription in the
+        specified resource group
+      operationId: Certificates_GetCsrs
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Csr'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/csrs/{name}':
+    get:
+      tags:
+        - Certificates
+      summary: >-
+        Gets a certificate signing request by certificate name for a
+        subscription in the specified resource group
+      operationId: Certificates_GetCsr
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the certificate.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Csr'
+      deprecated: false
+    put:
+      tags:
+        - Certificates
+      summary: Creates or modifies an existing certificate signing request.
+      operationId: Certificates_CreateOrUpdateCsr
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the certificate.
+          required: true
+          type: string
+        - name: csrEnvelope
+          in: body
+          description: Details of certificate signing request if it exists already.
+          required: true
+          schema:
+            $ref: '#/definitions/Csr'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Csr'
+      deprecated: false
+    delete:
+      tags:
+        - Certificates
+      summary: Delete the certificate signing request.
+      operationId: Certificates_DeleteCsr
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the certificate signing request.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Certificates
+      summary: Creates or modifies an existing certificate signing request.
+      operationId: Certificates_UpdateCsr
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the certificate.
+          required: true
+          type: string
+        - name: csrEnvelope
+          in: body
+          description: Details of certificate signing request if it exists already.
+          required: true
+          schema:
+            $ref: '#/definitions/Csr'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Csr'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/classicMobileServices':
+    get:
+      tags:
+        - ClassicMobileServices
+      summary: Get all mobile services in a resource group.
+      operationId: ClassicMobileServices_GetClassicMobileServices
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ClassicMobileServiceCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/classicMobileServices/{name}':
+    get:
+      tags:
+        - ClassicMobileServices
+      summary: Get a mobile service.
+      operationId: ClassicMobileServices_GetClassicMobileService
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of mobile service
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ClassicMobileService'
+      deprecated: false
+    delete:
+      tags:
+        - ClassicMobileServices
+      summary: Delete a mobile service.
+      operationId: ClassicMobileServices_DeleteClassicMobileService
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of mobile service
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DomainRegistration/domains':
+    get:
+      tags:
+        - Domains
+      summary: Lists domains under a resource group
+      operationId: Domains_GetDomains
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DomainCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DomainRegistration/domains/{domainName}':
+    get:
+      tags:
+        - Domains
+      summary: Gets details of a domain
+      operationId: Domains_GetDomain
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: domainName
+          in: path
+          description: Name of the domain
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Domain'
+      deprecated: false
+    put:
+      tags:
+        - Domains
+      summary: Creates a domain
+      operationId: Domains_CreateOrUpdateDomain
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: '&gt;Name of the resource group'
+          required: true
+          type: string
+        - name: domainName
+          in: path
+          description: Name of the domain
+          required: true
+          type: string
+        - name: domain
+          in: body
+          description: Domain registration information
+          required: true
+          schema:
+            $ref: '#/definitions/Domain'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: Domain purchase was successful
+          schema:
+            $ref: '#/definitions/Domain'
+        '202':
+          description: Domain purchase is in progress
+          schema:
+            $ref: '#/definitions/Domain'
+      deprecated: false
+    delete:
+      tags:
+        - Domains
+      summary: Deletes a domain
+      operationId: Domains_DeleteDomain
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: domainName
+          in: path
+          description: Name of the domain
+          required: true
+          type: string
+        - name: forceHardDeleteDomain
+          in: query
+          description: >-
+            If true then the domain will be deleted immediately instead of after
+            24 hours
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '204':
+          description: >-
+            Domain does not exist in Azure database probably because it has
+            already been deleted
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Domains
+      summary: Creates a domain
+      operationId: Domains_UpdateDomain
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: '&gt;Name of the resource group'
+          required: true
+          type: string
+        - name: domainName
+          in: path
+          description: Name of the domain
+          required: true
+          type: string
+        - name: domain
+          in: body
+          description: Domain registration information
+          required: true
+          schema:
+            $ref: '#/definitions/Domain'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: Domain purchase was successful
+          schema:
+            $ref: '#/definitions/Domain'
+        '202':
+          description: Domain purchase is in progress
+          schema:
+            $ref: '#/definitions/Domain'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DomainRegistration/domains/{domainName}/operationresults/{operationId}':
+    get:
+      tags:
+        - Domains
+      summary: Retrieves the latest status of a domain purchase operation
+      operationId: Domains_GetDomainOperation
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: domainName
+          in: path
+          description: Name of the domain
+          required: true
+          type: string
+        - name: operationId
+          in: path
+          description: Domain purchase operation Id
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: Domain purchase was successful
+          schema:
+            $ref: '#/definitions/Domain'
+        '202':
+          description: Domain purchase is in progress
+          schema:
+            $ref: '#/definitions/Domain'
+        '500':
+          description: Domain purchase request failed
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/publishingCredentials':
+    get:
+      tags:
+        - Global
+      summary: Gets publishing credentials for the subscription owner
+      operationId: Global_GetSubscriptionPublishingCredentials
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/User'
+      deprecated: false
+    put:
+      tags:
+        - Global
+      summary: Updates publishing credentials for the subscription owner
+      operationId: Global_UpdateSubscriptionPublishingCredentials
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: requestMessage
+          in: body
+          description: requestMessage with new publishing credentials
+          required: true
+          schema:
+            $ref: '#/definitions/User'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/User'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/geoRegions':
+    get:
+      tags:
+        - Global
+      summary: Gets list of available geo regions
+      operationId: Global_GetSubscriptionGeoRegions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: sku
+          in: query
+          description: Filter only to regions that support this sku
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/GeoRegionCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/certificates':
+    get:
+      tags:
+        - Global
+      summary: Get all certificates for a subscription
+      operationId: Global_GetAllCertificates
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/serverfarms':
+    get:
+      tags:
+        - Global
+      summary: Gets all App Service Plans for a subcription
+      operationId: Global_GetAllServerFarms
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: detailed
+          in: query
+          description: "False to return a subset of App Service Plan properties, true to return all of the properties.\r\n            Retrieval of all properties may increase the API latency."
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/sites':
+    get:
+      tags:
+        - Global
+      summary: Gets all Web Apps for a subscription
+      operationId: Global_GetAllSites
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/hostingEnvironments':
+    get:
+      tags:
+        - Global
+      summary: >-
+        Gets all hostingEnvironments (App Service Environment) for a
+        subscription
+      operationId: Global_GetAllHostingEnvironments
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostingEnvironmentCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/managedHostingEnvironments':
+    get:
+      tags:
+        - Global
+      summary: Gets all managed hosting environments for a subscription
+      operationId: Global_GetAllManagedHostingEnvironments
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ManagedHostingEnvironmentCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/classicMobileServices':
+    get:
+      tags:
+        - Global
+      summary: Gets all mobile services for a subscription
+      operationId: Global_GetAllClassicMobileServices
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ClassicMobileServiceCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/premieraddonoffers':
+    get:
+      tags:
+        - Global
+      summary: List premier add on offers
+      operationId: Global_ListPremierAddOnOffers
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/ishostingenvironmentnameavailable':
+    get:
+      tags:
+        - Global
+      summary: Whether hosting environment name is available
+      operationId: Global_IsHostingEnvironmentNameAvailable
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: name
+          in: query
+          description: Hosting environment name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/ishostingenvironmentnameavailable/{name}':
+    get:
+      tags:
+        - Global
+      summary: Whether hosting environment name is available
+      operationId: Global_IsHostingEnvironmentWithLegacyNameAvailable
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: name
+          in: path
+          description: Hosting environment name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/checknameavailability':
+    post:
+      tags:
+        - Global
+      summary: Check if resource name is available
+      operationId: Global_CheckNameAvailability
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: request
+          in: body
+          description: Name availability request
+          required: true
+          schema:
+            $ref: '#/definitions/ResourceNameAvailabilityRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ResourceNameAvailability'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.CertificateRegistration/certificateOrders':
+    get:
+      tags:
+        - GlobalCertificateOrder
+      summary: Lists all domains in a subscription
+      operationId: GlobalCertificateOrder_GetAllCertificateOrders
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CertificateOrderCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.CertificateRegistration/validateCertificateRegistrationInformation':
+    post:
+      tags:
+        - GlobalCertificateOrder
+      summary: Validate certificate purchase information
+      operationId: GlobalCertificateOrder_ValidateCertificatePurchaseInformation
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: certificateOrder
+          in: body
+          description: Certificate order
+          required: true
+          schema:
+            $ref: '#/definitions/CertificateOrder'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.DomainRegistration/domains':
+    get:
+      tags:
+        - GlobalDomainRegistration
+      summary: Lists all domains in a subscription
+      operationId: GlobalDomainRegistration_GetAllDomains
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DomainCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.DomainRegistration/generateSsoRequest':
+    post:
+      tags:
+        - GlobalDomainRegistration
+      summary: Generates a single sign on request for domain management portal
+      operationId: GlobalDomainRegistration_GetDomainControlCenterSsoRequest
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DomainControlCenterSsoRequest'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.DomainRegistration/validateDomainRegistrationInformation':
+    post:
+      tags:
+        - GlobalDomainRegistration
+      summary: Validates domain registration information
+      operationId: GlobalDomainRegistration_ValidateDomainPurchaseInformation
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: domainRegistrationInput
+          in: body
+          description: Domain registration information
+          required: true
+          schema:
+            $ref: '#/definitions/DomainRegistrationInput'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.DomainRegistration/checkDomainAvailability':
+    post:
+      tags:
+        - GlobalDomainRegistration
+      summary: Checks if a domain is available for registration
+      operationId: GlobalDomainRegistration_CheckDomainAvailability
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: identifier
+          in: body
+          description: Name of the domain
+          required: true
+          schema:
+            $ref: '#/definitions/NameIdentifier'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DomainAvailablilityCheckResult'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.DomainRegistration/listDomainRecommendations':
+    post:
+      tags:
+        - GlobalDomainRegistration
+      summary: Lists domain recommendations based on keywords
+      operationId: GlobalDomainRegistration_ListDomainRecommendations
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: parameters
+          in: body
+          description: Domain recommendation search parameters
+          required: true
+          schema:
+            $ref: '#/definitions/DomainRecommendationSearchParameters'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/NameIdentifierCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/moveResources':
+    post:
+      tags:
+        - GlobalResourceGroups
+      operationId: GlobalResourceGroups_MoveResources
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces: []
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: moveResourceEnvelope
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/CsmMoveResourceEnvelope'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '204':
+          description: No Content
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get properties of hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostingEnvironment'
+      deprecated: false
+    put:
+      tags:
+        - HostingEnvironments
+      summary: Create or update a hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_CreateOrUpdateHostingEnvironment
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: hostingEnvironmentEnvelope
+          in: body
+          description: Properties of hostingEnvironment (App Service Environment)
+          required: true
+          schema:
+            $ref: '#/definitions/HostingEnvironment'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostingEnvironment'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/HostingEnvironment'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
+      deprecated: false
+      x-ms-long-running-operation: true
+    delete:
+      tags:
+        - HostingEnvironments
+      summary: Delete a hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_DeleteHostingEnvironment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: forceDelete
+          in: query
+          description: >-
+            Delete even if the hostingEnvironment (App Service Environment)
+            contains resources
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/Object'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/diagnostics':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get diagnostic information for hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentDiagnostics
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/HostingEnvironmentDiagnostics'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/diagnostics/{diagnosticsName}':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get diagnostic information for hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentDiagnosticsItem
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: diagnosticsName
+          in: path
+          description: Name of the diagnostics
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostingEnvironmentDiagnostics'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/capacities/compute':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get used, available, and total worker capacity for hostingEnvironment
+        (App Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentCapacities
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StampCapacityCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/capacities/virtualip':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get IP addresses assigned to the hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentVips
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/AddressResponse'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get all hostingEnvironments (App Service Environments) in a resource
+        group.
+      operationId: HostingEnvironments_GetHostingEnvironments
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostingEnvironmentCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/reboot':
+    post:
+      tags:
+        - HostingEnvironments
+      summary: Reboots all machines in a hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_RebootHostingEnvironment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/Object'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/operations':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        List all currently running operations on the hostingEnvironment (App
+        Service Environment)
+      operationId: HostingEnvironments_GetHostingEnvironmentOperations
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/operations/{operationId}':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get status of an operation on a hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentOperation
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: operationId
+          in: path
+          description: operation identifier GUID
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: Operation completed successfully
+          schema:
+            $ref: '#/definitions/Object'
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/Object'
+        '404':
+          description: Not found
+        '500':
+          description: Operation failed
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/metrics':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get global metrics of hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentMetrics
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: details
+          in: query
+          description: Include instance details
+          type: boolean
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages/metrics specified in the filter. Filter conforms
+            to odata syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ResourceMetricCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/metricdefinitions':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get global metric definitions of hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentMetricDefinitions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/MetricDefinition'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/usages':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get global usages of hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentUsages
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages/metrics specified in the filter. Filter conforms
+            to odata syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CsmUsageQuotaCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools/default/metrics':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get metrics for a multiRole pool of a hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentMultiRoleMetrics
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: startTime
+          in: query
+          description: Beginning time of metrics query
+          type: string
+        - name: endTime
+          in: query
+          description: End time of metrics query
+          type: string
+        - name: timeGrain
+          in: query
+          description: Time granularity of metrics query
+          type: string
+        - name: details
+          in: query
+          description: Include instance details
+          type: boolean
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages/metrics specified in the filter. Filter conforms
+            to odata syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ResourceMetricCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools/{workerPoolName}/metrics':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get metrics for a worker pool of a hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentWebWorkerMetrics
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: workerPoolName
+          in: path
+          description: Name of worker pool
+          required: true
+          type: string
+        - name: details
+          in: query
+          description: Include instance details
+          type: boolean
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages/metrics specified in the filter. Filter conforms
+            to odata syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ResourceMetricCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools/default/metricdefinitions':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get metric definitions for a multiRole pool of a hostingEnvironment (App
+        Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentMultiRoleMetricDefinitions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/MetricDefinitionCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools/{workerPoolName}/metricdefinitions':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get metric definitions for a worker pool of a hostingEnvironment (App
+        Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentWebWorkerMetricDefinitions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: workerPoolName
+          in: path
+          description: Name of worker pool
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/MetricDefinitionCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools/default/usages':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get usages for a multiRole pool of a hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentMultiRoleUsages
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/UsageCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools/{workerPoolName}/usages':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get usages for a worker pool of a hostingEnvironment (App Service
+        Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentWebWorkerUsages
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: workerPoolName
+          in: path
+          description: Name of worker pool
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/UsageCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/sites':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get all sites on the hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentSites
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: propertiesToInclude
+          in: query
+          description: Comma separated list of site properties to include
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/webhostingplans':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get all serverfarms (App Service Plans) on the hostingEnvironment (App
+        Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentWebHostingPlans
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/serverfarms':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get all serverfarms (App Service Plans) on the hostingEnvironment (App
+        Service Environment).
+      operationId: HostingEnvironments_GetHostingEnvironmentServerFarms
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get all multi role pools
+      operationId: HostingEnvironments_GetMultiRolePools
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/WorkerPoolCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools/default':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get properties of a multiRool pool.
+      operationId: HostingEnvironments_GetMultiRolePool
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/WorkerPool'
+      deprecated: false
+    put:
+      tags:
+        - HostingEnvironments
+      summary: Create or update a multiRole pool.
+      operationId: HostingEnvironments_CreateOrUpdateMultiRolePool
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: multiRolePoolEnvelope
+          in: body
+          description: Properties of multiRole pool
+          required: true
+          schema:
+            $ref: '#/definitions/WorkerPool'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/WorkerPool'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/WorkerPool'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools/default/skus':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get available skus for scaling a multiRole pool.
+      operationId: HostingEnvironments_GetMultiRolePoolSkus
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SkuInfoCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get all worker pools
+      operationId: HostingEnvironments_GetWorkerPools
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/WorkerPoolCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools/{workerPoolName}':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get properties of a worker pool.
+      operationId: HostingEnvironments_GetWorkerPool
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: workerPoolName
+          in: path
+          description: Name of worker pool
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/WorkerPool'
+      deprecated: false
+    put:
+      tags:
+        - HostingEnvironments
+      summary: Create or update a worker pool.
+      operationId: HostingEnvironments_CreateOrUpdateWorkerPool
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: workerPoolName
+          in: path
+          description: Name of worker pool
+          required: true
+          type: string
+        - name: workerPoolEnvelope
+          in: body
+          description: Properties of worker pool
+          required: true
+          schema:
+            $ref: '#/definitions/WorkerPool'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/WorkerPool'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/WorkerPool'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools/{workerPoolName}/skus':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: Get available skus for scaling a worker pool.
+      operationId: HostingEnvironments_GetWorkerPoolSkus
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: workerPoolName
+          in: path
+          description: Name of worker pool
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SkuInfoCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools/{workerPoolName}/instances/{instance}/metrics':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get metrics for a specific instance of a worker pool of a
+        hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_GetWorkerPoolInstanceMetrics
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: workerPoolName
+          in: path
+          description: Name of worker pool
+          required: true
+          type: string
+        - name: instance
+          in: path
+          description: Name of instance in the worker pool
+          required: true
+          type: string
+        - name: details
+          in: query
+          description: Include instance details
+          type: boolean
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages/metrics specified in the filter. Filter conforms
+            to odata syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools/{workerPoolName}/instances/{instance}/metricdefinitions':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get metric definitions for a specific instance of a worker pool of a
+        hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_GetWorkerPoolInstanceMetricDefinitions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: workerPoolName
+          in: path
+          description: Name of worker pool
+          required: true
+          type: string
+        - name: instance
+          in: path
+          description: Name of instance in the worker pool
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools/default/instances/{instance}/metrics':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get metrics for a specific instance of a multiRole pool of a
+        hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_GetMultiRolePoolInstanceMetrics
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: instance
+          in: path
+          description: Name of instance in the multiRole pool
+          required: true
+          type: string
+        - name: details
+          in: query
+          description: Include instance details
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools/default/instances/{instance}/metricdefinitions':
+    get:
+      tags:
+        - HostingEnvironments
+      summary: >-
+        Get metric definitions for a specific instance of a multiRole pool of a
+        hostingEnvironment (App Service Environment).
+      operationId: HostingEnvironments_GetMultiRolePoolInstanceMetricDefinitions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - name: instance
+          in: path
+          description: Name of instance in the multiRole pool&gt;
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/suspend':
+    post:
+      tags:
+        - HostingEnvironments
+      summary: Suspends the hostingEnvironment.
+      operationId: HostingEnvironments_SuspendHostingEnvironment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCollection'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/SiteCollection'
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/resume':
+    post:
+      tags:
+        - HostingEnvironments
+      summary: Resumes the hostingEnvironment.
+      operationId: HostingEnvironments_ResumeHostingEnvironment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of hostingEnvironment (App Service Environment)
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCollection'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/SiteCollection'
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/managedHostingEnvironments/{name}':
+    get:
+      tags:
+        - ManagedHostingEnvironments
+      summary: Get properties of a managed hosting environment.
+      operationId: ManagedHostingEnvironments_GetManagedHostingEnvironment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of managed hosting environment
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ManagedHostingEnvironment'
+      deprecated: false
+    put:
+      tags:
+        - ManagedHostingEnvironments
+      summary: Create or update a managed hosting environment.
+      operationId: ManagedHostingEnvironments_CreateOrUpdateManagedHostingEnvironment
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of managed hosting environment
+          required: true
+          type: string
+        - name: ManagedHostingEnvironmentEnvelope
+          in: body
+          description: Properties of managed hosting environment
+          required: true
+          schema:
+            $ref: '#/definitions/HostingEnvironment'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/HostingEnvironment'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
+      deprecated: false
+      x-ms-long-running-operation: true
+    delete:
+      tags:
+        - ManagedHostingEnvironments
+      summary: Delete a managed hosting environment.
+      operationId: ManagedHostingEnvironments_DeleteManagedHostingEnvironment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of managed hosting environment
+          required: true
+          type: string
+        - name: forceDelete
+          in: query
+          description: Delete even if the managed hosting environment contains resources
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/Object'
+        '400':
+          description: Bad request
+        '404':
+          description: Not found
+        '409':
+          description: Conflict
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/managedHostingEnvironments':
+    get:
+      tags:
+        - ManagedHostingEnvironments
+      summary: Get all managed hosting environments in a resource group.
+      operationId: ManagedHostingEnvironments_GetManagedHostingEnvironments
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostingEnvironmentCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/managedHostingEnvironments/{name}/capacities/virtualip':
+    get:
+      tags:
+        - ManagedHostingEnvironments
+      summary: Get list of ip addresses assigned to a managed hosting environment
+      operationId: ManagedHostingEnvironments_GetManagedHostingEnvironmentVips
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of managed hosting environment
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/AddressResponse'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/managedHostingEnvironments/{name}/operations/{operationId}':
+    get:
+      tags:
+        - ManagedHostingEnvironments
+      summary: Get status of an operation on a managed hosting environment.
+      operationId: ManagedHostingEnvironments_GetManagedHostingEnvironmentOperation
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of managed hosting environment
+          required: true
+          type: string
+        - name: operationId
+          in: path
+          description: operation identifier GUID
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: Operation completed successfully
+          schema:
+            $ref: '#/definitions/Object'
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/Object'
+        '404':
+          description: Not found
+        '500':
+          description: Operation failed
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/managedHostingEnvironments/{name}/sites':
+    get:
+      tags:
+        - ManagedHostingEnvironments
+      summary: Get all sites on the managed hosting environment.
+      operationId: ManagedHostingEnvironments_GetManagedHostingEnvironmentSites
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of managed hosting environment
+          required: true
+          type: string
+        - name: propertiesToInclude
+          in: query
+          description: Comma separated list of site properties to include
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/managedHostingEnvironments/{name}/webhostingplans':
+    get:
+      tags:
+        - ManagedHostingEnvironments
+      summary: >-
+        Get all serverfarms (App Service Plans) on the managed hosting
+        environment.
+      operationId: ManagedHostingEnvironments_GetManagedHostingEnvironmentWebHostingPlans
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of managed hosting environment
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/managedHostingEnvironments/{name}/serverfarms':
+    get:
+      tags:
+        - ManagedHostingEnvironments
+      summary: >-
+        Get all serverfarms (App Service Plans) on the managed hosting
+        environment.
+      operationId: ManagedHostingEnvironments_GetManagedHostingEnvironmentServerFarms
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of managed hosting environment
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmCollection'
+      deprecated: false
+  /providers/Microsoft.Web/sourcecontrols:
+    get:
+      tags:
+        - Provider
+      summary: Gets the source controls available for Azure websites
+      operationId: Provider_GetSourceControls
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SourceControlCollection'
+      deprecated: false
+  '/providers/Microsoft.Web/sourcecontrols/{sourceControlType}':
+    get:
+      tags:
+        - Provider
+      summary: Gets source control token
+      operationId: Provider_GetSourceControl
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: sourceControlType
+          in: path
+          description: Type of source control
+          required: true
+          type: string
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SourceControl'
+      deprecated: false
+    put:
+      tags:
+        - Provider
+      summary: Updates source control token
+      operationId: Provider_UpdateSourceControl
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: sourceControlType
+          in: path
+          description: Type of source control
+          required: true
+          type: string
+        - name: requestMessage
+          in: body
+          description: Source control token information
+          required: true
+          schema:
+            $ref: '#/definitions/SourceControl'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SourceControl'
+      deprecated: false
+  /providers/Microsoft.Web/publishingUsers/web:
+    get:
+      tags:
+        - Provider
+      summary: Gets publishing user
+      operationId: Provider_GetPublishingUser
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/User'
+      deprecated: false
+    put:
+      tags:
+        - Provider
+      summary: Updates publishing user
+      operationId: Provider_UpdatePublishingUser
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: requestMessage
+          in: body
+          description: Details of publishing user
+          required: true
+          schema:
+            $ref: '#/definitions/User'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/User'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.Web/recommendations':
+    get:
+      tags:
+        - Recommendations
+      summary: >-
+        Gets a list of recommendations associated with the specified
+        subscription.
+      operationId: Recommendations_GetRecommendationBySubscription
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: featured
+          in: query
+          description: >-
+            If set, this API returns only the most critical recommendation among
+            the others. Otherwise this API returns all recommendations available
+          type: boolean
+        - name: $filter
+          in: query
+          description: >-
+            Return only channels specified in the filter. Filter is specified by
+            using OData syntax. Example: $filter=channels eq 'Api' or channel eq
+            'Notification'
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Recommendation'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName}/recommendations/{name}':
+    get:
+      tags:
+        - Recommendations
+      summary: >-
+        Gets the detailed properties of the recommendation object for the
+        specified web site.
+      operationId: Recommendations_GetRuleDetailsBySiteName
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Resource group name
+          required: true
+          type: string
+        - name: siteName
+          in: path
+          description: Site name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Recommendation rule name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RecommendationRule'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName}/recommendations':
+    get:
+      tags:
+        - Recommendations
+      summary: Gets a list of recommendations associated with the specified web site.
+      operationId: Recommendations_GetRecommendedRulesForSite
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Resource group name
+          required: true
+          type: string
+        - name: siteName
+          in: path
+          description: Site name
+          required: true
+          type: string
+        - name: featured
+          in: query
+          description: >-
+            If set, this API returns only the most critical recommendation among
+            the others. Otherwise this API returns all recommendations available
+          type: boolean
+        - name: siteSku
+          in: query
+          description: The name of site SKU.
+          type: string
+        - name: numSlots
+          in: query
+          description: The number of site slots associated to the site
+          type: integer
+          format: int32
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Recommendation'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName}/recommendationHistory':
+    get:
+      tags:
+        - Recommendations
+      summary: >-
+        Gets the list of past recommendations optionally specified by the time
+        range.
+      operationId: Recommendations_GetRecommendationHistoryForSite
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Resource group name
+          required: true
+          type: string
+        - name: siteName
+          in: path
+          description: Site name
+          required: true
+          type: string
+        - name: startTime
+          in: query
+          description: >-
+            The start time of a time range to query, e.g. $filter=startTime eq
+            '2015-01-01T00:00:00Z' and endTime eq '2015-01-02T00:00:00Z'
+          type: string
+        - name: endTime
+          in: query
+          description: >-
+            The end time of a time range to query, e.g. $filter=startTime eq
+            '2015-01-01T00:00:00Z' and endTime eq '2015-01-02T00:00:00Z'
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Recommendation'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms':
+    get:
+      tags:
+        - ServerFarms
+      summary: >-
+        Gets collection of App Service Plans in a resource group for a given
+        subscription.
+      operationId: ServerFarms_GetServerFarms
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}':
+    get:
+      tags:
+        - ServerFarms
+      summary: Gets specified App Service Plan in a resource group
+      operationId: ServerFarms_GetServerFarm
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmWithRichSku'
+      deprecated: false
+    put:
+      tags:
+        - ServerFarms
+      summary: Creates or updates an App Service Plan
+      operationId: ServerFarms_CreateOrUpdateServerFarm
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: serverFarmEnvelope
+          in: body
+          description: Details of App Service Plan
+          required: true
+          schema:
+            $ref: '#/definitions/ServerFarmWithRichSku'
+        - name: allowPendingState
+          in: query
+          description: 'OBSOLETE: If true, allow pending state for App Service Plan'
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmWithRichSku'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/ServerFarmWithRichSku'
+      deprecated: false
+      x-ms-long-running-operation: true
+    delete:
+      tags:
+        - ServerFarms
+      summary: Deletes a App Service Plan
+      operationId: ServerFarms_DeleteServerFarm
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/metrics':
+    get:
+      tags:
+        - ServerFarms
+      summary: Queries for App Serice Plan metrics
+      operationId: ServerFarms_GetServerFarmMetrics
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: details
+          in: query
+          description: 'If true, metrics are broken down per App Service Plan instance'
+          type: boolean
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages/metrics specified in the filter. Filter conforms
+            to odata syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ResourceMetricCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/metricdefinitions':
+    get:
+      tags:
+        - ServerFarms
+      summary: List of metrics that can be queried for an App Service Plan
+      operationId: ServerFarms_GetServerFarmMetricDefintions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/MetricDefinitionCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/virtualNetworkConnections':
+    get:
+      tags:
+        - ServerFarms
+      summary: Gets list of vnets associated with App Service Plan
+      operationId: ServerFarms_GetVnetsForServerFarm
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/VnetInfo'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/virtualNetworkConnections/{vnetName}':
+    get:
+      tags:
+        - ServerFarms
+      summary: Gets a vnet associated with an App Service Plan
+      operationId: ServerFarms_GetVnetFromServerFarm
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: Name of virtual network
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetInfo'
+        '404':
+          description: Virtual network could not be found
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/virtualNetworkConnections/{vnetName}/routes':
+    get:
+      tags:
+        - ServerFarms
+      summary: 'Gets a list of all routes associated with a vnet, in an app service plan'
+      operationId: ServerFarms_GetRoutesForVnet
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: Name of virtual network
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/VnetRoute'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/virtualNetworkConnections/{vnetName}/routes/{routeName}':
+    get:
+      tags:
+        - ServerFarms
+      summary: 'Gets a specific route associated with a vnet, in an app service plan'
+      operationId: ServerFarms_GetRouteForVnet
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: Name of virtual network
+          required: true
+          type: string
+        - name: routeName
+          in: path
+          description: Name of the virtual network route
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/VnetRoute'
+        '404':
+          description: Specified route does not exist
+      deprecated: false
+    put:
+      tags:
+        - ServerFarms
+      summary: >-
+        Creates a new route or updates an existing route for a vnet in an app
+        service plan.
+      operationId: ServerFarms_CreateOrUpdateVnetRoute
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: Name of virtual network
+          required: true
+          type: string
+        - name: routeName
+          in: path
+          description: Name of the virtual network route
+          required: true
+          type: string
+        - name: route
+          in: body
+          description: The route object
+          required: true
+          schema:
+            $ref: '#/definitions/VnetRoute'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetRoute'
+        '400':
+          description: >-
+            Invalid request. Ensure that required parameters are given, and that
+            addresses and address spaces are valid
+        '404':
+          description: Route not found. This will only occur when using the PATCH verb.
+      deprecated: false
+    delete:
+      tags:
+        - ServerFarms
+      summary: Deletes an existing route for a vnet in an app service plan.
+      operationId: ServerFarms_DeleteVnetRoute
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: Name of virtual network
+          required: true
+          type: string
+        - name: routeName
+          in: path
+          description: Name of the virtual network route
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+        '404':
+          description: Specified route does not exist.
+      deprecated: false
+    patch:
+      tags:
+        - ServerFarms
+      summary: >-
+        Creates a new route or updates an existing route for a vnet in an app
+        service plan.
+      operationId: ServerFarms_UpdateVnetRoute
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: Name of virtual network
+          required: true
+          type: string
+        - name: routeName
+          in: path
+          description: Name of the virtual network route
+          required: true
+          type: string
+        - name: route
+          in: body
+          description: The route object
+          required: true
+          schema:
+            $ref: '#/definitions/VnetRoute'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetRoute'
+        '400':
+          description: >-
+            Invalid request. Ensure that required parameters are given, and that
+            addresses and address spaces are valid
+        '404':
+          description: Route not found. This will only occur when using the PATCH verb.
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/virtualNetworkConnections/{vnetName}/gateways/{gatewayName}':
+    get:
+      tags:
+        - ServerFarms
+      summary: Gets the vnet gateway.
+      operationId: ServerFarms_GetServerFarmVnetGateway
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the App Service Plan
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: Name of the virtual network
+          required: true
+          type: string
+        - name: gatewayName
+          in: path
+          description: Name of the gateway. Only the 'primary' gateway is supported.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetGateway'
+      deprecated: false
+    put:
+      tags:
+        - ServerFarms
+      summary: Updates the vnet gateway
+      operationId: ServerFarms_UpdateServerFarmVnetGateway
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the App Service Plan
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the virtual network
+          required: true
+          type: string
+        - name: gatewayName
+          in: path
+          description: The name of the gateway. Only 'primary' is supported.
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The gateway entity.
+          required: true
+          schema:
+            $ref: '#/definitions/VnetGateway'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetGateway'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/sites':
+    get:
+      tags:
+        - ServerFarms
+      summary: Gets list of Apps associated with an App Service Plan
+      operationId: ServerFarms_GetServerFarmSites
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: $skipToken
+          in: query
+          description: >-
+            Skip to of web apps in a list. If specified, the resulting list will
+            contain web apps starting from (including) the skipToken. Else, the
+            resulting list contains web apps from the start of the list
+          type: string
+        - name: $filter
+          in: query
+          description: >-
+            Supported filter: $filter=state eq running. Returns only web apps
+            that are currently running
+          type: string
+        - name: $top
+          in: query
+          description: 'List page size. If specified, results are paged.'
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCollection'
+      deprecated: false
+      x-ms-pageable:
+        nextLinkName: nextLink
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/workers/{workerName}/reboot':
+    post:
+      tags:
+        - ServerFarms
+      summary: >-
+        Submit a reboot request for a worker machine in the specified server
+        farm
+      operationId: ServerFarms_RebootWorkerForServerFarm
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of server farm
+          required: true
+          type: string
+        - name: workerName
+          in: path
+          description: 'Name of worker machine, typically starts with RD'
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/restartSites':
+    post:
+      tags:
+        - ServerFarms
+      summary: Restarts web apps in a specified App Service Plan
+      operationId: ServerFarms_RestartSitesForServerFarm
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of App Service Plan
+          required: true
+          type: string
+        - name: softRestart
+          in: query
+          description: >-
+            Soft restart applies the configuration settings and restarts the
+            apps if necessary. Hard restart always restarts and reprovisions the
+            apps
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}/operationresults/{operationId}':
+    get:
+      tags:
+        - ServerFarms
+      summary: Gets a server farm operation
+      operationId: ServerFarms_GetServerFarmOperation
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of server farm
+          required: true
+          type: string
+        - name: operationId
+          in: path
+          description: Id of Server farm operation"&gt;
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ServerFarmWithRichSku'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/virtualNetworkConnections/{vnetName}':
+    get:
+      tags:
+        - Sites
+      summary: >-
+        Retrieves a specific Virtual Network Connection associated with this web
+        app.
+      operationId: Sites_GetSiteVNETConnectionSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetInfo'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Adds a Virtual Network Connection or updates it's properties.
+      operationId: Sites_CreateOrUpdateSiteVNETConnectionSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The properties of this Virtual Network Connection
+          required: true
+          schema:
+            $ref: '#/definitions/VnetInfo'
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetInfo'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: >-
+        Removes the specified Virtual Network Connection association from this
+        web app.
+      operationId: Sites_DeleteSiteVNETConnectionSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: Adds a Virtual Network Connection or updates it's properties.
+      operationId: Sites_UpdateSiteVNETConnectionSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The properties of this Virtual Network Connection
+          required: true
+          schema:
+            $ref: '#/definitions/VnetInfo'
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetInfo'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/virtualNetworkConnections/{vnetName}':
+    get:
+      tags:
+        - Sites
+      summary: >-
+        Retrieves a specific Virtual Network Connection associated with this web
+        app.
+      operationId: Sites_GetSiteVNETConnection
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetInfo'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Adds a Virtual Network Connection or updates it's properties.
+      operationId: Sites_CreateOrUpdateSiteVNETConnection
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The properties of this Virtual Network Connection
+          required: true
+          schema:
+            $ref: '#/definitions/VnetInfo'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetInfo'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: >-
+        Removes the specified Virtual Network Connection association from this
+        web app.
+      operationId: Sites_DeleteSiteVNETConnection
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: Adds a Virtual Network Connection or updates it's properties.
+      operationId: Sites_UpdateSiteVNETConnection
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The properties of this Virtual Network Connection
+          required: true
+          schema:
+            $ref: '#/definitions/VnetInfo'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetInfo'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/networkFeatures/{view}':
+    get:
+      tags:
+        - Sites
+      summary: Retrieves a view of all network features in use on this web app.
+      operationId: Sites_GetSiteNetworkFeaturesSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: view
+          in: path
+          description: The type of view. This can either be "summary" or "detailed".
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/NetworkFeatures'
+        '404':
+          description: The requested view does not exist.
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/networkFeatures/{view}':
+    get:
+      tags:
+        - Sites
+      summary: Retrieves a view of all network features in use on this web app.
+      operationId: Sites_GetSiteNetworkFeatures
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: view
+          in: path
+          description: The type of view. This can either be "summary" or "detailed".
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/NetworkFeatures'
+        '404':
+          description: The requested view does not exist.
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/operationresults/{operationId}':
+    get:
+      tags:
+        - Sites
+      summary: Gets the operation for a web app
+      operationId: Sites_GetSiteOperationSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: operationId
+          in: path
+          description: Id of an operation
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/operationresults/{operationId}':
+    get:
+      tags:
+        - Sites
+      summary: Gets the operation for a web app
+      operationId: Sites_GetSiteOperation
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: operationId
+          in: path
+          description: Id of an operation
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slotsswap':
+    post:
+      tags:
+        - Sites
+      summary: Swaps web app slots
+      operationId: Sites_SwapSlotWithProduction
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slotSwapEntity
+          in: body
+          description: Request body that contains the target slot name
+          required: true
+          schema:
+            $ref: '#/definitions/CsmSlotEntity'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/slotsswap':
+    post:
+      tags:
+        - Sites
+      summary: Swaps web app slots
+      operationId: Sites_SwapSlotsSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slotSwapEntity
+          in: body
+          description: Request body that contains the target slot name
+          required: true
+          schema:
+            $ref: '#/definitions/CsmSlotEntity'
+        - name: slot
+          in: path
+          description: Name of source slot for the swap
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+        '202':
+          description: Operation is in progress
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slotsdiffs':
+    post:
+      tags:
+        - Sites
+      summary: Get the difference in configuration settings between two web app slots
+      operationId: Sites_GetSlotsDifferencesFromProduction
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slotSwapEntity
+          in: body
+          description: Request body that contains the target slot name
+          required: true
+          schema:
+            $ref: '#/definitions/CsmSlotEntity'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SlotDifferenceCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/slotsdiffs':
+    post:
+      tags:
+        - Sites
+      summary: Get the difference in configuration settings between two web app slots
+      operationId: Sites_GetSlotsDifferencesSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slotSwapEntity
+          in: body
+          description: Request body that contains the target slot name
+          required: true
+          schema:
+            $ref: '#/definitions/CsmSlotEntity'
+        - name: slot
+          in: path
+          description: Name of the source slot
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SlotDifferenceCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/applySlotConfig':
+    post:
+      tags:
+        - Sites
+      summary: >-
+        Applies the configuration settings from the target slot onto the current
+        slot
+      operationId: Sites_ApplySlotConfigToProduction
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slotSwapEntity
+          in: body
+          description: >-
+            Request body that contains the target slot name. Settings from that
+            slot will be applied on the source slot
+          required: true
+          schema:
+            $ref: '#/definitions/CsmSlotEntity'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/applySlotConfig':
+    post:
+      tags:
+        - Sites
+      summary: >-
+        Applies the configuration settings from the target slot onto the current
+        slot
+      operationId: Sites_ApplySlotConfigSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slotSwapEntity
+          in: body
+          description: >-
+            Request body that contains the target slot name. Settings from that
+            slot will be applied on the source slot
+          required: true
+          schema:
+            $ref: '#/definitions/CsmSlotEntity'
+        - name: slot
+          in: path
+          description: >-
+            Name of the source slot. Settings from the target slot will be
+            applied onto this slot
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/resetSlotConfig':
+    post:
+      tags:
+        - Sites
+      summary: >-
+        Resets the configuration settings of the current slot if they were
+        previously modified by calling ApplySlotConfig API
+      operationId: Sites_ResetProductionSlotConfig
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/resetSlotConfig':
+    post:
+      tags:
+        - Sites
+      summary: >-
+        Resets the configuration settings of the current slot if they were
+        previously modified by calling ApplySlotConfig API
+      operationId: Sites_ResetSlotConfigSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/slotConfigNames':
+    get:
+      tags:
+        - Sites
+      summary: >-
+        Gets the names of application settings and connection string that remain
+        with the slot during swap operation
+      operationId: Sites_GetSlotConfigNames
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SlotConfigNamesResource'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: >-
+        Updates the names of application settings and connection string that
+        remain with the slot during swap operation
+      operationId: Sites_UpdateSlotConfigNames
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slotConfigNames
+          in: body
+          description: >-
+            Request body containing the names of application settings and
+            connection strings
+          required: true
+          schema:
+            $ref: '#/definitions/SlotConfigNamesResource'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SlotConfigNamesResource'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots':
+    get:
+      tags:
+        - Sites
+      summary: Gets all the slots for a web apps
+      operationId: Sites_GetSiteSlots
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: propertiesToInclude
+          in: query
+          description: List of app properties to include in the response
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites':
+    get:
+      tags:
+        - Sites
+      summary: Gets the web apps for a subscription in the specified resource group
+      operationId: Sites_GetSites
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: propertiesToInclude
+          in: query
+          description: Additional web app properties included in the response
+          type: string
+        - name: includeSiteTypes
+          in: query
+          description: Types of apps included in the response
+          type: string
+        - name: includeSlots
+          in: query
+          description: Whether or not to include deployments slots in results
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}':
+    get:
+      tags:
+        - Sites
+      summary: Get details of a web app
+      operationId: Sites_GetSite
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: propertiesToInclude
+          in: query
+          description: Additional web app properties included in the response
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Site'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Creates a new web app or modifies an existing web app.
+      operationId: Sites_CreateOrUpdateSite
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the web app
+          required: true
+          type: string
+        - name: siteEnvelope
+          in: body
+          description: Details of web app if it exists already
+          required: true
+          schema:
+            $ref: '#/definitions/Site'
+        - name: skipDnsRegistration
+          in: query
+          description: "If true web app hostname is not registered with DNS on creation. This parameter is\r\n            only used for app creation"
+          type: string
+        - name: skipCustomDomainVerification
+          in: query
+          description: >-
+            If true, custom (non *.azurewebsites.net) domains associated with
+            web app are not verified.
+          type: string
+        - name: forceDnsRegistration
+          in: query
+          description: 'If true, web app hostname is force registered with DNS'
+          type: string
+        - name: ttlInSeconds
+          in: query
+          description: Time to live in seconds for web app's default domain name
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Site'
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/Site'
+      deprecated: false
+      x-ms-long-running-operation: true
+    delete:
+      tags:
+        - Sites
+      summary: Deletes a web app
+      operationId: Sites_DeleteSite
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: deleteMetrics
+          in: query
+          description: 'If true, web app metrics are also deleted'
+          type: string
+        - name: deleteEmptyServerFarm
+          in: query
+          description: >-
+            If true and App Service Plan is empty after web app deletion, App
+            Service Plan is also deleted
+          type: string
+        - name: skipDnsRegistration
+          in: query
+          description: 'If true, DNS registration is skipped'
+          type: string
+        - name: deleteAllSlots
+          in: query
+          description: 'If true, all slots associated with web app are also deleted'
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}':
+    get:
+      tags:
+        - Sites
+      summary: Get details of a web app
+      operationId: Sites_GetSiteSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: propertiesToInclude
+          in: query
+          description: Additional web app properties included in the response
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Site'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Creates a new web app or modifies an existing web app.
+      operationId: Sites_CreateOrUpdateSiteSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the web app
+          required: true
+          type: string
+        - name: siteEnvelope
+          in: body
+          description: Details of web app if it exists already
+          required: true
+          schema:
+            $ref: '#/definitions/Site'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: skipDnsRegistration
+          in: query
+          description: "If true web app hostname is not registered with DNS on creation. This parameter is\r\n            only used for app creation"
+          type: string
+        - name: skipCustomDomainVerification
+          in: query
+          description: >-
+            If true, custom (non *.azurewebsites.net) domains associated with
+            web app are not verified.
+          type: string
+        - name: forceDnsRegistration
+          in: query
+          description: 'If true, web app hostname is force registered with DNS'
+          type: string
+        - name: ttlInSeconds
+          in: query
+          description: Time to live in seconds for web app's default domain name
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Site'
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/Site'
+      deprecated: false
+      x-ms-long-running-operation: true
+    delete:
+      tags:
+        - Sites
+      summary: Deletes a web app
+      operationId: Sites_DeleteSiteSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: deleteMetrics
+          in: query
+          description: 'If true, web app metrics are also deleted'
+          type: string
+        - name: deleteEmptyServerFarm
+          in: query
+          description: >-
+            If true and App Service Plan is empty after web app deletion, App
+            Service Plan is also deleted
+          type: string
+        - name: skipDnsRegistration
+          in: query
+          description: 'If true, DNS registration is skipped'
+          type: string
+        - name: deleteAllSlots
+          in: query
+          description: 'If true, all slots associated with web app are also deleted'
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/iscloneable':
+    post:
+      tags:
+        - Sites
+      summary: Creates a new web app or modifies an existing web app.
+      operationId: Sites_IsSiteCloneable
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCloneability'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/iscloneable':
+    post:
+      tags:
+        - Sites
+      summary: Creates a new web app or modifies an existing web app.
+      operationId: Sites_IsSiteCloneableSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of the resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of the web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteCloneability'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/recover':
+    post:
+      tags:
+        - Sites
+      summary: Recovers a deleted web app
+      operationId: Sites_RecoverSite
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: recoveryEntity
+          in: body
+          description: >-
+            Snapshot data used for web app recovery. Snapshot information can be
+            obtained by calling GetDeletedSites or GetSiteSnapshots API.
+          required: true
+          schema:
+            $ref: '#/definitions/CsmSiteRecoveryEntity'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/Site'
+        '404':
+          description: Web app not found
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/recover':
+    post:
+      tags:
+        - Sites
+      summary: Recovers a deleted web app
+      operationId: Sites_RecoverSiteSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: recoveryEntity
+          in: body
+          description: >-
+            Snapshot data used for web app recovery. Snapshot information can be
+            obtained by calling GetDeletedSites or GetSiteSnapshots API.
+          required: true
+          schema:
+            $ref: '#/definitions/CsmSiteRecoveryEntity'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '202':
+          description: Asynchronous operation in progress
+          schema:
+            $ref: '#/definitions/Site'
+        '404':
+          description: Web app not found
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/snapshots':
+    put:
+      tags:
+        - Sites
+      summary: Returns all Snapshots to the user.
+      operationId: Sites_GetSiteSnapshots
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Webspace
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Website Name
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/snapshots':
+    put:
+      tags:
+        - Sites
+      summary: Returns all Snapshots to the user.
+      operationId: Sites_GetSiteSnapshotsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Webspace
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Website Name
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: Website Slot
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/deletedSites':
+    get:
+      tags:
+        - Sites
+      summary: Gets deleted web apps in subscription
+      operationId: Sites_GetDeletedSites
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: propertiesToInclude
+          in: query
+          description: Additional web app properties included in the response
+          type: string
+        - name: includeSiteTypes
+          in: query
+          description: Types of apps included in the response
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DeletedSiteCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/deployments':
+    get:
+      tags:
+        - Sites
+      summary: List deployments
+      operationId: Sites_GetDeployments
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DeploymentCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/deployments':
+    get:
+      tags:
+        - Sites
+      summary: List deployments
+      operationId: Sites_GetDeploymentsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DeploymentCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/instances/{instanceId}/deployments':
+    get:
+      tags:
+        - Sites
+      summary: List deployments
+      operationId: Sites_GetInstanceDeployments
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: instanceId
+          in: path
+          description: Id of web app instance
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DeploymentCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/instances/{instanceId}/deployments':
+    get:
+      tags:
+        - Sites
+      summary: List deployments
+      operationId: Sites_GetInstanceDeploymentsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: instanceId
+          in: path
+          description: Id of web app instance
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/DeploymentCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/instances/{instanceId}/deployments/{id}':
+    get:
+      tags:
+        - Sites
+      summary: Get the deployment
+      operationId: Sites_GetInstanceDeployment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: instanceId
+          in: path
+          description: Id of web app instance
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Deployment'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Create a deployment
+      operationId: Sites_CreateInstanceDeployment
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: instanceId
+          in: path
+          description: Id of web app instance
+          required: true
+          type: string
+        - name: deployment
+          in: body
+          description: Details of deployment
+          required: true
+          schema:
+            $ref: '#/definitions/Deployment'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Deployment'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Delete the deployment
+      operationId: Sites_DeleteInstanceDeployment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: instanceId
+          in: path
+          description: Id of web app instance
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/deployments/{id}':
+    get:
+      tags:
+        - Sites
+      summary: Get the deployment
+      operationId: Sites_GetDeployment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Deployment'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Create a deployment
+      operationId: Sites_CreateDeployment
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: deployment
+          in: body
+          description: Details of deployment
+          required: true
+          schema:
+            $ref: '#/definitions/Deployment'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Deployment'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Delete the deployment
+      operationId: Sites_DeleteDeployment
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/deployments/{id}':
+    get:
+      tags:
+        - Sites
+      summary: Get the deployment
+      operationId: Sites_GetDeploymentSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Deployment'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Create a deployment
+      operationId: Sites_CreateDeploymentSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: deployment
+          in: body
+          description: Details of deployment
+          required: true
+          schema:
+            $ref: '#/definitions/Deployment'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Deployment'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Delete the deployment
+      operationId: Sites_DeleteDeploymentSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/instances/{instanceId}/deployments/{id}':
+    get:
+      tags:
+        - Sites
+      summary: Get the deployment
+      operationId: Sites_GetInstanceDeploymentSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: instanceId
+          in: path
+          description: Id of web app instance
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Deployment'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Create a deployment
+      operationId: Sites_CreateInstanceDeploymentSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: instanceId
+          in: path
+          description: Id of web app instance
+          required: true
+          type: string
+        - name: deployment
+          in: body
+          description: Details of deployment
+          required: true
+          schema:
+            $ref: '#/definitions/Deployment'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Deployment'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Delete the deployment
+      operationId: Sites_DeleteInstanceDeploymentSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: Id of the deployment
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: instanceId
+          in: path
+          description: Id of web app instance
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/instances':
+    get:
+      tags:
+        - Sites
+      summary: Gets all instance of a web app
+      operationId: Sites_GetSiteInstanceIdentifiers
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteInstanceCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/instances':
+    get:
+      tags:
+        - Sites
+      summary: Gets all instance of a web app
+      operationId: Sites_GetSiteInstanceIdentifiersSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteInstanceCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/hostNameBindings':
+    get:
+      tags:
+        - Sites
+      summary: Get web app hostname bindings
+      operationId: Sites_GetSiteHostNameBindings
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostNameBindingCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/hostNameBindings':
+    get:
+      tags:
+        - Sites
+      summary: Get web app hostname bindings
+      operationId: Sites_GetSiteHostNameBindingsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostNameBindingCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/hostNameBindings/{hostName}':
+    get:
+      tags:
+        - Sites
+      summary: Get web app binding for a hostname
+      operationId: Sites_GetSiteHostNameBinding
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: hostName
+          in: path
+          description: Name of host
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostNameBinding'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Creates a web app hostname binding
+      operationId: Sites_CreateOrUpdateSiteHostNameBinding
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: hostName
+          in: path
+          description: Name of host
+          required: true
+          type: string
+        - name: hostNameBinding
+          in: body
+          description: Host name binding information
+          required: true
+          schema:
+            $ref: '#/definitions/HostNameBinding'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostNameBinding'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Deletes a host name binding
+      operationId: Sites_DeleteSiteHostNameBinding
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: hostName
+          in: path
+          description: Name of host
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/hostNameBindings/{hostName}':
+    get:
+      tags:
+        - Sites
+      summary: Get web app binding for a hostname
+      operationId: Sites_GetSiteHostNameBindingSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: hostName
+          in: path
+          description: Name of host
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostNameBinding'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Creates a web app hostname binding
+      operationId: Sites_CreateOrUpdateSiteHostNameBindingSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: hostName
+          in: path
+          description: Name of host
+          required: true
+          type: string
+        - name: hostNameBinding
+          in: body
+          description: Host name binding information
+          required: true
+          schema:
+            $ref: '#/definitions/HostNameBinding'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/HostNameBinding'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Deletes a host name binding
+      operationId: Sites_DeleteSiteHostNameBindingSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: hostName
+          in: path
+          description: Name of host
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/web':
+    get:
+      tags:
+        - Sites
+      summary: Gets the configuration of the web app
+      operationId: Sites_GetSiteConfig
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteConfig'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Update the configuration of web app
+      operationId: Sites_CreateOrUpdateSiteConfig
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteConfig
+          in: body
+          description: Request body that contains the configuraiton setting for the web app
+          required: true
+          schema:
+            $ref: '#/definitions/SiteConfig'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteConfig'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: Update the configuration of web app
+      operationId: Sites_UpdateSiteConfig
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteConfig
+          in: body
+          description: Request body that contains the configuraiton setting for the web app
+          required: true
+          schema:
+            $ref: '#/definitions/SiteConfig'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteConfig'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/web':
+    get:
+      tags:
+        - Sites
+      summary: Gets the configuration of the web app
+      operationId: Sites_GetSiteConfigSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteConfig'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Update the configuration of web app
+      operationId: Sites_CreateOrUpdateSiteConfigSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteConfig
+          in: body
+          description: Request body that contains the configuraiton setting for the web app
+          required: true
+          schema:
+            $ref: '#/definitions/SiteConfig'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteConfig'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: Update the configuration of web app
+      operationId: Sites_UpdateSiteConfigSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteConfig
+          in: body
+          description: Request body that contains the configuraiton setting for the web app
+          required: true
+          schema:
+            $ref: '#/definitions/SiteConfig'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteConfig'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/sourcecontrols/web':
+    get:
+      tags:
+        - Sites
+      summary: Get the source control configuration of web app
+      operationId: Sites_GetSiteSourceControl
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Update the source control configuration of web app
+      operationId: Sites_CreateOrUpdateSiteSourceControl
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteSourceControl
+          in: body
+          description: Request body that contains the source control parameters
+          required: true
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Delete source control configuration of web app
+      operationId: Sites_DeleteSiteSourceControl
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: Update the source control configuration of web app
+      operationId: Sites_UpdateSiteSourceControl
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteSourceControl
+          in: body
+          description: Request body that contains the source control parameters
+          required: true
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/sourcecontrols/web':
+    get:
+      tags:
+        - Sites
+      summary: Get the source control configuration of web app
+      operationId: Sites_GetSiteSourceControlSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Update the source control configuration of web app
+      operationId: Sites_CreateOrUpdateSiteSourceControlSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteSourceControl
+          in: body
+          description: Request body that contains the source control parameters
+          required: true
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Delete source control configuration of web app
+      operationId: Sites_DeleteSiteSourceControlSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: Update the source control configuration of web app
+      operationId: Sites_UpdateSiteSourceControlSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteSourceControl
+          in: body
+          description: Request body that contains the source control parameters
+          required: true
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteSourceControl'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/appsettings/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the application settings of web app
+      operationId: Sites_ListSiteAppSettingsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/appsettings/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the application settings of web app
+      operationId: Sites_ListSiteAppSettings
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/appsettings':
+    put:
+      tags:
+        - Sites
+      summary: Updates the application settings of web app
+      operationId: Sites_UpdateSiteAppSettings
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: appSettings
+          in: body
+          description: Application settings of web app
+          required: true
+          schema:
+            $ref: '#/definitions/StringDictionary'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/appsettings':
+    put:
+      tags:
+        - Sites
+      summary: Updates the application settings of web app
+      operationId: Sites_UpdateSiteAppSettingsSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: appSettings
+          in: body
+          description: Application settings of web app
+          required: true
+          schema:
+            $ref: '#/definitions/StringDictionary'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/connectionstrings/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the connection strings associated with web app
+      operationId: Sites_ListSiteConnectionStrings
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ConnectionStringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/connectionstrings/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the connection strings associated with web app
+      operationId: Sites_ListSiteConnectionStringsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ConnectionStringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/connectionstrings':
+    put:
+      tags:
+        - Sites
+      summary: Updates the connection strings associated with web app
+      operationId: Sites_UpdateSiteConnectionStrings
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: connectionStrings
+          in: body
+          description: Connection strings associated with web app
+          required: true
+          schema:
+            $ref: '#/definitions/ConnectionStringDictionary'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ConnectionStringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/connectionstrings':
+    put:
+      tags:
+        - Sites
+      summary: Updates the connection strings associated with web app
+      operationId: Sites_UpdateSiteConnectionStringsSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: connectionStrings
+          in: body
+          description: Connection strings associated with web app
+          required: true
+          schema:
+            $ref: '#/definitions/ConnectionStringDictionary'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ConnectionStringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/authsettings/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the Authentication / Authorization settings associated with web app
+      operationId: Sites_ListSiteAuthSettings
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteAuthSettings'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/authsettings/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the Authentication / Authorization settings associated with web app
+      operationId: Sites_ListSiteAuthSettingsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteAuthSettings'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/authsettings':
+    put:
+      tags:
+        - Sites
+      summary: >-
+        Updates the Authentication / Authorization settings associated with web
+        app
+      operationId: Sites_UpdateSiteAuthSettings
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteAuthSettings
+          in: body
+          description: Auth settings associated with web app
+          required: true
+          schema:
+            $ref: '#/definitions/SiteAuthSettings'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteAuthSettings'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/authsettings':
+    put:
+      tags:
+        - Sites
+      summary: >-
+        Updates the Authentication / Authorization settings associated with web
+        app
+      operationId: Sites_UpdateSiteAuthSettingsSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteAuthSettings
+          in: body
+          description: Auth settings associated with web app
+          required: true
+          schema:
+            $ref: '#/definitions/SiteAuthSettings'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteAuthSettings'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/publishingcredentials/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the web app publishing credentials
+      operationId: Sites_ListSitePublishingCredentials
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/User'
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/publishingcredentials/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the web app publishing credentials
+      operationId: Sites_ListSitePublishingCredentialsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/User'
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/metadata/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the web app meta data.
+      operationId: Sites_ListSiteMetadata
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/metadata/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the web app meta data.
+      operationId: Sites_ListSiteMetadataSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/metadata':
+    put:
+      tags:
+        - Sites
+      summary: Updates the meta data for web app
+      operationId: Sites_UpdateSiteMetadata
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: metadata
+          in: body
+          description: Meta data of web app
+          required: true
+          schema:
+            $ref: '#/definitions/StringDictionary'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/metadata':
+    put:
+      tags:
+        - Sites
+      summary: Updates the meta data for web app
+      operationId: Sites_UpdateSiteMetadataSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: metadata
+          in: body
+          description: Meta data of web app
+          required: true
+          schema:
+            $ref: '#/definitions/StringDictionary'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/StringDictionary'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/logs':
+    get:
+      tags:
+        - Sites
+      summary: Gets the web app logs configuration
+      operationId: Sites_GetSiteLogsConfig
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteLogsConfig'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Updates the meta data for web app
+      operationId: Sites_UpdateSiteLogsConfig
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteLogsConfig
+          in: body
+          description: Site logs configuration
+          required: true
+          schema:
+            $ref: '#/definitions/SiteLogsConfig'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteLogsConfig'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/logs':
+    get:
+      tags:
+        - Sites
+      summary: Gets the web app logs configuration
+      operationId: Sites_GetSiteLogsConfigSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteLogsConfig'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Updates the meta data for web app
+      operationId: Sites_UpdateSiteLogsConfigSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: siteLogsConfig
+          in: body
+          description: Site logs configuration
+          required: true
+          schema:
+            $ref: '#/definitions/SiteLogsConfig'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/SiteLogsConfig'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/premieraddons':
+    get:
+      tags:
+        - Sites
+      operationId: Sites_ListSitePremierAddOns
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/premieraddons':
+    get:
+      tags:
+        - Sites
+      operationId: Sites_ListSitePremierAddOnsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: slot
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/premieraddons/{premierAddOnName}':
+    get:
+      tags:
+        - Sites
+      operationId: Sites_GetSitePremierAddOn
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: premierAddOnName
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      operationId: Sites_AddSitePremierAddOn
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: premierAddOnName
+          in: path
+          required: true
+          type: string
+        - name: premierAddOn
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PremierAddOnRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      operationId: Sites_DeleteSitePremierAddOn
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: premierAddOnName
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/premieraddons/{premierAddOnName}':
+    get:
+      tags:
+        - Sites
+      operationId: Sites_GetSitePremierAddOnSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: premierAddOnName
+          in: path
+          required: true
+          type: string
+        - name: slot
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      operationId: Sites_AddSitePremierAddOnSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: premierAddOnName
+          in: path
+          required: true
+          type: string
+        - name: premierAddOn
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PremierAddOnRequest'
+        - name: slot
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      operationId: Sites_DeleteSitePremierAddOnSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: premierAddOnName
+          in: path
+          required: true
+          type: string
+        - name: slot
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/backup/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the backup configuration for a web app
+      operationId: Sites_GetSiteBackupConfiguration
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupRequest'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/backup/list':
+    post:
+      tags:
+        - Sites
+      summary: Gets the backup configuration for a web app
+      operationId: Sites_GetSiteBackupConfigurationSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupRequest'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/backup':
+    put:
+      tags:
+        - Sites
+      summary: Updates backup configuration of web app
+      operationId: Sites_UpdateSiteBackupConfiguration
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on backup request
+          required: true
+          schema:
+            $ref: '#/definitions/BackupRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupRequest'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/backup':
+    put:
+      tags:
+        - Sites
+      summary: Updates backup configuration of web app
+      operationId: Sites_UpdateSiteBackupConfigurationSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on backup request
+          required: true
+          schema:
+            $ref: '#/definitions/BackupRequest'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupRequest'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/backup':
+    post:
+      tags:
+        - Sites
+      summary: Creates web app backup
+      operationId: Sites_BackupSite
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on backup request
+          required: true
+          schema:
+            $ref: '#/definitions/BackupRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItem'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/backup':
+    post:
+      tags:
+        - Sites
+      summary: Creates web app backup
+      operationId: Sites_BackupSiteSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on backup request
+          required: true
+          schema:
+            $ref: '#/definitions/BackupRequest'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItem'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/backups/discover':
+    put:
+      tags:
+        - Sites
+      summary: Discovers existing web app backups that can be restored
+      operationId: Sites_DiscoverSiteRestore
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on restore request
+          required: true
+          schema:
+            $ref: '#/definitions/RestoreRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RestoreRequest'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/backups/discover':
+    put:
+      tags:
+        - Sites
+      summary: Discovers existing web app backups that can be restored
+      operationId: Sites_DiscoverSiteRestoreSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on restore request
+          required: true
+          schema:
+            $ref: '#/definitions/RestoreRequest'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RestoreRequest'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/backups':
+    get:
+      tags:
+        - Sites
+      summary: Lists all available backups for web app
+      operationId: Sites_ListSiteBackups
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItemCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/backups':
+    get:
+      tags:
+        - Sites
+      summary: Lists all available backups for web app
+      operationId: Sites_ListSiteBackupsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItemCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/backups/{backupId}':
+    get:
+      tags:
+        - Sites
+      summary: Gets status of a web app backup that may be in progress.
+      operationId: Sites_GetSiteBackupStatus
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: backupId
+          in: path
+          description: Id of backup
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItem'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Deletes a backup from Azure Storage
+      operationId: Sites_DeleteBackup
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: backupId
+          in: path
+          description: Id of backup
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItem'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/backups/{backupId}':
+    get:
+      tags:
+        - Sites
+      summary: Gets status of a web app backup that may be in progress.
+      operationId: Sites_GetSiteBackupStatusSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: backupId
+          in: path
+          description: Id of backup
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItem'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: Deletes a backup from Azure Storage
+      operationId: Sites_DeleteBackupSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: backupId
+          in: path
+          description: Id of backup
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItem'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/backups/{backupId}/list':
+    post:
+      tags:
+        - Sites
+      summary: >-
+        Gets status of a web app backup that may be in progress, including
+        secrets associated with the backup, such as the Azure Storage SAS URL.
+        Also can be used to update the SAS URL for the backup if a new URL is
+        passed in the request body.
+      operationId: Sites_GetSiteBackupStatusSecretsSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: backupId
+          in: path
+          description: Id of backup
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on backup request
+          required: true
+          schema:
+            $ref: '#/definitions/BackupRequest'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItem'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/backups/{backupId}/list':
+    post:
+      tags:
+        - Sites
+      summary: >-
+        Gets status of a web app backup that may be in progress, including
+        secrets associated with the backup, such as the Azure Storage SAS URL.
+        Also can be used to update the SAS URL for the backup if a new URL is
+        passed in the request body.
+      operationId: Sites_GetSiteBackupStatusSecrets
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: backupId
+          in: path
+          description: Id of backup
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on backup request
+          required: true
+          schema:
+            $ref: '#/definitions/BackupRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/BackupItem'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/backups/{backupId}/restore':
+    post:
+      tags:
+        - Sites
+      summary: Restores a web app
+      operationId: Sites_RestoreSite
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: backupId
+          in: path
+          description: Id of backup to restore
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on restore request
+          required: true
+          schema:
+            $ref: '#/definitions/RestoreRequest'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RestoreResponse'
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/backups/{backupId}/restore':
+    post:
+      tags:
+        - Sites
+      summary: Restores a web app
+      operationId: Sites_RestoreSiteSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: backupId
+          in: path
+          description: Id of backup to restore
+          required: true
+          type: string
+        - name: request
+          in: body
+          description: Information on restore request
+          required: true
+          schema:
+            $ref: '#/definitions/RestoreRequest'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RestoreResponse'
+      deprecated: false
+      x-ms-long-running-operation: true
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/usages':
+    get:
+      tags:
+        - Sites
+      summary: Gets the quota usage numbers for web app
+      operationId: Sites_GetSiteUsages
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages specified in the filter. Filter is specified by
+            using OData syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CsmUsageQuotaCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/usages':
+    get:
+      tags:
+        - Sites
+      summary: Gets the quota usage numbers for web app
+      operationId: Sites_GetSiteUsagesSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages specified in the filter. Filter is specified by
+            using OData syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CsmUsageQuotaCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/metrics':
+    get:
+      tags:
+        - Sites
+      summary: Gets metrics for web app
+      operationId: Sites_GetSiteMetrics
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: details
+          in: query
+          description: 'If true, metric details are included in response'
+          type: boolean
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages/metrics specified in the filter. Filter conforms
+            to odata syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ResourceMetricCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/metrics':
+    get:
+      tags:
+        - Sites
+      summary: Gets metrics for web app
+      operationId: Sites_GetSiteMetricsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: details
+          in: query
+          description: 'If true, metric details are included in response'
+          type: boolean
+        - name: $filter
+          in: query
+          description: >-
+            Return only usages/metrics specified in the filter. Filter conforms
+            to odata syntax. Example: $filter=(name.value eq 'Metric1' or
+            name.value eq 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and
+            endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
+            duration'[Hour|Minute|Day]'.
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ResourceMetricCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/metricdefinitions':
+    get:
+      tags:
+        - Sites
+      summary: Gets metric definitions for web app
+      operationId: Sites_GetSiteMetricDefinitionsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/MetricDefinitionCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/metricdefinitions':
+    get:
+      tags:
+        - Sites
+      summary: Gets metric definitions for web app
+      operationId: Sites_GetSiteMetricDefinitions
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/MetricDefinitionCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/publishxml':
+    post:
+      tags:
+        - Sites
+      summary: Gets the publishing profile for web app
+      operationId: Sites_ListSitePublishingProfileXml
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: options
+          in: body
+          description: >-
+            Specifies options for publishing profile. Pass
+            CsmPublishingProfileOptions.Format=FileZilla3 for FileZilla FTP
+            format.
+          required: true
+          schema:
+            $ref: '#/definitions/CsmPublishingProfileOptions'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: file
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/publishxml':
+    post:
+      tags:
+        - Sites
+      summary: Gets the publishing profile for web app
+      operationId: Sites_ListSitePublishingProfileXmlSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: options
+          in: body
+          description: >-
+            Specifies options for publishing profile. Pass
+            CsmPublishingProfileOptions.Format=FileZilla3 for FileZilla FTP
+            format.
+          required: true
+          schema:
+            $ref: '#/definitions/CsmPublishingProfileOptions'
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: file
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/restart':
+    post:
+      tags:
+        - Sites
+      summary: Restarts web app
+      operationId: Sites_RestartSiteSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - name: softRestart
+          in: query
+          description: >-
+            Soft restart applies the configuration settings and restarts the app
+            if necessary. Hard restart always restarts and reprovisions the app
+          type: boolean
+        - name: synchronous
+          in: query
+          description: If true then the API will block until the app has been restarted
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/restart':
+    post:
+      tags:
+        - Sites
+      summary: Restarts web app
+      operationId: Sites_RestartSite
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: softRestart
+          in: query
+          description: >-
+            Soft restart applies the configuration settings and restarts the app
+            if necessary. Hard restart always restarts and reprovisions the app
+          type: boolean
+        - name: synchronous
+          in: query
+          description: If true then the API will block until the app has been restarted
+          type: boolean
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/start':
+    post:
+      tags:
+        - Sites
+      summary: Starts web app
+      operationId: Sites_StartSite
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/start':
+    post:
+      tags:
+        - Sites
+      summary: Starts web app
+      operationId: Sites_StartSiteSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/stop':
+    post:
+      tags:
+        - Sites
+      summary: Stops web app
+      operationId: Sites_StopSite
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/stop':
+    post:
+      tags:
+        - Sites
+      summary: Stops web app
+      operationId: Sites_StopSiteSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/sync':
+    post:
+      tags:
+        - Sites
+      operationId: Sites_SyncSiteRepository
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/sync':
+    post:
+      tags:
+        - Sites
+      operationId: Sites_SyncSiteRepositorySlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: slot
+          in: path
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/newpassword':
+    post:
+      tags:
+        - Sites
+      summary: Generates new random app publishing password
+      operationId: Sites_GenerateNewSitePublishingPasswordSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: >-
+            Name of web app slot. If not specified then will default to
+            production slot.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/newpassword':
+    post:
+      tags:
+        - Sites
+      summary: Generates new random app publishing password
+      operationId: Sites_GenerateNewSitePublishingPassword
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Name of web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/hybridconnection/{entityName}':
+    get:
+      tags:
+        - Sites
+      summary: Retrieves a Biztalk Hybrid Connection identified by its entity name.
+      operationId: Sites_GetSiteRelayServiceConnection
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: entityName
+          in: path
+          description: The name by which the Hybrid Connection is identified
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: >-
+        Creates a new association to a Biztalk Hybrid Connection, or updates an
+        existing one.
+      operationId: Sites_CreateOrUpdateSiteRelayServiceConnection
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: entityName
+          in: path
+          description: The name by which the Hybrid Connection is identified
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The details of the Hybrid Connection
+          required: true
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: >-
+        Removes the association to a Biztalk Hybrid Connection, identified by
+        its entity name.
+      operationId: Sites_DeleteSiteRelayServiceConnection
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: entityName
+          in: path
+          description: The name by which the Hybrid Connection is identified
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: >-
+        Creates a new association to a Biztalk Hybrid Connection, or updates an
+        existing one.
+      operationId: Sites_UpdateSiteRelayServiceConnection
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: entityName
+          in: path
+          description: The name by which the Hybrid Connection is identified
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The details of the Hybrid Connection
+          required: true
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/hybridconnection/{entityName}':
+    get:
+      tags:
+        - Sites
+      summary: Retrieves a Biztalk Hybrid Connection identified by its entity name.
+      operationId: Sites_GetSiteRelayServiceConnectionSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: entityName
+          in: path
+          description: The name by which the Hybrid Connection is identified
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: The name of the slot for the web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: >-
+        Creates a new association to a Biztalk Hybrid Connection, or updates an
+        existing one.
+      operationId: Sites_CreateOrUpdateSiteRelayServiceConnectionSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: entityName
+          in: path
+          description: The name by which the Hybrid Connection is identified
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The details of the Hybrid Connection
+          required: true
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+        - name: slot
+          in: path
+          description: The name of the slot for the web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+      deprecated: false
+    delete:
+      tags:
+        - Sites
+      summary: >-
+        Removes the association to a Biztalk Hybrid Connection, identified by
+        its entity name.
+      operationId: Sites_DeleteSiteRelayServiceConnectionSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: entityName
+          in: path
+          description: The name by which the Hybrid Connection is identified
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: The name of the slot for the web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: >-
+        Creates a new association to a Biztalk Hybrid Connection, or updates an
+        existing one.
+      operationId: Sites_UpdateSiteRelayServiceConnectionSlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: entityName
+          in: path
+          description: The name by which the Hybrid Connection is identified
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The details of the Hybrid Connection
+          required: true
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+        - name: slot
+          in: path
+          description: The name of the slot for the web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/hybridconnection':
+    get:
+      tags:
+        - Sites
+      summary: Retrieves all Biztalk Hybrid Connections associated with this web app.
+      operationId: Sites_ListSiteRelayServiceConnectionsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: The name of the slot for the web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/hybridconnection':
+    get:
+      tags:
+        - Sites
+      summary: Retrieves all Biztalk Hybrid Connections associated with this web app.
+      operationId: Sites_ListSiteRelayServiceConnections
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/RelayServiceConnectionEntity'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/virtualNetworkConnections/{vnetName}/gateways/{gatewayName}':
+    get:
+      tags:
+        - Sites
+      summary: >-
+        Retrieves a Virtual Network connection gateway associated with this web
+        app and virtual network.
+      operationId: Sites_GetSiteVnetGatewaySlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: gatewayName
+          in: path
+          description: >-
+            The name of the gateway. The only gateway that exists presently is
+            "primary"
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+        '404':
+          description: Gateway does not exist. Only the "primary" gateway exists presently.
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Updates the Virtual Network Gateway.
+      operationId: Sites_CreateOrUpdateSiteVNETConnectionGatewaySlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: gatewayName
+          in: path
+          description: >-
+            The name of the gateway. The only gateway that exists presently is
+            "primary"
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The properties to update this gateway with.
+          required: true
+          schema:
+            $ref: '#/definitions/VnetGateway'
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetGateway'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: Updates the Virtual Network Gateway.
+      operationId: Sites_UpdateSiteVNETConnectionGatewaySlot
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: gatewayName
+          in: path
+          description: >-
+            The name of the gateway. The only gateway that exists presently is
+            "primary"
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The properties to update this gateway with.
+          required: true
+          schema:
+            $ref: '#/definitions/VnetGateway'
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetGateway'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/virtualNetworkConnections/{vnetName}/gateways/{gatewayName}':
+    get:
+      tags:
+        - Sites
+      summary: >-
+        Retrieves a Virtual Network connection gateway associated with this web
+        app and virtual network.
+      operationId: Sites_GetSiteVnetGateway
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: gatewayName
+          in: path
+          description: >-
+            The name of the gateway. The only gateway that exists presently is
+            "primary"
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+        '404':
+          description: Gateway does not exist. Only the "primary" gateway exists presently.
+      deprecated: false
+    put:
+      tags:
+        - Sites
+      summary: Updates the Virtual Network Gateway.
+      operationId: Sites_CreateOrUpdateSiteVNETConnectionGateway
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: gatewayName
+          in: path
+          description: >-
+            The name of the gateway. The only gateway that exists presently is
+            "primary"
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The properties to update this gateway with.
+          required: true
+          schema:
+            $ref: '#/definitions/VnetGateway'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetGateway'
+      deprecated: false
+    patch:
+      tags:
+        - Sites
+      summary: Updates the Virtual Network Gateway.
+      operationId: Sites_UpdateSiteVNETConnectionGateway
+      consumes:
+        - application/json
+        - text/json
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: vnetName
+          in: path
+          description: The name of the Virtual Network
+          required: true
+          type: string
+        - name: gatewayName
+          in: path
+          description: >-
+            The name of the gateway. The only gateway that exists presently is
+            "primary"
+          required: true
+          type: string
+        - name: connectionEnvelope
+          in: body
+          description: The properties to update this gateway with.
+          required: true
+          schema:
+            $ref: '#/definitions/VnetGateway'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/VnetGateway'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/virtualNetworkConnections':
+    get:
+      tags:
+        - Sites
+      summary: >-
+        Retrieves a list of all Virtual Network Connections associated with this
+        web app.
+      operationId: Sites_GetSiteVNETConnections
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/VnetInfo'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/virtualNetworkConnections':
+    get:
+      tags:
+        - Sites
+      summary: >-
+        Retrieves a list of all Virtual Network Connections associated with this
+        web app.
+      operationId: Sites_GetSiteVNETConnectionsSlot
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The resource group name
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: The name of the web app
+          required: true
+          type: string
+        - name: slot
+          in: path
+          description: The name of the slot for this web app.
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/VnetInfo'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.DomainRegistration/topLevelDomains':
+    get:
+      tags:
+        - TopLevelDomains
+      summary: Lists all top level domains supported for registration
+      operationId: TopLevelDomains_GetGetTopLevelDomains
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/TopLevelDomainCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.DomainRegistration/topLevelDomains/{name}':
+    get:
+      tags:
+        - TopLevelDomains
+      summary: Gets details of a top level domain
+      operationId: TopLevelDomains_GetTopLevelDomain
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: name
+          in: path
+          description: Name of the top level domain
+          required: true
+          type: string
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/TopLevelDomain'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/providers/Microsoft.DomainRegistration/topLevelDomains/{name}/listAgreements':
+    post:
+      tags:
+        - TopLevelDomains
+      summary: >-
+        Lists legal agreements that user needs to accept before purchasing
+        domain
+      operationId: TopLevelDomains_ListTopLevelDomainAgreements
+      consumes:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - text/json
+      parameters:
+        - name: name
+          in: path
+          description: Name of the top level domain
+          required: true
+          type: string
+        - name: agreementOption
+          in: body
+          description: Domain agreement options
+          required: true
+          schema:
+            $ref: '#/definitions/TopLevelDomainAgreementOption'
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/TldLegalAgreementCollection'
+      deprecated: false
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web.Admin/environments/{environmentName}/usage':
+    get:
+      tags:
+        - Usage
+      summary: Returns usage records for specified subscription and resource groups
+      operationId: Usage_GetUsage
+      consumes: []
+      produces:
+        - application/json
+        - text/json
+        - application/xml
+        - text/xml
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: Name of resource group
+          required: true
+          type: string
+        - name: environmentName
+          in: path
+          description: Environment name
+          required: true
+          type: string
+        - name: lastId
+          in: query
+          description: Last marker that was returned from the batch
+          required: true
+          type: string
+        - name: batchSize
+          in: query
+          description: size of the batch to be returned.
+          required: true
+          type: integer
+          format: int32
+        - $ref: '#/parameters/subscriptionIdParameter'
+        - $ref: '#/parameters/apiVersionParameter'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Object'
+      deprecated: false
+definitions:
+  ArmPlan:
+    description: 'The plan object in an ARM, represents a marketplace plan'
+    type: object
+    properties:
+      name:
+        description: The name
+        type: string
+      publisher:
+        description: The publisher
+        type: string
+      product:
+        description: The product
+        type: string
+      promotionCode:
+        description: The promotion code
+        type: string
+      version:
+        description: Version of product
+        type: string
+  CertificateOrderCertificate:
+    description: >-
+      Class representing the Key Vault container for certificate purchased
+      through Azure
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          keyVaultId:
+            description: Key Vault Csm resource Id
+            type: string
+          keyVaultSecretName:
+            description: Key Vault secret name
+            type: string
+          provisioningState:
+            description: Status of the Key Vault secret
+            enum:
+              - Initialized
+              - WaitingOnCertificateOrder
+              - Succeeded
+              - CertificateOrderFailed
+              - OperationNotPermittedOnKeyVault
+              - AzureServiceUnauthorizedToAccessKeyVault
+              - KeyVaultDoesNotExist
+              - KeyVaultSecretDoesNotExist
+              - UnknownError
+              - Unknown
+            type: string
+            x-ms-enum:
+              name: KeyVaultSecretStatus
+              modelAsString: false
+        x-ms-client-flatten: true
+  SkuDescription:
+    description: Describes a sku for a scalable resource
+    type: object
+    properties:
+      name:
+        description: Name of the resource sku
+        type: string
+      tier:
+        description: Service Tier of the resource sku
+        type: string
+      size:
+        description: Size specifier of the resource sku
+        type: string
+      family:
+        description: Family code of the resource sku
+        type: string
+      capacity:
+        format: int32
+        description: Current number of instances assigned to the resource
+        type: integer
+  Object:
+    type: object
+    properties: {}
+  CertificateOrder:
+    description: Certificate purchase order
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          certificates:
+            description: State of the Key Vault secret
+            type: object
+            additionalProperties:
+              $ref: '#/definitions/CertificateOrderCertificate'
+          distinguishedName:
+            description: Certificate distinguished name
+            type: string
+          domainVerificationToken:
+            description: Domain Verification Token
+            type: string
+          validityInYears:
+            format: int32
+            description: Duration in years (must be between 1 and 3)
+            type: integer
+          keySize:
+            format: int32
+            description: Certificate Key Size
+            type: integer
+          productType:
+            description: Certificate product type
+            enum:
+              - StandardDomainValidatedSsl
+              - StandardDomainValidatedWildCardSsl
+            type: string
+            x-ms-enum:
+              name: CertificateProductType
+              modelAsString: false
+          autoRenew:
+            description: Auto renew
+            type: boolean
+          provisioningState:
+            description: Status of certificate order
+            enum:
+              - Succeeded
+              - Failed
+              - Canceled
+              - InProgress
+              - Deleting
+            type: string
+            x-ms-enum:
+              name: ProvisioningState
+              modelAsString: false
+          status:
+            description: Current order status
+            enum:
+              - Pendingissuance
+              - Issued
+              - Revoked
+              - Canceled
+              - Denied
+              - Pendingrevocation
+              - PendingRekey
+              - Unused
+              - Expired
+              - NotSubmitted
+            type: string
+            x-ms-enum:
+              name: CertificateOrderStatus
+              modelAsString: false
+          signedCertificate:
+            $ref: '#/definitions/CertificateDetails'
+            description: Signed certificate
+          csr:
+            description: Last CSR that was created for this order
+            type: string
+          intermediate:
+            $ref: '#/definitions/CertificateDetails'
+            description: Intermediate certificate
+          root:
+            $ref: '#/definitions/CertificateDetails'
+            description: Root certificate
+          serialNumber:
+            description: Current serial number of the certificate
+            type: string
+          lastCertificateIssuanceTime:
+            format: date-time
+            description: Certificate last issuance time
+            type: string
+          expirationTime:
+            format: date-time
+            description: Certificate expiration time
+            type: string
+        x-ms-client-flatten: true
+  CertificateDetails:
+    description: Certificate Details
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          version:
+            format: int32
+            description: Version
+            type: integer
+          serialNumber:
+            description: Serial Number
+            type: string
+          thumbprint:
+            description: Thumbprint
+            type: string
+          subject:
+            description: Subject
+            type: string
+          notBefore:
+            format: date-time
+            description: Valid from
+            type: string
+          notAfter:
+            format: date-time
+            description: Valid to
+            type: string
+          signatureAlgorithm:
+            description: Signature Algorithm
+            type: string
+          issuer:
+            description: Issuer
+            type: string
+          rawData:
+            description: Raw certificate data
+            type: string
+        x-ms-client-flatten: true
+  CertificateOrderCollection:
+    description: Collection of ceritificate orders
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/CertificateOrder'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  CertificateOrderCertificateCollection:
+    description: Collection of ceritificateorder certificates
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/CertificateOrderCertificate'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  ReissueCertificateOrderRequest:
+    description: Class representing certificate reissue request
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          keySize:
+            format: int32
+            description: Certificate Key Size
+            type: integer
+          delayExistingRevokeInHours:
+            format: int32
+            description: >-
+              Delay in hours to revoke existing certificate after the new
+              certificate is issued
+            type: integer
+        x-ms-client-flatten: true
+  RenewCertificateOrderRequest:
+    description: Class representing certificate renew request
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          keySize:
+            format: int32
+            description: Certificate Key Size
+            type: integer
+        x-ms-client-flatten: true
+  CertificateOrderAction:
+    description: Represents a certificate action
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - type
+        properties:
+          type:
+            description: Type
+            enum:
+              - CertificateIssued
+              - CertificateOrderCanceled
+              - CertificateOrderCreated
+              - CertificateRevoked
+              - DomainValidationComplete
+              - FraudDetected
+              - OrgNameChange
+              - OrgValidationComplete
+              - SanDrop
+            type: string
+            x-ms-enum:
+              name: CertificateOrderActionType
+              modelAsString: false
+          createdAt:
+            format: date-time
+            description: Time at which the certificate action was performed
+            type: string
+        x-ms-client-flatten: true
+  CertificateEmail:
+    description: Certificate Email
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          emailId:
+            description: Email id
+            type: string
+          timeStamp:
+            format: date-time
+            description: Time stamp
+            type: string
+        x-ms-client-flatten: true
+  CertificateCollection:
+    description: Collection of certificates
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/Certificate'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  Certificate:
+    description: App certificate
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          friendlyName:
+            description: Friendly name of the certificate
+            type: string
+          subjectName:
+            description: Subject name of the certificate
+            type: string
+          hostNames:
+            description: Host names the certificate applies to
+            type: array
+            items:
+              type: string
+          pfxBlob:
+            description: Pfx blob
+            type: string
+          siteName:
+            description: App name
+            type: string
+          selfLink:
+            description: Self link
+            type: string
+          issuer:
+            description: Certificate issuer
+            type: string
+          issueDate:
+            format: date-time
+            description: Certificate issue Date
+            type: string
+          expirationDate:
+            format: date-time
+            description: Certificate expriration date
+            type: string
+          password:
+            description: Certificate password
+            type: string
+          thumbprint:
+            description: Certificate thumbprint
+            type: string
+          valid:
+            description: Is the certificate valid?
+            type: boolean
+          cerBlob:
+            description: Raw bytes of .cer file
+            type: string
+          publicKeyHash:
+            description: Public key hash
+            type: string
+          hostingEnvironmentProfile:
+            $ref: '#/definitions/HostingEnvironmentProfile'
+            description: >-
+              Specification for the hosting environment (App Service
+              Environment) to use for the certificate
+        x-ms-client-flatten: true
+  HostingEnvironmentProfile:
+    description: >-
+      Specification for a hostingEnvironment (App Service Environment) to use
+      for this resource
+    type: object
+    properties:
+      id:
+        description: Resource id of the hostingEnvironment (App Service Environment)
+        type: string
+      name:
+        description: Name of the hostingEnvironment (App Service Environment) (read only)
+        type: string
+      type:
+        description: >-
+          Resource type of the hostingEnvironment (App Service Environment)
+          (read only)
+        type: string
+  Csr:
+    description: Certificate signing request object
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Name used to locate CSR object
+            type: string
+          distinguishedName:
+            description: Distinguished name of certificate to be created
+            type: string
+          csrString:
+            description: Actual CSR string created
+            type: string
+          pfxBlob:
+            description: PFX certifcate of created certificate
+            type: string
+          password:
+            description: PFX password
+            type: string
+          publicKeyHash:
+            description: Hash of the certificates public key
+            type: string
+          hostingEnvironment:
+            description: Hosting environment
+            type: string
+        x-ms-client-flatten: true
+  ClassicMobileServiceCollection:
+    description: Collection of Classic Mobile Services
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/ClassicMobileService'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  ClassicMobileService:
+    description: A mobile service
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Name of the mobile service
+            type: string
+        x-ms-client-flatten: true
+  DomainCollection:
+    description: Collection of domains
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/Domain'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  Domain:
+    description: Represents a domain
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          contactAdmin:
+            $ref: '#/definitions/Contact'
+            description: Admin contact information
+          contactBilling:
+            $ref: '#/definitions/Contact'
+            description: Billing contact information
+          contactRegistrant:
+            $ref: '#/definitions/Contact'
+            description: Registrant contact information
+          contactTech:
+            $ref: '#/definitions/Contact'
+            description: Technical contact information
+          registrationStatus:
+            description: Domain registration status
+            enum:
+              - Active
+              - Awaiting
+              - Cancelled
+              - Confiscated
+              - Disabled
+              - Excluded
+              - Expired
+              - Failed
+              - Held
+              - Locked
+              - Parked
+              - Pending
+              - Reserved
+              - Reverted
+              - Suspended
+              - Transferred
+              - Unknown
+              - Unlocked
+              - Unparked
+              - Updated
+              - JsonConverterFailed
+            type: string
+            x-ms-enum:
+              name: DomainStatus
+              modelAsString: false
+          provisioningState:
+            description: Domain provisioning state
+            enum:
+              - Succeeded
+              - Failed
+              - Canceled
+              - InProgress
+              - Deleting
+            type: string
+            x-ms-enum:
+              name: ProvisioningState
+              modelAsString: false
+          nameServers:
+            description: Name servers
+            type: array
+            items:
+              type: string
+          privacy:
+            description: If true then domain privacy is enabled for this domain
+            type: boolean
+          createdTime:
+            format: date-time
+            description: Domain creation timestamp
+            type: string
+          expirationTime:
+            format: date-time
+            description: Domain expiration timestamp
+            type: string
+          lastRenewedTime:
+            format: date-time
+            description: Timestamp when the domain was renewed last time
+            type: string
+          autoRenew:
+            description: If true then domain will renewed automatically
+            type: boolean
+          readyForDnsRecordManagement:
+            description: >-
+              If true then Azure can assign this domain to Web Apps. This value
+              will be true if domain registration status is active and it is
+              hosted on name servers Azure has programmatic access to
+            type: boolean
+          managedHostNames:
+            description: >-
+              All hostnames derived from the domain and assigned to Azure
+              resources
+            type: array
+            items:
+              $ref: '#/definitions/HostName'
+          consent:
+            $ref: '#/definitions/DomainPurchaseConsent'
+            description: Legal agreement consent
+          domainNotRenewableReasons:
+            description: Reasons why domain is not renewable
+            type: array
+            items:
+              enum:
+                - RegistrationStatusNotSupportedForRenewal
+                - ExpirationNotInRenewalTimeRange
+                - SubscriptionNotActive
+              type: string
+        x-ms-client-flatten: true
+  Contact:
+    description: >-
+      Contact information for domain registration. If 'Domain Privacy' option is
+      not selected then the contact information will be  be made publicly
+      available through the Whois directories as per ICANN requirements.
+    type: object
+    properties:
+      addressMailing:
+        $ref: '#/definitions/Address'
+        description: Mailing address
+      email:
+        description: Email address
+        type: string
+      fax:
+        description: Fax number
+        type: string
+      jobTitle:
+        description: Job title
+        type: string
+      nameFirst:
+        description: First name
+        type: string
+      nameLast:
+        description: Last name
+        type: string
+      nameMiddle:
+        description: Middle name
+        type: string
+      organization:
+        description: Organization
+        type: string
+      phone:
+        description: Phone number
+        type: string
+  HostName:
+    description: Details of a hostname derived from a domain
+    type: object
+    properties:
+      name:
+        description: Name of the hostname
+        type: string
+      siteNames:
+        description: >-
+          List of sites the hostname is assigned to. This list will have more
+          than one site only if the hostname is pointing to a Traffic Manager
+        type: array
+        items:
+          type: string
+      azureResourceName:
+        description: >-
+          Name of the Azure resource the hostname is assigned to. If it is
+          assigned to a traffic manager then it will be the traffic manager name
+          otherwise it will be the website name
+        type: string
+      azureResourceType:
+        description: Type of the Azure resource the hostname is assigned to
+        enum:
+          - Website
+          - TrafficManager
+        type: string
+        x-ms-enum:
+          name: AzureResourceType
+          modelAsString: false
+      customHostNameDnsRecordType:
+        description: Type of the Dns record
+        enum:
+          - CName
+          - A
+        type: string
+        x-ms-enum:
+          name: CustomHostNameDnsRecordType
+          modelAsString: false
+      hostNameType:
+        description: Type of the hostname
+        enum:
+          - Verified
+          - Managed
+        type: string
+        x-ms-enum:
+          name: HostNameType
+          modelAsString: false
+  DomainPurchaseConsent:
+    description: >-
+      Domain purchase consent object representing acceptance of applicable legal
+      agreements
+    type: object
+    properties:
+      agreementKeys:
+        description: >-
+          List of applicable legal agreement keys. This list can be retrieved
+          using ListLegalAgreements Api under TopLevelDomain resource
+        type: array
+        items:
+          type: string
+      agreedBy:
+        description: Client IP address
+        type: string
+      agreedAt:
+        format: date-time
+        description: Timestamp when the agreements were accepted
+        type: string
+  Address:
+    description: Address information for domain registration
+    type: object
+    properties:
+      address1:
+        description: Address 1
+        type: string
+      address2:
+        description: Address 2
+        type: string
+      city:
+        description: City
+        type: string
+      country:
+        description: Country
+        type: string
+      postalCode:
+        description: Postal code
+        type: string
+      state:
+        description: State
+        type: string
+  User:
+    description: Represents user crendentials used for publishing activity
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Username (internal)
+            type: string
+          publishingUserName:
+            description: Username used for publishing
+            type: string
+          publishingPassword:
+            description: Password used for publishing
+            type: string
+        x-ms-client-flatten: true
+  GeoRegionCollection:
+    description: Collection of geo regions
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/GeoRegion'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  GeoRegion:
+    description: Geographical region
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Region name
+            type: string
+          description:
+            description: Region description
+            type: string
+          displayName:
+            description: Display name for region
+            type: string
+        x-ms-client-flatten: true
+  ServerFarmCollection:
+    description: Collection of serverfarms
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/ServerFarmWithRichSku'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  ServerFarmWithRichSku:
+    description: App Service Plan Model
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - status
+        properties:
+          name:
+            description: Name for the App Service Plan
+            type: string
+          workerTierName:
+            description: Target worker tier assigned to the App Service Plan
+            type: string
+          status:
+            description: App Service Plan Status
+            enum:
+              - Ready
+              - Pending
+            type: string
+            readOnly: true
+            x-ms-enum:
+              name: StatusOptions
+              modelAsString: false
+          subscription:
+            description: App Service Plan Subscription
+            type: string
+            readOnly: true
+          adminSiteName:
+            description: App Service Plan administration site
+            type: string
+          hostingEnvironmentProfile:
+            $ref: '#/definitions/HostingEnvironmentProfile'
+            description: >-
+              Specification for the hosting environment (App Service
+              Environment) to use for the App Service Plan
+          maximumNumberOfWorkers:
+            format: int32
+            description: >-
+              Maximum number of instances that can be assigned to this App
+              Service Plan
+            type: integer
+          geoRegion:
+            description: Geographical location for the App Service Plan
+            type: string
+            readOnly: true
+          perSiteScaling:
+            description: "If True apps assigned to this App Service Plan can be scaled independently\r\n            If False apps assigned to this App Service Plan will scale to all instances of the plan"
+            type: boolean
+          numberOfSites:
+            format: int32
+            description: Number of web apps assigned to this App Service Plan
+            type: integer
+            readOnly: true
+          resourceGroup:
+            description: Resource group of the serverfarm
+            type: string
+            readOnly: true
+        x-ms-client-flatten: true
+      sku:
+        $ref: '#/definitions/SkuDescription'
+  SiteCollection:
+    description: Collection of sites
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/Site'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  Site:
+    description: Represents a web app
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - usageState
+          - availabilityState
+        properties:
+          name:
+            description: Name of web app
+            type: string
+          state:
+            description: State of the web app
+            type: string
+            readOnly: true
+          hostNames:
+            description: Hostnames associated with web app
+            type: array
+            items:
+              type: string
+            readOnly: true
+          repositorySiteName:
+            description: Name of repository site
+            type: string
+            readOnly: true
+          usageState:
+            description: State indicating whether web app has exceeded its quota usage
+            enum:
+              - Normal
+              - Exceeded
+            type: string
+            readOnly: true
+            x-ms-enum:
+              name: UsageState
+              modelAsString: false
+          enabled:
+            description: >-
+              True if the site is enabled; otherwise, false. Setting this  value
+              to false disables the site (takes the site off line).
+            type: boolean
+          enabledHostNames:
+            description: "Hostnames for the web app that are enabled. Hostnames need to be assigned and enabled. If some hostnames are assigned but not enabled\r\n            the app is not served on those hostnames"
+            type: array
+            items:
+              type: string
+            readOnly: true
+          availabilityState:
+            description: "Management information availability state for the web app. Possible values are Normal or Limited. \r\n            Normal means that the site is running correctly and that management information for the site is available. \r\n            Limited means that only partial management information for the site is available and that detailed site information is unavailable."
+            enum:
+              - Normal
+              - Limited
+              - DisasterRecoveryMode
+            type: string
+            readOnly: true
+            x-ms-enum:
+              name: SiteAvailabilityState
+              modelAsString: false
+          hostNameSslStates:
+            description: >-
+              Hostname SSL states are  used to manage the SSL bindings for
+              site's hostnames.
+            type: array
+            items:
+              $ref: '#/definitions/HostNameSslState'
+          serverFarmId:
+            type: string
+          lastModifiedTimeUtc:
+            format: date-time
+            description: Last time web app was modified in UTC
+            type: string
+            readOnly: true
+          siteConfig:
+            $ref: '#/definitions/SiteConfig'
+            description: Configuration of web app
+          trafficManagerHostNames:
+            description: >-
+              Read-only list of Azure Traffic manager hostnames associated with
+              web app
+            type: array
+            items:
+              type: string
+            readOnly: true
+          premiumAppDeployed:
+            description: If set indicates whether web app is deployed as a premium app
+            type: boolean
+            readOnly: true
+          scmSiteAlsoStopped:
+            description: >-
+              If set indicates whether to stop SCM (KUDU) site when the web app
+              is stopped. Default is false.
+            type: boolean
+          targetSwapSlot:
+            description: >-
+              Read-only property that specifies which slot this app will swap
+              into
+            type: string
+            readOnly: true
+          hostingEnvironmentProfile:
+            $ref: '#/definitions/HostingEnvironmentProfile'
+            description: >-
+              Specification for the hosting environment (App Service
+              Environment) to use for the web app
+          microService:
+            description: ''
+            type: string
+          gatewaySiteName:
+            description: Name of gateway app associated with web app
+            type: string
+          clientAffinityEnabled:
+            description: >-
+              Specifies if the client affinity is enabled when load balancing
+              http request for multiple instances of the web app
+            type: boolean
+          clientCertEnabled:
+            description: Specifies if the client certificate is enabled for the web app
+            type: boolean
+          hostNamesDisabled:
+            description: "Specifies if the public hostnames are disabled the web app.\r\n            If set to true the app is only accessible via API Management process"
+            type: boolean
+          outboundIpAddresses:
+            description: >-
+              List of comma separated IP addresses that this web app uses for
+              outbound connections. Those can be used when configuring firewall
+              rules for databases accessed by this web app.
+            type: string
+            readOnly: true
+          containerSize:
+            format: int32
+            description: Size of a function container
+            type: integer
+          maxNumberOfWorkers:
+            format: int32
+            description: "Maximum number of workers\r\n            This only applies to function container"
+            type: integer
+          cloningInfo:
+            $ref: '#/definitions/CloningInfo'
+            description: "This is only valid for web app creation. If specified, web app is cloned from \r\n            a source web app"
+          resourceGroup:
+            description: Resource group web app belongs to
+            type: string
+            readOnly: true
+          isDefaultContainer:
+            description: Site is a default container
+            type: boolean
+            readOnly: true
+          defaultHostName:
+            description: Default hostname of the web app
+            type: string
+            readOnly: true
+        x-ms-client-flatten: true
+  SiteProperties:
+    type: object
+    properties:
+      metadata:
+        type: array
+        items:
+          $ref: '#/definitions/NameValuePair'
+      properties:
+        type: array
+        items:
+          $ref: '#/definitions/NameValuePair'
+      appSettings:
+        type: array
+        items:
+          $ref: '#/definitions/NameValuePair'
+  HostNameSslState:
+    description: Object that represents a SSL-enabled host name.
+    required:
+      - sslState
+    type: object
+    properties:
+      name:
+        description: Host name
+        type: string
+      sslState:
+        description: SSL type
+        enum:
+          - Disabled
+          - SniEnabled
+          - IpBasedEnabled
+        type: string
+        x-ms-enum:
+          name: SslState
+          modelAsString: false
+      virtualIP:
+        description: >-
+          Virtual IP address assigned to the host name if IP based SSL is
+          enabled
+        type: string
+      thumbprint:
+        description: SSL cert thumbprint
+        type: string
+      toUpdate:
+        description: Set this flag to update existing host name
+        type: boolean
+  SiteConfig:
+    description: Configuration of Azure web site
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          numberOfWorkers:
+            format: int32
+            description: Number of workers
+            type: integer
+          defaultDocuments:
+            description: Default documents
+            type: array
+            items:
+              type: string
+          netFrameworkVersion:
+            description: Net Framework Version
+            type: string
+          phpVersion:
+            description: Version of PHP
+            type: string
+          pythonVersion:
+            description: Version of Python
+            type: string
+          requestTracingEnabled:
+            description: Enable request tracing
+            type: boolean
+          requestTracingExpirationTime:
+            format: date-time
+            description: Request tracing expiration time
+            type: string
+          remoteDebuggingEnabled:
+            description: Remote Debugging Enabled
+            type: boolean
+          remoteDebuggingVersion:
+            description: Remote Debugging Version
+            type: string
+          httpLoggingEnabled:
+            description: HTTP logging Enabled
+            type: boolean
+          logsDirectorySizeLimit:
+            format: int32
+            description: HTTP Logs Directory size limit
+            type: integer
+          detailedErrorLoggingEnabled:
+            description: Detailed error logging enabled
+            type: boolean
+          publishingUsername:
+            description: Publishing user name
+            type: string
+          publishingPassword:
+            description: Publishing password
+            type: string
+          appSettings:
+            description: Application Settings
+            type: array
+            items:
+              $ref: '#/definitions/NameValuePair'
+          metadata:
+            description: Site Metadata
+            type: array
+            items:
+              $ref: '#/definitions/NameValuePair'
+          connectionStrings:
+            description: Connection strings
+            type: array
+            items:
+              $ref: '#/definitions/ConnStringInfo'
+          handlerMappings:
+            description: Handler mappings
+            type: array
+            items:
+              $ref: '#/definitions/HandlerMapping'
+          documentRoot:
+            description: Document root
+            type: string
+          scmType:
+            description: SCM type
+            type: string
+          use32BitWorkerProcess:
+            description: Use 32 bit worker process
+            type: boolean
+          webSocketsEnabled:
+            description: Web socket enabled.
+            type: boolean
+          alwaysOn:
+            description: Always On
+            type: boolean
+          javaVersion:
+            description: Java version
+            type: string
+          javaContainer:
+            description: Java container
+            type: string
+          javaContainerVersion:
+            description: Java container version
+            type: string
+          managedPipelineMode:
+            description: Managed pipeline mode
+            enum:
+              - Integrated
+              - Classic
+            type: string
+            x-ms-enum:
+              name: ManagedPipelineMode
+              modelAsString: false
+          virtualApplications:
+            description: Virtual applications
+            type: array
+            items:
+              $ref: '#/definitions/VirtualApplication'
+          loadBalancing:
+            description: Site load balancing
+            enum:
+              - WeightedRoundRobin
+              - LeastRequests
+              - LeastResponseTime
+              - WeightedTotalTraffic
+              - RequestHash
+            type: string
+            x-ms-enum:
+              name: SiteLoadBalancing
+              modelAsString: false
+          experiments:
+            $ref: '#/definitions/Experiments'
+            description: This is work around for polymophic types
+          limits:
+            $ref: '#/definitions/SiteLimits'
+            description: Site limits
+          autoHealEnabled:
+            description: Auto heal enabled
+            type: boolean
+          autoHealRules:
+            $ref: '#/definitions/AutoHealRules'
+            description: Auto heal rules
+          tracingOptions:
+            description: Tracing options
+            type: string
+          vnetName:
+            description: Vnet name
+            type: string
+          cors:
+            $ref: '#/definitions/CorsSettings'
+            description: Cross-Origin Resource Sharing (CORS) settings.
+          apiDefinition:
+            $ref: '#/definitions/ApiDefinitionInfo'
+            description: Information about the formal API definition for the web app.
+          autoSwapSlotName:
+            description: Auto swap slot name
+            type: string
+          localMySqlEnabled:
+            description: Local mysql enabled
+            type: boolean
+          ipSecurityRestrictions:
+            description: Ip Security restrictions
+            type: array
+            items:
+              $ref: '#/definitions/IpSecurityRestriction'
+        x-ms-client-flatten: true
+  CloningInfo:
+    description: Represents information needed for cloning operation
+    type: object
+    properties:
+      correlationId:
+        description: "Correlation Id of cloning operation. This id ties multiple cloning operations\r\n            together to use the same snapshot"
+        type: string
+      overwrite:
+        description: Overwrite destination web app
+        type: boolean
+      cloneCustomHostNames:
+        description: 'If true, clone custom hostnames from source web app'
+        type: boolean
+      cloneSourceControl:
+        description: Clone source control from source web app
+        type: boolean
+      sourceWebAppId:
+        description: "ARM resource id of the source web app. Web app resource id is of the form \r\n            /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName} for production slots and \r\n            /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName}/slots/{slotName} for other slots"
+        type: string
+      hostingEnvironment:
+        description: Hosting environment
+        type: string
+      appSettingsOverrides:
+        description: "Application settings overrides for cloned web app. If specified these settings will override the settings cloned \r\n            from source web app. If not specified, application settings from source web app are retained."
+        type: object
+        additionalProperties:
+          type: string
+      configureLoadBalancing:
+        description: If specified configure load balancing for source and clone site
+        type: boolean
+      trafficManagerProfileId:
+        description: "ARM resource id of the traffic manager profile to use if it exists. Traffic manager resource id is of the form \r\n            /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{profileName}"
+        type: string
+      trafficManagerProfileName:
+        description: >-
+          Name of traffic manager profile to create. This is only needed if
+          traffic manager profile does not already exist
+        type: string
+  NameValuePair:
+    description: Name value pair
+    type: object
+    properties:
+      name:
+        description: Pair name
+        type: string
+      value:
+        description: Pair value
+        type: string
+  ConnStringInfo:
+    description: Represents database connection string information
+    required:
+      - type
+    type: object
+    properties:
+      name:
+        description: Name of connection string
+        type: string
+      connectionString:
+        description: Connection string value
+        type: string
+      type:
+        description: Type of database
+        enum:
+          - MySql
+          - SQLServer
+          - SQLAzure
+          - Custom
+        type: string
+        x-ms-enum:
+          name: DatabaseServerType
+          modelAsString: false
+  HandlerMapping:
+    description: "The IIS handler mappings used to define which handler processes HTTP requests with certain extension. \r\n            For example it is used to configure php-cgi.exe process to handle all HTTP requests with *.php extension."
+    type: object
+    properties:
+      extension:
+        description: >-
+          Requests with this extension will be handled using the specified
+          FastCGI application.
+        type: string
+      scriptProcessor:
+        description: The absolute path to the FastCGI application.
+        type: string
+      arguments:
+        description: Command-line arguments to be passed to the script processor.
+        type: string
+  VirtualApplication:
+    type: object
+    properties:
+      virtualPath:
+        type: string
+      physicalPath:
+        type: string
+      preloadEnabled:
+        type: boolean
+      virtualDirectories:
+        type: array
+        items:
+          $ref: '#/definitions/VirtualDirectory'
+  RoutingRule:
+    description: Routing rules for TiP
+    type: object
+    properties:
+      name:
+        description: >-
+          Name of the routing rule. The recommended name would be to point to
+          the slot which will receive the traffic in the experiment.
+        type: string
+  Experiments:
+    description: Class containing Routing in production experiments
+    type: object
+    properties:
+      rampUpRules:
+        description: 'List of {Microsoft.Web.Hosting.Administration.RampUpRule} objects.'
+        type: array
+        items:
+          $ref: '#/definitions/RampUpRule'
+  SiteLimits:
+    description: Represents metric limits set on a web app.
+    type: object
+    properties:
+      maxPercentageCpu:
+        format: double
+        description: Maximum allowed CPU usage percentage
+        type: number
+      maxMemoryInMb:
+        format: int64
+        description: Maximum allowed memory usage in MB
+        type: integer
+      maxDiskSizeInMb:
+        format: int64
+        description: Maximum allowed disk size usage in MB
+        type: integer
+  AutoHealRules:
+    description: AutoHealRules - describes the rules which can be defined for auto-heal
+    type: object
+    properties:
+      triggers:
+        $ref: '#/definitions/AutoHealTriggers'
+        description: >-
+          Triggers - Conditions that describe when to execute the auto-heal
+          actions
+      actions:
+        $ref: '#/definitions/AutoHealActions'
+        description: Actions - Actions to be executed when a rule is triggered
+  SiteAuthSettings:
+    description: >-
+      Configuration settings for the Azure App Service Authentication /
+      Authorization feature.
+    type: object
+    properties:
+      enabled:
+        description: >-
+          Gets or sets a value indicating whether the Authentication /
+          Authorization feature is enabled for the current app.
+        type: boolean
+      httpApiPrefixPath:
+        description: "Gets or sets the relative path prefix used by platform HTTP APIs.\r\n            Changing this value is not recommended except for compatibility reasons."
+        type: string
+      unauthenticatedClientAction:
+        description: >-
+          Gets or sets the action to take when an unauthenticated client
+          attempts to access the app.
+        enum:
+          - RedirectToLoginPage
+          - AllowAnonymous
+        type: string
+        x-ms-enum:
+          name: UnauthenticatedClientAction
+          modelAsString: false
+      tokenStoreEnabled:
+        description: "Gets or sets a value indicating whether to durably store platform-specific security tokens\r\n            obtained during login flows. This capability is disabled by default."
+        type: boolean
+      allowedExternalRedirectUrls:
+        description: "Gets or sets a collection of external URLs that can be redirected to as part of logging in\r\n            or logging out of the web app. Note that the query string part of the URL is ignored.\r\n            This is an advanced setting typically only needed by Windows Store application backends.\r\n            Note that URLs within the current domain are always implicitly allowed."
+        type: array
+        items:
+          type: string
+      defaultProvider:
+        description: "Gets or sets the default authentication provider to use when multiple providers are configured.\r\n            This setting is only needed if multiple providers are configured and the unauthenticated client\r\n            action is set to \"RedirectToLoginPage\"."
+        enum:
+          - AzureActiveDirectory
+          - Facebook
+          - Google
+          - MicrosoftAccount
+          - Twitter
+        type: string
+        x-ms-enum:
+          name: BuiltInAuthenticationProvider
+          modelAsString: false
+      tokenRefreshExtensionHours:
+        format: double
+        description: "Gets or sets the number of hours after session token expiration that a session token can be used to\r\n            call the token refresh API. The default is 72 hours."
+        type: number
+      clientId:
+        description: "Gets or sets the Client ID of this relying party application, known as the client_id.\r\n            This setting is required for enabling OpenID Connection authentication with Azure Active Directory or \r\n            other 3rd party OpenID Connect providers.\r\n            More information on OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html"
+        type: string
+      clientSecret:
+        description: "Gets or sets the Client Secret of this relying party application (in Azure Active Directory, this is also referred to as the Key).\r\n            This setting is optional. If no client secret is configured, the OpenID Connect implicit auth flow is used to authenticate end users.\r\n            Otherwise, the OpenID Connect Authorization Code Flow is used to authenticate end users.\r\n            More information on OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html"
+        type: string
+      issuer:
+        description: "Gets or sets the OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\r\n            When using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\r\n            This URI is a case-sensitive identifier for the token issuer.\r\n            More information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html"
+        type: string
+      allowedAudiences:
+        description: "Gets or sets a list of allowed audience values to consider when validating JWTs issued by \r\n            Azure Active Directory. Note that the {Microsoft.Web.Hosting.Administration.SiteAuthSettings.ClientId} value is always considered an\r\n            allowed audience, regardless of this setting."
+        type: array
+        items:
+          type: string
+      additionalLoginParams:
+        description: "Gets or sets a list of login parameters to send to the OpenID Connect authorization endpoint when\r\n            a user logs in. Each parameter must be in the form \"key=value\"."
+        type: array
+        items:
+          type: string
+      aadClientId:
+        type: string
+      openIdIssuer:
+        type: string
+      googleClientId:
+        description: "Gets or sets the OpenID Connect Client ID for the Google web application.\r\n            This setting is required for enabling Google Sign-In.\r\n            Google Sign-In documentation: https://developers.google.com/identity/sign-in/web/"
+        type: string
+      googleClientSecret:
+        description: "Gets or sets the client secret associated with the Google web application.\r\n            This setting is required for enabling Google Sign-In.\r\n            Google Sign-In documentation: https://developers.google.com/identity/sign-in/web/"
+        type: string
+      googleOAuthScopes:
+        description: "Gets or sets the OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication.\r\n            This setting is optional. If not specified, \"openid\", \"profile\", and \"email\" are used as default scopes.\r\n            Google Sign-In documentation: https://developers.google.com/identity/sign-in/web/"
+        type: array
+        items:
+          type: string
+      facebookAppId:
+        description: "Gets or sets the App ID of the Facebook app used for login.\r\n            This setting is required for enabling Facebook Login.\r\n            Facebook Login documentation: https://developers.facebook.com/docs/facebook-login"
+        type: string
+      facebookAppSecret:
+        description: "Gets or sets the App Secret of the Facebook app used for Facebook Login.\r\n            This setting is required for enabling Facebook Login.\r\n            Facebook Login documentation: https://developers.facebook.com/docs/facebook-login"
+        type: string
+      facebookOAuthScopes:
+        description: "Gets or sets the OAuth 2.0 scopes that will be requested as part of Facebook Login authentication.\r\n            This setting is optional.\r\n            Facebook Login documentation: https://developers.facebook.com/docs/facebook-login"
+        type: array
+        items:
+          type: string
+      twitterConsumerKey:
+        description: "Gets or sets the OAuth 1.0a consumer key of the Twitter application used for sign-in.\r\n            This setting is required for enabling Twitter Sign-In.\r\n            Twitter Sign-In documentation: https://dev.twitter.com/web/sign-in"
+        type: string
+      twitterConsumerSecret:
+        description: "Gets or sets the OAuth 1.0a consumer secret of the Twitter application used for sign-in.\r\n            This setting is required for enabling Twitter Sign-In.\r\n            Twitter Sign-In documentation: https://dev.twitter.com/web/sign-in"
+        type: string
+      microsoftAccountClientId:
+        description: "Gets or sets the OAuth 2.0 client ID that was created for the app used for authentication.\r\n            This setting is required for enabling Microsoft Account authentication.\r\n            Microsoft Account OAuth documentation: https://dev.onedrive.com/auth/msa_oauth.htm"
+        type: string
+      microsoftAccountClientSecret:
+        description: "Gets or sets the OAuth 2.0 client secret that was created for the app used for authentication.\r\n            This setting is required for enabling Microsoft Account authentication.\r\n            Microsoft Account OAuth documentation: https://dev.onedrive.com/auth/msa_oauth.htm"
+        type: string
+      microsoftAccountOAuthScopes:
+        description: "Gets or sets the OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication.\r\n            This setting is optional. If not specified, \"wl.basic\" is used as the default scope.\r\n            Microsoft Account Scopes and permissions documentation: https://msdn.microsoft.com/en-us/library/dn631845.aspx"
+        type: array
+        items:
+          type: string
+  CorsSettings:
+    description: Cross-Origin Resource Sharing (CORS) settings for the web app.
+    type: object
+    properties:
+      allowedOrigins:
+        description: "Gets or sets the list of origins that should be allowed to make cross-origin\r\n            calls (for example: http://example.com:12345). Use \"*\" to allow all."
+        type: array
+        items:
+          type: string
+  ApiDefinitionInfo:
+    description: Information about the formal API definition for the web app.
+    type: object
+    properties:
+      url:
+        description: The URL of the API definition.
+        type: string
+  IpSecurityRestriction:
+    description: Represents an ip security restriction on a web app.
+    type: object
+    properties:
+      ipAddress:
+        description: IP address the security restriction is valid for
+        type: string
+      subnetMask:
+        description: Subnet mask for the range of IP addresses the restriction is valid for
+        type: string
+  VirtualDirectory:
+    type: object
+    properties:
+      virtualPath:
+        type: string
+      physicalPath:
+        type: string
+  RampUpRule:
+    description: >-
+      Routing rules for ramp up testing. This rule allows to redirect static
+      traffic % to a slot or to gradually change routing % based on performance
+    type: object
+    properties:
+      actionHostName:
+        description: >-
+          Hostname of a slot to which the traffic will be redirected if decided
+          to. E.g. mysite-stage.azurewebsites.net
+        type: string
+      reroutePercentage:
+        format: double
+        description: >-
+          Percentage of the traffic which will be redirected to
+          {Microsoft.Web.Hosting.Administration.RampUpRule.ActionHostName}
+        type: number
+      changeStep:
+        format: double
+        description: "[Optional] In auto ramp up scenario this is the step to to add/remove from {Microsoft.Web.Hosting.Administration.RampUpRule.ReroutePercentage} until it reaches \r\n            {Microsoft.Web.Hosting.Administration.RampUpRule.MinReroutePercentage} or {Microsoft.Web.Hosting.Administration.RampUpRule.MaxReroutePercentage}. Site metrics are checked every N minutes specificed in {Microsoft.Web.Hosting.Administration.RampUpRule.ChangeIntervalInMinutes}.\r\n            Custom decision algorithm can be provided in TiPCallback site extension which Url can be specified in {Microsoft.Web.Hosting.Administration.RampUpRule.ChangeDecisionCallbackUrl}"
+        type: number
+      changeIntervalInMinutes:
+        format: int32
+        description: >-
+          [Optional] Specifies interval in mimuntes to reevaluate
+          ReroutePercentage
+        type: integer
+      minReroutePercentage:
+        format: double
+        description: >-
+          [Optional] Specifies lower boundary above which ReroutePercentage will
+          stay.
+        type: number
+      maxReroutePercentage:
+        format: double
+        description: >-
+          [Optional] Specifies upper boundary below which ReroutePercentage will
+          stay.
+        type: number
+      changeDecisionCallbackUrl:
+        description: "Custom decision algorithm can be provided in TiPCallback site extension which Url can be specified. See TiPCallback site extension for the scaffold and contracts.\r\n            https://www.siteextensions.net/packages/TiPCallback/"
+        type: string
+      name:
+        description: >-
+          Name of the routing rule. The recommended name would be to point to
+          the slot which will receive the traffic in the experiment.
+        type: string
+  AutoHealTriggers:
+    description: AutoHealTriggers - describes the triggers for auto-heal.
+    type: object
+    properties:
+      requests:
+        $ref: '#/definitions/RequestsBasedTrigger'
+        description: Requests - Defines a rule based on total requests
+      privateBytesInKB:
+        format: int32
+        description: PrivateBytesInKB - Defines a rule based on private bytes
+        type: integer
+      statusCodes:
+        description: StatusCodes - Defines a rule based on status codes
+        type: array
+        items:
+          $ref: '#/definitions/StatusCodesBasedTrigger'
+      slowRequests:
+        $ref: '#/definitions/SlowRequestsBasedTrigger'
+        description: SlowRequests - Defines a rule based on request execution time
+  AutoHealActions:
+    description: "AutoHealActions - Describes the actions which can be\r\n            taken by the auto-heal module when a rule is triggered."
+    required:
+      - actionType
+    type: object
+    properties:
+      actionType:
+        description: ActionType - predefined action to be taken
+        enum:
+          - Recycle
+          - LogEvent
+          - CustomAction
+        type: string
+        x-ms-enum:
+          name: AutoHealActionType
+          modelAsString: false
+      customAction:
+        $ref: '#/definitions/AutoHealCustomAction'
+        description: CustomAction - custom action to be taken
+      minProcessExecutionTime:
+        description: "MinProcessExecutionTime - minimum time the process must execute\r\n            before taking the action"
+        type: string
+  RequestsBasedTrigger:
+    description: RequestsBasedTrigger
+    type: object
+    properties:
+      count:
+        format: int32
+        description: Count
+        type: integer
+      timeInterval:
+        description: TimeInterval
+        type: string
+  StatusCodesBasedTrigger:
+    description: StatusCodeBasedTrigger
+    type: object
+    properties:
+      status:
+        format: int32
+        description: HTTP status code
+        type: integer
+      subStatus:
+        format: int32
+        description: SubStatus
+        type: integer
+      win32Status:
+        format: int32
+        description: Win32 error code
+        type: integer
+      count:
+        format: int32
+        description: Count
+        type: integer
+      timeInterval:
+        description: TimeInterval
+        type: string
+  SlowRequestsBasedTrigger:
+    description: SlowRequestsBasedTrigger
+    type: object
+    properties:
+      timeTaken:
+        description: TimeTaken
+        type: string
+      count:
+        format: int32
+        description: Count
+        type: integer
+      timeInterval:
+        description: TimeInterval
+        type: string
+  AutoHealCustomAction:
+    description: "AutoHealCustomAction - Describes the custom action to be executed\r\n            when an auto heal rule is triggered."
+    type: object
+    properties:
+      exe:
+        description: Executable to be run
+        type: string
+      parameters:
+        description: Parameters for the executable
+        type: string
+  HostingEnvironmentCollection:
+    description: Collection of hosting environments (App Service Environments)
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/HostingEnvironment'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  HostingEnvironment:
+    description: Description of an hostingEnvironment (App Service Environment)
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - status
+        properties:
+          name:
+            description: Name of the hostingEnvironment (App Service Environment)
+            type: string
+          location:
+            description: >-
+              Location of the hostingEnvironment (App Service Environment), e.g.
+              "West US"
+            type: string
+          provisioningState:
+            description: >-
+              Provisioning state of the hostingEnvironment (App Service
+              Environment)
+            enum:
+              - Succeeded
+              - Failed
+              - Canceled
+              - InProgress
+              - Deleting
+            type: string
+            x-ms-enum:
+              name: ProvisioningState
+              modelAsString: false
+          status:
+            description: Current status of the hostingEnvironment (App Service Environment)
+            enum:
+              - Preparing
+              - Ready
+              - Scaling
+              - Deleting
+            type: string
+            x-ms-enum:
+              name: HostingEnvironmentStatus
+              modelAsString: false
+          vnetName:
+            description: >-
+              Name of the hostingEnvironment's (App Service Environment) virtual
+              network
+            type: string
+          vnetResourceGroupName:
+            description: >-
+              Resource group of the hostingEnvironment's (App Service
+              Environment) virtual network
+            type: string
+          vnetSubnetName:
+            description: >-
+              Subnet of the hostingEnvironment's (App Service Environment)
+              virtual network
+            type: string
+          virtualNetwork:
+            $ref: '#/definitions/VirtualNetworkProfile'
+            description: >-
+              Description of the hostingEnvironment's (App Service Environment)
+              virtual network
+          internalLoadBalancingMode:
+            description: >-
+              Specifies which endpoints to serve internally in the
+              hostingEnvironment's (App Service Environment) VNET
+            enum:
+              - None
+              - Web
+              - Publishing
+            type: string
+            x-ms-enum:
+              name: InternalLoadBalancingMode
+              modelAsString: false
+          multiSize:
+            description: 'Front-end VM size, e.g. "Medium", "Large"'
+            type: string
+          multiRoleCount:
+            format: int32
+            description: Number of front-end instances
+            type: integer
+          workerPools:
+            description: >-
+              Description of worker pools with worker size ids, VM sizes, and
+              number of workers in each pool
+            type: array
+            items:
+              $ref: '#/definitions/WorkerPool'
+          ipsslAddressCount:
+            format: int32
+            description: >-
+              Number of IP SSL addresses reserved for this hostingEnvironment
+              (App Service Environment)
+            type: integer
+          databaseEdition:
+            description: >-
+              Edition of the metadata database for the hostingEnvironment (App
+              Service Environment) e.g. "Standard"
+            type: string
+          databaseServiceObjective:
+            description: >-
+              Service objective of the metadata database for the
+              hostingEnvironment (App Service Environment) e.g. "S0"
+            type: string
+          upgradeDomains:
+            format: int32
+            description: >-
+              Number of upgrade domains of this hostingEnvironment (App Service
+              Environment)
+            type: integer
+          subscriptionId:
+            description: Subscription of the hostingEnvironment (App Service Environment)
+            type: string
+          dnsSuffix:
+            description: DNS suffix of the hostingEnvironment (App Service Environment)
+            type: string
+          lastAction:
+            description: >-
+              Last deployment action on this hostingEnvironment (App Service
+              Environment)
+            type: string
+          lastActionResult:
+            description: >-
+              Result of the last deployment action on this hostingEnvironment
+              (App Service Environment)
+            type: string
+          allowedMultiSizes:
+            description: >-
+              List of comma separated strings describing which VM sizes are
+              allowed for front-ends
+            type: string
+          allowedWorkerSizes:
+            description: >-
+              List of comma separated strings describing which VM sizes are
+              allowed for workers
+            type: string
+          maximumNumberOfMachines:
+            format: int32
+            description: >-
+              Maximum number of VMs in this hostingEnvironment (App Service
+              Environment)
+            type: integer
+          vipMappings:
+            description: >-
+              Description of IP SSL mapping for this hostingEnvironment (App
+              Service Environment)
+            type: array
+            items:
+              $ref: '#/definitions/VirtualIPMapping'
+          environmentCapacities:
+            description: 'Current total, used, and available worker capacities'
+            type: array
+            items:
+              $ref: '#/definitions/StampCapacity'
+          networkAccessControlList:
+            description: >-
+              Access control list for controlling traffic to the
+              hostingEnvironment (App Service Environment)
+            type: array
+            items:
+              $ref: '#/definitions/NetworkAccessControlEntry'
+          environmentIsHealthy:
+            description: >-
+              True/false indicating whether the hostingEnvironment (App Service
+              Environment) is healthy
+            type: boolean
+          environmentStatus:
+            description: >-
+              Detailed message about with results of the last check of the
+              hostingEnvironment (App Service Environment)
+            type: string
+          resourceGroup:
+            description: Resource group of the hostingEnvironment (App Service Environment)
+            type: string
+          apiManagementAccountId:
+            description: Api Management Account associated with this Hosting Environment
+            type: string
+          suspended:
+            description: "True/false indicating whether the hostingEnvironment is suspended. The environment can be suspended e.g. when the management endpoint is no longer available\r\n            (most likely because NSG blocked the incoming traffic)"
+            type: boolean
+          clusterSettings:
+            description: >-
+              Custom settings for changing the behavior of the hosting
+              environment
+            type: array
+            items:
+              $ref: '#/definitions/NameValuePair'
+        x-ms-client-flatten: true
+  VirtualNetworkProfile:
+    description: Specification for using a virtual network
+    type: object
+    properties:
+      id:
+        description: Resource id of the virtual network
+        type: string
+      name:
+        description: Name of the virtual network (read-only)
+        type: string
+      type:
+        description: Resource type of the virtual network (read-only)
+        type: string
+      subnet:
+        description: Subnet within the virtual network
+        type: string
+  WorkerPool:
+    description: Worker pool of a hostingEnvironment (App Service Environment)
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          workerSizeId:
+            format: int32
+            description: Worker size id for referencing this worker pool
+            type: integer
+          computeMode:
+            description: Shared or dedicated web app hosting
+            enum:
+              - Shared
+              - Dedicated
+              - Dynamic
+            type: string
+            x-ms-enum:
+              name: ComputeModeOptions
+              modelAsString: false
+          workerSize:
+            description: VM size of the worker pool instances
+            type: string
+          workerCount:
+            format: int32
+            description: Number of instances in the worker pool
+            type: integer
+          instanceNames:
+            description: Names of all instances in the worker pool (read only)
+            type: array
+            items:
+              type: string
+        x-ms-client-flatten: true
+      sku:
+        $ref: '#/definitions/SkuDescription'
+  VirtualIPMapping:
+    description: Class that represents a VIP mapping
+    type: object
+    properties:
+      virtualIP:
+        description: Virtual IP address
+        type: string
+      internalHttpPort:
+        format: int32
+        description: Internal HTTP port
+        type: integer
+      internalHttpsPort:
+        format: int32
+        description: Internal HTTPS port
+        type: integer
+      inUse:
+        description: Is VIP mapping in use
+        type: boolean
+  StampCapacity:
+    description: Class containing stamp capacity information
+    type: object
+    properties:
+      name:
+        description: Name of the stamp
+        type: string
+      availableCapacity:
+        format: int64
+        description: 'Available capacity (# of machines, bytes of storage etc...)'
+        type: integer
+      totalCapacity:
+        format: int64
+        description: 'Total capacity (# of machines, bytes of storage etc...)'
+        type: integer
+      unit:
+        description: Name of the unit
+        type: string
+      computeMode:
+        description: Shared/Dedicated workers
+        enum:
+          - Shared
+          - Dedicated
+          - Dynamic
+        type: string
+        x-ms-enum:
+          name: ComputeModeOptions
+          modelAsString: false
+      workerSize:
+        description: Size of the machines
+        enum:
+          - Default
+          - Small
+          - Medium
+          - Large
+        type: string
+        x-ms-enum:
+          name: WorkerSizeOptions
+          modelAsString: false
+      workerSizeId:
+        format: int32
+        description: "Size Id of machines: \r\n            0 - Small\r\n            1 - Medium\r\n            2 - Large"
+        type: integer
+      excludeFromCapacityAllocation:
+        description: "If true it includes basic sites\r\n            Basic sites are not used for capacity allocation."
+        type: boolean
+      isApplicableForAllComputeModes:
+        description: Is capacity applicable for all sites?
+        type: boolean
+      siteMode:
+        description: Shared or Dedicated
+        type: string
+  NetworkAccessControlEntry:
+    type: object
+    properties:
+      action:
+        enum:
+          - Permit
+          - Deny
+        type: string
+        x-ms-enum:
+          name: AccessControlEntryAction
+          modelAsString: false
+      description:
+        type: string
+      order:
+        format: int32
+        type: integer
+      remoteSubnet:
+        type: string
+  ManagedHostingEnvironmentCollection:
+    description: Collection of managed hosting environments
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/ManagedHostingEnvironment'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  ManagedHostingEnvironment:
+    description: Description of a managed hosting environment
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - status
+        properties:
+          name:
+            description: Name of the managed hosting environment
+            type: string
+          location:
+            description: Location of the managed hosting environment e.g. "West US"
+            type: string
+          status:
+            description: Current status of the managed hosting environment
+            enum:
+              - Preparing
+              - Ready
+              - Deleting
+            type: string
+            x-ms-enum:
+              name: ManagedHostingEnvironmentStatus
+              modelAsString: false
+          virtualNetwork:
+            $ref: '#/definitions/VirtualNetworkProfile'
+            description: Description of the managed hosting environment's virtual network
+          ipsslAddressCount:
+            format: int32
+            description: >-
+              Number of ip ssl addresses reserved for the managed hosting
+              environment
+            type: integer
+          dnsSuffix:
+            description: DNS suffix of the managed hosting environment
+            type: string
+          subscriptionId:
+            description: Subscription of the managed hosting environment (read only)
+            type: string
+          resourceGroup:
+            description: Resource group of the managed hosting environment (read only)
+            type: string
+          environmentIsHealthy:
+            description: >-
+              True/false indicating whether the managed hosting environment is
+              healthy
+            type: boolean
+          environmentStatus:
+            description: >-
+              Detailed message about with results of the last check of the
+              managed hosting environment
+            type: string
+          suspended:
+            description: "True/false indicating whether the managed hosting environment is suspended. The environment can be suspended e.g. when the management endpoint is no longer available\r\n            (most likely because NSG blocked the incoming traffic)"
+            type: boolean
+          apiManagementAccount:
+            description: >-
+              Resource id of the api management account associated with this
+              managed hosting environment (read only)
+            type: string
+        x-ms-client-flatten: true
+  ResourceNameAvailabilityRequest:
+    description: Resource name availability request content
+    type: object
+    properties:
+      name:
+        description: Resource name to verify
+        type: string
+      type:
+        description: Resource type used for verification
+        type: string
+      isFqdn:
+        description: Is fully qualified domain name
+        type: boolean
+  ResourceNameAvailability:
+    description: Describes if a resource name is available
+    type: object
+    properties:
+      nameAvailable:
+        description: >-
+          True indicates name is valid and available.  False indicates the name
+          is invalid, unavailable, or both.
+        type: boolean
+      reason:
+        description: >-
+          Required if nameAvailable is false. 'Invalid' indicates the name
+          provided does not match Azure WebApp service’s naming requirements.
+          'AlreadyExists' indicates that the name is already in use and is
+          therefore unavailable.
+        type: string
+      message:
+        type: string
+  DomainControlCenterSsoRequest:
+    description: Single sign on request information for domain management
+    type: object
+    properties:
+      url:
+        description: Url where the single sign on request is to be made
+        type: string
+      postParameterKey:
+        description: Post parameter key
+        type: string
+      postParameterValue:
+        description: >-
+          Post parameter value. Client should use
+          'application/x-www-form-urlencoded' encoding for this value.
+        type: string
+  DomainRegistrationInput:
+    description: Domain registration input for validation Api
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Name of the domain
+            type: string
+          contactAdmin:
+            $ref: '#/definitions/Contact'
+            description: Admin contact information
+          contactBilling:
+            $ref: '#/definitions/Contact'
+            description: Billing contact information
+          contactRegistrant:
+            $ref: '#/definitions/Contact'
+            description: Registrant contact information
+          contactTech:
+            $ref: '#/definitions/Contact'
+            description: Technical contact information
+          registrationStatus:
+            description: Domain registration status
+            enum:
+              - Active
+              - Awaiting
+              - Cancelled
+              - Confiscated
+              - Disabled
+              - Excluded
+              - Expired
+              - Failed
+              - Held
+              - Locked
+              - Parked
+              - Pending
+              - Reserved
+              - Reverted
+              - Suspended
+              - Transferred
+              - Unknown
+              - Unlocked
+              - Unparked
+              - Updated
+              - JsonConverterFailed
+            type: string
+            x-ms-enum:
+              name: DomainStatus
+              modelAsString: false
+          provisioningState:
+            description: Domain provisioning state
+            enum:
+              - Succeeded
+              - Failed
+              - Canceled
+              - InProgress
+              - Deleting
+            type: string
+            x-ms-enum:
+              name: ProvisioningState
+              modelAsString: false
+          nameServers:
+            description: Name servers
+            type: array
+            items:
+              type: string
+          privacy:
+            description: If true then domain privacy is enabled for this domain
+            type: boolean
+          createdTime:
+            format: date-time
+            description: Domain creation timestamp
+            type: string
+          expirationTime:
+            format: date-time
+            description: Domain expiration timestamp
+            type: string
+          lastRenewedTime:
+            format: date-time
+            description: Timestamp when the domain was renewed last time
+            type: string
+          autoRenew:
+            description: If true then domain will renewed automatically
+            type: boolean
+          readyForDnsRecordManagement:
+            description: >-
+              If true then Azure can assign this domain to Web Apps. This value
+              will be true if domain registration status is active and it is
+              hosted on name servers Azure has programmatic access to
+            type: boolean
+          managedHostNames:
+            description: >-
+              All hostnames derived from the domain and assigned to Azure
+              resources
+            type: array
+            items:
+              $ref: '#/definitions/HostName'
+          consent:
+            $ref: '#/definitions/DomainPurchaseConsent'
+            description: Legal agreement consent
+          domainNotRenewableReasons:
+            description: Reasons why domain is not renewable
+            type: array
+            items:
+              enum:
+                - RegistrationStatusNotSupportedForRenewal
+                - ExpirationNotInRenewalTimeRange
+                - SubscriptionNotActive
+              type: string
+        x-ms-client-flatten: true
+  NameIdentifier:
+    description: Identifies an object
+    type: object
+    properties:
+      name:
+        description: Name of the object
+        type: string
+  DomainAvailablilityCheckResult:
+    description: Domain availablility check result
+    type: object
+    properties:
+      name:
+        description: Name of the domain
+        type: string
+      available:
+        description: If true then domain can be purchased using CreateDomain Api
+        type: boolean
+      domainType:
+        description: Domain type
+        enum:
+          - Regular
+          - SoftDeleted
+        type: string
+        x-ms-enum:
+          name: DomainType
+          modelAsString: false
+  DomainRecommendationSearchParameters:
+    description: Domain recommendation search parameters
+    type: object
+    properties:
+      keywords:
+        description: Keywords to be used for generating domain recommendations
+        type: string
+      maxDomainRecommendations:
+        format: int32
+        description: Maximum number of recommendations
+        type: integer
+  NameIdentifierCollection:
+    description: Collection of domain name identifiers
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/NameIdentifier'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  CsmMoveResourceEnvelope:
+    description: >-
+      Class containing a list of the resources that need to be moved and the
+      resource group they should be moved to
+    type: object
+    properties:
+      targetResourceGroup:
+        type: string
+      resources:
+        type: array
+        items:
+          type: string
+  HostingEnvironmentDiagnostics:
+    description: Diagnostics for a hosting environment (App Service Environment)
+    type: object
+    properties:
+      name:
+        description: Name/identifier of the diagnostics
+        type: string
+      diagnosicsOutput:
+        description: Diagnostics output
+        type: string
+  StampCapacityCollection:
+    description: Collection of stamp capacities
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/StampCapacity'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  AddressResponse:
+    description: Describes main public ip address and any extra vips
+    type: object
+    properties:
+      serviceIpAddress:
+        description: Main public vip
+        type: string
+      internalIpAddress:
+        description: >-
+          VNET internal ip address of the hostingEnvironment (App Service
+          Environment) if it is in internal load-balancing mode
+        type: string
+      outboundIpAddresses:
+        description: IP addresses appearing on outbound connections
+        type: array
+        items:
+          type: string
+      vipMappings:
+        description: Additional vips
+        type: array
+        items:
+          $ref: '#/definitions/VirtualIPMapping'
+  ResourceMetricCollection:
+    description: Collection of metric responses
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/ResourceMetric'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  ResourceMetric:
+    description: Object representing a metric for any resource
+    type: object
+    properties:
+      name:
+        $ref: '#/definitions/ResourceMetricName'
+        description: Name of metric
+      unit:
+        description: Metric unit
+        type: string
+      timeGrain:
+        description: 'Metric granularity. E.g PT1H, PT5M, P1D'
+        type: string
+      startTime:
+        format: date-time
+        description: Metric start time
+        type: string
+      endTime:
+        format: date-time
+        description: Metric end time
+        type: string
+      resourceId:
+        description: Metric resource Id
+        type: string
+      metricValues:
+        description: Metric values
+        type: array
+        items:
+          $ref: '#/definitions/ResourceMetricValue'
+      properties:
+        description: Properties
+        type: array
+        items:
+          $ref: '#/definitions/KeyValuePair[String,String]'
+  ResourceMetricName:
+    description: Name of a metric for any resource
+    type: object
+    properties:
+      value:
+        description: metric name value
+        type: string
+      localizedValue:
+        description: Localized metric name value
+        type: string
+  ResourceMetricValue:
+    description: Value of resource metric
+    type: object
+    properties:
+      timeStamp:
+        description: Value timestamp
+        type: string
+      average:
+        format: float
+        description: Value average
+        type: number
+      minimum:
+        format: float
+        description: Value minimum
+        type: number
+      maximum:
+        format: float
+        description: Value maximum
+        type: number
+      total:
+        format: float
+        description: Value total
+        type: number
+      count:
+        format: float
+        description: Value count
+        type: number
+  'KeyValuePair[String,String]':
+    type: object
+    properties:
+      key:
+        type: string
+        readOnly: true
+      value:
+        type: string
+        readOnly: true
+  MetricDefinition:
+    description: Class repesenting metadata for the metrics
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Name of the metric
+            type: string
+          unit:
+            description: Unit of the metric
+            type: string
+          primaryAggregationType:
+            description: Primary aggregation type
+            type: string
+          metricAvailabilities:
+            description: >-
+              List of time grains supported for the metric together with
+              retention period
+            type: array
+            items:
+              $ref: '#/definitions/MetricAvailabilily'
+          displayName:
+            description: Friendly name shown in the UI
+            type: string
+        x-ms-client-flatten: true
+  MetricAvailabilily:
+    description: Class repesenting metrics availability and retention
+    type: object
+    properties:
+      timeGrain:
+        description: Time grain
+        type: string
+      retention:
+        description: >-
+          Retention period for the current
+          {Microsoft.Web.Hosting.Administration.MetricAvailabilily.TimeGrain}
+        type: string
+  CsmUsageQuotaCollection:
+    description: Collection of csm usage quotas
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/CsmUsageQuota'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  CsmUsageQuota:
+    description: Usage of the quota resource
+    type: object
+    properties:
+      unit:
+        description: Units of measurement for the quota resourse
+        type: string
+      nextResetTime:
+        format: date-time
+        description: Next reset time for the resource counter
+        type: string
+      currentValue:
+        format: int64
+        description: The current value of the resource counter
+        type: integer
+      limit:
+        format: int64
+        description: The resource limit
+        type: integer
+      name:
+        $ref: '#/definitions/LocalizableString'
+        description: Quota name
+  LocalizableString:
+    description: LocalizableString object containing the name and a localized value.
+    type: object
+    properties:
+      value:
+        description: Non localized name
+        type: string
+      localizedValue:
+        description: Localized name
+        type: string
+  MetricDefinitionCollection:
+    description: Collection of metric defintions
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/MetricDefinition'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  UsageCollection:
+    description: Collection of usages
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/Usage'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  Usage:
+    description: Class that represents usage of the quota resource.
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          displayName:
+            description: Friendly name shown in the UI
+            type: string
+          name:
+            description: Name of the quota
+            type: string
+          resourceName:
+            description: Name of the quota resource
+            type: string
+          unit:
+            description: Units of measurement for the quota resource
+            type: string
+          currentValue:
+            format: int64
+            description: The current value of the resource counter
+            type: integer
+          limit:
+            format: int64
+            description: The resource limit
+            type: integer
+          nextResetTime:
+            format: date-time
+            description: Next reset time for the resource counter
+            type: string
+          computeMode:
+            description: ComputeMode used for this usage
+            enum:
+              - Shared
+              - Dedicated
+              - Dynamic
+            type: string
+            x-ms-enum:
+              name: ComputeModeOptions
+              modelAsString: false
+          siteMode:
+            description: SiteMode used for this usage
+            type: string
+        x-ms-client-flatten: true
+  WorkerPoolCollection:
+    description: Collection of worker pools
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/WorkerPool'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  SkuInfoCollection:
+    description: Collection of SkuInfos
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/SkuInfo'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  SkuInfo:
+    description: Sku discovery information
+    type: object
+    properties:
+      resourceType:
+        description: Resource type that this sku applies to
+        type: string
+      sku:
+        $ref: '#/definitions/SkuDescription'
+        description: Name and tier of the sku
+      capacity:
+        $ref: '#/definitions/SkuCapacity'
+        description: 'Min, max, and default scale values of the sku'
+  SkuCapacity:
+    description: Description of the App Service Plan scale options
+    type: object
+    properties:
+      minimum:
+        format: int32
+        description: Minimum number of Workers for this App Service Plan SKU
+        type: integer
+      maximum:
+        format: int32
+        description: Maximum number of Workers for this App Service Plan SKU
+        type: integer
+      default:
+        format: int32
+        description: Default number of Workers for this App Service Plan SKU
+        type: integer
+      scaleType:
+        description: Available scale configurations for an App Service Plan
+        type: string
+  SourceControlCollection:
+    description: Collection of soure controls
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/SourceControl'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  SourceControl:
+    description: Describes the Source Control OAuth Token
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Name or Source Control Type
+            type: string
+          token:
+            description: OAuth Access Token
+            type: string
+          tokenSecret:
+            description: OAuth Access Token Secret
+            type: string
+          refreshToken:
+            description: OAuth Refresh Token
+            type: string
+          expirationTime:
+            format: date-time
+            description: OAuth Token Expiration
+            type: string
+        x-ms-client-flatten: true
+  Recommendation:
+    description: Represents a recommendation result generated by the recommendation engine
+    required:
+      - level
+      - channels
+    type: object
+    properties:
+      creationTime:
+        format: date-time
+        description: Timestamp when this instance was created.
+        type: string
+      recommendationId:
+        description: A GUID value that each recommendation object is associated with.
+        type: string
+      resourceId:
+        description: >-
+          Full ARM resource ID string that this recommendation object is
+          associated with.
+        type: string
+      resourceScope:
+        description: >-
+          Name of a resource type this recommendation applies, e.g.
+          Subscription, ServerFarm, Site.
+        type: string
+      ruleName:
+        description: Unique name of the rule
+        type: string
+      displayName:
+        description: UI friendly name of the rule (may not be unique)
+        type: string
+      message:
+        description: 'Localized text of recommendation, good for UI.'
+        type: string
+      level:
+        description: Level indicating how critical this recommendation can impact.
+        enum:
+          - Critical
+          - Warning
+          - Information
+          - NonUrgentSuggestion
+        type: string
+        x-ms-enum:
+          name: NotificationLevel
+          modelAsString: false
+      channels:
+        description: List of channels that this recommendation can apply.
+        enum:
+          - Notification
+          - Api
+          - Email
+          - All
+        type: string
+        x-ms-enum:
+          name: Channels
+          modelAsString: false
+      tags:
+        description: The list of category tags that this recommendation belongs to.
+        type: array
+        items:
+          type: string
+      actionName:
+        description: Name of action recommended by this object.
+        type: string
+      enabled:
+        format: int32
+        description: On/off flag indicating the rule is currently enabled or disabled.
+        type: integer
+      startTime:
+        format: date-time
+        description: The beginning time of a range that the recommendation refers to.
+        type: string
+      endTime:
+        format: date-time
+        description: The end time of a range that the recommendation refers to.
+        type: string
+      nextNotificationTime:
+        format: date-time
+        description: >-
+          When to notify this recommendation next. Null means that this will
+          never be notified anymore.
+        type: string
+      notificationExpirationTime:
+        format: date-time
+        description: Date and time when this notification expires.
+        type: string
+      notifiedTime:
+        format: date-time
+        description: >-
+          Last timestamp this instance was actually notified. Null means that
+          this recommendation hasn't been notified yet.
+        type: string
+      score:
+        format: double
+        description: A metric value measured by the rule.
+        type: number
+  RecommendationRule:
+    description: >-
+      Represents a recommendation rule that the recommendation engine can
+      perform
+    required:
+      - level
+      - channels
+    type: object
+    properties:
+      name:
+        description: Unique name of the rule
+        type: string
+      displayName:
+        description: UI friendly name of the rule
+        type: string
+      message:
+        description: Localized name of the rule (Good for UI)
+        type: string
+      recommendationId:
+        description: "Recommendation ID of an associated recommendation object tied to the rule, if exists.\r\n            If such an object doesn't exist, it is set to null."
+        type: string
+      description:
+        description: Localized detailed description of the rule
+        type: string
+      actionName:
+        description: Name of action that is recommended by this rule in string
+        type: string
+      enabled:
+        format: int32
+        description: On/off flag indicating the rule is currently enabled or disabled.
+        type: integer
+      level:
+        description: Level of impact indicating how critical this rule is.
+        enum:
+          - Critical
+          - Warning
+          - Information
+          - NonUrgentSuggestion
+        type: string
+        x-ms-enum:
+          name: NotificationLevel
+          modelAsString: false
+      channels:
+        description: List of available channels that this rule applies.
+        enum:
+          - Notification
+          - Api
+          - Email
+          - All
+        type: string
+        x-ms-enum:
+          name: Channels
+          modelAsString: false
+      tags:
+        description: An array of category tags that the rule contains.
+        type: array
+        items:
+          type: string
+  VnetInfo:
+    description: >-
+      VNETInfo contract. This contract is public and is a stripped down version
+      of VNETInfoInternal
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          vnetResourceId:
+            description: The vnet resource id
+            type: string
+          certThumbprint:
+            description: The client certificate thumbprint
+            type: string
+          certBlob:
+            description: "A certificate file (.cer) blob containing the public key of the private key used to authenticate a \r\n            Point-To-Site VPN connection."
+            type: string
+          routes:
+            description: The routes that this virtual network connection uses.
+            type: array
+            items:
+              $ref: '#/definitions/VnetRoute'
+          resyncRequired:
+            description: Flag to determine if a resync is required
+            type: boolean
+          dnsServers:
+            description: >-
+              Dns servers to be used by this VNET. This should be a
+              comma-separated list of IP addresses.
+            type: string
+        x-ms-client-flatten: true
+  VnetRoute:
+    description: VnetRoute contract used to pass routing information for a vnet.
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: >-
+              The name of this route. This is only returned by the server and
+              does not need to be set by the client.
+            type: string
+          startAddress:
+            description: >-
+              The starting address for this route. This may also include a CIDR
+              notation, in which case the end address must not be specified.
+            type: string
+          endAddress:
+            description: >-
+              The ending address for this route. If the start address is
+              specified in CIDR notation, this must be omitted.
+            type: string
+          routeType:
+            description: "The type of route this is:\r\n            DEFAULT - By default, every web app has routes to the local address ranges specified by RFC1918\r\n            INHERITED - Routes inherited from the real Virtual Network routes\r\n            STATIC - Static route set on the web app only\r\n            \r\n            These values will be used for syncing a Web App's routes with those from a Virtual Network. This operation will clear all DEFAULT and INHERITED routes and replace them\r\n            with new INHERITED routes."
+            type: string
+        x-ms-client-flatten: true
+  VnetGateway:
+    description: >-
+      The VnetGateway contract. This is used to give the vnet gateway access to
+      the VPN package.
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          vnetName:
+            description: The VNET name.
+            type: string
+          vpnPackageUri:
+            description: The URI where the Vpn package can be downloaded
+            type: string
+        x-ms-client-flatten: true
+  NetworkFeatures:
+    description: "This is an object used to store a full view of network features (presently VNET integration and Hybrid Connections)\r\n            for a web app."
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          virtualNetworkName:
+            description: The Vnet Name
+            type: string
+          virtualNetworkConnection:
+            $ref: '#/definitions/VnetInfo'
+            description: The Vnet Summary view
+          hybridConnections:
+            description: The Hybrid Connections Summary view
+            type: array
+            items:
+              $ref: '#/definitions/RelayServiceConnectionEntity'
+        x-ms-client-flatten: true
+  RelayServiceConnectionEntity:
+    description: Class that represents a Biztalk Hybrid Connection
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          entityName:
+            type: string
+          entityConnectionString:
+            type: string
+          resourceType:
+            type: string
+          resourceConnectionString:
+            type: string
+          hostname:
+            type: string
+          port:
+            format: int32
+            type: integer
+          biztalkUri:
+            type: string
+        x-ms-client-flatten: true
+  CsmSlotEntity:
+    description: Class containing deployment slot parameters
+    type: object
+    properties:
+      targetSlot:
+        description: Set the destination deployment slot during swap operation
+        type: string
+      preserveVnet:
+        description: >-
+          Get or set the flag indicating it should preserve VNet to the slot
+          during swap
+        type: boolean
+  SlotDifferenceCollection:
+    description: Collection of Slot Differences
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/SlotDifference'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  SlotDifference:
+    description: >-
+      An object describing the difference in setting values between two web app
+      slots
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          type:
+            description: >-
+              Indicates the type of the difference: Information, Warning or
+              Error.
+            type: string
+          settingType:
+            description: 'The type of the settings: General, AppSetting or ConnectionString'
+            type: string
+          diffRule:
+            description: >-
+              Rule that describes how to process the difference in settings
+              during web app slot swap.
+            type: string
+          settingName:
+            description: Name of the setting
+            type: string
+          valueInCurrentSlot:
+            description: Value of the setting in the current web app slot
+            type: string
+          valueInTargetSlot:
+            description: Value of the setting in the target web app slot
+            type: string
+          description:
+            description: Description of the difference
+            type: string
+        x-ms-client-flatten: true
+  SlotConfigNamesResource:
+    description: Slot Config names azure resource
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          connectionStringNames:
+            description: List of connection string names
+            type: array
+            items:
+              type: string
+          appSettingNames:
+            description: List of application settings names
+            type: array
+            items:
+              type: string
+        x-ms-client-flatten: true
+  SlotConfigNames:
+    description: "Class containing names for connection strings and application settings to be marked as sticky to the slot \r\n            and not moved during swap operation\r\n            This is valid for all deployment slots under the site"
+    type: object
+    properties:
+      connectionStringNames:
+        description: List of connection string names
+        type: array
+        items:
+          type: string
+      appSettingNames:
+        description: List of application settings names
+        type: array
+        items:
+          type: string
+  SiteCloneability:
+    description: Represents whether or not a web app is cloneable
+    required:
+      - result
+    type: object
+    properties:
+      result:
+        description: Name of web app
+        enum:
+          - Cloneable
+          - PartiallyCloneable
+          - NotCloneable
+        type: string
+        x-ms-enum:
+          name: CloneAbilityResult
+          modelAsString: false
+      blockingFeatures:
+        description: List of features enabled on web app that prevent cloning
+        type: array
+        items:
+          $ref: '#/definitions/SiteCloneabilityCriterion'
+      unsupportedFeatures:
+        description: "List of features enabled on web app that are non-blocking but cannot be cloned. The web app can still be cloned\r\n            but the features in this list will not be set up on cloned web app."
+        type: array
+        items:
+          $ref: '#/definitions/SiteCloneabilityCriterion'
+      blockingCharacteristics:
+        description: List of blocking application characteristics
+        type: array
+        items:
+          $ref: '#/definitions/SiteCloneabilityCriterion'
+  SiteCloneabilityCriterion:
+    description: Represents a site cloneability criterion
+    type: object
+    properties:
+      name:
+        description: Name of criterion
+        type: string
+      description:
+        description: Description of criterion
+        type: string
+  CsmSiteRecoveryEntity:
+    description: Class containting details about site recovery operation.
+    type: object
+    properties:
+      snapshotTime:
+        format: date-time
+        description: Point in time in which the site recover should be attempted.
+        type: string
+      recoverConfig:
+        description: >-
+          If true, then the website's configuration will be reverted to its
+          state at SnapshotTime
+        type: boolean
+      siteName:
+        description: >-
+          [Optional] Destination web app name into which web app should be
+          recovered. This is case when new web app should be created instead.
+        type: string
+      slotName:
+        description: >-
+          [Optional] Destination web app slot name into which web app should be
+          recovered
+        type: string
+  DeletedSiteCollection:
+    description: Collection of deleted sites
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/DeletedSite'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  DeletedSite:
+    description: Reports deleted site including the timestamp of operation
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - usageState
+          - availabilityState
+        properties:
+          deletedTimestamp:
+            format: date-time
+            description: Time when the site was deleted
+            type: string
+          name:
+            description: Name of web app
+            type: string
+          state:
+            description: State of the web app
+            type: string
+            readOnly: true
+          hostNames:
+            description: Hostnames associated with web app
+            type: array
+            items:
+              type: string
+            readOnly: true
+          repositorySiteName:
+            description: Name of repository site
+            type: string
+            readOnly: true
+          usageState:
+            description: State indicating whether web app has exceeded its quota usage
+            enum:
+              - Normal
+              - Exceeded
+            type: string
+            readOnly: true
+            x-ms-enum:
+              name: UsageState
+              modelAsString: false
+          enabled:
+            description: >-
+              True if the site is enabled; otherwise, false. Setting this  value
+              to false disables the site (takes the site off line).
+            type: boolean
+          enabledHostNames:
+            description: "Hostnames for the web app that are enabled. Hostnames need to be assigned and enabled. If some hostnames are assigned but not enabled\r\n            the app is not served on those hostnames"
+            type: array
+            items:
+              type: string
+            readOnly: true
+          availabilityState:
+            description: "Management information availability state for the web app. Possible values are Normal or Limited. \r\n            Normal means that the site is running correctly and that management information for the site is available. \r\n            Limited means that only partial management information for the site is available and that detailed site information is unavailable."
+            enum:
+              - Normal
+              - Limited
+              - DisasterRecoveryMode
+            type: string
+            readOnly: true
+            x-ms-enum:
+              name: SiteAvailabilityState
+              modelAsString: false
+          hostNameSslStates:
+            description: >-
+              Hostname SSL states are  used to manage the SSL bindings for
+              site's hostnames.
+            type: array
+            items:
+              $ref: '#/definitions/HostNameSslState'
+          serverFarmId:
+            type: string
+          lastModifiedTimeUtc:
+            format: date-time
+            description: Last time web app was modified in UTC
+            type: string
+            readOnly: true
+          siteConfig:
+            $ref: '#/definitions/SiteConfig'
+            description: Configuration of web app
+          trafficManagerHostNames:
+            description: >-
+              Read-only list of Azure Traffic manager hostnames associated with
+              web app
+            type: array
+            items:
+              type: string
+            readOnly: true
+          premiumAppDeployed:
+            description: If set indicates whether web app is deployed as a premium app
+            type: boolean
+            readOnly: true
+          scmSiteAlsoStopped:
+            description: >-
+              If set indicates whether to stop SCM (KUDU) site when the web app
+              is stopped. Default is false.
+            type: boolean
+          targetSwapSlot:
+            description: >-
+              Read-only property that specifies which slot this app will swap
+              into
+            type: string
+            readOnly: true
+          hostingEnvironmentProfile:
+            $ref: '#/definitions/HostingEnvironmentProfile'
+            description: >-
+              Specification for the hosting environment (App Service
+              Environment) to use for the web app
+          microService:
+            description: ''
+            type: string
+          gatewaySiteName:
+            description: Name of gateway app associated with web app
+            type: string
+          clientAffinityEnabled:
+            description: >-
+              Specifies if the client affinity is enabled when load balancing
+              http request for multiple instances of the web app
+            type: boolean
+          clientCertEnabled:
+            description: Specifies if the client certificate is enabled for the web app
+            type: boolean
+          hostNamesDisabled:
+            description: "Specifies if the public hostnames are disabled the web app.\r\n            If set to true the app is only accessible via API Management process"
+            type: boolean
+          outboundIpAddresses:
+            description: >-
+              List of comma separated IP addresses that this web app uses for
+              outbound connections. Those can be used when configuring firewall
+              rules for databases accessed by this web app.
+            type: string
+            readOnly: true
+          containerSize:
+            format: int32
+            description: Size of a function container
+            type: integer
+          maxNumberOfWorkers:
+            format: int32
+            description: "Maximum number of workers\r\n            This only applies to function container"
+            type: integer
+          cloningInfo:
+            $ref: '#/definitions/CloningInfo'
+            description: "This is only valid for web app creation. If specified, web app is cloned from \r\n            a source web app"
+          resourceGroup:
+            description: Resource group web app belongs to
+            type: string
+            readOnly: true
+          isDefaultContainer:
+            description: Site is a default container
+            type: boolean
+            readOnly: true
+          defaultHostName:
+            description: Default hostname of the web app
+            type: string
+            readOnly: true
+        x-ms-client-flatten: true
+  DeploymentCollection:
+    description: Collection of app deployments
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/Deployment'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  Deployment:
+    description: Represents user crendentials used for publishing activity
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          id:
+            description: Id
+            type: string
+          status:
+            format: int32
+            description: Status
+            type: integer
+          message:
+            description: Message
+            type: string
+          author:
+            description: Author
+            type: string
+          deployer:
+            description: Deployer
+            type: string
+          author_email:
+            description: AuthorEmail
+            type: string
+          start_time:
+            format: date-time
+            description: StartTime
+            type: string
+          end_time:
+            format: date-time
+            description: EndTime
+            type: string
+          active:
+            description: Active
+            type: boolean
+          details:
+            description: Detail
+            type: string
+        x-ms-client-flatten: true
+  SiteInstanceCollection:
+    description: Collection of site instances
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/SiteInstance'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  SiteInstance:
+    description: Instance of a web app
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Name of instance
+            type: string
+        x-ms-client-flatten: true
+  HostNameBindingCollection:
+    description: Collection of host name bindings
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/HostNameBinding'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  HostNameBinding:
+    description: A host name binding object
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Hostname
+            type: string
+          siteName:
+            description: Web app name
+            type: string
+          domainId:
+            description: Fully qualified ARM domain resource URI
+            type: string
+          azureResourceName:
+            description: Azure resource name
+            type: string
+          azureResourceType:
+            description: Azure resource type
+            enum:
+              - Website
+              - TrafficManager
+            type: string
+            x-ms-enum:
+              name: AzureResourceType
+              modelAsString: false
+          customHostNameDnsRecordType:
+            description: Custom DNS record type
+            enum:
+              - CName
+              - A
+            type: string
+            x-ms-enum:
+              name: CustomHostNameDnsRecordType
+              modelAsString: false
+          hostNameType:
+            description: Host name type
+            enum:
+              - Verified
+              - Managed
+            type: string
+            x-ms-enum:
+              name: HostNameType
+              modelAsString: false
+        x-ms-client-flatten: true
+  SiteSourceControl:
+    description: Describes the source control configuration for web app
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          repoUrl:
+            description: Repository or source control url
+            type: string
+          branch:
+            description: Name of branch to use for deployment
+            type: string
+          isManualIntegration:
+            description: Whether to manual or continuous integration
+            type: boolean
+          deploymentRollbackEnabled:
+            description: Whether to manual or continuous integration
+            type: boolean
+          isMercurial:
+            description: Mercurial or Git repository type
+            type: boolean
+        x-ms-client-flatten: true
+  StringDictionary:
+    description: String dictionary resource
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        description: Settings
+        type: object
+        additionalProperties:
+          type: string
+        x-ms-client-flatten: true
+  ConnectionStringDictionary:
+    description: String dictionary resource
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        description: Connection strings
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/ConnStringValueTypePair'
+        x-ms-client-flatten: true
+  ConnStringValueTypePair:
+    description: Database connection string value to type pair
+    required:
+      - type
+    type: object
+    properties:
+      value:
+        description: Value of pair
+        type: string
+      type:
+        description: Type of database
+        enum:
+          - MySql
+          - SQLServer
+          - SQLAzure
+          - Custom
+        type: string
+        x-ms-enum:
+          name: DatabaseServerType
+          modelAsString: false
+  SiteLogsConfig:
+    description: Configuration of Azure web site
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          applicationLogs:
+            $ref: '#/definitions/ApplicationLogsConfig'
+            description: Application logs configuration
+          httpLogs:
+            $ref: '#/definitions/HttpLogsConfig'
+            description: Http logs configuration
+          failedRequestsTracing:
+            $ref: '#/definitions/EnabledConfig'
+            description: Failed requests tracing configuration
+          detailedErrorMessages:
+            $ref: '#/definitions/EnabledConfig'
+            description: Detailed error messages configuration
+        x-ms-client-flatten: true
+  ApplicationLogsConfig:
+    description: Application logs configuration
+    type: object
+    properties:
+      fileSystem:
+        $ref: '#/definitions/FileSystemApplicationLogsConfig'
+        description: Application logs to file system configuration
+      azureTableStorage:
+        $ref: '#/definitions/AzureTableStorageApplicationLogsConfig'
+        description: Application logs to azure table storage configuration
+      azureBlobStorage:
+        $ref: '#/definitions/AzureBlobStorageApplicationLogsConfig'
+        description: Application logs to blob storage configuration
+  HttpLogsConfig:
+    description: Http logs configuration
+    type: object
+    properties:
+      fileSystem:
+        $ref: '#/definitions/FileSystemHttpLogsConfig'
+        description: Http logs to file system configuration
+      azureBlobStorage:
+        $ref: '#/definitions/AzureBlobStorageHttpLogsConfig'
+        description: Http logs to azure blob storage configuration
+  EnabledConfig:
+    description: Enabled configuration
+    type: object
+    properties:
+      enabled:
+        description: Enabled
+        type: boolean
+  FileSystemApplicationLogsConfig:
+    description: Application logs to file system configuration
+    type: object
+    properties:
+      level:
+        description: Log level
+        enum:
+          - 'Off'
+          - Verbose
+          - Information
+          - Warning
+          - Error
+        type: string
+        x-ms-enum:
+          name: LogLevel
+          modelAsString: false
+  AzureTableStorageApplicationLogsConfig:
+    description: Application logs to azure table storage configuration
+    type: object
+    properties:
+      level:
+        description: Log level
+        enum:
+          - 'Off'
+          - Verbose
+          - Information
+          - Warning
+          - Error
+        type: string
+        x-ms-enum:
+          name: LogLevel
+          modelAsString: false
+      sasUrl:
+        description: SAS url to an azure table with add/query/delete permissions
+        type: string
+  AzureBlobStorageApplicationLogsConfig:
+    description: Application logs azure blob storage configuration
+    type: object
+    properties:
+      level:
+        description: Log level
+        enum:
+          - 'Off'
+          - Verbose
+          - Information
+          - Warning
+          - Error
+        type: string
+        x-ms-enum:
+          name: LogLevel
+          modelAsString: false
+      sasUrl:
+        description: >-
+          SAS url to a azure blob container with read/write/list/delete
+          permissions
+        type: string
+      retentionInDays:
+        format: int32
+        description: "Retention in days.\r\n            Remove blobs older than X days.\r\n            0 or lower means no retention."
+        type: integer
+  FileSystemHttpLogsConfig:
+    description: Http logs to file system configuration
+    type: object
+    properties:
+      retentionInMb:
+        format: int32
+        description: "Maximum size in megabytes that http log files can use.\r\n            When reached old log files will be removed to make space for new ones.\r\n            Value can range between 25 and 100."
+        type: integer
+      retentionInDays:
+        format: int32
+        description: "Retention in days.\r\n            Remove files older than X days.\r\n            0 or lower means no retention."
+        type: integer
+      enabled:
+        description: Enabled
+        type: boolean
+  AzureBlobStorageHttpLogsConfig:
+    description: Http logs to azure blob storage configuration
+    type: object
+    properties:
+      sasUrl:
+        description: >-
+          SAS url to a azure blob container with read/write/list/delete
+          permissions
+        type: string
+      retentionInDays:
+        format: int32
+        description: "Retention in days.\r\n            Remove blobs older than X days.\r\n            0 or lower means no retention."
+        type: integer
+      enabled:
+        description: Enabled
+        type: boolean
+  PremierAddOnRequest:
+    type: object
+    properties:
+      location:
+        description: 'Geo region resource belongs to e.g. SouthCentralUS, SouthEastAsia'
+        type: string
+      tags:
+        description: Tags associated with resource
+        type: object
+        additionalProperties:
+          type: string
+      plan:
+        $ref: '#/definitions/ArmPlan'
+        description: Azure resource manager plan
+      properties:
+        $ref: '#/definitions/Object'
+        description: Resource specific properties
+      sku:
+        $ref: '#/definitions/SkuDescription'
+        description: Sku description of the resource
+  BackupRequest:
+    description: Description of a backup which will be performed
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - type
+        properties:
+          name:
+            description: Name of the backup
+            type: string
+          enabled:
+            description: >-
+              True if the backup schedule is enabled (must be included in that
+              case), false if the backup schedule should be disabled
+            type: boolean
+          storageAccountUrl:
+            description: SAS URL to the container
+            type: string
+          backupSchedule:
+            $ref: '#/definitions/BackupSchedule'
+            description: Schedule for the backup if it is executed periodically
+          databases:
+            description: Databases included in the backup
+            type: array
+            items:
+              $ref: '#/definitions/DatabaseBackupSetting'
+          type:
+            description: Type of the backup
+            enum:
+              - Default
+              - Clone
+              - Relocation
+            type: string
+            x-ms-enum:
+              name: BackupRestoreOperationType
+              modelAsString: false
+        x-ms-client-flatten: true
+  BackupSchedule:
+    description: >-
+      Description of a backup schedule. Describes how often should be the backup
+      performed and what should be the retention policy.
+    required:
+      - frequencyUnit
+    type: object
+    properties:
+      frequencyInterval:
+        format: int32
+        description: >-
+          How often should be the backup executed (e.g. for weekly backup, this
+          should be set to 7 and FrequencyUnit should be set to Day)
+        type: integer
+      frequencyUnit:
+        description: >-
+          How often should be the backup executed (e.g. for weekly backup, this
+          should be set to Day and FrequencyInterval should be set to 7)
+        enum:
+          - Day
+          - Hour
+        type: string
+        x-ms-enum:
+          name: FrequencyUnit
+          modelAsString: false
+      keepAtLeastOneBackup:
+        description: >-
+          True if the retention policy should always keep at least one backup in
+          the storage account, regardless how old it is; false otherwise.
+        type: boolean
+      retentionPeriodInDays:
+        format: int32
+        description: After how many days backups should be deleted
+        type: integer
+      startTime:
+        format: date-time
+        description: When the schedule should start working
+        type: string
+      lastExecutionTime:
+        format: date-time
+        description: The last time when this schedule was triggered
+        type: string
+  DatabaseBackupSetting:
+    description: "Note: properties are serialized in JSON format and stored in DB. \r\n            if new properties are added they might not be in the previous data rows \r\n            so please handle nulls"
+    type: object
+    properties:
+      databaseType:
+        description: SqlAzure / MySql
+        type: string
+      name:
+        type: string
+      connectionStringName:
+        description: "Contains a connection string name that is linked to the SiteConfig.ConnectionStrings.\r\n            This is used during restore with overwrite connection strings options."
+        type: string
+      connectionString:
+        description: >-
+          Contains a connection string to a database which is being backed
+          up/restored. If the restore should happen to a new database, the
+          database name inside is the new one.
+        type: string
+  BackupItem:
+    description: Backup description
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - status
+        properties:
+          id:
+            format: int32
+            description: Id of the backup.
+            type: integer
+          storageAccountUrl:
+            description: >-
+              SAS URL for the storage account container which contains this
+              backup
+            type: string
+          blobName:
+            description: Name of the blob which contains data for this backup
+            type: string
+          name:
+            description: Name of this backup
+            type: string
+          status:
+            description: Backup status
+            enum:
+              - InProgress
+              - Failed
+              - Succeeded
+              - TimedOut
+              - Created
+              - Skipped
+              - PartiallySucceeded
+              - DeleteInProgress
+              - DeleteFailed
+              - Deleted
+            type: string
+            x-ms-enum:
+              name: BackupItemStatus
+              modelAsString: false
+          sizeInBytes:
+            format: int64
+            description: Size of the backup in bytes
+            type: integer
+          created:
+            format: date-time
+            description: Timestamp of the backup creation
+            type: string
+          log:
+            description: Details regarding this backup. Might contain an error message.
+            type: string
+          databases:
+            description: List of databases included in the backup
+            type: array
+            items:
+              $ref: '#/definitions/DatabaseBackupSetting'
+          scheduled:
+            description: >-
+              True if this backup has been created due to a schedule being
+              triggered.
+            type: boolean
+          lastRestoreTimeStamp:
+            format: date-time
+            description: Timestamp of a last restore operation which used this backup.
+            type: string
+          finishedTimeStamp:
+            format: date-time
+            description: Timestamp when this backup finished.
+            type: string
+          correlationId:
+            description: >-
+              Unique correlation identifier. Please use this along with the
+              timestamp while communicating with Azure support.
+            type: string
+          websiteSizeInBytes:
+            format: int64
+            description: Size of the original web app which has been backed up
+            type: integer
+        x-ms-client-flatten: true
+  RestoreRequest:
+    description: Description of a restore request
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        required:
+          - operationType
+        properties:
+          storageAccountUrl:
+            description: SAS URL to the container
+            type: string
+          blobName:
+            description: Name of a blob which contains the backup
+            type: string
+          overwrite:
+            description: >-
+              True if the restore operation can overwrite target site. "True"
+              needed if trying to restore over an existing site.
+            type: boolean
+          siteName:
+            description: Name of a site (Web App)
+            type: string
+          databases:
+            description: >-
+              Collection of databses which should be restored. This list has to
+              match the list of databases included in the backup.
+            type: array
+            items:
+              $ref: '#/definitions/DatabaseBackupSetting'
+          ignoreConflictingHostNames:
+            description: "Changes a logic when restoring a site with custom domains. If \"true\", custom domains are removed automatically. If \"false\", custom domains are added to \r\n            the site object when it is being restored, but that might fail due to conflicts during the operation."
+            type: boolean
+          operationType:
+            description: Operation type
+            enum:
+              - Default
+              - Clone
+              - Relocation
+            type: string
+            x-ms-enum:
+              name: BackupRestoreOperationType
+              modelAsString: false
+          adjustConnectionStrings:
+            description: >-
+              Gets or sets a flag showing if SiteConfig.ConnectionStrings should
+              be set in new site
+            type: boolean
+          hostingEnvironment:
+            description: >-
+              App Service Environment name, if needed (only when restoring a
+              site to an App Service Environment)
+            type: string
+        x-ms-client-flatten: true
+  BackupItemCollection:
+    description: Collection of Backup Items
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/BackupItem'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  RestoreResponse:
+    description: Response for a restore site request
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          operationId:
+            description: >-
+              When server starts the restore process, it will return an
+              OperationId identifying that particular restore operation
+            type: string
+        x-ms-client-flatten: true
+  CsmPublishingProfileOptions:
+    description: Publishing options for requested profile
+    type: object
+    properties:
+      format:
+        description: "Name of the format. Valid values are: \r\n            FileZilla3\r\n            WebDeploy -- default\r\n            Ftp"
+        type: string
+  TopLevelDomainCollection:
+    description: Collection of Top Level Domains
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/TopLevelDomain'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  TopLevelDomain:
+    description: A top level domain object
+    type: object
+    allOf:
+      - $ref: '#/definitions/Resource'
+    properties:
+      properties:
+        properties:
+          name:
+            description: Name of the top level domain
+            type: string
+          privacy:
+            description: If true then the top level domain supports domain privacy
+            type: boolean
+        x-ms-client-flatten: true
+  TopLevelDomainAgreementOption:
+    description: Options for retrieving the list of top level domain legal agreements
+    type: object
+    properties:
+      includePrivacy:
+        description: >-
+          If true then the list of agreements will inclue agreements for domain
+          privacy as well.
+        type: boolean
+  TldLegalAgreementCollection:
+    description: Collection of Tld Legal Agreements
+    type: object
+    properties:
+      value:
+        description: Collection of resources
+        type: array
+        items:
+          $ref: '#/definitions/TldLegalAgreement'
+      nextLink:
+        description: Link to next page of resources
+        type: string
+  TldLegalAgreement:
+    description: Represents a legal agreement for top level domain
+    type: object
+    properties:
+      agreementKey:
+        description: Unique identifier for the agreement
+        type: string
+      title:
+        description: Agreement title
+        type: string
+      content:
+        description: Agreement details
+        type: string
+      url:
+        description: Url where a copy of the agreement details is hosted
+        type: string
+  Resource:
+    required:
+      - location
+    properties:
+      id:
+        description: Resource Id
+        type: string
+      name:
+        description: Resource Name
+        type: string
+      kind:
+        description: Kind of resource
+        type: string
+      location:
+        description: Resource Location
+        type: string
+      type:
+        description: Resource type
+        type: string
+      tags:
+        description: Resource tags
+        type: object
+        additionalProperties:
+          type: string
+    x-ms-azure-resource: true
+parameters:
+  subscriptionIdParameter:
+    name: subscriptionId
+    in: path
+    description: Subscription Id
+    required: true
+    type: string
+  apiVersionParameter:
+    name: api-version
+    in: query
+    description: API Version
+    required: true
+    type: string
+securityDefinitions:
+  azure_auth:
+    type: oauth2
+    description: Azure Active Directory OAuth2 Flow
+    flow: implicit
+    authorizationUrl: 'https://login.microsoftonline.com/common/oauth2/authorize'
+    scopes:
+      user_impersonation: impersonate your user account
+security:
+  - azure_auth:
+      - user_impersonation

--- a/AutoRest/Modelers/Swagger.Tests/AutoRest.Modeler.Swagger.Tests.csproj
+++ b/AutoRest/Modelers/Swagger.Tests/AutoRest.Modeler.Swagger.Tests.csproj
@@ -51,7 +51,7 @@
     <None Include="Swagger\swagger-data-types.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-	<None Include="Swagger\swagger-composite-constants.json">
+    <None Include="Swagger\swagger-composite-constants.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Swagger\swagger-external-def.json">
@@ -82,6 +82,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Swagger\swagger-response-headers.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Swagger\swagger-simple-spec.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Swagger\swagger-x-ms-parameterized-host.json">

--- a/AutoRest/Modelers/Swagger.Tests/Swagger/swagger-simple-spec.yaml
+++ b/AutoRest/Modelers/Swagger.Tests/Swagger/swagger-simple-spec.yaml
@@ -1,0 +1,128 @@
+swagger: '2.0'
+info:
+  title: Microsoft Azure Redis Cache Management API
+  description: Some cool documentation.
+  version: 2014-04-01-preview
+host: management.azure.com
+schemes:
+  - https
+basePath: /
+produces:
+  - application/json
+consumes:
+  - application/json
+paths:
+  '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis?api-version={apiVersion}':
+    get:
+      operationId: list
+      summary: Product Types
+      description: >-
+        The Products endpoint returns information about the Uber products
+        offered at a given location. The response includes the display name and
+        other details about each product, and lists the products in the proper
+        display order.
+      parameters:
+        - $ref: '#/parameters/SubscriptionIdParamterer'
+        - name: resourceGroupName
+          in: path
+          description: Resource Group ID.
+          required: true
+          type: string
+        - $ref: ApiVersionParameter
+      tags:
+        - Redis
+      responses:
+        '200':
+          description: A list of caches
+          schema:
+            $ref: Product
+        default:
+          description: Unexpected error
+          schema:
+            $ref: Error
+    post:
+      operationId: reset
+      summary: Resets products
+      description: Resets products.
+      parameters:
+        - name: subscriptionId
+          in: path
+          description: Subscription ID.
+          required: true
+          type: string
+        - name: resourceGroupName
+          in: path
+          description: Resource Group ID.
+          required: true
+          type: string
+        - name: apiVersion
+          in: path
+          description: API ID.
+          required: true
+          type: string
+      tags:
+        - Redis
+      responses:
+        '204':
+          description: A list of caches
+          examples:
+            application/json:
+              id: 9
+              category:
+                name: domestic
+              name: monster
+              tags:
+                - name: for sale
+              status: alive
+        default:
+          description: Unexpected error
+          schema:
+            $ref: Error
+definitions:
+  Product:
+    description: The product documentation.
+    properties:
+      product_id:
+        type: string
+        description: >-
+          Unique identifier representing a specific product for a given latitude
+          & longitude. For example, uberX in San Francisco will have a different
+          product_id than uberX in Los Angeles.
+      description:
+        type: string
+        description: Description of product.
+      display_name:
+        type: string
+        description: Display name of product.
+      capacity:
+        type: string
+        description: 'Capacity of product. For example, 4 people.'
+        default: '100'
+      image:
+        type: string
+        description: Image URL representing the product.
+    example:
+      name: Puma
+      id: 1
+  Error:
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      fields:
+        type: string
+parameters:
+  SubscriptionIdParamterer:
+    name: subscriptionId
+    in: path
+    description: Subscription ID.
+    required: true
+    type: string
+  ApiVersionParameter:
+    name: apiVersion
+    in: path
+    description: API ID.
+    required: true
+    type: string

--- a/AutoRest/Modelers/Swagger.Tests/SwaggerModelerTests.cs
+++ b/AutoRest/Modelers/Swagger.Tests/SwaggerModelerTests.cs
@@ -621,5 +621,18 @@ namespace Microsoft.Rest.Modeler.Swagger.Tests
             Assert.Equal(2, jArrayParameters.Count);
             Assert.Equal("{accountName}.{host}", hostTemplate);
         }
+
+        [Fact]
+        public void TestYamlParsing()
+        {
+            Generator.Modeler modeler = new SwaggerModeler(new Settings
+            {
+                Namespace = "Test",
+                Input = Path.Combine("Swagger", "swagger-simple-spec.yaml")
+            });
+            var clientModel = modeler.Build();
+
+            Assert.NotNull(clientModel);
+        }
     }
 }

--- a/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
+++ b/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Model\Info.cs" />
     <Compile Include="Model\Tag.cs" />
     <Compile Include="Model\TransferProtocolScheme.cs" />
+    <Compile Include="YamlBoolDeserializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -87,6 +88,12 @@
     <CodeAnalysisDictionary Include="..\..\..\Tools\CustomDictionary.xml">
       <Link>CustomDictionary.xml</Link>
     </CodeAnalysisDictionary>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="YamlDotNet, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\YamlDotNet.3.8.0\lib\net35\YamlDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AutoRest/Modelers/Swagger/Extensions.cs
+++ b/AutoRest/Modelers/Swagger/Extensions.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using System.Net;
 using Microsoft.Rest.Generator.ClientModel;
+using Newtonsoft.Json;
+using YamlDotNet.Serialization;
 
 namespace Microsoft.Rest.Modeler.Swagger
 {
@@ -76,6 +79,25 @@ namespace Microsoft.Rest.Modeler.Swagger
             }
 
             return reference;
+        }
+
+        public static string EnsureYamlIsJson(this string text)
+        {
+            // is this something other than JSON?
+            if (!string.IsNullOrWhiteSpace(text) && text[0] != '{')
+            {
+                using (var y = new StringReader(text))
+                {
+                    using (var s = new StringWriter(CultureInfo.CurrentCulture))
+                    {
+                        var d = new Deserializer();
+                        d.NodeDeserializers.Insert( 0,new YamlBoolDeserializer() );
+                        new JsonSerializer().Serialize(s, d.Deserialize(y));
+                        return s.ToString();
+                    }
+                }
+            }
+            return text;
         }
     }
 }

--- a/AutoRest/Modelers/Swagger/SwaggerParser.cs
+++ b/AutoRest/Modelers/Swagger/SwaggerParser.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Rest.Modeler.Swagger
         {
             try
             {
+                swaggerDocument = swaggerDocument.EnsureYamlIsJson();
                 var settings = new JsonSerializerSettings
                 {
                     TypeNameHandling = TypeNameHandling.None,

--- a/AutoRest/Modelers/Swagger/YamlBoolDeserializer.cs
+++ b/AutoRest/Modelers/Swagger/YamlBoolDeserializer.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.Rest.Modeler.Swagger
+{
+    public class YamlBoolDeserializer : INodeDeserializer
+    {
+        public bool Deserialize(EventReader reader, Type expectedType, Func<EventReader, Type, object> nestedObjectDeserializer, out object value)
+        {
+            if (reader == null)
+            {
+                value = null;
+                return false;
+            }
+
+            // only try this if we're targeting a boolean or an untyped object
+            if (expectedType == typeof(object) || expectedType == typeof(bool) ) 
+            {
+                // peek at the current token
+                Scalar scalar = reader.Peek<Scalar>();
+
+                // if it's unquoted 
+                if (scalar != null && scalar.Style == ScalarStyle.Plain)
+                {
+                    // and the value is actually true or false
+                    switch (scalar.Value.ToUpperInvariant())
+                    {
+                        case "TRUE":
+                            value = true;
+                            reader.Allow<Scalar>();
+                            return true;
+                        case "FALSE":
+                            value = false;
+                            reader.Allow<Scalar>();
+                            return true;
+
+                    }
+                }
+            }
+
+            // otherwise, fall thru
+            value = null;
+            return false;
+        }
+    }
+}

--- a/AutoRest/Modelers/Swagger/packages.config
+++ b/AutoRest/Modelers/Swagger/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="YamlDotNet" version="3.8.0" targetFramework="net45" />
 </packages>

--- a/Tools/CustomDictionary.xml
+++ b/Tools/CustomDictionary.xml
@@ -37,6 +37,8 @@
       <Word>Impl</Word>
       <Word>odata</Word>
       <Word>Uuid</Word>
+    <Word>Yaml</Word>
+      <Word>Deserializer</Word>
     </Recognized>
   </Words>
 </Dictionary>

--- a/Tools/references.net45.props
+++ b/Tools/references.net45.props
@@ -18,5 +18,8 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(CommonNugetPackageFolder)\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="YamlDotNet">
+      <HintPath>$(CommonNugetPackageFolder)\YamlDotNet.3.8.0\lib\dotnet\YamlDotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -199,7 +199,7 @@
     <Copy SourceFiles="@(DelaySignedAssembliesToValidate)" DestinationFolder="binaries\net45" Condition="$(DelaySign)" />
     <ItemGroup>
       <AfterSignedAssembliesToValidate Include="binaries\net45\*.dll;binaries\net45\*.exe"
-        Exclude="binaries\net45\Newtonsoft.*.dll" />
+        Exclude="binaries\net45\Newtonsoft.*.dll;binaries\net45\YamlDotNet.*.dll" />
     </ItemGroup>
     <ValidateStrongNameSignatureTask
         SdkPath="$(SdkPath)"


### PR DESCRIPTION
This addresses #735 (Support YAML for spec format).

A fairly straightforward fix, this takes the input document and if it's not JSON tries to deserialize it as YAML and then reserializes it as JSON.

The only tricky bit was to handle unquoted booleans in YAML as unquoted booleans in JSON (see `YamlBoolDeserializer` ).
