### PR TITLE
CSharp: Allow CodeGenSettings to support objects in JSON. Also add support to suppress non-required properties in constructors

### DIFF
--- a/src/core/AutoRest.Core.Tests/AutoRestSettingsTests.cs
+++ b/src/core/AutoRest.Core.Tests/AutoRestSettingsTests.cs
@@ -52,6 +52,7 @@ namespace AutoRest.Core.Tests
             Assert.Equal(2, ((JArray) settings.CustomSettings["filePathArray"]).Count);
             Assert.Equal(typeof (JArray), settings.CustomSettings["intArray"].GetType());
             Assert.Equal(typeof (long), settings.CustomSettings["intFoo"].GetType());
+            Assert.Equal(typeof(JObject), settings.CustomSettings["complexObject"].GetType());
         }
 
         [Fact]

--- a/src/core/AutoRest.Core.Tests/Resource/SampleSettings.json
+++ b/src/core/AutoRest.Core.Tests/Resource/SampleSettings.json
@@ -4,5 +4,13 @@
     "sampleString":  "Foo",
     "filePathArray": [ "C:\\Foo.dll", "C:\\Bar.dll" ],
     "intArray": [ 1, 2, 3 ],
-    "intFoo": 5
+    "intFoo": 5,
+    "complexObject": {
+        "objectKey1": "value1",
+        "subObject1": {
+            "subObjectKey1": "subValue1",
+            "subObjectKey2": "subValue2"
+        },
+        "objectKey2": "value2"
+    }
 }

--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -378,6 +378,11 @@ Licensed under the MIT License. See License.txt in the project root for license 
                                     property.SetValue(entityToPopulate, intValues);
                                 }
                             }
