### PR TITLE
Ruby bug fixes

### DIFF
--- a/Samples/azure-storage/Azure.Java.Fluent/implementation/StorageAccountInner.java
+++ b/Samples/azure-storage/Azure.Java.Fluent/implementation/StorageAccountInner.java
@@ -5,6 +5,7 @@ package petstore.implementation;
 
 import petstore.StorageAccountProperties;
 import com.microsoft.azure.Resource;
+import com.microsoft.azure.Resource;
 
 /**
  * The storage account.

--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_accounts.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_accounts.rb
@@ -144,10 +144,28 @@ module Petstore
     # @param custom_headers [Hash{String => String}] A hash of custom headers that
     # will be added to the HTTP request.
     #
+    # @return [StorageAccount] operation results.
+    #
+    def create(resource_group_name, account_name, parameters, custom_headers = nil)
+      response = create_async(resource_group_name, account_name, parameters, custom_headers).value!
+      response.body unless response.nil?
+    end
+
+    #
+    # @param resource_group_name [String] The name of the resource group within
+    # the user's subscription.
+    # @param account_name [String] The name of the storage account within the
+    # specified resource group. Storage account names must be between 3 and 24
+    # characters in length and use numbers and lower-case letters only.
+    # @param parameters [StorageAccountCreateParameters] The parameters to provide
+    # for the created account.
+    # @param custom_headers [Hash{String => String}] A hash of custom headers that
+    # will be added to the HTTP request.
+    #
     # @return [Concurrent::Promise] promise which provides async access to http
     # response.
     #
-    def create(resource_group_name, account_name, parameters, custom_headers = nil)
+    def create_async(resource_group_name, account_name, parameters, custom_headers = nil)
       # Send request
       promise = begin_create_async(resource_group_name, account_name, parameters, custom_headers)
 

--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
@@ -5,7 +5,6 @@ module Petstore
   # A service client - single point of access to the REST API.
   #
   class StorageManagementClient < MsRestAzure::AzureServiceClient
-    include Petstore::Models
     include MsRest::Serialization
     include MsRestAzure
 

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/async_operation_status.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/async_operation_status.rb
@@ -65,7 +65,6 @@ module MsRestAzure
       return if object.nil?
       output_object = AsyncOperationStatus.new
 
-      fail AzureOperationError, "Invalid status was recieved during polling: #{object['status']}" unless ALL_STATUSES.include?(object['status'])
       output_object.status = object['status']
 
       output_object.error = CloudErrorData.deserialize_object(object['error'])

--- a/src/client/Ruby/ms-rest-azure/spec/async_operation_status_spec.rb
+++ b/src/client/Ruby/ms-rest-azure/spec/async_operation_status_spec.rb
@@ -40,14 +40,18 @@ module MsRestAzure
       expect(status.retry_after).to eq(10)
     end
 
-    it 'should throw error during deserialization if invalid status was provided' do
+    it 'should not throw error during deserialization if unknown status was provided' do
       response_json = {
-          'status' => 'NotValidStatus',
+          'status' => 'Provisioning',
           'error' => nil,
           'retryAfter' => 5
       }
 
-      expect { status = AsyncOperationStatus.deserialize_object response_json }.to raise_error(AzureOperationError)
+      status = AsyncOperationStatus.deserialize_object response_json
+
+      expect(status.status).to eq('Provisioning')
+      expect(status.error).to be_nil
+      expect(status.retry_after).to eq(5)
     end
   end
 

--- a/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/lro_spec.rb
+++ b/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/lro_spec.rb
@@ -29,194 +29,223 @@ describe 'Long Running Operation' do
 
   # Happy path tests
   it 'should wait for succeeded status for create operation' do
-    result = @lros_client.put201creating_succeeded200(@product).value!
+    result = @lros_client.put201creating_succeeded200_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should rise error on "failed" operation result' do
-    expect { @lros_client.put201creating_failed200(@product).value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lros_client.put201creating_failed200(@product) }.to raise_error(MsRestAzure::AzureOperationError)
   end
 
   it 'should wait for succeeded status for update operation' do
-    result = @lros_client.put200updating_succeeded204(@product).value!
+    result = @lros_client.put200updating_succeeded204_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should rise error on "canceled" operation result' do
-    expect { @lros_client.put200acceptedcanceled200(@product).value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lros_client.put200acceptedcanceled200(@product) }.to raise_error(MsRestAzure::AzureOperationError)
   end
 
   it 'should retry on 202 server response in POST request' do
-    result = @lros_client.post202retry200(@product).value!
+    result = @lros_client.post202retry200_async(@product).value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should not retry on 202 server response in POST request' do
-    result = @lros_client.post202no_retry204(@product).value!
+    result = @lros_client.post202no_retry204_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.response.status).to eq(204)
   end
 
   it 'should serve success response on initial PUT request' do
-    result = @lros_client.put200succeeded(@product).value!
+    result = @lros_client.put200succeeded_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should serve success response on initial request without provision state' do
-    result = @lros_client.put200succeeded_no_state(@product).value!
+    result = @lros_client.put200succeeded_no_state_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.id).to eq("100")
     expect(result.body.provisioning_state).to eq(nil)
   end
 
   it 'should serve 202 on initial response and status response without provision state' do
-    result = @lros_client.put202retry200(@product).value!
+    result = @lros_client.put202retry200_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.id).to eq("100")
     expect(result.body.provisioning_state).to eq(nil)
   end
 
   it 'should serve success response on initial DELETE request' do
-    result = @lros_client.delete204succeeded().value!
+    result = @lros_client.delete204succeeded_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(204)
   end
 
   it 'should return payload on POST async request' do
-    result = @lros_client.post200with_payload().value!
+    result = @lros_client.post200with_payload_async().value!
+    expect(result.body).to be_instance_of(Sku)
     expect(result.body.id).to eq(1)
   end
 
   it 'should succeed for put async retry' do
-    result = @lros_client.put_async_retry_succeeded(@product).value!
+    result = @lros_client.put_async_retry_succeeded_async(@product).value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should succeed for put async no retry' do
-    result = @lros_client.put_async_no_retry_succeeded(@product).value!
+    result = @lros_client.put_async_no_retry_succeeded_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.response.status).to eq(200)
   end
 
   it 'should fail for put async retry' do
-    expect { @lros_client.put_async_retry_failed(@product).value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lros_client.put_async_retry_failed(@product) }.to raise_error(MsRestAzure::AzureOperationError)
   end
 
   it 'should fail for put async no retry canceled' do
-    expect { @lros_client.put_async_no_retrycanceled(@product).value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lros_client.put_async_no_retrycanceled(@product) }.to raise_error(MsRestAzure::AzureOperationError)
   end
 
   it 'should succeed for post async retry' do
-    result = @lros_client.post_async_retry_succeeded(@product).value!
+    result = @lros_client.post_async_retry_succeeded_async(@product).value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should succeed for post async no retry' do
-    result = @lros_client.post_async_no_retry_succeeded(@product).value!
+    result = @lros_client.post_async_no_retry_succeeded_async(@product).value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should fail for post async retry' do
-    expect { @lros_client.post_async_retry_failed(@product).value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lros_client.post_async_retry_failed(@product) }.to raise_error(MsRestAzure::AzureOperationError)
   end
 
   it 'should fail for post async retry canceled' do
-    expect { @lros_client.post_async_retrycanceled(@product).value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lros_client.post_async_retrycanceled(@product) }.to raise_error(MsRestAzure::AzureOperationError)
   end
 
   it 'should succeed for put no header in retry' do
-    result = @lros_client.put_no_header_in_retry(@product).value!
+    result = @lros_client.put_no_header_in_retry_async(@product).value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should succeed for put async no header in retry' do
-    result = @lros_client.put_async_no_header_in_retry(@product).value!
+    result = @lros_client.put_async_no_header_in_retry_async(@product).value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should succeed for delete no header in retry' do
-    result = @lros_client.delete_no_header_in_retry().value!
+    result = @lros_client.delete_no_header_in_retry_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(204)
   end
 
   it 'should succeed for delete async no header in retry' do
-    result = @lros_client.delete_async_no_header_in_retry().value!
+    result = @lros_client.delete_async_no_header_in_retry_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should succeed for put sub resource' do
-    result = @lros_client.put_sub_resource(@product).value!
+    result = @lros_client.put_sub_resource_async(@product).value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(SubProduct)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should succeed for put async sub resource' do
-    result = @lros_client.put_async_sub_resource(@product).value!
+    result = @lros_client.put_async_sub_resource_async(@product).value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(SubProduct)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should succeed for put non resource' do
-    result = @lros_client.put_non_resource(@sku).value!
+    result = @lros_client.put_non_resource_async(@sku).value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(Sku)
     expect(result.body.id).to eq('100')
     expect(result.body.name).to eq('sku')
   end
 
   it 'should succeed for put async non resource' do
-    result = @lros_client.put_async_non_resource(@sku).value!
+    result = @lros_client.put_async_non_resource_async(@sku).value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(Sku)
     expect(result.body.id).to eq('100')
     expect(result.body.name).to eq('sku')
   end
 
   it 'should succeed for delete provisioning 202 accepted 200' do
-    result = @lros_client.delete_provisioning202accepted200succeeded().value!
+    result = @lros_client.delete_provisioning202accepted200succeeded_async().value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should succeed for delete provisioning 202 deleting failed 200' do
-    result = @lros_client.delete_provisioning202deleting_failed200().value!
+    result = @lros_client.delete_provisioning202deleting_failed200_async().value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Failed")
   end
 
   it 'should succeed for delete provisioning 202 deleting canceled 200' do
-    result = @lros_client.delete_provisioning202deletingcanceled200().value!
+    result = @lros_client.delete_provisioning202deletingcanceled200_async().value!
     expect(result.response.status).to eq(200)
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Canceled")
   end
 
   it 'should succeed for delete 204' do
-    result = @lros_client.delete204succeeded().value!
+    result = @lros_client.delete204succeeded_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(204)
   end
 
   it 'should succeed for delete 202 retry 200' do
-    result = @lros_client.delete202retry200().value!
+    result = @lros_client.delete202retry200_async().value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.response.status).to eq(200)
   end
 
   it 'should succeed for delete 202 no retry 204' do
-    result = @lros_client.delete202no_retry204().value!
+    result = @lros_client.delete202no_retry204_async().value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.response.status).to eq(204)
   end
 
   it 'should succeed for delete async retry' do
-    result = @lros_client.delete_async_retry_succeeded().value!
+    result = @lros_client.delete_async_retry_succeeded_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should succeed for delete async no retry' do
-    result = @lros_client.delete_async_no_retry_succeeded().value!
+    result = @lros_client.delete_async_no_retry_succeeded_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should fail for delete async retry failed' do
-    expect { @lros_client.delete_async_retry_failed().value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lros_client.delete_async_retry_failed() }.to raise_error(MsRestAzure::AzureOperationError)
   end
 
   it 'should fail for delete async retry canceled' do
-    expect { @lros_client.delete_async_retrycanceled().value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lros_client.delete_async_retrycanceled() }.to raise_error(MsRestAzure::AzureOperationError)
   end
 end
 
@@ -236,42 +265,50 @@ describe 'Long Running Operation with retry' do
 
   # Retryable errors
   it 'should retry PUT request on 500 response' do
-    result = @lroretrys_client.put201creating_succeeded200(@product).value!
+    result = @lroretrys_client.put201creating_succeeded200_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should retry PUT request on 500 response for async operation' do
-    result = @lroretrys_client.put_async_relative_retry_succeeded(@product).value!
+    result = @lroretrys_client.put_async_relative_retry_succeeded_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should retry DELETE request for provisioning status' do
-    result = @lroretrys_client.delete_provisioning202accepted200succeeded().value!
+    result = @lroretrys_client.delete_provisioning202accepted200succeeded_async().value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.response.status).to eq(200)
   end
 
   it 'should retry DELETE request on 500 response' do
-    result = @lroretrys_client.delete202retry200().value!
+    result = @lroretrys_client.delete202retry200_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should retry POST request on 500 response' do
-    result = @lroretrys_client.post202retry200(@product).value!
+    result = @lroretrys_client.post202retry200_async(@product).value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should retry POST request on 500 response for async operation' do
-    result = @lroretrys_client.post_async_relative_retry_succeeded(@product).value!
+    result = @lroretrys_client.post_async_relative_retry_succeeded_async(@product).value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should retry on 500 server response in PUT request' do
-    result = @lroretrys_client.put_async_relative_retry_succeeded(@product).value!
+    result = @lroretrys_client.put_async_relative_retry_succeeded_async(@product).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should retry on 500 server response in DELETE request' do
-    result = @lroretrys_client.delete_async_relative_retry_succeeded().value!
+    result = @lroretrys_client.delete_async_relative_retry_succeeded_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 end
@@ -292,106 +329,107 @@ describe 'Long Running Operation with ads' do
 
   # Sad path tests
   it 'should rise error on response 400 for PUT request' do
-    expect { @lroads_client.put_non_retry400(@product).value! }.to raise_exception(MsRest::HttpOperationError)
+    expect { @lroads_client.put_non_retry400(@product) }.to raise_exception(MsRest::HttpOperationError)
   end
 
   it 'should rise error if 400 response comes in the middle of PUT operation' do
-    expect { @lroads_client.put_non_retry201creating400(@product).value! }.to raise_error(MsRestAzure::AzureOperationError)
+    expect { @lroads_client.put_non_retry201creating400(@product) }.to raise_error(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if 400 response comes in the middle of async PUT operation' do
-    expect { @lroads_client.put_async_relative_retry400(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect { @lroads_client.put_async_relative_retry400(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error on response 400 for DELETE request' do
-    expect { @lroads_client.delete_non_retry400().value! }.to raise_exception(MsRest::HttpOperationError)
+    expect { @lroads_client.delete_non_retry400() }.to raise_exception(MsRest::HttpOperationError)
   end
 
   it 'should rise error if 400 response comes in the middle of DELETE operation' do
-    expect{ @lroads_client.delete_async_relative_retry400().value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.delete_async_relative_retry400() }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if 400 response comes from POST request' do
-    expect{ @lroads_client.post_non_retry400(@product).value! }.to raise_exception(MsRest::HttpOperationError)
+    expect{ @lroads_client.post_non_retry400(@product) }.to raise_exception(MsRest::HttpOperationError)
   end
 
   it 'should rise error on response 400 for POST request' do
-    expect{ @lroads_client.post202non_retry400(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.post202non_retry400(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if 400 response comes in the middle of async POST operation' do
-    expect{ @lroads_client.post_async_relative_retry400(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.post_async_relative_retry400(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if no provisioning state in payload provided on PUT request' do
-    expect{ @lroads_client.put_error201no_provisioning_state_payload(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.put_error201no_provisioning_state_payload(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if no state provided on PUT request' do
-    expect{ @lroads_client.put_async_relative_retry_no_status(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.put_async_relative_retry_no_status(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if no provisioning state in payload provided on async PUT request' do
-    expect{ @lroads_client.put_async_relative_retry_no_status_payload(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.put_async_relative_retry_no_status_payload(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error on invalid JSON response on initial request' do
-    expect{ @lroads_client.put200invalid_json(@product).value! }.to raise_exception(MsRest::DeserializationError)
+    expect{ @lroads_client.put200invalid_json(@product) }.to raise_exception(MsRest::DeserializationError)
   end
 
   it 'should rise error on invalid endpoint received in initial PUT request' do
-    expect{ @lroads_client.put_async_relative_retry_invalid_header(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.put_async_relative_retry_invalid_header(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error on invalid JSON response in status polling request during PUT operation' do
-    expect{ @lroads_client.put_async_relative_retry_invalid_json_polling(@product).value! }.to raise_exception(MsRest::DeserializationError)
+    expect{ @lroads_client.put_async_relative_retry_invalid_json_polling(@product) }.to raise_exception(MsRest::DeserializationError)
   end
 
   it 'should rise error on invalid Location and Retry-After headers during DELETE operation' do
-    expect{ @lroads_client.delete202retry_invalid_header().value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.delete202retry_invalid_header() }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error on invalid endpoint received in initial DELETE request' do
-    expect{ @lroads_client.delete_async_relative_retry_invalid_header().value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.delete_async_relative_retry_invalid_header() }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error on invalid JSON response in status polling request during DELETE operation' do
-   expect{ @lroads_client.delete_async_relative_retry_invalid_json_polling().value! }.to raise_exception(MsRest::DeserializationError)
+   expect{ @lroads_client.delete_async_relative_retry_invalid_json_polling() }.to raise_exception(MsRest::DeserializationError)
   end
 
   it 'should rise error on invalid Location and Retry-After headers during POST operation' do
-    expect{ @lroads_client.post202retry_invalid_header(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.post202retry_invalid_header(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error on invalid endpoint received in initial POST request' do
-    expect{ @lroads_client.post_async_relative_retry_invalid_header(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.post_async_relative_retry_invalid_header(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error on invalid JSON response in status polling request during POST operation' do
-    expect{ @lroads_client.post_async_relative_retry_invalid_json_polling(@product).value! }.to raise_exception(MsRest::DeserializationError)
+    expect{ @lroads_client.post_async_relative_retry_invalid_json_polling(@product) }.to raise_exception(MsRest::DeserializationError)
   end
 
   it 'should not rise error on DELETE operation with 204 response without location provided' do
-    result = @lroads_client.delete204succeeded().value!
+    result = @lroads_client.delete204succeeded_async().value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(204)
   end
 
   it 'should rise error on no status provided for DELETE async operation' do
-   expect{ @lroads_client.delete_async_relative_retry_no_status().value! }.to raise_exception(MsRestAzure::AzureOperationError)
+   expect{ @lroads_client.delete_async_relative_retry_no_status() }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if no location provided' do
     pending 'fails for in travis'
     fail
-    expect { @lroads_client.post202no_location(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect { @lroads_client.post202no_location(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if no payload provided on POST async retry request' do
-    expect{ @lroads_client.post_async_relative_retry_no_payload(@product).value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.post_async_relative_retry_no_payload(@product) }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 
   it 'should rise error if no payload provided on DELETE non retry request' do
-    expect{ @lroads_client.delete202non_retry400().value! }.to raise_exception(MsRestAzure::AzureOperationError)
+    expect{ @lroads_client.delete202non_retry400() }.to raise_exception(MsRestAzure::AzureOperationError)
   end
 end
 
@@ -410,22 +448,32 @@ describe 'Long Running Operation with custom header' do
   end
 
   it 'should succeed for custom header put async' do
-    result = @lros_custom_header_client.put_async_retry_succeeded(@product, @custom_header).value!
+    result = @lros_custom_header_client.put_async_retry_succeeded_async(@product, @custom_header).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
   it 'should succeed for custom header post async' do
-    result = @lros_custom_header_client.post_async_retry_succeeded(@product, @custom_header).value!
+    result = @lros_custom_header_client.post_async_retry_succeeded_async(@product, @custom_header).value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should succeed for custom header put' do
-    result = @lros_custom_header_client.put201creating_succeeded200(@product, @custom_header).value!
+    result = @lros_custom_header_client.put201creating_succeeded200_async(@product, @custom_header).value!
+    expect(result.body).to be_instance_of(Product)
     expect(result.body.provisioning_state).to eq("Succeeded")
   end
 
+  it 'should succeed for custom header put with begin' do
+    result = @lros_custom_header_client.begin_put201creating_succeeded200(@product, @custom_header)
+    expect(result).to be_instance_of(Product)
+    expect(result.provisioning_state).to eq("Creating")
+  end
+
   it 'should succeed for custom header post' do
-    result = @lros_custom_header_client.post202retry200(@product, @custom_header).value!
+    result = @lros_custom_header_client.post202retry200_async(@product, @custom_header).value!
+    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 end

--- a/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
@@ -62,9 +62,25 @@ else
 }
 @WrapComment("# ", string.Format("@param custom_headers [{0}] A hash of custom headers that will be added to the HTTP request.", "Hash{String => String}"))
 #
+@if (Model.ReturnType.Body != null)
+{
+@WrapComment("# ", string.Format("@return [{0}] operation results.", Model.OperationReturnTypeString))@:
+@:#
+}
+def @(Model.Name)(@(Model.MethodParameterDeclaration))
+  @Model.ResponseGeneration()
+end
+@EmptyLine
+#
+@foreach (var parameter in Model.LocalParameters)
+{
+@:@WrapComment("# ", string.Format("@param {0} {1}{2}", parameter.Name, parameter.Type.GetYardDocumentation(), parameter.Documentation))
+}
+@WrapComment("# ", string.Format("@param custom_headers [{0}] A hash of custom headers that will be added to the HTTP request.", "Hash{String => String}"))
+#
 @WrapComment("# ", "@return [Concurrent::Promise] promise which provides async access to http response.")
 #
-def @(Model.Name)(@(Model.MethodParameterDeclaration))
+def @(Model.Name)_async(@(Model.MethodParameterDeclaration))
   # Send request
   promise = begin_@(Model.Name)_async(@(Model.MethodParameterInvocation))
   @EmptyLine

--- a/src/generator/AutoRest.Ruby.Azure/Templates/PageModelTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby.Azure/Templates/PageModelTemplate.cshtml
@@ -29,7 +29,6 @@ module @(Settings.Namespace)
     @if (Model.IsPolymorphic && Model.BaseModelType == null)
     {
       @:@@@@discriminatorMap = Hash.new
-      @:@@@@discriminatorMap["@Model.SerializedName"] = "@Model.Name"
       foreach (var derivedType in Model.DerivedTypes)
         {
           @:@@@@discriminatorMap["@derivedType.SerializedName"] = "@derivedType.Name"

--- a/src/generator/AutoRest.Ruby/ClientModelExtensions.cs
+++ b/src/generator/AutoRest.Ruby/ClientModelExtensions.cs
@@ -265,7 +265,7 @@ namespace AutoRest.Ruby
         /// <returns>True if client contain model types, false otherwise.</returns>
         public static bool HasModelTypes(this ServiceClient client)
         {
-            return client.ModelTypes.Any(mt => mt.Extensions.Count == 0);
+            return client.ModelTypes.Any();
         }
 
         /// <summary>

--- a/src/generator/AutoRest.Ruby/RubyCodeNamer.cs
+++ b/src/generator/AutoRest.Ruby/RubyCodeNamer.cs
@@ -300,6 +300,10 @@ namespace AutoRest.Ruby
         /// <returns>Normalized enum type.</returns>
         private IType NormalizeEnumType(EnumType enumType)
         {
+            if (!String.IsNullOrWhiteSpace(enumType.Name))
+            {
+                enumType.Name = PascalCase(RemoveInvalidCharacters(enumType.Name));
+            }
             for (int i = 0; i < enumType.Values.Count; i++)
             {
                 if (enumType.Values[i].Name != null)
@@ -441,6 +445,12 @@ namespace AutoRest.Ruby
                         return "'" + defaultValue + "'.bytes.pack('C*')";
                     }
                 }
+            }
+
+            EnumType enumType = type as EnumType;
+            if (defaultValue != null && enumType != null)
+            {
+                return CodeNamer.QuoteValue(defaultValue, quoteChar: "'");
             }
             return defaultValue;
         }

--- a/src/generator/AutoRest.Ruby/Templates/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/ModelTemplate.cshtml
@@ -25,7 +25,6 @@ module @(Settings.Namespace)
     @if (Model.IsPolymorphic && Model.BaseModelType == null)
     {
       @:@@@@discriminatorMap = Hash.new
-      @:@@@@discriminatorMap["@Model.SerializedName"] = "@Model.Name"
       foreach (var derivedType in Model.DerivedTypes)
       {
       @:@@@@discriminatorMap["@derivedType.SerializedName"] = "@derivedType.Name"

--- a/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
@@ -10,10 +10,7 @@ module @Settings.Namespace
   # A service client - single point of access to the REST API.
   #
   class @Model.Name < @Model.BaseType
-@if (Model.HasModelTypes)
-{
-    @:include @(Settings.Namespace)::Models
-}
+
     include MsRest::Serialization
 @foreach (var include in Model.Includes)
 {


### PR DESCRIPTION
1. Client Runtime should not throw on unknown provisioning state from server
2. Enum model names must be PascalCase
3. Ruby model should fall back to the current class model when no discriminator found from server
4. Invalid enum values should not throw exceptions. only warnings
5. Default values for enum for EnumType should be escape quoted
6. Client template should not include models