### PR TITLE
Leave the initial exception as final exception

### DIFF
--- a/src/client/Python/msrestazure/msrestazure/azure_operation.py
+++ b/src/client/Python/msrestazure/msrestazure/azure_operation.py
@@ -422,9 +422,7 @@ class AzureOperationPoller(object):
             self._exception = CloudError(self._response, str(err))
 
         except OperationFailed:
-            error = "Long running operation failed with status {!r}".format(
-                str(self._operation.status))
-            self._exception = CloudError(self._response, error)
+            self._exception = CloudError(self._response)
 
         except OperationFinished:
             pass


### PR DESCRIPTION
Do not override the initial exception by a useless message.

Fix https://github.com/Azure/azure-sdk-for-python/issues/592

@annatisch for review please :)