### PR TITLE
Ruby - Adding Model name on the properties of the ServiceClient

### DIFF
--- a/AutoRest/Generators/Ruby/Ruby/Templates/ServiceClientTemplate.cshtml
+++ b/AutoRest/Generators/Ruby/Ruby/Templates/ServiceClientTemplate.cshtml
@@ -35,7 +35,7 @@ module @Settings.Namespace
 
 @foreach (var operation in Model.MethodGroups)
 {
-    @:@WrapComment("# ", string.Format("@return {0}", RubyCodeNamer.UnderscoreCase(operation)))
+    @:@WrapComment("# ", string.Format("@return [{0}] {1}", operation, RubyCodeNamer.UnderscoreCase(operation)))
     @:attr_reader :@(RubyCodeNamer.UnderscoreCase(operation))
 @EmptyLine
 }


### PR DESCRIPTION
Addressing Issue #1156 

As per the existing [ServiceClient ](https://github.com/Azure/azure-sdk-ruby/blob/master/resource_management/azure_mgmt_resources/lib/azure_mgmt_resources/models/deployment_properties.rb) & [Models](https://github.com/Azure/azure-sdk-ruby/blob/master/resource_management/azure_mgmt_resources/lib/azure_mgmt_resources/models/deployment_properties.rb), we can see that properties of the model has been documents correctly but not all the properties of ServiceClient. For example, In the [resource_management_client.rb](resource_management_client.rb) properties generated from MethodGroups does not specify correct return types like for resources, tags, deployment_operations. 

This change will add the return type on properties generated from MethodGroups in the ServiceClients. 