### PR TITLE
Ruby - ms_rest should throw validation error instead of NameError

### DIFF
--- a/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb
@@ -315,7 +315,12 @@ module MsRest
 
         unless model_props.nil?
           model_props.each do |key, value|
-            instance_variable = object.instance_variable_get("@#{key}")
+            begin
+              instance_variable = object.instance_variable_get("@#{key}")
+            rescue NameError
+              fail ValidationError, "instance variable '#{key}' is expected on '#{object}'."
+            end
+
             if !instance_variable.nil? && instance_variable.respond_to?(:validate)
               instance_variable.validate
             end

--- a/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb
@@ -318,7 +318,7 @@ module MsRest
             begin
               instance_variable = object.instance_variable_get("@#{key}")
             rescue NameError
-              fail ValidationError, "instance variable '#{key}' is expected on '#{object}'."
+              fail ValidationError, "instance variable '#{key}' is expected on '#{object.class}'."
             end
 
             if !instance_variable.nil? && instance_variable.respond_to?(:validate)


### PR DESCRIPTION
ms_rest should throw validation error instead of NameError when property not found on ruby object.

Reference: http://apidock.com/ruby/Object/instance_variable_get 