+                            else if (setting.Value.GetType() == typeof (JObject) && property.PropertyType.IsClass)
+                            {
+                                var valueAsObject = ((JObject)setting.Value).ToObject(property.PropertyType);
+                                property.SetValue(entityToPopulate, valueAsObject);
+                            }
                             else
                             {
                                 property.SetValue(entityToPopulate,

--- a/src/generator/AutoRest.CSharp.Azure/AzureCSharpCodeGenerator.cs
+++ b/src/generator/AutoRest.CSharp.Azure/AzureCSharpCodeGenerator.cs
@@ -149,7 +149,7 @@ namespace AutoRest.CSharp.Azure
 
                 var modelTemplate = new ModelTemplate
                 {
-                    Model = new AzureModelTemplateModel(model),
+                    Model = new AzureModelTemplateModel(model, this.CodeOptions.ModelOptions),
                 };
 
                 await Write(modelTemplate, Path.Combine(Settings.ModelsName, model.Name + ".cs"));
@@ -185,7 +185,7 @@ namespace AutoRest.CSharp.Azure
 
                 var exceptionTemplate = new ExceptionTemplate
                 {
-                    Model = new ModelTemplateModel(exceptionType),
+                    Model = new ModelTemplateModel(exceptionType, CodeOptions.ModelOptions),
                 };
                 await Write(exceptionTemplate, Path.Combine(Settings.ModelsName, exceptionTemplate.Model.ExceptionTypeDefinitionName + ".cs"));
             }

--- a/src/generator/AutoRest.CSharp.Azure/TemplateModels/AzureModelTemplateModel.cs
+++ b/src/generator/AutoRest.CSharp.Azure/TemplateModels/AzureModelTemplateModel.cs
@@ -9,7 +9,7 @@ namespace AutoRest.CSharp.Azure.TemplateModels
 {
     public class AzureModelTemplateModel : ModelTemplateModel
     {
-        public AzureModelTemplateModel(CompositeType source) : base(source)
+        public AzureModelTemplateModel(CompositeType source, ModelTemplateOptions options = null) : base(source, options)
         {
         }
 

--- a/src/generator/AutoRest.CSharp.Tests/AcceptanceTests.cs
+++ b/src/generator/AutoRest.CSharp.Tests/AcceptanceTests.cs
@@ -1946,6 +1946,16 @@ namespace AutoRest.CSharp.Tests
         }
 
         [Fact]
+        public void ModelConstructorsUseRequiredPropertiesOnly()
+        {
+            var productType = typeof(Fixtures.DateTimeOffset.Models.Product);
+
+            var constructorInfo = productType.GetConstructors();
+            Assert.Equal(1, constructorInfo.Length); //there should only be 1 constructor for Product
+            Assert.Equal(0, constructorInfo[0].GetParameters().Length); //check that there are no parameters to the constructor
+        }
+
+        [Fact]
         public void FormatUuidModeledAsGuidTest()
         {
             var productType = typeof(Fixtures.MirrorPrimitives.Models.Product);

--- a/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Error.cs
@@ -10,6 +10,7 @@ namespace Fixtures.DateTimeOffset.Models
 {
     using System.Linq;
 
+    [System.Runtime.Serialization.DataContract]
     public partial class Error
     {
         /// <summary>
@@ -21,16 +22,19 @@ namespace Fixtures.DateTimeOffset.Models
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [System.Runtime.Serialization.DataMember(Name = "code", EmitDefaultValue = false)]
         public int? Code { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        [System.Runtime.Serialization.DataMember(Name = "message", EmitDefaultValue = false)]
         public string Message { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "fields")]
+        [System.Runtime.Serialization.DataMember(Name = "fields", EmitDefaultValue = false)]
         public string Fields { get; set; }
 
     }

--- a/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Error.cs
@@ -17,15 +17,6 @@ namespace Fixtures.DateTimeOffset.Models
         /// </summary>
         public Error() { }
 
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error(int? code = default(int?), string message = default(string), string fields = default(string))
-        {
-            Code = code;
-            Message = message;
-            Fields = fields;
-        }
 
         /// <summary>
         /// </summary>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Product.cs
@@ -17,16 +17,6 @@ namespace Fixtures.DateTimeOffset.Models
         /// </summary>
         public Product() { }
 
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product(System.DateTime? date = default(System.DateTime?), System.DateTimeOffset? dateTime = default(System.DateTimeOffset?), System.Collections.Generic.IList<System.DateTime?> dateArray = default(System.Collections.Generic.IList<System.DateTime?>), System.Collections.Generic.IList<System.DateTimeOffset?> dateTimeArray = default(System.Collections.Generic.IList<System.DateTimeOffset?>))
-        {
-            Date = date;
-            DateTime = dateTime;
-            DateArray = dateArray;
-            DateTimeArray = dateTimeArray;
-        }
 
         /// <summary>
         /// </summary>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Product.cs
@@ -10,6 +10,7 @@ namespace Fixtures.DateTimeOffset.Models
 {
     using System.Linq;
 
+    [System.Runtime.Serialization.DataContract]
     public partial class Product
     {
         /// <summary>
@@ -22,21 +23,25 @@ namespace Fixtures.DateTimeOffset.Models
         /// </summary>
         [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateJsonConverter))]
         [Newtonsoft.Json.JsonProperty(PropertyName = "date")]
+        [System.Runtime.Serialization.DataMember(Name = "date", EmitDefaultValue = false)]
         public System.DateTime? Date { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "dateTime")]
+        [System.Runtime.Serialization.DataMember(Name = "dateTime", EmitDefaultValue = false)]
         public System.DateTimeOffset? DateTime { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "dateArray")]
+        [System.Runtime.Serialization.DataMember(Name = "dateArray", EmitDefaultValue = false)]
         public System.Collections.Generic.IList<System.DateTime?> DateArray { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "dateTimeArray")]
+        [System.Runtime.Serialization.DataMember(Name = "dateTimeArray", EmitDefaultValue = false)]
         public System.Collections.Generic.IList<System.DateTimeOffset?> DateTimeArray { get; set; }
 
     }

