### PR TITLE
requestLibrarySink should be called with requestOptions if no additional arguments specified

### DIFF
--- a/ClientRuntimes/NodeJS/ms-rest/lib/requestPipeline.js
+++ b/ClientRuntimes/NodeJS/ms-rest/lib/requestPipeline.js
@@ -142,7 +142,7 @@ exports.requestLibrarySink = function (requestOptions) {
 exports.create = function (requestOptions) {
   return function () {
     if (arguments.length === 0) {
-      return exports.createWithSink(exports.requestLibrarySink);
+      return exports.createWithSink(exports.requestLibrarySink(requestOptions));
     }
     // User passed filters to add to the pipeline.
     // build up appropriate arguments and call exports.createWithSink


### PR DESCRIPTION
In requestPipline.create, requestLibrarySink should be called with requestOptions if no additional arguments specified.


In following commit
https://github.com/Azure/autorest/commit/876f74b86c9b9b3ffe876e9d6de64c50a0a2e499#diff-c89a34dee81e6cb2f17bfc58c53cc484L117

requestLibrarySink is changed to return a function taking requestOptions, but only the case when 'arguments.length === 0 is false' is updated, should also update the remaining case.