### PR TITLE
Ruby - Polymorphic discriminator hashmap should have exact model name

### DIFF
--- a/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb
@@ -146,7 +146,7 @@ module MsRest
           parent_class = get_model(mapper[:type][:class_name])
           discriminator = parent_class.class_eval("@@discriminatorMap")
           model_name = response_body["#{mapper[:type][:polymorphic_discriminator]}"]
-          model_class = get_model(discriminator[model_name].capitalize)
+          model_class = get_model(discriminator[model_name])
         else
           model_class = get_model(mapper[:type][:class_name])
         end

--- a/src/generator/AutoRest.Ruby/Templates/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/ModelTemplate.cshtml
@@ -25,10 +25,10 @@ module @(Settings.Namespace)
     @if (Model.IsPolymorphic && Model.BaseModelType == null)
     {
       @:@@@@discriminatorMap = Hash.new
-      @:@@@@discriminatorMap["@Model.SerializedName"] = "@Model.Name.ToLowerInvariant()"
+      @:@@@@discriminatorMap["@Model.SerializedName"] = "@Model.Name"
       foreach (var derivedType in Model.DerivedTypes)
       {
-      @:@@@@discriminatorMap["@derivedType.SerializedName"] = "@derivedType.Name.ToLowerInvariant()"
+      @:@@@@discriminatorMap["@derivedType.SerializedName"] = "@derivedType.Name"
       }
     }
     


### PR DESCRIPTION
Polymorphic discriminator hashmap should have exact model name as hash value instead of lowercased in Ruby.