### PR TITLE
[experiments] Adding tests to validate that that linter shows errors for known spec issues

### DIFF
--- a/AutoRest/Modelers/Swagger.Tests/AutoRest.Modeler.Swagger.Tests.csproj
+++ b/AutoRest/Modelers/Swagger.Tests/AutoRest.Modeler.Swagger.Tests.csproj
@@ -36,6 +36,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="SwaggerModelerValidationTests.cs" />
     <Compile Include="VendorExtensionInPath.cs" />
     <Compile Include="SwaggerSpecHelper.cs" />
     <Compile Include="SwaggerModelerTests.cs" />
@@ -89,6 +90,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Swagger\swagger-simple-spec.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Swagger\Validator\definition-missing-description.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Swagger\vendor-extension-in-path.json">
@@ -159,7 +163,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties Swagger_4swagger-validation_1json__JSONSchema="http://json.schemastore.org/swagger-2.0" Swagger_4swagger-x-ms-code-generation-settings_1json__JSONSchema="..\..\..\..\schema\swagger-extensions.json" />
+      <UserProperties Swagger_4swagger-x-ms-code-generation-settings_1json__JSONSchema="..\..\..\..\schema\swagger-extensions.json" Swagger_4swagger-validation_1json__JSONSchema="http://json.schemastore.org/swagger-2.0" />
     </VisualStudio>
   </ProjectExtensions>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/AutoRest/Modelers/Swagger.Tests/AutoRest.Modeler.Swagger.Tests.csproj
+++ b/AutoRest/Modelers/Swagger.Tests/AutoRest.Modeler.Swagger.Tests.csproj
@@ -92,6 +92,9 @@
     <None Include="Swagger\swagger-simple-spec.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Swagger\Validator\default-value-not-in-enum.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Swagger\Validator\definition-missing-description.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/AutoRest/Modelers/Swagger.Tests/Swagger/Validator/default-value-not-in-enum.json
+++ b/AutoRest/Modelers/Swagger.Tests/Swagger/Validator/default-value-not-in-enum.json
@@ -20,18 +20,21 @@
         "description": "Foo operation",
         "responses": {
           "default": {
-            "description": "Unexpected error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
+            "description": "Unexpected error"
           }
         }
       }
     }
   },
-  "definitions" : {
-    "Error": {
-      // Missing "description" field
+  "definitions": {
+    "Test": {
+      "type": "string",
+      "description": "Property for foo path",
+      "enum": [
+        "Foo",
+        "Bar"
+      ],
+      "default": "Baz" // Does not appear in enum
     }
   }
 }

--- a/AutoRest/Modelers/Swagger.Tests/Swagger/Validator/definition-missing-description.json
+++ b/AutoRest/Modelers/Swagger.Tests/Swagger/Validator/definition-missing-description.json
@@ -1,0 +1,37 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Definition missing description",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/foo": {
+      "post": {
+        "operationId": "PostFood",
+        "summary": "Food path",
+        "description": "Foo operation",
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "Error": {
+      // Missing "description" field
+    }
+  }
+}

--- a/AutoRest/Modelers/Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/AutoRest/Modelers/Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Rest.Modeler.Swagger.Tests
                 Namespace = "Test",
                 Input = Path.Combine("Swagger", "Validator", "definition-missing-description.json")
             });
-            var clientModel = modeler.Build();
+            modeler.Build();
             // TODO: we want to get errors from the modeler.Build or Validate step, with known error types. Not inspect logger
             Assert.Equal(1, Logger.Entries.Count(l => l.Message.Contains("Consider adding a 'description'")));
         }
@@ -42,7 +42,7 @@ namespace Microsoft.Rest.Modeler.Swagger.Tests
             });
             Assert.Throws<CodeGenerationException>(() =>
             {
-                var clientModel = modeler.Build();
+                modeler.Build();
             });
             // TODO: we want to get errors from the modeler.Build or Validate step, with known error types. Not inspect logger
             Assert.Equal(1, Logger.Entries.Count(l => l.Message.Contains("The default value is not one of the values enumerated as valid for this element.")));

