### PR TITLE
Changing nuget reference from YamlDotNet to YamlDotNet.Signed

### DIFF
--- a/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
+++ b/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
@@ -90,8 +90,8 @@
     </CodeAnalysisDictionary>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="YamlDotNet, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\YamlDotNet.3.8.0\lib\net35\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=3.8.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\YamlDotNet.Signed.3.8.0\lib\net35\YamlDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/AutoRest/Modelers/Swagger/packages.config
+++ b/AutoRest/Modelers/Swagger/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="YamlDotNet" version="3.8.0" targetFramework="net45" />
+  <package id="YamlDotNet.Signed" version="3.8.0" targetFramework="net45" />
 </packages>

--- a/Tools/references.net45.props
+++ b/Tools/references.net45.props
@@ -19,7 +19,7 @@
       <HintPath>$(CommonNugetPackageFolder)\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="YamlDotNet">
-      <HintPath>$(CommonNugetPackageFolder)\YamlDotNet.3.8.0\lib\dotnet\YamlDotNet.dll</HintPath>
+      <HintPath>$(CommonNugetPackageFolder)\YamlDotNet.Signed.3.8.0\lib\dotnet\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Since we're referencing it from a signed assembly, we need to use the signed version