### PR TITLE
(C#) Adding support for "see" URLs in documentation

### DIFF
--- a/AutoRest/AutoRest.Core/ClientModel/CompositeType.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/CompositeType.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Microsoft.Rest.Generator.ClientModel
@@ -64,6 +65,8 @@ namespace Microsoft.Rest.Generator.ClientModel
         /// <summary>
         /// Gets or sets a URL pointing to related external documentation.
         /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings",
+            Justification = "May not parse as a valid URI.")]
         public string ExternalDocsUrl { get; set; }
 
         /// <summary>

--- a/AutoRest/AutoRest.Core/ClientModel/CompositeType.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/CompositeType.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Rest.Generator.ClientModel
         public string Documentation { get; set; }
 
         /// <summary>
+        /// Gets or sets a URL pointing to related external documentation.
+        /// </summary>
+        public string ExternalDocsUrl { get; set; }
+
+        /// <summary>
         /// Returns true if any of the properties is a Constant or is 
         /// a CompositeType which ContainsConstantProperties set to true.
         /// </summary>

--- a/AutoRest/AutoRest.Core/ClientModel/Method.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/Method.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -46,7 +47,7 @@ namespace Microsoft.Rest.Generator.ClientModel
         /// <summary>
         /// Gets or sets the HTTP url.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings",
+        [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings",
             Justification= "Url might be used as a template, thus making it invalid url in certain scenarios.")]
         public string Url { get; set; }
 
@@ -138,6 +139,8 @@ namespace Microsoft.Rest.Generator.ClientModel
         /// <summary>
         /// Gets or sets a URL pointing to related external documentation.
         /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings",
+            Justification = "May not parse as a valid URI.")]
         public string ExternalDocsUrl { get; set; }
 
         /// <summary>

--- a/AutoRest/AutoRest.Core/ClientModel/Method.cs
+++ b/AutoRest/AutoRest.Core/ClientModel/Method.cs
@@ -136,6 +136,11 @@ namespace Microsoft.Rest.Generator.ClientModel
         public string Summary { get; set; }
 
         /// <summary>
+        /// Gets or sets a URL pointing to related external documentation.
+        /// </summary>
+        public string ExternalDocsUrl { get; set; }
+
+        /// <summary>
         /// Gets or sets the content type.
         /// </summary>
         public string RequestContentType { get; set; }

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/AutoRestDurationTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/AutoRestDurationTestService.cs
@@ -265,6 +265,10 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationAllSync
         }
 
         /// <summary>
+        /// An optional partial-method to perform custom initialization.
+        /// </summary>
+        partial void CustomInitialize();
+        /// <summary>
         /// Initializes client properties.
         /// </summary>
         private void Initialize()
@@ -299,6 +303,7 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationAllSync
                         new Iso8601TimeSpanConverter()
                     }
             };
+            CustomInitialize();
             DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
         }    
     }

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/AutoRestDurationTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/AutoRestDurationTestService.cs
@@ -265,6 +265,10 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationNoSync
         }
 
         /// <summary>
+        /// An optional partial-method to perform custom initialization.
+        /// </summary>
+        partial void CustomInitialize();
+        /// <summary>
         /// Initializes client properties.
         /// </summary>
         private void Initialize()
@@ -299,6 +303,7 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationNoSync
                         new Iso8601TimeSpanConverter()
                     }
             };
+            CustomInitialize();
             DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
         }    
     }

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureResource/AutoRestResourceFlatteningTestService.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureResource/AutoRestResourceFlatteningTestService.cs
@@ -304,6 +304,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         }    
         /// <summary>
         /// Put External Resource as an Array
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='resourceArray'>
         /// External Resource as an Array to put
@@ -445,6 +446,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
         /// <summary>
         /// Get External Resource as an Array
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -597,6 +599,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
         /// <summary>
         /// Put External Resource as a Dictionary
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='resourceDictionary'>
         /// External Resource as a Dictionary to put
@@ -738,6 +741,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
         /// <summary>
         /// Get External Resource as a Dictionary
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -890,6 +894,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
         /// <summary>
         /// Put External Resource as a ResourceCollection
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='resourceComplexObject'>
         /// External Resource as a ResourceCollection to put