--- a/AutoRest/Modelers/Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/AutoRest/Modelers/Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Rest.Modeler.Swagger.Tests
     public class SwaggerModelerValidationTests
     {
         [Fact]
-        public void TestClientModelFromSimpleSwagger()
+        public void MissingDescriptionValidation()
         {
             Generator.Modeler modeler = new SwaggerModeler(new Settings
             {
@@ -30,6 +30,22 @@ namespace Microsoft.Rest.Modeler.Swagger.Tests
             var clientModel = modeler.Build();
             // TODO: we want to get errors from the modeler.Build or Validate step, with known error types. Not inspect logger
             Assert.Equal(1, Logger.Entries.Count(l => l.Message.Contains("Consider adding a 'description'")));
+        }
+
+        [Fact]
+        public void DefaultValueInEnumValidation()
+        {
+            Generator.Modeler modeler = new SwaggerModeler(new Settings
+            {
+                Namespace = "Test",
+                Input = Path.Combine("Swagger", "Validator", "default-value-not-in-enum.json")
+            });
+            Assert.Throws<CodeGenerationException>(() =>
+            {
+                var clientModel = modeler.Build();
+            });
+            // TODO: we want to get errors from the modeler.Build or Validate step, with known error types. Not inspect logger
+            Assert.Equal(1, Logger.Entries.Count(l => l.Message.Contains("The default value is not one of the values enumerated as valid for this element.")));
         }
     }
 }

--- a/AutoRest/Modelers/Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/AutoRest/Modelers/Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using Microsoft.Rest.Generator;
+using Microsoft.Rest.Generator.ClientModel;
+using Microsoft.Rest.Generator.CSharp;
+using Microsoft.Rest.Generator.Extensibility;
+using Microsoft.Rest.Generator.Utilities;
+using Xunit;
+using Newtonsoft.Json.Linq;
+using Microsoft.Rest.Generator.Logging;
+
+namespace Microsoft.Rest.Modeler.Swagger.Tests
+{
+    [Collection("AutoRest Tests")]
+    public class SwaggerModelerValidationTests
+    {
+        [Fact]
+        public void TestClientModelFromSimpleSwagger()
+        {
+            Generator.Modeler modeler = new SwaggerModeler(new Settings
+            {
+                Namespace = "Test",
+                Input = Path.Combine("Swagger", "Validator", "definition-missing-description.json")
+            });
+            var clientModel = modeler.Build();
+            // TODO: we want to get errors from the modeler.Build or Validate step, with known error types. Not inspect logger
+            Assert.Equal(1, Logger.Entries.Count(l => l.Message.Contains("Consider adding a 'description'")));
+        }
+    }
+}

--- a/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
+++ b/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
@@ -71,7 +71,7 @@
     <Compile Include="Model\Info.cs" />
     <Compile Include="Model\Tag.cs" />
     <Compile Include="Model\TransferProtocolScheme.cs" />
-    <Compile Include="ValidationResult.cs" />
+    <Compile Include="ValidationMessage.cs" />
     <Compile Include="Validators\SwaggerObjectValidator.cs" />
     <Compile Include="Validators\IValidator.cs" />
     <Compile Include="YamlBoolDeserializer.cs" />

--- a/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
+++ b/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Model\Info.cs" />
     <Compile Include="Model\Tag.cs" />
     <Compile Include="Model\TransferProtocolScheme.cs" />
+    <Compile Include="ValidationResult.cs" />
     <Compile Include="Validators\SwaggerObjectValidator.cs" />
     <Compile Include="Validators\IValidator.cs" />
     <Compile Include="YamlBoolDeserializer.cs" />

--- a/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
+++ b/AutoRest/Modelers/Swagger/AutoRest.Modeler.Swagger.csproj
@@ -71,6 +71,8 @@
     <Compile Include="Model\Info.cs" />
     <Compile Include="Model\Tag.cs" />
     <Compile Include="Model\TransferProtocolScheme.cs" />
+    <Compile Include="Validators\SwaggerObjectValidator.cs" />
+    <Compile Include="Validators\IValidator.cs" />
     <Compile Include="YamlBoolDeserializer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AutoRest/Modelers/Swagger/Model/SwaggerObject.cs
+++ b/AutoRest/Modelers/Swagger/Model/SwaggerObject.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using Resources = Microsoft.Rest.Modeler.Swagger.Properties.Resources;
 using Newtonsoft.Json;
 using Microsoft.Rest.Generator.ClientModel;
-using Microsoft.Rest.Modeler.Swagger.Properties;
 using Microsoft.Rest.Generator.Logging;
 using System.Text.RegularExpressions;
 
@@ -172,7 +171,7 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
 
             base.Validate(context);
 
-            var validator = new Validators.SwaggerObjectValidator();
+            var validator = new SwaggerObjectValidator();
             foreach (var validationResult in validator.ValidationExceptions(this))
             {
                 // TODO: put logging somewhere else

--- a/AutoRest/Modelers/Swagger/Model/SwaggerObject.cs
+++ b/AutoRest/Modelers/Swagger/Model/SwaggerObject.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
                     return new PrimaryType(KnownPrimaryType.Stream);
                 default:
                     throw new NotImplementedException(
-                        string.Format(CultureInfo.InvariantCulture, 
+                        string.Format(CultureInfo.InvariantCulture,
                            Resources.InvalidTypeInSwaggerSchema,
                             Type));
             }
@@ -172,10 +172,17 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
 
             base.Validate(context);
 
-            if (string.IsNullOrEmpty(Description) && string.IsNullOrEmpty(Reference))
+            var validator = new Validators.SwaggerObjectValidator();
+            foreach (var message in validator.ValidationExceptions(this))
             {
-                context.LogWarning(Resources.MissingDescription);
+                // TODO: put logging somewhere else & have a way to specify level
+                context.LogWarning(message);
             }
+
+            //if (string.IsNullOrEmpty(Description) && string.IsNullOrEmpty(Reference))
+            //{
+            //    context.LogWarning(Resources.MissingDescription);
+            //}
 
             ValidateConstraints(context);
 
@@ -316,7 +323,7 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1806:DoNotIgnoreMethodResults", Justification = "The call to 'new Regex' is made only to look for exceptions.")]
-        private void ValidateConstraints(ValidationContext context) 
+        private void ValidateConstraints(ValidationContext context)
         {
             double numberValue;
             long integerValue = 0;
@@ -348,10 +355,11 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
 
             if (!string.IsNullOrEmpty(Pattern))
             {
-                try {
+                try
+                {
                     new Regex(Pattern);
                 }
-                catch(ArgumentException ae)
+                catch (ArgumentException ae)
                 {
                     context.LogError(string.Format(CultureInfo.InvariantCulture, Resources.InvalidPattern2, Pattern, ae.Message));
                 }
@@ -376,13 +384,13 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
                 context.LogBreakingChange(string.Format(CultureInfo.InvariantCulture, Resources.PropertyValueChanged1, "multipleOf"));
             }
             if ((prior.Maximum == null && Maximum != null) ||
-                (prior.Maximum != null && !prior.Maximum.Equals(Maximum)) || 
+                (prior.Maximum != null && !prior.Maximum.Equals(Maximum)) ||
                 prior.ExclusiveMaximum != ExclusiveMaximum)
             {
                 context.LogBreakingChange(string.Format(CultureInfo.InvariantCulture, Resources.PropertyValueChanged1, "maximum"));
             }
             if ((prior.Minimum == null && Minimum != null) ||
-                (prior.Minimum != null && !prior.Minimum.Equals(Minimum)) || 
+                (prior.Minimum != null && !prior.Minimum.Equals(Minimum)) ||
                 prior.ExclusiveMinimum != ExclusiveMinimum)
             {
                 context.LogBreakingChange(string.Format(CultureInfo.InvariantCulture, Resources.PropertyValueChanged1, "minimum"));
@@ -402,7 +410,7 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
             {
                 context.LogBreakingChange(string.Format(CultureInfo.InvariantCulture, Resources.PropertyValueChanged1, "pattern"));
             }
-            if ((prior.MaxItems  == null && MaxItems != null) ||
+            if ((prior.MaxItems == null && MaxItems != null) ||
                 (prior.MaxItems != null && !prior.MaxItems.Equals(MaxItems)))
             {
                 context.LogBreakingChange(string.Format(CultureInfo.InvariantCulture, Resources.PropertyValueChanged1, "maxItems"));

--- a/AutoRest/Modelers/Swagger/Model/SwaggerObject.cs
+++ b/AutoRest/Modelers/Swagger/Model/SwaggerObject.cs
@@ -173,29 +173,21 @@ namespace Microsoft.Rest.Modeler.Swagger.Model
             base.Validate(context);
 
             var validator = new Validators.SwaggerObjectValidator();
-            foreach (var message in validator.ValidationExceptions(this))
+            foreach (var validationResult in validator.ValidationExceptions(this))
             {
-                // TODO: put logging somewhere else & have a way to specify level
-                context.LogWarning(message);
-            }
-
-            //if (string.IsNullOrEmpty(Description) && string.IsNullOrEmpty(Reference))
-            //{
-            //    context.LogWarning(Resources.MissingDescription);
-            //}
-
-            ValidateConstraints(context);
-
-
-            if (!string.IsNullOrEmpty(Default) && Enum != null)
-            {
-                // THere's a default, and there's an list of valid values. Make sure the default is one 
-                // of them.
-                if (!Enum.Contains(Default))
+                // TODO: put logging somewhere else
+                switch (validationResult.Severity)
                 {
-                    context.LogError(Resources.InvalidDefault);
+                    case LogEntrySeverity.Warning:
+                        context.LogWarning(validationResult.Message);
+                        break;
+                    case LogEntrySeverity.Error:
+                        context.LogError(validationResult.Message);
+                        break;
                 }
             }
+
+            ValidateConstraints(context);
 
             return context.ValidationErrors.Count == errorCount;
         }

--- a/AutoRest/Modelers/Swagger/ValidationMessage.cs
+++ b/AutoRest/Modelers/Swagger/ValidationMessage.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Rest.Generator.Logging;
+using Microsoft.Rest.Modeler.Swagger.Model;
+
+namespace Microsoft.Rest.Modeler.Swagger
+{
+    public class ValidationMessage
+    {
+        public SwaggerBase Source { get; set; }
+
+        public string Message { get; set; }
+
+        public LogEntrySeverity Severity { get; set; }
+    }
+}

--- a/AutoRest/Modelers/Swagger/Validators/IValidator.cs
+++ b/AutoRest/Modelers/Swagger/Validators/IValidator.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Rest.Generator.Logging;
 using System.Collections.Generic;
 
-namespace Microsoft.Rest.Modeler.Swagger.Validators
+namespace Microsoft.Rest.Modeler.Swagger
 {
     public interface IValidator<T>
     {

--- a/AutoRest/Modelers/Swagger/Validators/IValidator.cs
+++ b/AutoRest/Modelers/Swagger/Validators/IValidator.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Rest.Modeler.Swagger.Validators
         bool IsValid(T entity);
 
         // TODO: change to from log entry
-        IEnumerable<string> ValidationExceptions(T entity);
+        IEnumerable<ValidationMessage> ValidationExceptions(T entity);
     }
 }

--- a/AutoRest/Modelers/Swagger/Validators/IValidator.cs
+++ b/AutoRest/Modelers/Swagger/Validators/IValidator.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Rest.Generator.Logging;
+using System.Collections.Generic;
+
+namespace Microsoft.Rest.Modeler.Swagger.Validators
+{
+    public interface IValidator<T>
+    {
+        bool IsValid(T entity);
+
+        // TODO: change to from log entry
+        IEnumerable<string> ValidationExceptions(T entity);
+    }
+}

--- a/AutoRest/Modelers/Swagger/Validators/SwaggerObjectValidator.cs
+++ b/AutoRest/Modelers/Swagger/Validators/SwaggerObjectValidator.cs
@@ -4,7 +4,7 @@ using Microsoft.Rest.Modeler.Swagger.Properties;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.Rest.Modeler.Swagger.Validators
+namespace Microsoft.Rest.Modeler.Swagger
 {
     public class SwaggerObjectValidator : IValidator<SwaggerObject>
     {

--- a/AutoRest/Modelers/Swagger/Validators/SwaggerObjectValidator.cs
+++ b/AutoRest/Modelers/Swagger/Validators/SwaggerObjectValidator.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Rest.Generator.Logging;
+using Microsoft.Rest.Modeler.Swagger.Model;
+using Microsoft.Rest.Modeler.Swagger.Properties;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Rest.Modeler.Swagger.Validators
+{
+    public class SwaggerObjectValidator : IValidator<SwaggerObject>
+    {
+        public bool IsValid(SwaggerObject entity)
+        {
+            return !ValidationExceptions(entity).Any();
+        }
+
+        public IEnumerable<string> ValidationExceptions(SwaggerObject entity)
+        {
+            if (string.IsNullOrEmpty(entity.Description) && string.IsNullOrEmpty(entity.Reference))
+            {
+                // TODO: need to have a way to include warning, error level
+                yield return Resources.MissingDescription;
+            }
+            yield break;
+        }
+    }
+}

--- a/AutoRest/Modelers/Swagger/Validators/SwaggerObjectValidator.cs
+++ b/AutoRest/Modelers/Swagger/Validators/SwaggerObjectValidator.cs
@@ -13,12 +13,32 @@ namespace Microsoft.Rest.Modeler.Swagger.Validators
             return !ValidationExceptions(entity).Any();
         }
 
-        public IEnumerable<string> ValidationExceptions(SwaggerObject entity)
+        public IEnumerable<ValidationMessage> ValidationExceptions(SwaggerObject entity)
         {
             if (string.IsNullOrEmpty(entity.Description) && string.IsNullOrEmpty(entity.Reference))
             {
                 // TODO: need to have a way to include warning, error level
-                yield return Resources.MissingDescription;
+                yield return new ValidationMessage()
+                {
+                    Severity = LogEntrySeverity.Warning,
+                    Message = Resources.MissingDescription,
+                    Source = entity
+                };
+            }
+
+            if (!string.IsNullOrEmpty(entity.Default) && entity.Enum != null)
+            {
+                // THere's a default, and there's an list of valid values. Make sure the default is one 
+                // of them.
+                if (!entity.Enum.Contains(entity.Default))
+                {
+                    yield return new ValidationMessage()
+                    {
+                        Message = Resources.InvalidDefault,
+                        Severity = LogEntrySeverity.Error,
+                        Source = entity
+                    };
+                }
             }
             yield break;
         }


### PR DESCRIPTION
Adding tests that make sure the linter will output warnings and errors if the spec has objects without descriptions or if an object has an enum and a default value, but the default value does not appear in the enum.