### PR TITLE
[Ruby - In Review] 	Restructuring generated Ruby & Azure.Ruby code into generated sub-folder

### DIFF
--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/azure_report_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/azure_report_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/azure_report'
 
-require 'azure_report'
+require 'generated/azure_report'
 
 include AzureReportModule
 

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/azure_special_properties_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/azure_special_properties_spec.rb
@@ -5,7 +5,7 @@ $: << 'RspecTests/Generated/azure_special_properties'
 require 'rspec'
 require 'securerandom'
 
-require 'azure_special_properties'
+require 'generated/azure_special_properties'
 
 include AzureSpecialPropertiesModule
 

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/azure_url_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/azure_url_spec.rb
@@ -5,7 +5,7 @@ $: << 'RspecTests/Generated/azure_url'
 require 'rspec'
 require 'securerandom'
 
-require 'subscription_id_api_version'
+require 'generated/subscription_id_api_version'
 
 include AzureUrlModule
 

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/custom_base_uri_more_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/custom_base_uri_more_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/custom_base_uri_more'
 
-require 'custom_base_url_more_options'
+require 'generated/custom_base_url_more_options'
 require 'uri'
 
 module CustomBaseUriMoreModule

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/custom_base_uri_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/custom_base_uri_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/custom_base_uri'
 
-require 'custom_base_url'
+require 'generated/custom_base_url'
 require 'uri'
 
 module CustomBaseUriModule

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/head_exception_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/head_exception_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/head_exceptions'
 
 require 'rspec'
-require 'head_exceptions'
+require 'generated/head_exceptions'
 
 include HeadExceptionsModule
 

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/head_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/head_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/head'
 
 require 'rspec'
-require 'head'
+require 'generated/head'
 
 include HeadModule
 

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/lro_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/lro_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/lro'
 
 require 'rspec'
-require 'lro'
+require 'generated/lro'
 
 include LroModule
 include LroModule::Models

--- a/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/paging_spec.rb
+++ b/AutoRest/Generators/Ruby/Azure.Ruby.Tests/RspecTests/paging_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/paging'
 
 require 'rspec'
-require 'paging'
+require 'generated/paging'
 
 include PagingModule
 

--- a/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Rest.Generator.Azure.Ruby
                 {
                     Model = new VersionTemplateModel(packageVersion),
                 };
-                await Write(versionTemplate, "version" + ImplementationFileExtension);
+                await Write(versionTemplate, Path.Combine(sdkPath, "version" + ImplementationFileExtension));
             }
 
             // Module Definition File

