### PR TITLE
Enable x-ms-client-flatten extension for Ruby & Azure.Ruby generator

### DIFF
--- a/AutoRest/Generators/Extensions/Azure.Extensions/AzureExtensions.cs
+++ b/AutoRest/Generators/Extensions/Azure.Extensions/AzureExtensions.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Rest.Generator.Azure
                                     nextLinkMethod.Parameters.Add(newGroupingParam);
                                     //grouping.Key.Name = newGroupingParam.Name;
                                     var inputParameter = (Parameter) nextLinkMethod.InputParameterTransformation.First().ParameterMappings[0].InputParameter.Clone();
-                                    inputParameter.Name = newGroupingParam.Name.ToCamelCase();
+                                    inputParameter.Name = codeNamer.GetParameterName(newGroupingParam.Name);
                                     nextLinkMethod.InputParameterTransformation.ForEach(t => t.ParameterMappings[0].InputParameter = inputParameter);
                                 }
                             });

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/lro_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/lro_spec.rb
@@ -25,7 +25,7 @@ describe 'LongRunningOperation' do
   # Happy path tests
   it 'should wait for succeeded status for create operation' do
     result = @client.lros.put201creating_succeeded200(@product).value!
-    expect(result.body.properties.provisioning_state).to eq("Succeeded")
+    expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should rise error on "failed" operation result' do
@@ -34,7 +34,7 @@ describe 'LongRunningOperation' do
 
   it 'should wait for succeeded status for update operation' do
     result = @client.lros.put200updating_succeeded204(@product).value!
-    expect(result.body.properties.provisioning_state).to eq("Succeeded")
+    expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should rise error on "canceled" operation result' do
@@ -48,24 +48,24 @@ describe 'LongRunningOperation' do
 
   it 'should serve success responce on initial PUT request' do
     result = @client.lros.put200succeeded(@product).value!
-    expect(result.body.properties.provisioning_state).to eq("Succeeded")
+    expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should serve success responce on initial request without provision state' do
     result = @client.lros.put200succeeded_no_state(@product).value!
     expect(result.body.id).to eq("100")
-    expect(result.body.properties).to eq(nil)
+    expect(result.body.provisioning_state).to eq(nil)
   end
 
   it 'should serve 202 on initial responce and status responce without provision state' do
     result = @client.lros.put202retry200(@product).value!
     expect(result.body.id).to eq("100")
-    expect(result.body.properties).to eq(nil)
+    expect(result.body.provisioning_state).to eq(nil)
   end
 
   it 'should retry on 500 server responce in PUT request' do
     result = @client.lroretrys.put_async_relative_retry_succeeded(@product).value!
-    expect(result.body.properties.provisioning_state).to eq("Succeeded")
+    expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   # TODO: Fix flakey test
@@ -96,12 +96,12 @@ describe 'LongRunningOperation' do
   # Retryable errors
   it 'should retry PUT request on 500 responce' do
     result = @client.lroretrys.put201creating_succeeded200(@product).value!
-    expect(result.body.properties.provisioning_state).to eq("Succeeded")
+    expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should retry PUT request on 500 responce for async operation' do
     result = @client.lroretrys.put_async_relative_retry_succeeded(@product).value!
-    expect(result.body.properties.provisioning_state).to eq("Succeeded")
+    expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should retry DELETE request for provisioning status' do

--- a/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
@@ -55,13 +55,7 @@ namespace Microsoft.Rest.Generator.Azure.Ruby
         public override void NormalizeClientModel(ServiceClient serviceClient)
         {
             Settings.AddCredentials = true;
-            AzureExtensions.ProcessClientRequestIdExtension(serviceClient);
-            AzureExtensions.UpdateHeadMethods(serviceClient);
-            AzureExtensions.ParseODataExtension(serviceClient);
-            AzureExtensions.AddPageableMethod(serviceClient, CodeNamer);
-            AzureExtensions.AddLongRunningOperations(serviceClient);
-            AzureExtensions.AddAzureProperties(serviceClient);
-            AzureExtensions.SetDefaultResponses(serviceClient);
+            AzureExtensions.NormalizeAzureClientModel(serviceClient, Settings, CodeNamer);
             CorrectFilterParameters(serviceClient);
             base.NormalizeClientModel(serviceClient);
         }

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/model_flattening_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/model_flattening_spec.rb
@@ -8,7 +8,7 @@ require 'model_flattening'
 include ModelFlatteningModule
 include ModelFlatteningModule::Models
 