--- a/src/generator/AutoRest.CSharp.Tests/Swagger/swagger-datetimeoffset.json
+++ b/src/generator/AutoRest.CSharp.Tests/Swagger/swagger-datetimeoffset.json
@@ -12,7 +12,10 @@
     "x-ms-code-generation-settings": {
         "useDateTimeOffset": true,
         "csharpOptions": {
-            "modelOptions": { "constructorsIncludeOnlyRequiredProperties": true }
+            "modelOptions": {
+                "constructorsIncludeOnlyRequiredProperties": true,
+                "addDataContractAttributes":  true
+            }
         }
     }
   },

--- a/src/generator/AutoRest.CSharp.Tests/Swagger/swagger-datetimeoffset.json
+++ b/src/generator/AutoRest.CSharp.Tests/Swagger/swagger-datetimeoffset.json
@@ -10,7 +10,10 @@
       "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
     },
     "x-ms-code-generation-settings": {
-      "useDateTimeOffset": true
+        "useDateTimeOffset": true,
+        "csharpOptions": {
+            "modelOptions": { "constructorsIncludeOnlyRequiredProperties": true }
+        }
     }
   },
   "host": "localhost:3000",

--- a/src/generator/AutoRest.CSharp/CSharpCodeGenerator.cs
+++ b/src/generator/AutoRest.CSharp/CSharpCodeGenerator.cs
@@ -23,22 +23,38 @@ namespace AutoRest.CSharp
         public CSharpCodeGenerator(Settings settings) : base(settings)
         {
             _namer = new CSharpCodeNamer();
+            CodeOptions = new CSharpCodeOptions();
             IsSingleFileGenerationSupported = true;
         }
+
+        /// <summary>
+        /// Options for CSharp code generation
+        /// </summary>
+        [SettingsInfo("CSharp code generation options")]
+        [SettingsAlias("csharpOptions")]
+        public CSharpCodeOptions CodeOptions { get; set; }
 
         /// <summary>
         /// Indicates whether ctor needs to be generated with internal protection level.
         /// </summary>
         [SettingsInfo("The namespace to use for generated code.")]
         [SettingsAlias("internal")]
-        public bool InternalConstructors { get; set; }
+        public bool InternalConstructors
+        {
+            get { return CodeOptions.InternalConstructors; }
+            set { CodeOptions.InternalConstructors = value; }
+        }
 
         /// <summary>
         /// Specifies mode for generating sync wrappers.
         /// </summary>
         [SettingsInfo("Specifies mode for generating sync wrappers.")]
         [SettingsAlias("syncMethods")]