--- a/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Azure.Ruby/AzureRubyCodeGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -108,13 +109,13 @@ namespace Microsoft.Rest.Generator.Azure.Ruby
             // Models
             foreach (var model in serviceClient.ModelTypes)
             {
-                if ((model.Extensions.ContainsKey(AzureExtensions.ExternalExtension) && 
-                    (bool) model.Extensions[AzureExtensions.ExternalExtension])
+                if ((model.Extensions.ContainsKey(AzureExtensions.ExternalExtension) &&
+                    (bool)model.Extensions[AzureExtensions.ExternalExtension])
                     || model.Name == "Resource" || model.Name == "SubResource")
                 {
                     continue;
                 }
-                
+
                 var modelTemplate = new ModelTemplate
                 {
                     Model = new AzureModelTemplateModel(model, serviceClient.ModelTypes),
@@ -136,28 +137,28 @@ namespace Microsoft.Rest.Generator.Azure.Ruby
             // Requirements
             var requirementsTemplate = new RequirementsTemplate
             {
-                Model = new AzureRequirementsTemplateModel(serviceClient, this.packageName ?? this.sdkName, this.ImplementationFileExtension, this.Settings.Namespace),
+                Model = new AzureRequirementsTemplateModel(serviceClient, this.packageName ?? this.sdkName, this.ImplementationFileExtension, this.Settings.Namespace, this.packageVersion),
             };
             await Write(requirementsTemplate, RubyCodeNamer.UnderscoreCase(this.packageName ?? this.sdkName) + ImplementationFileExtension);
-                
-                // Version File
-            if(this.packageVersion != null)
+
+            // Version File
+            if (this.packageVersion != null)
             {
                 var versionTemplate = new VersionTemplate
                 {
                     Model = new VersionTemplateModel(packageVersion),
                 };
-                await Write(versionTemplate, Path.Combine(sdkPath, "version" + ImplementationFileExtension));   
+                await Write(versionTemplate, "version" + ImplementationFileExtension);
             }
-            
+
             // Module Definition File
-            if(Settings.Namespace != null)
+            if (Settings.Namespace != null)
             {
                 var modTemplate = new ModuleDefinitionTemplate
                 {
                     Model = new ModuleDefinitionTemplateModel(Settings.Namespace),
                 };
-                await Write(modTemplate, Path.Combine(sdkPath, "module_definition" + ImplementationFileExtension));   
+                await Write(modTemplate, Path.Combine(sdkPath, "module_definition" + ImplementationFileExtension));
             }
         }
     }

--- a/AutoRest/Generators/Ruby/Azure.Ruby/TemplateModels/AzureRequirementsTemplateModel.cs
+++ b/AutoRest/Generators/Ruby/Azure.Ruby/TemplateModels/AzureRequirementsTemplateModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using Microsoft.Rest.Generator.ClientModel;
 using Microsoft.Rest.Generator.Ruby;
 
@@ -31,8 +32,9 @@ namespace Microsoft.Rest.Generator.Azure.Ruby
         /// <param name="sdkName">The name of the generated SDK, required for proper folder structuring.</param>
         /// <param name="filesExtension">The files extension.</param>
         /// <param name="ns">The namespace of the SDK.</param>
-        public AzureRequirementsTemplateModel(ServiceClient serviceClient, string sdkName, string filesExtension, string ns)
-            : base(serviceClient, sdkName, filesExtension, ns)
+        /// <param name="packageVersion">The name of the package version to be used in creating a version.rb file.</param>
+        public AzureRequirementsTemplateModel(ServiceClient serviceClient, string sdkName, string filesExtension, string ns, string packageVersion)
+            : base(serviceClient, sdkName, filesExtension, ns, packageVersion)
         {
         }
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/array_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/array_spec.rb
@@ -4,7 +4,7 @@ $: << 'RspecTests'
 $: << 'RspecTests/Generated/array'
 
 require 'rspec'
-require 'body_array'
+require 'generated/body_array'
 require 'helper'
 
 module ArrayModule

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/bool_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/bool_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests'
 $: << 'RspecTests/Generated/boolean'
 
-require 'body_boolean'
+require 'generated/body_boolean'
 
 module BooleanModule
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/byte_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/byte_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/byte'
 
-require 'body_byte'
+require 'generated/body_byte'
 
 module ByteModule
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/complex_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/complex_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/complex'
 
 require 'base64'
-require 'body_complex'
+require 'generated/body_complex'
 
 module ComplexModule
   include ComplexModule::Models

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/date_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/date_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/date'
 
 require 'rspec'
-require 'body_date'
+require 'generated/body_date'
 
 describe DateModule::Date do
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/datetime_rfc1123_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/datetime_rfc1123_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/datetime_rfc1123'
 
 require 'rspec'
-require 'body_datetime_rfc1123'
+require 'generated/body_datetime_rfc1123'
 require_relative './helper'
 
 include DatetimeRfc1123Module

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/datetime_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/datetime_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/datetime'
 
 require 'rspec'
-require 'body_datetime'
+require 'generated/body_datetime'
 require_relative './helper'
 
 include DatetimeModule

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/dictionary_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/dictionary_spec.rb
@@ -4,7 +4,7 @@ $: << 'RspecTests/Generated/dictionary'
 $: << 'RspecTests'
 
 require 'base64'
-require 'body_dictionary'
+require 'generated/body_dictionary'
 require 'helper'
 
 include DictionaryModule

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/header_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/header_spec.rb
@@ -5,7 +5,7 @@ $: << 'RspecTests/Generated/header_folder'
 
 
 require "base64"
-require 'header'
+require 'generated/header'
 
 module HeaderModule
   include HeaderModule::Models

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/http_infrastructure_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/http_infrastructure_spec.rb
@@ -4,7 +4,7 @@ $: << 'RspecTests/Generated/http_infrastructure'
 $: << 'RspecTests'
 
 require 'rspec'
-require 'http_infrastructure.rb'
+require 'generated/http_infrastructure.rb'
 require 'helper'
 
 module HttpInfrastructureModule

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/integer_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/integer_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/integer'
 
-require 'body_integer'
+require 'generated/body_integer'
 
 include IntegerModule
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/model_flattening_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/model_flattening_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/model_flattening'
 
 require 'securerandom'
-require 'model_flattening'
+require 'generated/model_flattening'
 
 include ModelFlatteningModule
 include ModelFlatteningModule::Models

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/number_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/number_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/number'
 
-require 'body_number'
+require 'generated/body_number'
 
 include NumberModule
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/parameter_grouping_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/parameter_grouping_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/parameter_grouping'
 
 require 'rspec'
-require 'azure_parameter_grouping'
+require 'generated/azure_parameter_grouping'
 
 include ParameterGroupingModule
 include ParameterGroupingModule::Models

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/path_items_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/path_items_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/url_items'
 
-require 'url'
+require 'generated/url'
 
 include UrlModule
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/path_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/path_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/url'
 
-require 'url'
+require 'generated/url'
 
 include UrlModule
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/query_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/query_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/url_query'
 
 require 'rspec'
-require 'url'
+require 'generated/url'
 
 include UrlModule
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/report_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/report_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/report'
 
-require 'report'
+require 'generated/report'
 
 include ReportModule
 

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/required_optional_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/required_optional_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/required_optional'
 
-require 'required_optional'
+require 'generated/required_optional'
 
 include RequiredOptionalModule
 include RequiredOptionalModule::Models

--- a/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/string_spec.rb
+++ b/AutoRest/Generators/Ruby/Ruby.Tests/RspecTests/string_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/string'
 
-require 'body_string'
+require 'generated/body_string'
 
 include StringModule
 

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Rest.Generator.Ruby
                 {
                     Model = new VersionTemplateModel(packageVersion),
                 };
-                await Write(versionTemplate, "version" + ImplementationFileExtension);
+                await Write(versionTemplate, Path.Combine(sdkPath, "version" + ImplementationFileExtension));
             }
 
             // Module Definition File

