### PR TITLE
Throw code gen error if pageable operation does not return pageable type

### DIFF
--- a/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using AutoRest.Core.ClientModel;
+using AutoRest.Core.Logging;
 using AutoRest.Extensions.Azure;
 using AutoRest.Extensions.Azure.Model;
 using AutoRest.Ruby.Azure.Properties;
@@ -274,8 +275,15 @@ namespace AutoRest.Ruby.Azure.TemplateModels
             {
                 if (Extensions.ContainsKey("nextMethodName") && !Extensions.ContainsKey(AzureExtensions.PageableExtension))
                 {
-                    SequenceType sequenceType = ((CompositeType)ReturnType.Body).Properties.Select(p => p.Type).FirstOrDefault(t => t is SequenceType) as SequenceType;
-                    return string.Format(CultureInfo.InvariantCulture, "Array<{0}>", sequenceType.ElementType.Name);
+                    try
+                    {
+                        SequenceType sequenceType = ((CompositeType)ReturnType.Body).Properties.Select(p => p.Type).FirstOrDefault(t => t is SequenceType) as SequenceType;
+                        return string.Format(CultureInfo.InvariantCulture, "Array<{0}>", sequenceType.ElementType.Name);
+                    }
+                    catch (NullReferenceException nr)
+                    {
+                        throw ErrorManager.CreateError(nr, AutoRest.Core.Properties.Resources.CodeGenerationFailed, nr.Message);
+                    }
                 }
                 return base.OperationReturnTypeString;
             }

--- a/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
@@ -282,7 +282,7 @@ namespace AutoRest.Ruby.Azure.TemplateModels
                     }
                     catch (NullReferenceException nr)
                     {
-                        throw ErrorManager.CreateError(nr, AutoRest.Core.Properties.Resources.CodeGenerationFailed, nr.Message);
+                        throw ErrorManager.CreateError(string.Format(CultureInfo.InvariantCulture, "No collection type exists in pageable operation return type: {0}", nr.StackTrace));
                     }
                 }
                 return base.OperationReturnTypeString;


### PR DESCRIPTION
If return type of a pageable operation does not contain a collection, there should be a mismatch in the spec, and we can't find the element type of the collection that should be returned by the operation.