-        public SyncMethodsGenerationMode SyncMethods { get; set; }
+        public SyncMethodsGenerationMode SyncMethods
+        {
+            get { return CodeOptions.SyncMethods; }
+            set { CodeOptions.SyncMethods = value; }
+        }
 
         public override string Name
         {
@@ -159,7 +175,7 @@ namespace AutoRest.CSharp
             {
                 var modelTemplate = new ModelTemplate
                 {
-                    Model = new ModelTemplateModel(model),
+                    Model = new ModelTemplateModel(model, this.CodeOptions.ModelOptions),
                 };
                 await Write(modelTemplate, Path.Combine(Settings.ModelsName, model.Name + ".cs"));
             }
@@ -179,7 +195,7 @@ namespace AutoRest.CSharp
             {
                 var exceptionTemplate = new ExceptionTemplate
                 {
-                    Model = new ModelTemplateModel(exceptionType),
+                    Model = new ModelTemplateModel(exceptionType, this.CodeOptions.ModelOptions),
                 };
                 await Write(exceptionTemplate, Path.Combine(Settings.ModelsName, exceptionTemplate.Model.ExceptionTypeDefinitionName + ".cs"));
             }

--- a/src/generator/AutoRest.CSharp/CSharpCodeOptions.cs
+++ b/src/generator/AutoRest.CSharp/CSharpCodeOptions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoRest.CSharp.TemplateModels;
+using Newtonsoft.Json;
+
+namespace AutoRest.CSharp
+{
+    public class CSharpCodeOptions
+    {
+        public CSharpCodeOptions()
+        {
+            ModelOptions = new ModelTemplateOptions();
+        }
+
+        [JsonProperty("modelOptions")]
+        public ModelTemplateOptions ModelOptions { get; set; }
+
+        /// <summary>
+        /// Indicates whether the client ctor needs to be generated with internal protection level.
+        /// </summary>
+        [JsonProperty("internalConstructors")]
+        public bool InternalConstructors { get; set; }
+
+        /// <summary>
+        /// Specifies mode for generating sync wrappers.
+        /// </summary>
+        [JsonProperty("syncMethods")]
+        public SyncMethodsGenerationMode SyncMethods { get; set; }
+    }
+}

--- a/src/generator/AutoRest.CSharp/TemplateModels/ModelTemplateModel.cs
+++ b/src/generator/AutoRest.CSharp/TemplateModels/ModelTemplateModel.cs
@@ -8,27 +8,38 @@ using AutoRest.Core;
 using AutoRest.Core.ClientModel;
 using AutoRest.Core.Utilities;
 using AutoRest.Extensions;
+using Newtonsoft.Json;
 
 namespace AutoRest.CSharp.TemplateModels
 {
+    public class ModelTemplateOptions
+    {
+        [JsonProperty("constructorsIncludeOnlyRequiredProperties")]
+        public bool ConstructorsIncludeOnlyRequiredProperties { get; set; }
+
+    }
+
     public class ModelTemplateModel : CompositeType
     {
         private readonly IScopeProvider _scope = new ScopeProvider();
         private readonly ModelTemplateModel _baseModel = null;
         private readonly ConstructorModel _constructorModel = null;
 
-        public ModelTemplateModel(CompositeType source)
+        public ModelTemplateModel(CompositeType source, ModelTemplateOptions options = null)
         {
+            this.ModelOptions = options;
             this.LoadFrom(source);
             PropertyTemplateModels = new List<PropertyTemplateModel>();
             source.Properties.ForEach(p => PropertyTemplateModels.Add(new PropertyTemplateModel(p)));
             if (source.BaseModelType != null)
             {
-                this._baseModel = new ModelTemplateModel(source.BaseModelType);
+                this._baseModel = new ModelTemplateModel(source.BaseModelType, options);
             }
 
             this._constructorModel = new ConstructorModel(this);
         }
+
+        public ModelTemplateOptions ModelOptions { get; set; }
 
         public IScopeProvider Scope
         {
@@ -167,12 +178,15 @@ namespace AutoRest.CSharp.TemplateModels
         {
             public ConstructorModel(ModelTemplateModel model)
             {
-                // TODO: this could just be the "required" parameters instead of required and all the optional ones
                 // with defaults if we wanted a bit cleaner constructors
-                IEnumerable<InheritedPropertyInfo> allProperties =
-                   model.AllPropertyTemplateModels.OrderBy(p => !p.Property.IsRequired).ThenBy(p => p.Depth);
+                var allProperties =
+                   model.AllPropertyTemplateModels;
 
-                Parameters = allProperties.Select(p => new ConstructorParameterModel(p.Property));
+                //If specified via options, suppress properties that are no required
+                if (model.ModelOptions?.ConstructorsIncludeOnlyRequiredProperties == true)
+                    allProperties = allProperties.Where(p => p.Property.IsRequired);
+
+                Parameters = allProperties.OrderBy(p => !p.Property.IsRequired).ThenBy(p => p.Depth).Select(p => new ConstructorParameterModel(p.Property)).ToList();
                 Signature = CreateSignature(Parameters);
                 SignatureDocumentation = CreateSignatureDocumentation(Parameters);
                 BaseCall = CreateBaseCall(model);

--- a/src/generator/AutoRest.CSharp/TemplateModels/ModelTemplateModel.cs
+++ b/src/generator/AutoRest.CSharp/TemplateModels/ModelTemplateModel.cs
@@ -17,6 +17,9 @@ namespace AutoRest.CSharp.TemplateModels
         [JsonProperty("constructorsIncludeOnlyRequiredProperties")]
         public bool ConstructorsIncludeOnlyRequiredProperties { get; set; }
 
+        [JsonProperty("addDataContractAttributes")]
+        public bool AddDataContractAttributes { get; set; }
+
     }
 
     public class ModelTemplateModel : CompositeType

--- a/src/generator/AutoRest.CSharp/Templates/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/ModelTemplate.cshtml
@@ -8,6 +8,7 @@
 namespace @(Settings.Namespace).@(Settings.ModelsName)
 {
     using System.Linq;
+
 @EmptyLine
 
 @if (!string.IsNullOrEmpty(Model.Summary) || !string.IsNullOrWhiteSpace(Model.Documentation))
@@ -32,7 +33,12 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
     @:[Newtonsoft.Json.JsonObject("@Model.SerializedName")]
     }
 
-    @if (Model.NeedsTransformationConverter)
+    @if (Model.ModelOptions.AddDataContractAttributes)
+    {
+    @:[System.Runtime.Serialization.DataContract]
+    }
+
+@if (Model.NeedsTransformationConverter)
     {
     @:[Microsoft.Rest.Serialization.JsonTransformation]
     }
@@ -147,6 +153,10 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
             else
             {
         @:[Newtonsoft.Json.JsonProperty(PropertyName = "@property.SerializedName")]
+            if (Model.ModelOptions.AddDataContractAttributes)
+                {
+        @:[System.Runtime.Serialization.DataMember(Name = "@property.SerializedName", EmitDefaultValue = false)]
+                }
             }
         @:public @property.Type.Name @property.Name { get; @(property.IsReadOnly ? "private " : "")set; }
         @EmptyLine

--- a/src/generator/AutoRest.CSharp/project.json
+++ b/src/generator/AutoRest.CSharp/project.json
@@ -24,7 +24,6 @@
 
   "dependencies": {
     "System.Threading.Tasks": "4.0.0",
-
     "AutoRest.Extensions": {
       "target": "project"
     },

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-x-ms-code-generation-settings.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-x-ms-code-generation-settings.json
@@ -4,8 +4,11 @@
     "version": "1.0.13",
     "title": "Swagger Custom Paths",
     "x-ms-code-generation-settings": {
-      "header": "MIT",
-      "internalConstructors": true
+        "header": "MIT",
+        "csharpOptions": {
+            "internalConstructors": true,
+            "modelOptions": { "constructorsIncludeOnlyRequiredProperties":  true }
+        }
     }    
   },
   "host": "autorestresourcesproxysite.azurewebsites.net",

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-x-ms-code-generation-settings.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-x-ms-code-generation-settings.json
@@ -7,7 +7,10 @@
         "header": "MIT",
         "csharpOptions": {
             "internalConstructors": true,
-            "modelOptions": { "constructorsIncludeOnlyRequiredProperties":  true }
+            "modelOptions": {
+                "constructorsIncludeOnlyRequiredProperties": true,
+                "addDataContractAttributes":  true
+            }
         }
     }    
   },

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerTests.cs
@@ -625,6 +625,7 @@ namespace AutoRest.Swagger.Tests
 
             Assert.Equal("MIT", settings.Header);
             Assert.Equal(true, codeGenerator.InternalConstructors);
+            Assert.Equal(true, codeGenerator.CodeOptions.ModelOptions.ConstructorsIncludeOnlyRequiredProperties);
         }
 
         [Fact]

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerTests.cs
@@ -626,6 +626,7 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal("MIT", settings.Header);
             Assert.Equal(true, codeGenerator.InternalConstructors);
             Assert.Equal(true, codeGenerator.CodeOptions.ModelOptions.ConstructorsIncludeOnlyRequiredProperties);
+            Assert.Equal(true, codeGenerator.CodeOptions.ModelOptions.AddDataContractAttributes);
         }
 
         [Fact]


### PR DESCRIPTION

Refactors somewhat how code generation options can be applied. Using a JSON document to provide code generation options seems more sustainable than continuing to add command line arguments to AutoRest.

If others like this approach of supplying code generation options, I could apply the same approach to some of the other generators.

Also addresses issue #747 