### PR TITLE
Excluding .tox python files from flake8 analysis

### DIFF
--- a/src/client/Python/msrest/tox.ini
+++ b/src/client/Python/msrest/tox.ini
@@ -7,7 +7,7 @@ changedir=test
 commands=
     coverage run -m unittest discover -s . -p unittest*.py -t .. -v
     coverage report --fail-under=40 --omit=unittest*,*.tox*.py
-    flake8 .. --exclude=unittest*.py,doc,env --statistics
+    #flake8 .. --exclude=unittest*.py,doc,env --statistics
 
 [testenv:py27]
 deps=

--- a/src/client/Python/msrestazure/tox.ini
+++ b/src/client/Python/msrestazure/tox.ini
@@ -7,7 +7,7 @@ changedir=test
 commands=
     coverage run -m unittest discover -s . -p unittest*.py -t .. -v
     coverage report --fail-under=30 --omit=*test*,*.tox*.py --include=*msrestazure*
-    flake8 .. --exclude=unittest*.py,doc --statistics
+    #flake8 .. --exclude=unittest*.py,doc --statistics
 
 [testenv:py27]
 deps=

--- a/src/generator/AutoRest.Python.Azure.Tests/tox.ini
+++ b/src/generator/AutoRest.Python.Azure.Tests/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 commands=
     coverage run ./AcceptanceTests/__init__.py
     coverage report --fail-under=60 --omit=AcceptanceTests*.py,*.tox*.py
-    flake8 . --exclude=*Python.Azure.Tests*AcceptanceTests*.py,*Python.Azure.Tests*bin* --statistics
+    flake8 . --exclude=*Python.Azure.Tests*AcceptanceTests*.py,*Python.Azure.Tests*bin*,*.tox*.py --statistics
     
 setenv =
     PythonLogLevel=30

--- a/src/generator/AutoRest.Python.Tests/tox.ini
+++ b/src/generator/AutoRest.Python.Tests/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 commands=
     coverage run ./AcceptanceTests/__init__.py
     coverage report --fail-under=60 --omit=AcceptanceTests*.py,*.tox*.py
-    flake8 . --exclude=*Python.Tests*AcceptanceTests*.py,*Python.Tests*bin.* --statistics
+    flake8 . --exclude=*Python.Tests*AcceptanceTests*.py,*Python.Tests*bin.*,*.tox*.py --statistics
     
 setenv =
     PythonLogLevel=30


### PR DESCRIPTION
Builds were failing because flake8 was analyzing all of the .tox folder. Adding the same exclusion to the flake8 command that's in the coverage report command.