--- a/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
+++ b/AutoRest/Generators/Ruby/Ruby/RubyCodeGenerator.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Rest.Generator.Ruby
     public class RubyCodeGenerator : CodeGenerator
     {
         /// <summary>
+        /// Name of the generated sub-folder inside ourput directory.
+        /// </summary>
+        private const string GeneratedFolderName = "generated";
+
+        /// <summary>
         /// The name of the SDK. Determined in the following way:
         /// if the parameter 'Name' is provided that it becomes the
         /// name of the SDK, otherwise the name of input swagger is converted
@@ -25,7 +30,7 @@ namespace Microsoft.Rest.Generator.Ruby
         /// The name of the package version to be used in creating a version.rb file
         /// </summary>
         protected readonly string packageVersion;
-        
+
         /// <summary>
         /// The name of the package name to be used in creating a version.rb file
         /// </summary>
@@ -74,6 +79,9 @@ namespace Microsoft.Rest.Generator.Ruby
             this.sdkName = RubyCodeNamer.UnderscoreCase(CodeNamer.RubyRemoveInvalidCharacters(this.sdkName));
             this.sdkPath = this.packageName ?? this.sdkName;
             this.modelsPath = Path.Combine(this.sdkPath, "models");
+
+            // AutoRest generated code for Ruby and Azure.Ruby generator will live inside "generated" sub-folder
+            settings.OutputDirectory = Path.Combine(settings.OutputDirectory, GeneratedFolderName);
         }
 
         /// <summary>
@@ -190,28 +198,28 @@ namespace Microsoft.Rest.Generator.Ruby
             // Requirements
             var requirementsTemplate = new RequirementsTemplate
             {
-                Model = new RequirementsTemplateModel(serviceClient, this.packageName ?? this.sdkName, this.ImplementationFileExtension, this.Settings.Namespace),
+                Model = new RequirementsTemplateModel(serviceClient, this.packageName ?? this.sdkName, this.ImplementationFileExtension, this.Settings.Namespace, this.packageVersion),
             };
             await Write(requirementsTemplate, RubyCodeNamer.UnderscoreCase(this.packageName ?? this.sdkName) + ImplementationFileExtension);
-                
+
             // Version File
-            if(!string.IsNullOrEmpty(this.packageVersion))
+            if (!string.IsNullOrEmpty(this.packageVersion))
             {
                 var versionTemplate = new VersionTemplate
                 {
                     Model = new VersionTemplateModel(packageVersion),
                 };
-                await Write(versionTemplate, Path.Combine(sdkPath, "version" + ImplementationFileExtension));   
+                await Write(versionTemplate, "version" + ImplementationFileExtension);
             }
-            
+
             // Module Definition File
-            if(!string.IsNullOrEmpty(Settings.Namespace))
+            if (!string.IsNullOrEmpty(Settings.Namespace))
             {
                 var modTemplate = new ModuleDefinitionTemplate
                 {
                     Model = new ModuleDefinitionTemplateModel(Settings.Namespace),
                 };
-                await Write(modTemplate, Path.Combine(sdkPath, "module_definition" + ImplementationFileExtension));   
+                await Write(modTemplate, Path.Combine(sdkPath, "module_definition" + ImplementationFileExtension));
             }
         }
     }

