### PR TITLE
Adding return type for the client in ruby operations templates

### DIFF
--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_accounts.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_accounts.rb
@@ -16,7 +16,7 @@ module Petstore
       @client = client
     end
 
-    # @return reference to the StorageManagementClient
+    # @return [StorageManagementClient] reference to the StorageManagementClient
     attr_reader :client
 
     #

--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/usage_operations.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/usage_operations.rb
@@ -16,7 +16,7 @@ module Petstore
       @client = client
     end
 
-    # @return reference to the StorageManagementClient
+    # @return [StorageManagementClient] reference to the StorageManagementClient
     attr_reader :client
 
     #

--- a/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodGroupTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodGroupTemplate.cshtml
@@ -28,7 +28,7 @@ module @Settings.Namespace
     end
 
     @EmptyLine
-    # @@return reference to the @(Model.Name)
+    # @@return [@(Model.Name)] reference to the @(Model.Name)
     attr_reader :client
 
     @EmptyLine

--- a/src/generator/AutoRest.Ruby/Templates/MethodGroupTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/MethodGroupTemplate.cshtml
@@ -27,7 +27,7 @@ module @Settings.Namespace
     end
 
     @EmptyLine
-    # @@return reference to the @(Model.Name)
+    # @@return [@(Model.Name)] reference to the @(Model.Name)
     attr_reader :client
 
     @EmptyLine


### PR DESCRIPTION
This improves the reference doc @ http://www.rubydoc.info/gems/azure_mgmt_cognitive_services/0.4.0/Azure/ARM/CognitiveServices/CognitiveServicesAccounts#client-instance_method.