### PR TITLE
Supply CodeGenSettings via a JSON file to AutoRest. CodeGenSettings i…

### DIFF
--- a/AutoRest/AutoRest.Core.Tests/AutoRest.Core.Tests.csproj
+++ b/AutoRest/AutoRest.Core.Tests/AutoRest.Core.Tests.csproj
@@ -88,6 +88,9 @@
     <None Include="Resource\RedisResource.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Resource\SampleSettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Templates\SampleModel.cshtml" />
   </ItemGroup>
   <ItemGroup>

--- a/AutoRest/AutoRest.Core.Tests/AutoRestSettingsTests.cs
+++ b/AutoRest/AutoRest.Core.Tests/AutoRestSettingsTests.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Rest.Generator.Logging;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Rest.Generator.Test
@@ -16,11 +20,11 @@ namespace Microsoft.Rest.Generator.Test
         {
             var settings = Settings.Create((string[]) null);
             Assert.NotNull(settings);
-            settings = Settings.Create((IDictionary<string, string>) null);
+            settings = Settings.Create((IDictionary<string, object>) null);
             Assert.NotNull(settings);
             settings = Settings.Create(new string[0]);
             Assert.NotNull(settings);
-            settings = Settings.Create(new Dictionary<string, string>());
+            settings = Settings.Create(new Dictionary<string, object>());
             Assert.NotNull(settings);
         }
 
@@ -31,6 +35,23 @@ namespace Microsoft.Rest.Generator.Test
             Assert.True(settings.ShowHelp);
             Assert.Equal("", settings.CustomSettings["Foo"]);
             Assert.Equal("", settings.CustomSettings["Bar"]);
+        }
+
+        [Fact]
+        public void LoadCodeGenSettingsFromJsonFile()
+        {
+            var codeBaseUrl = new Uri(Assembly.GetExecutingAssembly().CodeBase);
+            var codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
+            var dirPath = Path.GetDirectoryName(codeBasePath);
+            var settingsFile = Path.Combine(dirPath, "Resource\\SampleSettings.json");
+            var settings = Settings.Create(new[] {"-cgs", settingsFile});
+            Assert.False((bool) settings.CustomSettings["sampleSwitchFalse"]);
+            Assert.True((bool) settings.CustomSettings["sampleSwitchTrue"]);
+            Assert.Equal("Foo", settings.CustomSettings["sampleString"]);
+            Assert.Equal(typeof (JArray), settings.CustomSettings["filePathArray"].GetType());
+            Assert.Equal(2, ((JArray) settings.CustomSettings["filePathArray"]).Count);
+            Assert.Equal(typeof (JArray), settings.CustomSettings["intArray"].GetType());
+            Assert.Equal(typeof (long), settings.CustomSettings["intFoo"].GetType());
         }
 
         [Fact]

--- a/AutoRest/AutoRest.Core.Tests/Resource/SampleSettings.json
+++ b/AutoRest/AutoRest.Core.Tests/Resource/SampleSettings.json
@@ -1,0 +1,8 @@
+﻿{
+    "sampleSwitchFalse": false,
+    "sampleSwitchTrue": true,
+    "sampleString":  "Foo",
+    "filePathArray": [ "C:\\Foo.dll", "C:\\Bar.dll" ],
+    "intArray": [ 1, 2, 3 ],
+    "intFoo": 5
+}

--- a/AutoRest/AutoRest.Core/CodeGenerator.cs
+++ b/AutoRest/AutoRest.Core/CodeGenerator.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Rest.Generator
         /// Populate settings on self and any child objects
         /// </summary>
         /// <param name="settings">A dictionary of settings</param>
-        public virtual void PopulateSettings(IDictionary<string, string> settings)
+        public virtual void PopulateSettings(IDictionary<string, object> settings)
         {
             Settings.PopulateSettings(this, settings);
         }