-describe 'ModelFlattening' do
+describe 'Resource Flattening Operations' do
   before(:all) do
     @base_url = ENV['StubServerURI']
 
@@ -17,39 +17,44 @@ describe 'ModelFlattening' do
 
     @client = AutoRestResourceFlatteningTestService.new(@credentials, @base_url)
 
-    product1 = FlattenedProduct.new
-    product1.location = "West US"
-    product1.tags = {
+    @product1 = FlattenedProduct.new
+    @product1.location = "West US"
+    @product1.tags = {
         "tag1" => "value1",
         "tag2" => "value3"
     }
-
-    # product1.pname = "Product1"
+    @product1.pname = "Product1"
+    @product1.flattened_product_type = "Flat"
 
     product2 = FlattenedProduct.new
     product2.location = "Building 44"
-    # product2.pname = "Product2"
+    product2.pname = "Product2"
+    product2.flattened_product_type = "Flat"
 
     @dict_resource = {
-        "Resource1" => product1,
+        "Resource1" => @product1,
         "Resource2" => product2
     }
 
-    @array_resource = [product1, product2]
+    @array_resource = [@product1, product2]
   end
 
-  # Array tests
-  it 'should get array' do
+  it 'should get external resource as an array' do
     result = @client.get_array_async().value!
-    # Resource 1
+    
     expect(result.body.count).to eq(3)
+    result.body.each do |flatten_product|
+      expect(flatten_product).to be_instance_of(FlattenedProduct)
+    end
+
+    # Resource 1
     expect(result.body[0].id).to eq("1")
     expect(result.body[0].name).to eq("Resource1")
     expect(result.body[0].location).to eq("Building 44")
     expect(result.body[0].type).to eq("Microsoft.Web/sites")
-    expect(result.body[0].properties.pname).to eq("Product1")
-    expect(result.body[0].properties.provisioning_state).to eq("Succeeded")
-    expect(result.body[0].properties.provisioning_state_values).to eq("OK")
+    expect(result.body[0].pname).to eq("Product1")
+    expect(result.body[0].provisioning_state).to eq("Succeeded")
+    expect(result.body[0].provisioning_state_values).to eq("OK")
     expect(result.body[0].tags["tag1"]).to eq("value1")
     expect(result.body[0].tags["tag2"]).to eq("value3")
 
@@ -63,25 +68,27 @@ describe 'ModelFlattening' do
     expect(result.body[2].name).to eq("Resource3")
   end
 
-  # it 'should put array' do
-  #   result = @client.resource_flattening.put_array_async(@array_resource).value!
-  #   expect(result).to be_an_instance_of(Net::HTTPOK)
-  # end
+  it 'should put external resource as an array' do
+    result = @client.put_array_async(@array_resource).value!
+    expect(result.response.status).to eq(200)
+  end
 
-  # Dictionary tests
-  it 'should get dictionary' do
+  it 'should get external resource as a dictionary' do
     result = @client.get_dictionary_async().value!
-    # Resource 1
     expect(result.body.count).to eq(3)
+
+    result.body do |_, value|
+      expect(value).to be_instance_of(FlattenedProduct)
+    end
+
+    # Resource 1
     expect(result.body["Product1"].id).to eq("1")
     expect(result.body["Product1"].location).to eq("Building 44")
     expect(result.body["Product1"].name).to eq("Resource1")
     expect(result.body["Product1"].type).to eq("Microsoft.Web/sites")
-
-    expect(result.body["Product1"].properties.provisioning_state_values).to eq("OK")
-    expect(result.body["Product1"].properties.pname).to eq("Product1")
-    expect(result.body["Product1"].properties.provisioning_state).to eq("Succeeded")
-
+    expect(result.body["Product1"].provisioning_state_values).to eq("OK")
+    expect(result.body["Product1"].pname).to eq("Product1")
+    expect(result.body["Product1"].provisioning_state).to eq("Succeeded")
     expect(result.body["Product1"].tags["tag1"]).to eq("value1")
     expect(result.body["Product1"].tags["tag2"]).to eq("value3")
 
@@ -95,13 +102,12 @@ describe 'ModelFlattening' do
     expect(result.body["Product3"].name).to eq("Resource3")
   end
 
-  # it 'should put dictionary' do
-  #   result = @client.resource_flattening.put_dictionary_async(@dict_resource).value!.response
-  #   expect(result).to be_an_instance_of(Net::HTTPOK)
-  # end
+  it 'should put external resource as a dictionary' do
+    result = @client.put_dictionary_async(@dict_resource).value!
+    expect(result.response.status).to eq(200)
+  end
 
-  # Complex tests
-  it 'should get resource collection' do
+  it 'should get external resource as a complex type' do
     result = @client.get_resource_collection_async().value!
 
     # Resource 1
@@ -110,13 +116,11 @@ describe 'ModelFlattening' do
     expect(result.body.dictionaryofresources["Product1"].location).to eq("Building 44")
     expect(result.body.dictionaryofresources["Product1"].name).to eq("Resource1")
     expect(result.body.dictionaryofresources["Product1"].type).to eq("Microsoft.Web/sites")
-
     expect(result.body.dictionaryofresources["Product1"].tags["tag1"]).to eq("value1")
     expect(result.body.dictionaryofresources["Product1"].tags["tag2"]).to eq("value3")
-
-    expect(result.body.dictionaryofresources["Product1"].properties.provisioning_state_values).to eq("OK")
-    expect(result.body.dictionaryofresources["Product1"].properties.pname).to eq("Product1")
-    expect(result.body.dictionaryofresources["Product1"].properties.provisioning_state).to eq("Succeeded")
+    expect(result.body.dictionaryofresources["Product1"].provisioning_state_values).to eq("OK")
+    expect(result.body.dictionaryofresources["Product1"].pname).to eq("Product1")
+    expect(result.body.dictionaryofresources["Product1"].provisioning_state).to eq("Succeeded")
 
     # Resource 2
     expect(result.body.dictionaryofresources["Product2"].id).to eq("2")
@@ -133,11 +137,9 @@ describe 'ModelFlattening' do
     expect(result.body.arrayofresources[0].name).to eq("Resource4")
     expect(result.body.arrayofresources[0].location).to eq("Building 44")
     expect(result.body.arrayofresources[0].type).to eq("Microsoft.Web/sites")
-
-    expect(result.body.arrayofresources[0].properties.provisioning_state_values).to eq("OK")
-    expect(result.body.arrayofresources[0].properties.pname).to eq("Product4")
-    expect(result.body.arrayofresources[0].properties.provisioning_state).to eq("Succeeded")
-
+    expect(result.body.arrayofresources[0].provisioning_state_values).to eq("OK")
+    expect(result.body.arrayofresources[0].pname).to eq("Product4")
+    expect(result.body.arrayofresources[0].provisioning_state).to eq("Succeeded")
     expect(result.body.arrayofresources[0].tags["tag1"]).to eq("value1")
     expect(result.body.arrayofresources[0].tags["tag2"]).to eq("value3")
 
@@ -151,12 +153,70 @@ describe 'ModelFlattening' do
     expect(result.body.arrayofresources[2].name).to eq("Resource6")
   end
 
-  # it 'should put complex object' do
-  #   complex_resource = ResourceCollection.new
-  #   complex_resource.dictionaryOfResources = @dict_resource
-  #   complex_resource.arrayOfResources = @array_resource
-  #   result = @client.resource_flattening.put_resource_collection_async(complex_resource).value!.response
-  #   expect(result).to be_an_instance_of(Net::HTTPOK)
-  # end
+  it 'should put external resource as a complex type' do
+    complex_resource = ResourceCollection.new
 
+    product2 = FlattenedProduct.new
+    product2.location = "East US"
+    product2.pname = "Product2"
+    product2.flattened_product_type = "Flat"
+
+    product = FlattenedProduct.new
+    product.location = "India"
+    product.pname = "Azure"
+    product.flattened_product_type = "Flat"
+
+    complex_resource.dictionaryofresources = @dict_resource
+    complex_resource.arrayofresources = [@product1, product2]
+    complex_resource.productresource = product
+    result = @client.put_resource_collection_async(complex_resource).value!
+    expect(result.response.status).to eq(200)
+  end
+
+  it 'should put simple product to flatten' do
+    simple_product = SimpleProduct.new
+    simple_product.product_id = '123'
+    simple_product.description = 'product description'
+    simple_product.max_product_display_name = 'max name'
+    simple_product.odatavalue = 'http://foo'
+    simple_product.generic_value = 'https://generic'
+
+    result = @client.put_simple_product_async(simple_product).value!
+    expect(result.response.status).to eq(200)
+  end
+
+  it 'should post simple product with param flattening' do
+    result = @client.post_flattened_simple_product_async('123', 'max name', 'product description', nil, 'http://foo').value!
+    expect(result.response.status).to eq(200)
+
+    simple_product = result.body
+    expect(simple_product).to be_instance_of(SimpleProduct)
+    expect(simple_product.product_id).to eq('123')
+    expect(simple_product.max_product_display_name).to eq('max name')
+    expect(simple_product.description).to eq('product description')
+    expect(simple_product.odatavalue).to eq('http://foo')
+    expect(simple_product.capacity).to eq('Large')
+    expect(simple_product.generic_value).to be_nil
+  end
+
+  it 'should put flattened and grouped product' do
+    param_group = FlattenParameterGroup.new
+    param_group.product_id = '123'
+    param_group.description = 'product description'
+    param_group.max_product_display_name = 'max name'
+    param_group.odatavalue = 'http://foo'
+    param_group.name = 'groupproduct'
+
+    result = @client.put_simple_product_with_grouping_async(param_group).value!
+    expect(result.response.status).to eq(200)
+
+    simple_product = result.body
+    expect(simple_product).to be_instance_of(SimpleProduct)
+    expect(simple_product.product_id).to eq('123')
+    expect(simple_product.max_product_display_name).to eq('max name')
+    expect(simple_product.description).to eq('product description')
+    expect(simple_product.odatavalue).to eq('http://foo')
+    expect(simple_product.capacity).to eq('Large')
+    expect(simple_product.generic_value).to be_nil
+  end
 end

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
@@ -114,8 +114,7 @@ namespace Microsoft.Rest.Generator.Ruby
         /// <param name="serviceClient"></param>
         public override void NormalizeClientModel(ServiceClient serviceClient)
         {
-            ParameterGroupExtensionHelper.AddParameterGroups(serviceClient);
-            Extensions.ProcessParameterizedHost(serviceClient, Settings);
+            Extensions.NormalizeClientModel(serviceClient, Settings);
             PopulateAdditionalProperties(serviceClient);
             CodeNamer.NormalizeClientModel(serviceClient);
             CodeNamer.ResolveNameCollisions(serviceClient, Settings.Namespace,

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeNamer.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeNamer.cs
@@ -283,9 +283,9 @@ namespace Microsoft.Rest.Generator.Ruby
             foreach (var property in compositeType.Properties)
             {
                 property.Name = GetPropertyName(property.GetClientName());
-                if (property.SerializedName != null)
+                if (property.SerializedName != null && !property.WasFlattened())
                 {
-                    property.SerializedName = property.SerializedName.Replace("\\", "\\\\");
+                    property.SerializedName = property.SerializedName.Replace(".", "\\\\.");
                 }
                 property.Type = NormalizeTypeReference(property.Type);
             }

--- a/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_service_client.rb
+++ b/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_service_client.rb
@@ -122,8 +122,8 @@ module MsRestAzure
 
       fail AzureOperationError, 'The response from long running operation does not contain a body' if result.response.body.nil? || result.response.body.empty?
 
-      if result.body.respond_to?(:properties) && result.body.properties.respond_to?(:provisioning_state) && !result.body.properties.provisioning_state.nil?
-        polling_state.status = result.body.properties.provisioning_state
+      if result.body.respond_to?(:provisioning_state) && !result.body.provisioning_state.nil?
+        polling_state.status = result.body.provisioning_state
       else
         polling_state.status = AsyncOperationStatus::SUCCESS_STATUS
       end

--- a/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
+++ b/ClientRuntimes/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
@@ -35,8 +35,8 @@ module MsRestAzure
       update_response(azure_response.response)
       @resource = azure_response.body
 
-      if (!@resource.nil? && @resource.respond_to?(:properties) && @resource.properties.respond_to?(:provisioning_state) && !@resource.properties.provisioning_state.nil?)
-        @status = @resource.properties.provisioning_state
+      if (!@resource.nil? && @resource.respond_to?(:provisioning_state) && !@resource.provisioning_state.nil?)
+        @status = @resource.provisioning_state
       else
         case @response.status
           when 202

--- a/ClientRuntimes/Ruby/ms-rest-azure/spec/polling_state_spec.rb
+++ b/ClientRuntimes/Ruby/ms-rest-azure/spec/polling_state_spec.rb
@@ -9,8 +9,7 @@ module MsRestAzure
 
   describe PollingState do
     it 'should initialize status from response header' do
-      response_body_properties = double('response_body_properties', :provisioning_state => 'InProgress')
-      response_body = double('response_body', :properties => response_body_properties)
+      response_body = double('response_body', :provisioning_state => 'InProgress')
       response = double('response',
                         :request => nil,
                         :response => nil,

--- a/Samples/azure-storage/Azure.CSharp/StorageAccountsOperations.cs
+++ b/Samples/azure-storage/Azure.CSharp/StorageAccountsOperations.cs
@@ -635,7 +635,12 @@ namespace Petstore
             if ((int)_statusCode != 200 && (int)_statusCode != 204)
             {
                 var ex = new CloudException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_httpResponse.Headers.Contains("x-ms-request-id"))

--- a/Samples/petstore/CSharp/SwaggerPetstore.cs
+++ b/Samples/petstore/CSharp/SwaggerPetstore.cs
@@ -226,7 +226,12 @@ namespace Petstore
             if ((int)_statusCode != 405)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -336,7 +341,12 @@ namespace Petstore
             if ((int)_statusCode != 405)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -442,7 +452,12 @@ namespace Petstore
             if ((int)_statusCode != 405 && (int)_statusCode != 404 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -553,7 +568,12 @@ namespace Petstore
             if ((int)_statusCode != 200 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -683,7 +703,12 @@ namespace Petstore
             if ((int)_statusCode != 200 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -805,7 +830,12 @@ namespace Petstore
             if ((int)_statusCode != 404 && (int)_statusCode != 200 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -927,7 +957,12 @@ namespace Petstore
             if ((int)_statusCode != 404 && (int)_statusCode != 200 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1069,7 +1104,12 @@ namespace Petstore
             if ((int)_statusCode != 405)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1177,7 +1217,12 @@ namespace Petstore
             if ((int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1303,7 +1348,12 @@ namespace Petstore
             if (!_httpResponse.IsSuccessStatusCode)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1401,7 +1451,12 @@ namespace Petstore
             if ((int)_statusCode != 200)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1524,7 +1579,12 @@ namespace Petstore
             if ((int)_statusCode != 200 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1653,7 +1713,12 @@ namespace Petstore
             if ((int)_statusCode != 404 && (int)_statusCode != 200 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1779,7 +1844,12 @@ namespace Petstore
             if ((int)_statusCode != 404 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1884,7 +1954,12 @@ namespace Petstore
             if (!_httpResponse.IsSuccessStatusCode)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -1986,7 +2061,12 @@ namespace Petstore
             if (!_httpResponse.IsSuccessStatusCode)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -2088,7 +2168,12 @@ namespace Petstore
             if (!_httpResponse.IsSuccessStatusCode)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -2204,7 +2289,12 @@ namespace Petstore
             if ((int)_statusCode != 200 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -2314,7 +2404,12 @@ namespace Petstore
             if (!_httpResponse.IsSuccessStatusCode)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -2421,7 +2516,12 @@ namespace Petstore
             if ((int)_statusCode != 404 && (int)_statusCode != 200 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -2556,7 +2656,12 @@ namespace Petstore
             if ((int)_statusCode != 404 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
@@ -2663,7 +2768,12 @@ namespace Petstore
             if ((int)_statusCode != 404 && (int)_statusCode != 400)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,7 +86,8 @@ var rubyMappings = {
   'http_infrastructure':['../../../TestServer/swagger/httpInfrastructure.json','HttpInfrastructureModule'],
   'required_optional':['../../../TestServer/swagger/required-optional.json','RequiredOptionalModule'],
   'report':['../../../TestServer/swagger/report.json','ReportModule'],
-  'model_flattening':['../../../TestServer/swagger/model-flattening.json', 'ModelFlatteningModule'],  
+  'model_flattening':['../../../TestServer/swagger/model-flattening.json', 'ModelFlatteningModule'],
+  'parameter_flattening':['../../../TestServer/swagger/parameter-flattening.json', 'ParameterFlatteningModule'],
   'parameter_grouping':['../../../TestServer/swagger/azure-parameter-grouping.json', 'ParameterGroupingModule'],
 };
 


### PR DESCRIPTION
This PR unlocks 'x-ms-client-flatten' swagger extension for Ruby and Azure.Ruby generator. 