### PR TITLE
Handling lookup for provisioning_state in ruby client runtime

### DIFF
--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_service_client.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_service_client.rb
@@ -122,7 +122,11 @@ module MsRestAzure
 
       fail AzureOperationError, 'The response from long running operation does not contain a body' if result.response.body.nil? || result.response.body.empty?
 
-      if result.body.respond_to?(:provisioning_state) && !result.body.provisioning_state.nil?
+      # On non flattened resource, we should find provisioning_state inside 'properties'
+      if result.body.respond_to?(:properties) && result.body.properties.respond_to?(:provisioning_state) && !result.body.properties.provisioning_state.nil?
+        polling_state.status = result.body.properties.provisioning_state
+      # On flattened resource, we should find provisioning_state at the top level
+      elsif result.body.respond_to?(:provisioning_state) && !result.body.provisioning_state.nil?
         polling_state.status = result.body.provisioning_state
       else
         polling_state.status = AsyncOperationStatus::SUCCESS_STATUS

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
@@ -35,7 +35,11 @@ module MsRestAzure
       update_response(azure_response.response)
       @resource = azure_response.body
 
-      if !@resource.nil? && @resource.respond_to?(:provisioning_state) && !@resource.provisioning_state.nil?
+      # On non flattened resource, we should find provisioning_state inside 'properties'
+      if (!@resource.nil? && @resource.respond_to?(:properties) && @resource.properties.respond_to?(:provisioning_state) && !@resource.properties.provisioning_state.nil?)
+        @status = @resource.properties.provisioning_state
+      # On flattened resource, we should find provisioning_state at the top level
+      elsif !@resource.nil? && @resource.respond_to?(:provisioning_state) && !@resource.provisioning_state.nil?
         @status = @resource.provisioning_state
       else
         case @response.status

--- a/src/client/Ruby/ms-rest-azure/spec/polling_state_spec.rb
+++ b/src/client/Ruby/ms-rest-azure/spec/polling_state_spec.rb
@@ -8,7 +8,7 @@ require 'ms_rest_azure'
 module MsRestAzure
 
   describe PollingState do
-    it 'should initialize status from response header' do
+    it 'should initialize status from flattened response body' do
       response_body = double('response_body', :provisioning_state => 'InProgress')
       response = double('response',
                         :request => nil,
@@ -18,6 +18,19 @@ module MsRestAzure
       polling_state = PollingState.new response, 0
 
       expect(polling_state.status).to eq('InProgress')
+    end
+
+    it 'should initialize status from non-flattened response body' do
+      provisioning_state = double('provisioning_state', :provisioning_state => 'Succeeded')
+      response_body = double('response_body', :properties => provisioning_state)
+      response = double('response',
+                        :request => nil,
+                        :response => nil,
+                        :body => response_body)
+
+      polling_state = PollingState.new response, 0
+
+      expect(polling_state.status).to eq('Succeeded')
     end
 
     it 'should initialize status from response status' do


### PR DESCRIPTION
In ruby client runtime, 
On non flattened resource, we should find provisioning_state inside 'properties' & 
On flattened resource, we should find provisioning_state at the top level