@@ -1031,6 +1036,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
         /// <summary>
         /// Get External Resource as a ResourceCollection
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureResource/AutoRestResourceFlatteningTestServiceExtensions.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureResource/AutoRestResourceFlatteningTestServiceExtensions.cs
@@ -24,6 +24,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
     {
             /// <summary>
             /// Put External Resource as an Array
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -38,6 +39,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Put External Resource as an Array
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -55,6 +57,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Get External Resource as an Array
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -66,6 +69,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Get External Resource as an Array
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -83,6 +87,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Put External Resource as a Dictionary
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -97,6 +102,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Put External Resource as a Dictionary
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -114,6 +120,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Get External Resource as a Dictionary
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -125,6 +132,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Get External Resource as a Dictionary
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -142,6 +150,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Put External Resource as a ResourceCollection
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -156,6 +165,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Put External Resource as a ResourceCollection
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -173,6 +183,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Get External Resource as a ResourceCollection
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -184,6 +195,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
 
             /// <summary>
             /// Get External Resource as a ResourceCollection
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureResource/Models/Resource.cs
+++ b/AutoRest/Generators/CSharp/Azure.CSharp.Tests/Expected/AcceptanceTests/AzureResource/Models/Resource.cs
@@ -16,6 +16,10 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
     using Microsoft.Rest.Serialization;
     using Microsoft.Rest.Azure;
 
+    /// <summary>
+    /// Some resource
+    /// <see href="http://tempuri.org" />
+    /// </summary>
     public partial class Resource : IResource
     {
         /// <summary>

--- a/AutoRest/Generators/CSharp/Azure.CSharp/Templates/AzureMethodTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/Azure.CSharp/Templates/AzureMethodTemplate.cshtml
@@ -18,6 +18,10 @@ if (!string.IsNullOrWhiteSpace(Model.Description) || !string.IsNullOrWhiteSpace(
 {
 @:/// <summary>
 @:@WrapComment("/// ", String.IsNullOrEmpty(Model.Summary) ? Model.Description.EscapeXmlComment() : Model.Summary.EscapeXmlComment())
+if (!string.IsNullOrWhiteSpace(Model.ExternalDocsUrl))
+{
+@:/// <see href="@Model.ExternalDocsUrl" />
+}
 @:/// </summary>
 }
 if (!String.IsNullOrEmpty(Model.Description) && !String.IsNullOrEmpty(Model.Summary))
@@ -53,6 +57,10 @@ if (!String.IsNullOrEmpty(Model.Description) || !String.IsNullOrEmpty(Model.Summ
 {
 @:/// <summary>
 @:@WrapComment("/// ", String.IsNullOrEmpty(Model.Summary) ? Model.Description.EscapeXmlComment() : Model.Summary.EscapeXmlComment())
+if (!string.IsNullOrWhiteSpace(Model.ExternalDocsUrl))
+{
+@:/// <see href="@Model.ExternalDocsUrl" />
+}
 @:/// </summary>
 }
 if (!String.IsNullOrEmpty(Model.Description) && !String.IsNullOrEmpty(Model.Summary))

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestService.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestService.cs
@@ -155,6 +155,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
         }    
         /// <summary>
         /// Put External Resource as an Array
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='resourceArray'>
         /// External Resource as an Array to put
@@ -269,6 +270,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
         /// <summary>
         /// Get External Resource as an Array
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -394,6 +396,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
         /// <summary>
         /// Put External Resource as a Dictionary
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='resourceDictionary'>
         /// External Resource as a Dictionary to put
@@ -508,6 +511,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
         /// <summary>
         /// Get External Resource as a Dictionary
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -633,6 +637,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
         /// <summary>
         /// Put External Resource as a ResourceCollection
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='resourceComplexObject'>
         /// External Resource as a ResourceCollection to put
@@ -747,6 +752,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
         /// <summary>
         /// Get External Resource as a ResourceCollection
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -872,6 +878,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
         /// <summary>
         /// Put Simple Product with client flattening true on the model
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='simpleBodyProduct'>
         /// Simple body product to put
@@ -1011,6 +1018,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
         /// <summary>
         /// Put Flattened Simple Product with client flattening true on the parameter
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='productId'>
         /// Unique identifier representing a specific product for a given latitude
@@ -1181,6 +1189,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
         /// <summary>
         /// Put Simple Product with client flattening true on the model
+        /// <see href="http://tempuri.org" />
         /// </summary>
         /// <param name='flattenParameterGroup'>
         /// Additional parameters for the operation

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestServiceExtensions.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestServiceExtensions.cs
@@ -23,6 +23,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
     {
             /// <summary>
             /// Put External Resource as an Array
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -37,6 +38,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put External Resource as an Array
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -54,6 +56,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Get External Resource as an Array
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -65,6 +68,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Get External Resource as an Array
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -82,6 +86,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put External Resource as a Dictionary
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -96,6 +101,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put External Resource as a Dictionary
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -113,6 +119,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Get External Resource as a Dictionary
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -124,6 +131,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Get External Resource as a Dictionary
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -141,6 +149,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put External Resource as a ResourceCollection
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -155,6 +164,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put External Resource as a ResourceCollection
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -172,6 +182,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Get External Resource as a ResourceCollection
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -183,6 +194,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Get External Resource as a ResourceCollection
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -200,6 +212,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put Simple Product with client flattening true on the model
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -214,6 +227,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put Simple Product with client flattening true on the model
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -234,6 +248,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put Flattened Simple Product with client flattening true on the parameter
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -262,6 +277,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put Flattened Simple Product with client flattening true on the parameter
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -296,6 +312,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put Simple Product with client flattening true on the model
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -310,6 +327,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening
 
             /// <summary>
             /// Put Simple Product with client flattening true on the model
+            /// <see href="http://tempuri.org" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/FlattenedProduct.cs
+++ b/AutoRest/Generators/CSharp/CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/FlattenedProduct.cs
@@ -15,6 +15,10 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
 
+    /// <summary>
+    /// Flattened product.
+    /// <see href="http://tempuri.org" />
+    /// </summary>
     [JsonTransformation]
     public partial class FlattenedProduct : Resource
     {

--- a/AutoRest/Generators/CSharp/CSharp/Templates/ExtensionMethodTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/ExtensionMethodTemplate.cshtml
@@ -6,12 +6,16 @@
 @using Microsoft.Rest.Generator.Utilities
 @inherits Microsoft.Rest.Generator.Template<Microsoft.Rest.Generator.CSharp.MethodTemplateModel>
 @{
-    if (Model.SyncMethods == SyncMethodsGenerationMode.All || Model.SyncMethods == SyncMethodsGenerationMode.Essential)
+if (Model.SyncMethods == SyncMethodsGenerationMode.All || Model.SyncMethods == SyncMethodsGenerationMode.Essential)
+{
+    if (!String.IsNullOrEmpty(Model.Description) || !String.IsNullOrEmpty(Model.Summary))
     {
-        if (!String.IsNullOrEmpty(Model.Description) || !String.IsNullOrEmpty(Model.Summary))
-        {
 @:/// <summary>
 @:@WrapComment("/// ", String.IsNullOrEmpty(Model.Summary) ? Model.Description.EscapeXmlComment() : Model.Summary.EscapeXmlComment())
+        if (!String.IsNullOrEmpty(Model.ExternalDocsUrl))
+        {
+@:/// <see href="@Model.ExternalDocsUrl" />
+        }
 @:/// </summary>
     }
     if (!String.IsNullOrEmpty(Model.Description) && !String.IsNullOrEmpty(Model.Summary))
@@ -49,6 +53,10 @@ if (!String.IsNullOrEmpty(Model.Description) || !String.IsNullOrEmpty(Model.Summ
 {
 @:/// <summary>
 @:@WrapComment("/// ", String.IsNullOrEmpty(Model.Summary) ? Model.Description.EscapeXmlComment() : Model.Summary.EscapeXmlComment())
+    if (!String.IsNullOrEmpty(Model.ExternalDocsUrl))
+    {
+@:/// <see href="@Model.ExternalDocsUrl" />
+    }
 @:/// </summary>
 }
 if (!String.IsNullOrEmpty(Model.Description) && !String.IsNullOrEmpty(Model.Summary))
@@ -105,6 +113,10 @@ foreach (var parameter in Model.LocalParameters)
     {
 @:/// <summary>
 @:@WrapComment("/// ", String.IsNullOrEmpty(Model.Summary) ? Model.Description.EscapeXmlComment() : Model.Summary.EscapeXmlComment())
+        if (!String.IsNullOrEmpty(Model.ExternalDocsUrl))
+        {
+@:/// <see href="@Model.ExternalDocsUrl" />
+        }
 @:/// </summary>
     }
     if (!String.IsNullOrEmpty(Model.Description) && !String.IsNullOrEmpty(Model.Summary))

--- a/AutoRest/Generators/CSharp/CSharp/Templates/MethodGroupInterfaceTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/MethodGroupInterfaceTemplate.cshtml
@@ -27,6 +27,10 @@ namespace @Settings.Namespace
         {
         @:/// <summary>
         @:@WrapComment("/// ", String.IsNullOrEmpty(method.Summary) ? method.Description.EscapeXmlComment() : method.Summary.EscapeXmlComment())
+            if (!String.IsNullOrEmpty(method.ExternalDocsUrl))
+            {
+        @:/// <see href="@method.ExternalDocsUrl" />
+            }
         @:/// </summary>
         }
         if (!String.IsNullOrEmpty(method.Description) && !String.IsNullOrEmpty(method.Summary))

--- a/AutoRest/Generators/CSharp/CSharp/Templates/MethodTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/MethodTemplate.cshtml
@@ -10,6 +10,10 @@
 {
 @:/// <summary>
 @:@WrapComment("/// ", String.IsNullOrEmpty(Model.Summary) ? Model.Description.EscapeXmlComment() : Model.Summary.EscapeXmlComment())
+    if (!string.IsNullOrEmpty(Model.ExternalDocsUrl))
+    {
+@:/// <see href="@Model.ExternalDocsUrl" />
+    }
 @:/// </summary>
 }
 @if (!String.IsNullOrEmpty(Model.Description) && !String.IsNullOrEmpty(Model.Summary))

--- a/AutoRest/Generators/CSharp/CSharp/Templates/ModelTemplate.cshtml
+++ b/AutoRest/Generators/CSharp/CSharp/Templates/ModelTemplate.cshtml
@@ -22,6 +22,10 @@ namespace @(Settings.Namespace).Models
     {
     @:/// <summary>
     @:@WrapComment("/// ", Model.Documentation.EscapeXmlComment())
+        if (!string.IsNullOrEmpty(Model.ExternalDocsUrl))
+        {
+    @:/// <see href="@Model.ExternalDocsUrl" />
+        }
     @:/// </summary>
     }
 

--- a/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/modelflattening/models/FlattenedProduct.java
+++ b/AutoRest/Generators/Java/Java.Tests/src/main/java/fixtures/modelflattening/models/FlattenedProduct.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.rest.serializer.JsonFlatten;
 
 /**
- * The FlattenedProduct model.
+ * Flattened product.
  */
 @JsonFlatten
 public class FlattenedProduct extends Resource {

--- a/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/Expected/AcceptanceTests/AzureResource/models/index.d.ts
+++ b/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/Expected/AcceptanceTests/AzureResource/models/index.d.ts
@@ -28,6 +28,7 @@ export interface ErrorModel {
  * @class
  * Initializes a new instance of the Resource class.
  * @constructor
+ * Some resource
  * @member {string} [id] Resource Id
  * 
  * @member {string} [type] Resource Type

--- a/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/Expected/AcceptanceTests/AzureResource/models/resource.js
+++ b/AutoRest/Generators/NodeJS/Azure.NodeJS.Tests/Expected/AcceptanceTests/AzureResource/models/resource.js
@@ -18,6 +18,7 @@ var util = require('util');
  * @class
  * Initializes a new instance of the Resource class.
  * @constructor
+ * Some resource
  * @member {string} [id] Resource Id
  * 
  * @member {string} [type] Resource Type

--- a/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/ModelFlattening/models/flattenedProduct.js
+++ b/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/ModelFlattening/models/flattenedProduct.js
@@ -18,6 +18,7 @@ var util = require('util');
  * @class
  * Initializes a new instance of the FlattenedProduct class.
  * @constructor
+ * Flattened product.
  * @member {string} [pname]
  * 
  * @member {string} [flattenedProductType]

--- a/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/ModelFlattening/models/index.d.ts
+++ b/AutoRest/Generators/NodeJS/NodeJS.Tests/Expected/AcceptanceTests/ModelFlattening/models/index.d.ts
@@ -53,6 +53,7 @@ export interface Resource {
  * @class
  * Initializes a new instance of the FlattenedProduct class.
  * @constructor
+ * Flattened product.
  * @member {string} [pname]
  * 
  * @member {string} [flattenedProductType]

--- a/AutoRest/Generators/Python/Azure.Python.Tests/Expected/AcceptanceTests/AzureResource/autorestresourceflatteningtestservice/models/resource.py
+++ b/AutoRest/Generators/Python/Azure.Python.Tests/Expected/AcceptanceTests/AzureResource/autorestresourceflatteningtestservice/models/resource.py
@@ -13,7 +13,8 @@ from msrest.serialization import Model
 
 
 class Resource(Model):
-    """Resource
+    """
+    Some resource
 
     Variables are only populated by the server, and will be ignored when
     sending a request.

--- a/AutoRest/Generators/Python/Python.Tests/Expected/AcceptanceTests/ModelFlattening/autorestresourceflatteningtestservice/models/flattened_product.py
+++ b/AutoRest/Generators/Python/Python.Tests/Expected/AcceptanceTests/ModelFlattening/autorestresourceflatteningtestservice/models/flattened_product.py
@@ -13,7 +13,8 @@ from .resource import Resource
 
 
 class FlattenedProduct(Resource):
-    """FlattenedProduct
+    """
+    Flattened product.
 
     Variables are only populated by the server, and will be ignored when
     sending a request.

--- a/AutoRest/Modelers/Swagger/OperationBuilder.cs
+++ b/AutoRest/Modelers/Swagger/OperationBuilder.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Rest.Modeler.Swagger
             }
             method.Description = _operation.Description;
             method.Summary = _operation.Summary;
+            method.ExternalDocsUrl = _operation.ExternalDocs?.Url;
 
             // Service parameters
             if (_operation.Parameters != null)

--- a/AutoRest/Modelers/Swagger/OperationBuilder.cs
+++ b/AutoRest/Modelers/Swagger/OperationBuilder.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Rest.Modeler.Swagger
                 // Enable UTF-8 charset
                 method.RequestContentType += "; charset=utf-8";
             }
+
             method.Description = _operation.Description;
             method.Summary = _operation.Summary;
             method.ExternalDocsUrl = _operation.ExternalDocs?.Url;
@@ -77,21 +78,7 @@ namespace Microsoft.Rest.Modeler.Swagger
             // Service parameters
             if (_operation.Parameters != null)
             {
-                foreach (var swaggerParameter in DeduplicateParameters(_operation.Parameters))
-                {
-                    var parameter = ((ParameterBuilder) swaggerParameter.GetBuilder(_swaggerModeler)).Build();
-                    method.Parameters.Add(parameter);
-
-                    StringBuilder parameterName = new StringBuilder(parameter.Name);
-                    parameterName = CollectionFormatBuilder.OnBuildMethodParameter(method, swaggerParameter,
-                        parameterName);
-
-                    if (swaggerParameter.In == ParameterLocation.Header)
-                    {
-                        method.RequestHeaders[swaggerParameter.Name] =
-                            string.Format(CultureInfo.InvariantCulture, "{{{0}}}", parameterName);
-                    }
-                }
+                BuildMethodParameters(method);
             }
 
             // Build header object
@@ -100,7 +87,7 @@ namespace Microsoft.Rest.Modeler.Swagger
             {
                 if (response.Headers != null)
                 {
-                    response.Headers.ForEach( h => responseHeaders[h.Key] = h.Value);
+                    response.Headers.ForEach(h => responseHeaders[h.Key] = h.Value);
                 }
             }
 
@@ -130,30 +117,7 @@ namespace Microsoft.Rest.Modeler.Swagger
             }
 
             // Response format
-            var typesList = new List<Stack<IType>>();
-            foreach (var response in _operation.Responses)
-            {
-                if (string.Equals(response.Key, "default", StringComparison.OrdinalIgnoreCase))
-                {
-                    TryBuildDefaultResponse(methodName, response.Value, method, headerType);
-                }
-                else
-                {
-                    if (
-                        !(TryBuildResponse(methodName, response.Key.ToHttpStatusCode(), response.Value, method,
-                            typesList, headerType) ||
-                          TryBuildStreamResponse(response.Key.ToHttpStatusCode(), response.Value, method, typesList, headerType) ||
-                          TryBuildEmptyResponse(methodName, response.Key.ToHttpStatusCode(), response.Value, method,
-                              typesList, headerType)))
-                    {
-                        throw new InvalidOperationException(
-                            string.Format(CultureInfo.InvariantCulture,
-                            Resources.UnsupportedMimeTypeForResponseBody,
-                            methodName,
-                            response.Key));
-                    }
-                }
-            }
+            List<Stack<IType>> typesList = BuildResponses(method, headerType);
 
             method.ReturnType = BuildMethodReturnType(typesList, headerType);
             if (method.Responses.Count == 0)
@@ -207,6 +171,56 @@ namespace Microsoft.Rest.Modeler.Swagger
             var typeStack = new Stack<IType>();
             typeStack.Push(type);
             types.Add(typeStack);
+        }
+
+        private void BuildMethodParameters(Method method)
+        {
+            foreach (var swaggerParameter in DeduplicateParameters(_operation.Parameters))
+            {
+                var parameter = ((ParameterBuilder)swaggerParameter.GetBuilder(_swaggerModeler)).Build();
+                method.Parameters.Add(parameter);
+
+                StringBuilder parameterName = new StringBuilder(parameter.Name);
+                parameterName = CollectionFormatBuilder.OnBuildMethodParameter(method, swaggerParameter,
+                    parameterName);
+
+                if (swaggerParameter.In == ParameterLocation.Header)
+                {
+                    method.RequestHeaders[swaggerParameter.Name] =
+                        string.Format(CultureInfo.InvariantCulture, "{{{0}}}", parameterName);
+                }
+            }
+        }
+
+        private List<Stack<IType>> BuildResponses(Method method, CompositeType headerType)
+        {
+            string methodName = method.Name;
+            var typesList = new List<Stack<IType>>();
+            foreach (var response in _operation.Responses)
+            {
+                if (string.Equals(response.Key, "default", StringComparison.OrdinalIgnoreCase))
+                {
+                    TryBuildDefaultResponse(methodName, response.Value, method, headerType);
+                }
+                else
+                {
+                    if (
+                        !(TryBuildResponse(methodName, response.Key.ToHttpStatusCode(), response.Value, method,
+                            typesList, headerType) ||
+                          TryBuildStreamResponse(response.Key.ToHttpStatusCode(), response.Value, method, typesList, headerType) ||
+                          TryBuildEmptyResponse(methodName, response.Key.ToHttpStatusCode(), response.Value, method,
+                              typesList, headerType)))
+                    {
+                        throw new InvalidOperationException(
+                            string.Format(CultureInfo.InvariantCulture,
+                            Resources.UnsupportedMimeTypeForResponseBody,
+                            methodName,
+                            response.Key));
+                    }
+                }
+            }
+
+            return typesList;
         }
 
         private Response BuildMethodReturnType(List<Stack<IType>> types, IType headerType)

--- a/AutoRest/Modelers/Swagger/SchemaBuilder.cs
+++ b/AutoRest/Modelers/Swagger/SchemaBuilder.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Rest.Modeler.Swagger
                             { 
                                 Name = serviceTypeName, 
                                 SerializedName = serviceTypeName, 
-                                Documentation = _schema.Description 
+                                Documentation = _schema.Description,
+                                ExternalDocsUrl = _schema.ExternalDocs?.Url
                             };
 
             // Put this in already generated types serializationProperty

--- a/AutoRest/TestServer/swagger/azure-resource.json
+++ b/AutoRest/TestServer/swagger/azure-resource.json
@@ -20,6 +20,9 @@
       "put": {
         "operationId": "putArray",
         "description": "Put External Resource as an Array",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "ResourceArray",
@@ -48,6 +51,9 @@
       "get": {
         "operationId": "getArray",
         "description": "Get External Resource as an Array",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "responses": {
           "200": {
             "description": "External Resource as an Array from get",
@@ -71,6 +77,9 @@
       "put": {
         "operationId": "putDictionary",
         "description": "Put External Resource as a Dictionary",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "ResourceDictionary",
@@ -99,6 +108,9 @@
       "get": {
         "operationId": "getDictionary",
         "description": "Get External Resource as a Dictionary",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "responses": {
           "200": {
             "description": "External Resource as a Dictionary from get",
@@ -122,6 +134,9 @@
       "put": {
         "operationId": "putResourceCollection",
         "description": "Put External Resource as a ResourceCollection",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "ResourceComplexObject",
@@ -147,6 +162,9 @@
       "get": {
         "operationId": "getResourceCollection",
         "description": "Get External Resource as a ResourceCollection",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "responses": {
           "200": {
             "description": "External Resource as a ResourceCollection from get",
@@ -178,6 +196,10 @@
     },
     "Resource": {
       "x-ms-azure-resource": true,
+      "description": "Some resource",
+      "externalDocs": {
+        "url": "http://tempuri.org"
+      },
       "properties": {
         "id": {
           "type": "string",

--- a/AutoRest/TestServer/swagger/model-flattening.json
+++ b/AutoRest/TestServer/swagger/model-flattening.json
@@ -20,6 +20,9 @@
       "put": {
         "operationId": "putArray",
         "description": "Put External Resource as an Array",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "ResourceArray",
@@ -48,6 +51,9 @@
       "get": {
         "operationId": "getArray",
         "description": "Get External Resource as an Array",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "responses": {
           "200": {
             "description": "External Resource as an Array from get",
@@ -71,6 +77,9 @@
       "put": {
         "operationId": "putDictionary",
         "description": "Put External Resource as a Dictionary",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "ResourceDictionary",
@@ -99,6 +108,9 @@
       "get": {
         "operationId": "getDictionary",
         "description": "Get External Resource as a Dictionary",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "responses": {
           "200": {
             "description": "External Resource as a Dictionary from get",
@@ -122,6 +134,9 @@
       "put": {
         "operationId": "putResourceCollection",
         "description": "Put External Resource as a ResourceCollection",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "ResourceComplexObject",
@@ -147,6 +162,9 @@
       "get": {
         "operationId": "getResourceCollection",
         "description": "Get External Resource as a ResourceCollection",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "responses": {
           "200": {
             "description": "External Resource as a ResourceCollection from get",
@@ -167,6 +185,9 @@
       "put": {
         "operationId": "putSimpleProduct",
         "description": "Put Simple Product with client flattening true on the model",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "SimpleBodyProduct",
@@ -197,6 +218,9 @@
       "post": {
         "operationId": "postFlattenedSimpleProduct",
         "description": "Put Flattened Simple Product with client flattening true on the parameter",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "SimpleBodyProduct",
@@ -230,6 +254,9 @@
       "put": {
         "operationId": "putSimpleProductWithGrouping",
         "description": "Put Simple Product with client flattening true on the model",
+        "externalDocs": {
+          "url": "http://tempuri.org"
+        },
         "parameters": [
           {
             "name": "SimpleBodyProduct",
@@ -324,6 +351,10 @@
           "$ref": "Resource"
         }
       ],
+      "description": "Flattened product.",
+      "externalDocs": {
+        "url": "http://tempuri.org"
+      },           
       "properties": {
         "properties": {
           "x-ms-client-flatten": true,

--- a/Samples/azure-storage/Azure.CSharp/StorageManagementClient.cs
+++ b/Samples/azure-storage/Azure.CSharp/StorageManagementClient.cs
@@ -275,6 +275,10 @@ namespace Petstore
         }
 
         /// <summary>
+        /// An optional partial-method to perform custom initialization.
+        /// </summary>
+        partial void CustomInitialize();
+        /// <summary>
         /// Initializes client properties.
         /// </summary>
         private void Initialize()
@@ -311,6 +315,7 @@ namespace Petstore
                         new Iso8601TimeSpanConverter()
                     }
             };
+            CustomInitialize();
             DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
         }    
     }


### PR DESCRIPTION
This change allows you to use `externalDocs` in your OpenAPI spec to get a `<see href="..." />` link the `<summary>` comments of model classes and operation methods in generated C# code.

See issue for more details: https://github.com/Azure/autorest/issues/288

I haven't tackled the other languages because I have no means to test their generated documentation (whereas for C# I regularly publish SDK docs to MSDN, so I know what they need to look like). If anybody has the know-how to implement this across other languages, be my guest.

FYI @matthchr @tbombach @fearthecowboy @markcowl 