### PR TITLE
Remove HEAD operation status code warning

### DIFF
--- a/src/core/AutoRest.Extensions.Azure/AzureExtensions.cs
+++ b/src/core/AutoRest.Extensions.Azure/AzureExtensions.cs
@@ -111,7 +111,7 @@ namespace AutoRest.Extensions.Azure
                 }
                 else
                 {
-                    Logger.LogWarning(string.Format(CultureInfo.InvariantCulture, Resources.HeadMethodPossibleIncorrectSpecification, method.Name));
+                    Logger.LogInfo(string.Format(CultureInfo.InvariantCulture, Resources.HeadMethodPossibleIncorrectSpecification, method.Name));
                 }
             }
         }


### PR DESCRIPTION
 - HEAD methods now only LogInfo instead of LogWarning when
   pointing out that you might be mistaken if you're missing
   two status codes.