### PR TITLE
Fixes #1019 - Verbose parameter and other costmetic issues

### DIFF
--- a/AutoRest/AutoRest.Core/AutoRest.cs
+++ b/AutoRest/AutoRest.Core/AutoRest.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Rest.Generator
                 throw ErrorManager.CreateError(exception, Resources.ErrorGeneratingClientModel, exception.Message);
             }
             CodeGenerator codeGenerator = ExtensionsLoader.GetCodeGenerator(settings);
+            Logger.WriteOutput(codeGenerator.UsageInstructions);
+
             settings.Validate();
             try
             {

--- a/AutoRest/AutoRest.Core/Extensibility/ExtensionsLoader.cs
+++ b/AutoRest/AutoRest.Core/Extensibility/ExtensionsLoader.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Rest.Generator.Extensibility
         /// <returns>Modeler specified in Settings.Modeler</returns>
         public static Modeler GetModeler(Settings settings)
         {
-            Logger.LogInfo(Resources.ModelerInitialized);
+            Logger.LogInfo(Resources.InitializingModeler);
             if (settings == null)
             {
                 throw new ArgumentNullException("settings", "settings or settings.Modeler cannot be null.");

--- a/AutoRest/AutoRest.Core/Logging/Logger.cs
+++ b/AutoRest/AutoRest.Core/Logging/Logger.cs
@@ -38,6 +38,17 @@ namespace Microsoft.Rest.Generator.Logging
         }
 
         /// <summary>
+        /// An abstraction for the core to output text (ie not err,warning, or info)
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="args"></param>
+        public static void WriteOutput(string message, params object[] args)
+        {
+            Console.ResetColor();
+            Console.WriteLine(message, args);
+        }
+
+        /// <summary>
         /// Logs a message of severity LogEntrySeverity.Warning.
         /// </summary>
         /// <param name="text">Message to log. May include formatting.</param>

--- a/AutoRest/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/AutoRest/AutoRest.Core/Properties/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace Microsoft.Rest.Generator.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Initializing modeler..
+        /// </summary>
+        internal static string InitializingModeler {
+            get {
+                return ResourceManager.GetString("InitializingModeler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Property name {0} cannot be used as an Identifier, as it contains only invalid characters..
         /// </summary>
         internal static string InvalidIdentifierName {
@@ -196,7 +205,7 @@ namespace Microsoft.Rest.Generator.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Initializing modeler..
+        ///   Looks up a localized string similar to Successfully initialized modeler {0} v {1}..
         /// </summary>
         internal static string ModelerInitialized {
             get {

--- a/AutoRest/AutoRest.Core/Properties/Resources.resx
+++ b/AutoRest/AutoRest.Core/Properties/Resources.resx
@@ -156,6 +156,9 @@
   <data name="InitializingCodeGenerator" xml:space="preserve">
     <value>Initializing code generator.</value>
   </data>
+  <data name="InitializingModeler" xml:space="preserve">
+    <value>Initializing modeler.</value>
+  </data>
   <data name="InvalidIdentifierName" xml:space="preserve">
     <value>Property name {0} cannot be used as an Identifier, as it contains only invalid characters.</value>
   </data>
@@ -163,7 +166,7 @@
     <value>'{0}' code generator does not support code generation to a single file.</value>
   </data>
   <data name="ModelerInitialized" xml:space="preserve">
-    <value>Initializing modeler.</value>
+    <value>Successfully initialized modeler {0} v {1}.</value>
   </data>
   <data name="NamespaceConflictReasonMessage" xml:space="preserve">
     <value>{0} (already used in {1})</value>

--- a/AutoRest/AutoRest.Core/Settings.cs
+++ b/AutoRest/AutoRest.Core/Settings.cs
@@ -196,6 +196,12 @@ Licensed under the MIT License. See License.txt in the project root for license 
         public bool ShowHelp { get; set; }
 
         /// <summary>
+        /// If set to true, print out all messages.
+        /// </summary>
+        [SettingsAlias("verbose")]
+        public bool Verbose { get; set; }
+
+        /// <summary>
         /// PackageName of then generated code package. Should be then names wanted for the package in then package manager.
         /// </summary>
         [SettingsAlias("pn")]

--- a/AutoRest/AutoRest/Program.cs
+++ b/AutoRest/AutoRest/Program.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Rest.Generator.Cli
                     else
                     {
                         AutoRest.Generate(settings);
-                        var codeGenerator = ExtensionsLoader.GetCodeGenerator(settings);
-                        Console.WriteLine(codeGenerator.UsageInstructions);
                     }
                 }
                 catch (CodeGenerationException)
@@ -75,16 +73,20 @@ namespace Microsoft.Rest.Generator.Cli
                         }
                     }
 
-                    Logger.WriteErrors(Console.Error,
-                        args.Any(a => "-Verbose".Equals(a, StringComparison.OrdinalIgnoreCase)));
-
-                    Logger.WriteWarnings(Console.Out);
-
+                    Console.ResetColor();
                     // Include LogEntrySeverity.Infos for verbose logging.
                     if (args.Any(a => "-Verbose".Equals(a, StringComparison.OrdinalIgnoreCase)))
                     {
+                        Console.ForegroundColor = ConsoleColor.White;
                         Logger.WriteInfos(Console.Out);
                     }
+
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Logger.WriteWarnings(Console.Out);
+
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Logger.WriteErrors(Console.Error,
+                        args.Any(a => "-Verbose".Equals(a, StringComparison.OrdinalIgnoreCase)));
 
                     Console.ResetColor();
                 }

--- a/Documentation/cli.md
+++ b/Documentation/cli.md
@@ -4,7 +4,7 @@
 `AutoRest.exe -Input <value> [-Verbose] [-Namespace <value>] [-OutputDirectory <value>] [-CodeGenerator <value>] [-Modeler <value>] [-ClientName <value>] [-PayloadFlatteningThreshold <value>] [-Header <value>] [-AddCredentials <value>] [-OutputFileName <value>]`
 
 ##Parameters
-  **-Input** The location of the input specification. Aliases: -i, -input
+  **-Input** The location of the input specification. Aliases: -i, -input . The input file may be either in JSON or YAML format. 
   
   **-Namespace** The namespace to use for generated code. Aliases: -n
   

--- a/Documentation/cli.md
+++ b/Documentation/cli.md
@@ -1,7 +1,7 @@
 #AutoRest Command Line Interface Documentation
 
 ##Syntax
-`AutoRest.exe -Input <value> [-Namespace <value>] [-OutputDirectory <value>] [-CodeGenerator <value>] [-Modeler <value>] [-ClientName <value>] [-PayloadFlatteningThreshold <value>] [-Header <value>] [-AddCredentials <value>] [-OutputFileName <value>]`
+`AutoRest.exe -Input <value> [-Verbose] [-Namespace <value>] [-OutputDirectory <value>] [-CodeGenerator <value>] [-Modeler <value>] [-ClientName <value>] [-PayloadFlatteningThreshold <value>] [-Header <value>] [-AddCredentials <value>] [-OutputFileName <value>]`
 
 ##Parameters
   **-Input** The location of the input specification. Aliases: -i, -input
@@ -23,28 +23,29 @@
   **-AddCredentials** If true, the generated client includes a ServiceClientCredentials property and constructor parameter. Authentication behaviors are implemented by extending the ServiceClientCredentials type.
   
   **-OutputFileName** If set, will cause generated code to be output to a single file. Not supported by all code generators.
-
+  
+  **-Verbose** If set, will output verbose diagnostic messages.
 
 ##Code Generators
-  **-Ruby** Generic Ruby code generator.
+  **Ruby** Generic Ruby code generator.
   
-  **-Azure.Ruby** Azure specific Ruby code generator.
+  **Azure.Ruby** Azure specific Ruby code generator.
   
-  **-CSharp** Generic C# code generator.
+  **CSharp** Generic C# code generator.
   
-  **-Azure.CSharp** Azure specific C# code generator.
+  **Azure.CSharp** Azure specific C# code generator.
   
-  **-NodeJS** Generic NodeJS code generator.
+  **NodeJS** Generic NodeJS code generator.
   
-  **-Azure.NodeJS** Azure specific NodeJS code generator.
+  **Azure.NodeJS** Azure specific NodeJS code generator.
   
-  **-Java** Generic Java code generator.
+  **Java** Generic Java code generator.
   
-  **-Azure.Java** Azure specific Java code generator.
+  **Azure.Java** Azure specific Java code generator.
   
-  **-Python** Generic Python code generator.
+  **Python** Generic Python code generator.
   
-  **-Azure.Python** Azure specific Python code generator.
+  **Azure.Python** Azure specific Python code generator.
 
 ##Code Generator Specific Settings
 ###CSharp

--- a/Tools/verify-settings.ps1
+++ b/Tools/verify-settings.ps1
@@ -114,7 +114,7 @@ function which(
     if( $env:path ) {
         foreach( $dir in $env:path.Split(";")) {
             foreach( $ext in (";.ps1;"+$env:pathext).split(";")) {
-                if( $dir -and (resolve-path $dir) ) {
+                if( $dir -and (resolve-path $dir -ea 0 ) ) {
                     $p = join-path $dir "$cmd$ext"
                     if( exists $p ) { 
                         if( Validate -exe $p $arch $include $exclude $minimumVersion ) {


### PR DESCRIPTION
This resolves #1019 -- specifically:
- the `-verbose` parameter doesn't cause `Warning: Parameter 'Verbose' is not expected`
- added `-verbose` to the `cli.md` help
- fixed the second Initializing modeler` message (changed to `Initialized modeler ... `)
- changed the order of the Info/Warning/Error messages spit out.

**Bonus Fixes** (_while I was in there_)
- set the color for the messages before they print. Now warnings print yellow, errors print red, info prints white, and all other output prints as the default console color)
- added a `Logger.WriteOutput` method to supply an abstraction for when the core should print something to the console. (we can leverage that in the future to make the output stream pluggable)
- moved the printing of the usage information from the generator into the core (so that the generator doesn't get initialized twice and print duplicate loading messages)
- removed superfluous dashes in front of the allowed generator names in the `cli.md` file so that people don't try to use them like: `autorest -codegenerator -azure.csharp ...` 

###  Uh...
No tests were included with this since it's all just cosmetic reordering/recoloring of the content.

### and...
And I smuggled in a quick one-line fix into the verify-settings script to not spew errors when some directories are not present.