### PR TITLE
[In Review] Fix for inconsistency produced in generated code when operation is no…

### DIFF
--- a/src/generator/AutoRest.Ruby.Azure/AzureRubyCodeGenerator.cs
+++ b/src/generator/AutoRest.Ruby.Azure/AzureRubyCodeGenerator.cs
@@ -92,15 +92,14 @@ namespace AutoRest.Ruby.Azure
                 {
                     PageableExtension pageableExtension = JsonConvert.DeserializeObject<PageableExtension>(method.Extensions[AzureExtensions.PageableExtension].ToString());
                     if (pageableExtension != null && !method.Extensions.ContainsKey("nextLinkMethod") && !string.IsNullOrWhiteSpace(pageableExtension.NextLinkName))
-                    {
-                        
-                        if (serviceClient.Methods[i].Extensions.ContainsKey("nextMethodName"))
+                    {            
+                        if (method.Extensions.ContainsKey("nextMethodName"))
                         {
-                            serviceClient.Methods[i].Extensions["nextMethodName"] = CodeNamer.GetMethodName((string)method.Extensions["nextMethodName"]);
+                            method.Extensions["nextMethodName"] = CodeNamer.GetMethodName((string)method.Extensions["nextMethodName"]);
                         }
                         else if (!string.IsNullOrWhiteSpace(pageableExtension.OperationName))
                         {
-                            serviceClient.Methods[i].Extensions["nextMethodName"] = CodeNamer.GetMethodName(pageableExtension.OperationName);
+                            method.Extensions["nextMethodName"] = CodeNamer.GetMethodName(pageableExtension.OperationName);
                         }
                         if (!method.Extensions.ContainsKey(AzureExtensions.LongRunningExtension))
                         {

--- a/src/generator/AutoRest.Ruby.Azure/AzureRubyCodeGenerator.cs
+++ b/src/generator/AutoRest.Ruby.Azure/AzureRubyCodeGenerator.cs
@@ -93,14 +93,25 @@ namespace AutoRest.Ruby.Azure
                     PageableExtension pageableExtension = JsonConvert.DeserializeObject<PageableExtension>(method.Extensions[AzureExtensions.PageableExtension].ToString());
                     if (pageableExtension != null && !method.Extensions.ContainsKey("nextLinkMethod") && !string.IsNullOrWhiteSpace(pageableExtension.NextLinkName))
                     {
-                        serviceClient.Methods.Insert(i, (Method)method.Clone());
+                        
                         if (serviceClient.Methods[i].Extensions.ContainsKey("nextMethodName"))
                         {
                             serviceClient.Methods[i].Extensions["nextMethodName"] = CodeNamer.GetMethodName((string)method.Extensions["nextMethodName"]);
                         }
-                        i++;
+                        else if (!string.IsNullOrWhiteSpace(pageableExtension.OperationName))
+                        {
+                            serviceClient.Methods[i].Extensions["nextMethodName"] = CodeNamer.GetMethodName(pageableExtension.OperationName);
+                        }
+                        if (!method.Extensions.ContainsKey(AzureExtensions.LongRunningExtension))
+                        {
+                            serviceClient.Methods.Insert(i, (Method)method.Clone());
+                            i++;
+                        }
                     }
-                    serviceClient.Methods[i].Extensions.Remove(AzureExtensions.PageableExtension);
+                    if (!method.Extensions.ContainsKey(AzureExtensions.LongRunningExtension) || method.Extensions.ContainsKey("nextLinkMethod"))
+                    {
+                        serviceClient.Methods[i].Extensions.Remove(AzureExtensions.PageableExtension);
+                    }
                 }
             }
         }

--- a/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
@@ -119,7 +119,7 @@ namespace AutoRest.Ruby.Azure.TemplateModels
                 if (ReturnType.Body is CompositeType)
                 {
                     CompositeType compositeType = (CompositeType)ReturnType.Body;
-                    if (compositeType.Extensions.ContainsKey(AzureExtensions.PageableExtension))
+                    if (compositeType.Extensions.ContainsKey(AzureExtensions.PageableExtension) && this.Extensions.ContainsKey("nextMethodName"))
                     {
                         bool isNextLinkMethod = this.Extensions.ContainsKey("nextLinkMethod") && (bool)this.Extensions["nextLinkMethod"];
                         bool isPageable = (bool)compositeType.Extensions[AzureExtensions.PageableExtension];

--- a/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
@@ -273,7 +273,8 @@ namespace AutoRest.Ruby.Azure.TemplateModels
         {
             get
             {
-                if (Extensions.ContainsKey("nextMethodName") && !Extensions.ContainsKey(AzureExtensions.PageableExtension))
+                if (Extensions.ContainsKey("nextMethodName") && (!Extensions.ContainsKey(AzureExtensions.PageableExtension) ||
+                    (Extensions.ContainsKey(AzureExtensions.PageableExtension) && Extensions.ContainsKey(AzureExtensions.LongRunningExtension))))
                 {
                     try
                     {

--- a/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
@@ -8,7 +8,7 @@
 {
 @:@(Include(new MethodTemplate(), (MethodTemplateModel)Model))
 }
-else if (!Model.IsLongRunningOperation && Model.IsPageable)
+@if (Model.IsPageable) 
 {
 <text>
 #
@@ -42,7 +42,7 @@ def @(Model.Name)_as_lazy(@(Model.MethodParameterDeclaration))
 end
 </text>
 }
-else
+@if (Model.IsLongRunningOperation)
 {
 <text>
 #


### PR DESCRIPTION
Small change to address inconsistency in generated code when operation is not marked as pageable and therefore does not contain pageable methods, even if return type looks pageable. Without this change we make a call to a non-existent "as_lazy" method.