--- a/AutoRest/Generators/Ruby/Ruby/TemplateModels/RequirementsTemplateModel.cs
+++ b/AutoRest/Generators/Ruby/Ruby/TemplateModels/RequirementsTemplateModel.cs
@@ -17,6 +17,16 @@ namespace Microsoft.Rest.Generator.Ruby
     public class RequirementsTemplateModel : ServiceClient
     {
         /// <summary>
+        /// Name of the generated sub-folder inside ourput directory.
+        /// </summary>
+        private const string GeneratedFolderName = "generated";
+
+        /// <summary>
+        /// Format for the autoload module.
+        /// </summary>
+        private const string AutoloadFormat = "autoload :{0},{1}'" + GeneratedFolderName + "/{2}/{3}'";
+
+        /// <summary>
         /// Number of spaces between class name and file name required for better readability.
         /// </summary>
         private const int SpacingForAutoload = 50;
@@ -30,12 +40,16 @@ namespace Microsoft.Rest.Generator.Ruby
         /// Files extensions.
         /// </summary>
         private readonly string implementationFileExtension;
-        
+
         /// <summary>
         /// Namspace of the service client.
         /// </summary>
         private readonly string ns;
 
+        /// <summary>
+        /// The name of the package version to be used in creating a version.rb file.
+        /// </summary>
+        private readonly string packageVersion;
 
         /// <summary>
         /// Returns the ordered list of models. Ordered means that if some model has
@@ -87,7 +101,7 @@ namespace Microsoft.Rest.Generator.Ruby
                 spacing = sb.ToString();
             }
 
-            return string.Format("autoload :{0},{1}'{2}/{3}'", typeName, spacing, this.sdkName, fileName);
+            return string.Format(AutoloadFormat, typeName, spacing, this.sdkName, fileName);
         }
 
         /// <summary>
@@ -107,10 +121,12 @@ namespace Microsoft.Rest.Generator.Ruby
         /// <param name="sdkName">The name of the SDK.</param>
         /// <param name="implementationFileExtension">The files extension.</param>
         /// <param name="ns">The namespace of the SDK.</param>
-        public RequirementsTemplateModel(ServiceClient serviceClient, string sdkName, string implementationFileExtension, string ns)
+        /// <param name="packageVersion">The name of the package version to be used in creating a version.rb file.</param>
+        public RequirementsTemplateModel(ServiceClient serviceClient, string sdkName, string implementationFileExtension, string ns, string packageVersion)
         {
             this.LoadFrom(serviceClient);
             this.ns = ns;
+            this.packageVersion = packageVersion;
             this.sdkName = sdkName;
             this.implementationFileExtension = implementationFileExtension;
         }
@@ -174,16 +190,22 @@ require 'faraday'
 require 'faraday-cookie_jar'
 require 'concurrent'
 require 'ms_rest'";
-            if(!string.IsNullOrEmpty(this.ns))
+
+            if(!string.IsNullOrWhiteSpace(this.ns))
             {
-                return requirements 
+                requirements = requirements 
                     + Environment.NewLine 
-                    + string.Format(CultureInfo.InvariantCulture, "require '{0}/module_definition'", this.sdkName);
+                    + string.Format(CultureInfo.InvariantCulture, "require '{0}/{1}/module_definition'", GeneratedFolderName, this.sdkName);
             }
-            else
+
+            if (!string.IsNullOrWhiteSpace(this.packageVersion))
             {
-                return requirements;
+                requirements = requirements
+                    + Environment.NewLine
+                    + string.Format(CultureInfo.InvariantCulture, "require '{0}/version'", GeneratedFolderName);
             }
+
+            return requirements;
         }
     }
 }

--- a/AutoRest/Generators/Ruby/Ruby/TemplateModels/RequirementsTemplateModel.cs
+++ b/AutoRest/Generators/Ruby/Ruby/TemplateModels/RequirementsTemplateModel.cs
@@ -202,7 +202,7 @@ require 'ms_rest'";
             {
                 requirements = requirements
                     + Environment.NewLine
-                    + string.Format(CultureInfo.InvariantCulture, "require '{0}/version'", GeneratedFolderName);
+                    + string.Format(CultureInfo.InvariantCulture, "require '{0}/{1}/version'", GeneratedFolderName, this.sdkName);
             }
 
             return requirements;


### PR DESCRIPTION
Changes: 

1. There will be a default "generated" sub-folder inside the value of -o AutoRest parameter 
2. Requirements template is updated to load files from "generated" sub-folder
3. Added "require generated/{sdkpath}/version" line in the requirements template
4. Updated Ruby + Azure.Ruby tests to look inside generated folder for the modules