--- a/AutoRest/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/AutoRest/AutoRest.Core/Properties/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Rest.Generator.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not load CodeGenSettings file &apos;{0}&apos;. Exception: &apos;{1}&apos;..
+        /// </summary>
+        internal static string CodeGenSettingsFileInvalid {
+            get {
+                return ResourceManager.GetString("CodeGenSettingsFileInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to \\\\.
         /// </summary>
         internal static string CommentString {

--- a/AutoRest/AutoRest.Core/Properties/Resources.resx
+++ b/AutoRest/AutoRest.Core/Properties/Resources.resx
@@ -123,6 +123,9 @@
   <data name="CodeGenerationFailed" xml:space="preserve">
     <value>Code generation failed with errors. See inner exceptions for details.</value>
   </data>
+  <data name="CodeGenSettingsFileInvalid" xml:space="preserve">
+    <value>Could not load CodeGenSettings file '{0}'. Exception: '{1}'.</value>
+  </data>
   <data name="CommentString" xml:space="preserve">
     <value>\\\\</value>
   </data>

--- a/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/AzureCSharpCodeNamer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Rest.Generator.CSharp
                     if (setting.Equals("useDateTimeOffset", StringComparison.OrdinalIgnoreCase))
                     {
                         bool toUse;
-                        if (bool.TryParse(settings.CustomSettings[setting], out toUse))
+                        if (bool.TryParse(settings.CustomSettings[setting].ToString(), out toUse))
                         {
                             UseDateTimeOffset = toUse;
                         }

--- a/AutoRest/Generators/CSharp/CSharp/CSharpCodeGenerator.cs
+++ b/AutoRest/Generators/CSharp/CSharp/CSharpCodeGenerator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Rest.Generator.CSharp
             get { return ".cs"; }
         }
 
-        public override void PopulateSettings(IDictionary<string, string> settings)
+        public override void PopulateSettings(IDictionary<string, object> settings)
         {
             base.PopulateSettings(settings);
             Settings.PopulateSettings(_namer, settings);

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Rest.Generator.Ruby
 
             if (Settings.CustomSettings.ContainsKey("Name"))
             {
-                this.sdkName = Settings.CustomSettings["Name"];
+                this.sdkName = Settings.CustomSettings["Name"].ToString();
             }
 
             if (sdkName == null)

--- a/AutoRest/Modelers/Swagger/SwaggerModeler.cs
+++ b/AutoRest/Modelers/Swagger/SwaggerModeler.cs
@@ -144,7 +144,9 @@ namespace Microsoft.Rest.Modeler.Swagger
             {
                 foreach (var key in ServiceDefinition.Info.CodeGenerationSettings.Extensions.Keys)
                 {
-                    this.Settings.CustomSettings[key] = ServiceDefinition.Info.CodeGenerationSettings.Extensions[key].ToString();
+                    //Don't overwrite settings that come in from the command line
+                    if (!this.Settings.CustomSettings.ContainsKey(key))
+                        this.Settings.CustomSettings[key] = ServiceDefinition.Info.CodeGenerationSettings.Extensions[key];
                 }
                 Settings.PopulateSettings(this.Settings, this.Settings.CustomSettings);
             }

--- a/Documentation/cli.md
+++ b/Documentation/cli.md
@@ -25,7 +25,8 @@
   **-OutputFileName** If set, will cause generated code to be output to a single file. Not supported by all code generators.
   
   **-Verbose** If set, will output verbose diagnostic messages.
-
+  
+  **-CodeGenSettings** Optionally specifies a JSON file that contains code generation settings equivalent to the swagger document containing the same content in the [x-ms-code-generation-settings] extension. Aliases: -cgs
 ##Code Generators
   **Ruby** Generic Ruby code generator.
   
@@ -68,7 +69,7 @@ AutoRest.exe -Namespace MyNamespace -Input swagger.json
 AutoRest.exe -Namespace MyNamespace -Header "Copyright Contoso Ltd" -Input swagger.json
 ```
 
-  - Generate C# client with a credentials property in MyNamespace from swagger.json input:
+  - Generate C# client with a credentials property in MyNamespace from swagger.json input and with code generation settings specified by settings.json:
 ```bash
-AutoRest.exe -AddCredentials true -Namespace MyNamespace -CodeGenerator CSharp -Modeler Swagger -Input swagger.json
+AutoRest.exe -AddCredentials true -Namespace MyNamespace -CodeGenerator CSharp -Modeler Swagger -Input swagger.json -CodeGenSettings settings.json
 ```

--- a/Documentation/swagger-extensions.md
+++ b/Documentation/swagger-extensions.md
@@ -39,7 +39,8 @@ Field Name | Type | Description
 "info": {
    "x-ms-code-generation-settings": {
       "header": "MIT",
-      "internalConstructors": true
+      "internalConstructors": true,
+      "useDateTimeOffset": true
    }
 }
 ```


### PR DESCRIPTION
…s de-serialized as Dictionary<string, object> so it can contain more complex properties than just strings.

As requested in the discussion on PR #1043, I have separated out the pieces necessary for populating code gen settings from a JSON file.