### PR TITLE
Changing linting rules for $ref with siblings and requiring default responses

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -348,15 +348,6 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to There is no default response defined in the responses section.
-        /// </summary>
-        public static string NoDefaultResponse {
-            get {
-                return ResourceManager.GetString("NoDefaultResponse", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///    Looks up a localized string similar to Could not find a definition for the path parameter &apos;{0}&apos;.
         /// </summary>
         public static string NoDefinitionForPathParameter {
@@ -366,7 +357,7 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to No response objects defined..
+        ///    Looks up a localized string similar to No responses defined..
         /// </summary>
         public static string NoResponses {
             get {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -226,7 +226,7 @@
     <value>Could not find a definition for the path parameter '{0}'</value>
   </data>
   <data name="NoResponses" xml:space="preserve">
-    <value>No response objects defined.</value>
+    <value>No responses defined.</value>
   </data>
   <data name="OnlyOneUnderscoreAllowedInOperationId" xml:space="preserve">
     <value>Only 1 underscore is permitted in the operation id, following Noun_Verb conventions.</value>
@@ -239,9 +239,6 @@
   </data>
   <data name="CodeGenerationError" xml:space="preserve">
     <value>Errors found during Swagger document validation.</value>
-  </data>
-  <data name="NoDefaultResponse" xml:space="preserve">
-    <value>There is no default response defined in the responses section</value>
   </data>
   <data name="XMSPathBaseNotInPaths" xml:space="preserve">
     <value>Paths in x-ms-paths must overload a normal path in the paths section.</value>

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/clean-complex-spec.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/clean-complex-spec.json
@@ -244,6 +244,17 @@
           "x-ms-client-name": "Baz"
         }
       }
+    },
+    "NestedProperties": {
+      "description": "A model with nested properties that uses client flatten",
+      "properties": {
+        "properties": {
+          "foo": {
+            "description": "Foo property"
+          },
+          "x-ms-client-flatten": true
+        }
+      }
     }
   }
 }

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -80,20 +80,6 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-        public void RefSiblingPropertiesValidation()
-        {
-            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "ref-sibling-properties.json"));
-            messages.AssertOnlyValidationWarning(typeof(RefsMustNotHaveSiblings));
-        }
-
-        [Fact]
-        public void NoResponsesValidation()
-        {
-            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "operations-no-responses.json"));
-            messages.AssertOnlyValidationMessage(typeof(DefaultResponseRequired));
-        }
-
-        [Fact]
         public void AnonymousSchemasDiscouragedValidation()
         {
             var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "anonymous-response-type.json"));
@@ -115,10 +101,10 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-        public void MissingDefaultResponseValidation()
+        public void NoResponsesValidation()
         {
-            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "operations-no-default-response.json"));
-            messages.AssertOnlyValidationMessage(typeof(DefaultResponseRequired));
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "operations-no-responses.json"));
+            messages.AssertOnlyValidationMessage(typeof(ResponseRequired));
         }
 
         [Fact]

--- a/src/modeler/AutoRest.Swagger/Model/Operation.cs
+++ b/src/modeler/AutoRest.Swagger/Model/Operation.cs
@@ -75,7 +75,7 @@ namespace AutoRest.Swagger.Model
         /// <summary>
         /// The list of possible responses as they are returned from executing this operation.
         /// </summary>
-        [Rule(typeof(DefaultResponseRequired))]
+        [Rule(typeof(ResponseRequired))]
         public Dictionary<string, OperationResponse> Responses { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Validation/AvoidNestedProperties.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/AvoidNestedProperties.cs
@@ -6,18 +6,25 @@ using AutoRest.Core.Logging;
 using AutoRest.Core.Properties;
 using AutoRest.Core.Validation;
 using AutoRest.Swagger.Model;
+using System.Collections.Generic;
 
 namespace AutoRest.Swagger.Validation
 {
     public class AvoidNestedProperties : TypedRule<Schema>
     {
+        private const string ClientFlattenExtensionName = "x-ms-client-flatten";
         /// <summary>
         /// An <paramref name="entity" /> fails this rule if it 
         /// </summary>
         /// <param name="entity"></param>
         /// <returns></returns>
         public override bool IsValid(Schema schema, RuleContext context)
-            => context.Key != "properties" || schema.Extensions.ContainsKey("x-ms-client-flatten");
+            => context.Key != "properties" || IsClientFlattenUsed(schema.Extensions);
+
+        private static bool IsClientFlattenUsed(Dictionary<string, object> extensions)
+            => extensions.ContainsKey(ClientFlattenExtensionName)
+            && extensions[ClientFlattenExtensionName] is bool
+            && (bool)extensions[ClientFlattenExtensionName] == true;
 
         /// <summary>
         ///     The template message for this Rule.

--- a/src/modeler/AutoRest.Swagger/Validation/RefNoSiblings.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/RefNoSiblings.cs
@@ -39,7 +39,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override LogEntrySeverity Severity => LogEntrySeverity.Warning;
+        public override LogEntrySeverity Severity => LogEntrySeverity.Info;
 
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/ResponseRequired.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ResponseRequired.cs
@@ -6,10 +6,11 @@ using AutoRest.Swagger.Model;
 using System.Collections.Generic;
 using AutoRest.Core.Logging;
 using AutoRest.Core.Properties;
+using System.Linq;
 
 namespace AutoRest.Swagger.Validation
 {
-    public class DefaultResponseRequired : TypedRule<IDictionary<string, OperationResponse>>
+    public class ResponseRequired : TypedRule<IDictionary<string, OperationResponse>>
     {
         /// <summary>
         /// This rule fails if the <paramref name="entity"/> lacks responses or lacks a default response
@@ -17,7 +18,7 @@ namespace AutoRest.Swagger.Validation
         /// <param name="entity"></param>
         /// <returns></returns>
         public override bool IsValid(IDictionary<string, OperationResponse> entity)
-            => entity != null && entity.ContainsKey("default");
+            => entity != null && entity.Any();
 
         /// <summary>
         /// The template message for this Rule. 
@@ -25,7 +26,7 @@ namespace AutoRest.Swagger.Validation
         /// <remarks>
         /// This may contain placeholders '{0}' for parameterized messages.
         /// </remarks>
-        public override string MessageTemplate => Resources.NoDefaultResponse;
+        public override string MessageTemplate => Resources.NoResponses;
 
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)


### PR DESCRIPTION
- Changing $ref with siblings rule to info, since we don't handle it correctly in AutoRest yet 
- Changing the default responses rule to just require a response (since the default behavior of using code and message is fine)
- Making the "AvoidNestedProperties" rule respect the x-ms-client-flatten extension value