### PR TITLE
[Ruby] Sperating responsibilities of Ruby and Azure.Ruby serilization modules

### DIFF
--- a/Samples/azure-storage/Azure.CSharp/IStorageAccountsOperations.cs
+++ b/Samples/azure-storage/Azure.CSharp/IStorageAccountsOperations.cs
@@ -66,7 +66,7 @@ namespace Petstore
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> CreateWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, StorageAccountCreateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> CreateWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountCreateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Asynchronously creates a new storage account with the specified
         /// parameters. Existing accounts cannot be updated with this API and
@@ -100,7 +100,7 @@ namespace Petstore
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> BeginCreateWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, StorageAccountCreateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> BeginCreateWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountCreateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Deletes a storage account in Microsoft Azure.
         /// </summary>
@@ -124,7 +124,7 @@ namespace Petstore
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse> DeleteWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse> DeleteWithHttpMessagesAsync(string resourceGroupName, string accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Returns the properties for the specified storage account including
         /// but not limited to name, account type, location, and account
@@ -154,7 +154,7 @@ namespace Petstore
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> GetPropertiesWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> GetPropertiesWithHttpMessagesAsync(string resourceGroupName, string accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Updates the account type or tags for a storage account. It can
         /// also be used to add a custom domain (note that custom domains
@@ -198,7 +198,7 @@ namespace Petstore
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> UpdateWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, StorageAccountUpdateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> UpdateWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountUpdateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Lists the access keys for the specified storage account.
         /// </summary>
@@ -223,7 +223,7 @@ namespace Petstore
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccountKeys>> ListKeysWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccountKeys>> ListKeysWithHttpMessagesAsync(string resourceGroupName, string accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Lists all the storage accounts available under the subscription.
         /// Note that storage keys are not returned; use the ListKeys
@@ -268,7 +268,7 @@ namespace Petstore
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.Collections.Generic.IEnumerable<StorageAccount>>> ListByResourceGroupWithHttpMessagesAsync(System.String resourceGroupName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.Collections.Generic.IEnumerable<StorageAccount>>> ListByResourceGroupWithHttpMessagesAsync(string resourceGroupName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Regenerates the access keys for the specified storage account.
         /// </summary>
@@ -299,6 +299,6 @@ namespace Petstore
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccountKeys>> RegenerateKeyWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, StorageAccountRegenerateKeyParameters regenerateKey, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccountKeys>> RegenerateKeyWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountRegenerateKeyParameters regenerateKey, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
     }
 }

--- a/Samples/azure-storage/Azure.CSharp/IStorageManagementClient.cs
+++ b/Samples/azure-storage/Azure.CSharp/IStorageManagementClient.cs
@@ -34,29 +34,29 @@ namespace Petstore
         /// Azure subscription. The subscription ID forms part of the URI for
         /// every service call.
         /// </summary>
-        System.String SubscriptionId { get; set; }
+        string SubscriptionId { get; set; }
 
         /// <summary>
         /// Client Api Version.
         /// </summary>
-        System.String ApiVersion { get; }
+        string ApiVersion { get; }
 
         /// <summary>
         /// Gets or sets the preferred language for the response.
         /// </summary>
-        System.String AcceptLanguage { get; set; }
+        string AcceptLanguage { get; set; }
 
         /// <summary>
         /// Gets or sets the retry timeout in seconds for Long Running
         /// Operations. Default value is 30.
         /// </summary>
-        System.Int32? LongRunningOperationRetryTimeout { get; set; }
+        int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
         /// When set to true a unique x-ms-client-request-id value is
         /// generated and included in each request. Default is true.
         /// </summary>
-        System.Boolean? GenerateClientRequestId { get; set; }
+        bool? GenerateClientRequestId { get; set; }
 
 
         /// <summary>

--- a/Samples/azure-storage/Azure.CSharp/Models/CheckNameAvailabilityResult.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/CheckNameAvailabilityResult.cs
@@ -28,7 +28,7 @@ namespace Petstore.Models
         /// 'AccountNameInvalid', 'AlreadyExists'</param>
         /// <param name="message">Gets an error message explaining the Reason
         /// value in more detail.</param>
-        public CheckNameAvailabilityResult(System.Boolean? nameAvailable = default(System.Boolean?), Reason? reason = default(Reason?), System.String message = default(System.String))
+        public CheckNameAvailabilityResult(bool? nameAvailable = default(bool?), Reason? reason = default(Reason?), string message = default(string))
         {
             NameAvailable = nameAvailable;
             Reason = reason;
@@ -41,7 +41,7 @@ namespace Petstore.Models
         /// name has already been taken or invalid and cannot be used.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "nameAvailable")]
-        public System.Boolean? NameAvailable { get; set; }
+        public bool? NameAvailable { get; set; }
 
         /// <summary>
         /// Gets the reason that a storage account name could not be used. The
@@ -55,7 +55,7 @@ namespace Petstore.Models
         /// Gets an error message explaining the Reason value in more detail.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
-        public System.String Message { get; set; }
+        public string Message { get; set; }
 
     }
 }

--- a/Samples/azure-storage/Azure.CSharp/Models/CustomDomain.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/CustomDomain.cs
@@ -22,7 +22,7 @@ namespace Petstore.Models
         /// <param name="useSubDomain">Indicates whether indirect CName
         /// validation is enabled. Default value is false. This should only
         /// be set on updates</param>
-        public CustomDomain(System.String name, System.Boolean? useSubDomain = default(System.Boolean?))
+        public CustomDomain(string name, bool? useSubDomain = default(bool?))
         {
             Name = name;
             UseSubDomain = useSubDomain;
@@ -32,7 +32,7 @@ namespace Petstore.Models
         /// Gets or sets the custom domain name. Name is the CNAME source.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
-        public System.String Name { get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets indicates whether indirect CName validation is
@@ -40,7 +40,7 @@ namespace Petstore.Models
         /// updates
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "useSubDomain")]
-        public System.Boolean? UseSubDomain { get; set; }
+        public bool? UseSubDomain { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/Samples/azure-storage/Azure.CSharp/Models/Endpoints.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/Endpoints.cs
@@ -21,7 +21,7 @@ namespace Petstore.Models
         /// <param name="queue">Gets the queue endpoint.</param>
         /// <param name="table">Gets the table endpoint.</param>
         /// <param name="file">Gets the file endpoint.</param>
-        public Endpoints(System.String blob = default(System.String), System.String queue = default(System.String), System.String table = default(System.String), System.String file = default(System.String))
+        public Endpoints(string blob = default(string), string queue = default(string), string table = default(string), string file = default(string))
         {
             Blob = blob;
             Queue = queue;
@@ -33,25 +33,25 @@ namespace Petstore.Models
         /// Gets the blob endpoint.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "blob")]
-        public System.String Blob { get; set; }
+        public string Blob { get; set; }
 
         /// <summary>
         /// Gets the queue endpoint.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "queue")]
-        public System.String Queue { get; set; }
+        public string Queue { get; set; }
 
         /// <summary>
         /// Gets the table endpoint.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "table")]
-        public System.String Table { get; set; }
+        public string Table { get; set; }
 
         /// <summary>
         /// Gets the file endpoint.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "file")]
-        public System.String File { get; set; }
+        public string File { get; set; }
 
     }
 }

--- a/Samples/azure-storage/Azure.CSharp/Models/Resource.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/Resource.cs
@@ -18,7 +18,7 @@ namespace Petstore.Models
         /// <param name="type">Resource type</param>
         /// <param name="location">Resource location</param>
         /// <param name="tags">Resource tags</param>
-        public Resource(System.String id = default(System.String), System.String name = default(System.String), System.String type = default(System.String), System.String location = default(System.String), System.Collections.Generic.IDictionary<System.String, System.String> tags = default(System.Collections.Generic.IDictionary<System.String, System.String>))
+        public Resource(string id = default(string), string name = default(string), string type = default(string), string location = default(string), System.Collections.Generic.IDictionary<string, string> tags = default(System.Collections.Generic.IDictionary<string, string>))
         {
             Id = id;
             Name = name;
@@ -31,31 +31,31 @@ namespace Petstore.Models
         /// Gets resource Id
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
-        public System.String Id { get; private set; }
+        public string Id { get; private set; }
 
         /// <summary>
         /// Gets resource name
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
-        public System.String Name { get; private set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// Gets resource type
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "type")]
-        public System.String Type { get; private set; }
+        public string Type { get; private set; }
 
         /// <summary>
         /// Gets or sets resource location
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "location")]
-        public System.String Location { get; set; }
+        public string Location { get; set; }
 
         /// <summary>
         /// Gets or sets resource tags
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "tags")]
-        public System.Collections.Generic.IDictionary<System.String, System.String> Tags { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Tags { get; set; }
 
     }
 }

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccount.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccount.cs
@@ -21,7 +21,7 @@ namespace Petstore.Models
         /// <param name="type">Resource type</param>
         /// <param name="location">Resource location</param>
         /// <param name="tags">Resource tags</param>
-        public StorageAccount(System.String id = default(System.String), System.String name = default(System.String), System.String type = default(System.String), System.String location = default(System.String), System.Collections.Generic.IDictionary<System.String, System.String> tags = default(System.Collections.Generic.IDictionary<System.String, System.String>), StorageAccountProperties properties = default(StorageAccountProperties))
+        public StorageAccount(string id = default(string), string name = default(string), string type = default(string), string location = default(string), System.Collections.Generic.IDictionary<string, string> tags = default(System.Collections.Generic.IDictionary<string, string>), StorageAccountProperties properties = default(StorageAccountProperties))
             : base(id, name, type, location, tags)
         {
             Properties = properties;

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountCheckNameAvailabilityParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountCheckNameAvailabilityParameters.cs
@@ -15,7 +15,7 @@ namespace Petstore.Models
         /// Initializes a new instance of the
         /// StorageAccountCheckNameAvailabilityParameters class.
         /// </summary>
-        public StorageAccountCheckNameAvailabilityParameters(System.String name, System.String type = default(System.String))
+        public StorageAccountCheckNameAvailabilityParameters(string name, string type = default(string))
         {
             Name = name;
             Type = type;
@@ -24,12 +24,12 @@ namespace Petstore.Models
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
-        public System.String Name { get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "type")]
-        public System.String Type { get; set; }
+        public string Type { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountCreateParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountCreateParameters.cs
@@ -20,7 +20,7 @@ namespace Petstore.Models
         /// </summary>
         /// <param name="location">Resource location</param>
         /// <param name="tags">Resource tags</param>
-        public StorageAccountCreateParameters(System.String location, System.Collections.Generic.IDictionary<System.String, System.String> tags = default(System.Collections.Generic.IDictionary<System.String, System.String>), StorageAccountPropertiesCreateParameters properties = default(StorageAccountPropertiesCreateParameters))
+        public StorageAccountCreateParameters(string location, System.Collections.Generic.IDictionary<string, string> tags = default(System.Collections.Generic.IDictionary<string, string>), StorageAccountPropertiesCreateParameters properties = default(StorageAccountPropertiesCreateParameters))
         {
             Location = location;
             Tags = tags;
@@ -31,13 +31,13 @@ namespace Petstore.Models
         /// Gets or sets resource location
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "location")]
-        public System.String Location { get; set; }
+        public string Location { get; set; }
 
         /// <summary>
         /// Gets or sets resource tags
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "tags")]
-        public System.Collections.Generic.IDictionary<System.String, System.String> Tags { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Tags { get; set; }
 
         /// <summary>
         /// </summary>

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountKeys.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountKeys.cs
@@ -18,7 +18,7 @@ namespace Petstore.Models
         /// </summary>
         /// <param name="key1">Gets the value of key 1.</param>
         /// <param name="key2">Gets the value of key 2.</param>
-        public StorageAccountKeys(System.String key1 = default(System.String), System.String key2 = default(System.String))
+        public StorageAccountKeys(string key1 = default(string), string key2 = default(string))
         {
             Key1 = key1;
             Key2 = key2;
@@ -28,13 +28,13 @@ namespace Petstore.Models
         /// Gets the value of key 1.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "key1")]
-        public System.String Key1 { get; set; }
+        public string Key1 { get; set; }
 
         /// <summary>
         /// Gets the value of key 2.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "key2")]
-        public System.String Key2 { get; set; }
+        public string Key2 { get; set; }
 
     }
 }

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountProperties.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountProperties.cs
@@ -50,7 +50,7 @@ namespace Petstore.Models
         /// perform a retrieval of a public blob, queue or table object from
         /// the secondary location of the storage account. Only available if
         /// the accountType is StandardRAGRS.</param>
-        public StorageAccountProperties(ProvisioningState? provisioningState = default(ProvisioningState?), AccountType? accountType = default(AccountType?), Endpoints primaryEndpoints = default(Endpoints), System.String primaryLocation = default(System.String), AccountStatus? statusOfPrimary = default(AccountStatus?), System.DateTime? lastGeoFailoverTime = default(System.DateTime?), System.String secondaryLocation = default(System.String), AccountStatus? statusOfSecondary = default(AccountStatus?), System.DateTime? creationTime = default(System.DateTime?), CustomDomain customDomain = default(CustomDomain), Endpoints secondaryEndpoints = default(Endpoints))
+        public StorageAccountProperties(ProvisioningState? provisioningState = default(ProvisioningState?), AccountType? accountType = default(AccountType?), Endpoints primaryEndpoints = default(Endpoints), string primaryLocation = default(string), AccountStatus? statusOfPrimary = default(AccountStatus?), System.DateTime? lastGeoFailoverTime = default(System.DateTime?), string secondaryLocation = default(string), AccountStatus? statusOfSecondary = default(AccountStatus?), System.DateTime? creationTime = default(System.DateTime?), CustomDomain customDomain = default(CustomDomain), Endpoints secondaryEndpoints = default(Endpoints))
         {
             ProvisioningState = provisioningState;
             AccountType = accountType;
@@ -93,7 +93,7 @@ namespace Petstore.Models
         /// Gets the location of the primary for the storage account.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "primaryLocation")]
-        public System.String PrimaryLocation { get; set; }
+        public string PrimaryLocation { get; set; }
 
         /// <summary>
         /// Gets the status indicating whether the primary location of the
@@ -119,7 +119,7 @@ namespace Petstore.Models
         /// StandardRAGRS.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "secondaryLocation")]
-        public System.String SecondaryLocation { get; set; }
+        public string SecondaryLocation { get; set; }
 
         /// <summary>
         /// Gets the status indicating whether the secondary location of the

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountRegenerateKeyParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountRegenerateKeyParameters.cs
@@ -15,7 +15,7 @@ namespace Petstore.Models
         /// Initializes a new instance of the
         /// StorageAccountRegenerateKeyParameters class.
         /// </summary>
-        public StorageAccountRegenerateKeyParameters(System.String keyName)
+        public StorageAccountRegenerateKeyParameters(string keyName)
         {
             KeyName = keyName;
         }
@@ -23,7 +23,7 @@ namespace Petstore.Models
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "keyName")]
-        public System.String KeyName { get; set; }
+        public string KeyName { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountUpdateParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountUpdateParameters.cs
@@ -19,7 +19,7 @@ namespace Petstore.Models
         /// class.
         /// </summary>
         /// <param name="tags">Resource tags</param>
-        public StorageAccountUpdateParameters(System.Collections.Generic.IDictionary<System.String, System.String> tags = default(System.Collections.Generic.IDictionary<System.String, System.String>), StorageAccountPropertiesUpdateParameters properties = default(StorageAccountPropertiesUpdateParameters))
+        public StorageAccountUpdateParameters(System.Collections.Generic.IDictionary<string, string> tags = default(System.Collections.Generic.IDictionary<string, string>), StorageAccountPropertiesUpdateParameters properties = default(StorageAccountPropertiesUpdateParameters))
         {
             Tags = tags;
             Properties = properties;
@@ -29,7 +29,7 @@ namespace Petstore.Models
         /// Gets or sets resource tags
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "tags")]
-        public System.Collections.Generic.IDictionary<System.String, System.String> Tags { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Tags { get; set; }
 
         /// <summary>
         /// </summary>

--- a/Samples/azure-storage/Azure.CSharp/Models/Usage.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/Usage.cs
@@ -24,7 +24,7 @@ namespace Petstore.Models
         /// <param name="limit">Gets the maximum count of the resources that
         /// can be allocated in the subscription.</param>
         /// <param name="name">Gets the name of the type of usage.</param>
-        public Usage(UsageUnit unit, System.Int32 currentValue, System.Int32 limit, UsageName name)
+        public Usage(UsageUnit unit, int currentValue, int limit, UsageName name)
         {
             Unit = unit;
             CurrentValue = currentValue;
@@ -44,14 +44,14 @@ namespace Petstore.Models
         /// subscription.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "currentValue")]
-        public System.Int32 CurrentValue { get; set; }
+        public int CurrentValue { get; set; }
 
         /// <summary>
         /// Gets the maximum count of the resources that can be allocated in
         /// the subscription.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "limit")]
-        public System.Int32 Limit { get; set; }
+        public int Limit { get; set; }
 
         /// <summary>
         /// Gets the name of the type of usage.

--- a/Samples/azure-storage/Azure.CSharp/Models/UsageName.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/UsageName.cs
@@ -20,7 +20,7 @@ namespace Petstore.Models
         /// name.</param>
         /// <param name="localizedValue">Gets a localized string describing
         /// the resource name.</param>
-        public UsageName(System.String value = default(System.String), System.String localizedValue = default(System.String))
+        public UsageName(string value = default(string), string localizedValue = default(string))
         {
             Value = value;
             LocalizedValue = localizedValue;
@@ -30,13 +30,13 @@ namespace Petstore.Models
         /// Gets a string describing the resource name.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
-        public System.String Value { get; set; }
+        public string Value { get; set; }
 
         /// <summary>
         /// Gets a localized string describing the resource name.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "localizedValue")]
-        public System.String LocalizedValue { get; set; }
+        public string LocalizedValue { get; set; }
 
     }
 }

--- a/Samples/azure-storage/Azure.CSharp/StorageAccountsOperations.cs
+++ b/Samples/azure-storage/Azure.CSharp/StorageAccountsOperations.cs
@@ -251,7 +251,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> CreateWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, StorageAccountCreateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> CreateWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountCreateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Send Request
             Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount> _response = await BeginCreateWithHttpMessagesAsync(
@@ -297,7 +297,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> BeginCreateWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, StorageAccountCreateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> BeginCreateWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountCreateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (resourceGroupName == null)
             {
@@ -513,7 +513,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse> DeleteWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse> DeleteWithHttpMessagesAsync(string resourceGroupName, string accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (resourceGroupName == null)
             {
@@ -693,7 +693,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> GetPropertiesWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> GetPropertiesWithHttpMessagesAsync(string resourceGroupName, string accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (resourceGroupName == null)
             {
@@ -912,7 +912,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> UpdateWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, StorageAccountUpdateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccount>> UpdateWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountUpdateParameters parameters, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (resourceGroupName == null)
             {
@@ -1125,7 +1125,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccountKeys>> ListKeysWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccountKeys>> ListKeysWithHttpMessagesAsync(string resourceGroupName, string accountName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (resourceGroupName == null)
             {
@@ -1500,7 +1500,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.Collections.Generic.IEnumerable<StorageAccount>>> ListByResourceGroupWithHttpMessagesAsync(System.String resourceGroupName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.Collections.Generic.IEnumerable<StorageAccount>>> ListByResourceGroupWithHttpMessagesAsync(string resourceGroupName, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (resourceGroupName == null)
             {
@@ -1691,7 +1691,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccountKeys>> RegenerateKeyWithHttpMessagesAsync(System.String resourceGroupName, System.String accountName, StorageAccountRegenerateKeyParameters regenerateKey, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<StorageAccountKeys>> RegenerateKeyWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountRegenerateKeyParameters regenerateKey, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (resourceGroupName == null)
             {

--- a/Samples/azure-storage/Azure.CSharp/StorageAccountsOperationsExtensions.cs
+++ b/Samples/azure-storage/Azure.CSharp/StorageAccountsOperationsExtensions.cs
@@ -69,7 +69,7 @@ namespace Petstore
             /// <param name='parameters'>
             /// The parameters to provide for the created account.
             /// </param>
-            public static StorageAccount Create(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, StorageAccountCreateParameters parameters)
+            public static StorageAccount Create(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountCreateParameters parameters)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).CreateAsync(resourceGroupName, accountName, parameters), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -98,7 +98,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<StorageAccount> CreateAsync(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, StorageAccountCreateParameters parameters, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<StorageAccount> CreateAsync(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountCreateParameters parameters, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.CreateWithHttpMessagesAsync(resourceGroupName, accountName, parameters, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -127,7 +127,7 @@ namespace Petstore
             /// <param name='parameters'>
             /// The parameters to provide for the created account.
             /// </param>
-            public static StorageAccount BeginCreate(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, StorageAccountCreateParameters parameters)
+            public static StorageAccount BeginCreate(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountCreateParameters parameters)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).BeginCreateAsync(resourceGroupName, accountName, parameters), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -156,7 +156,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<StorageAccount> BeginCreateAsync(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, StorageAccountCreateParameters parameters, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<StorageAccount> BeginCreateAsync(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountCreateParameters parameters, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.BeginCreateWithHttpMessagesAsync(resourceGroupName, accountName, parameters, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -178,7 +178,7 @@ namespace Petstore
             /// Storage account names must be between 3 and 24 characters in length and
             /// use numbers and lower-case letters only.
             /// </param>
-            public static void Delete(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName)
+            public static void Delete(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
             {
                 System.Threading.Tasks.Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).DeleteAsync(resourceGroupName, accountName), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None,  System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -200,7 +200,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task DeleteAsync(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task DeleteAsync(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 await operations.DeleteWithHttpMessagesAsync(resourceGroupName, accountName, null, cancellationToken).ConfigureAwait(false);
             }
@@ -221,7 +221,7 @@ namespace Petstore
             /// Storage account names must be between 3 and 24 characters in length and
             /// use numbers and lower-case letters only.
             /// </param>
-            public static StorageAccount GetProperties(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName)
+            public static StorageAccount GetProperties(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).GetPropertiesAsync(resourceGroupName, accountName), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -245,7 +245,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<StorageAccount> GetPropertiesAsync(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<StorageAccount> GetPropertiesAsync(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.GetPropertiesWithHttpMessagesAsync(resourceGroupName, accountName, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -282,7 +282,7 @@ namespace Petstore
             /// The parameters to update on the account. Note that only one property can
             /// be changed at a time using this API.
             /// </param>
-            public static StorageAccount Update(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, StorageAccountUpdateParameters parameters)
+            public static StorageAccount Update(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountUpdateParameters parameters)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).UpdateAsync(resourceGroupName, accountName, parameters), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -319,7 +319,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<StorageAccount> UpdateAsync(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, StorageAccountUpdateParameters parameters, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<StorageAccount> UpdateAsync(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountUpdateParameters parameters, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.UpdateWithHttpMessagesAsync(resourceGroupName, accountName, parameters, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -339,7 +339,7 @@ namespace Petstore
             /// <param name='accountName'>
             /// The name of the storage account.
             /// </param>
-            public static StorageAccountKeys ListKeys(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName)
+            public static StorageAccountKeys ListKeys(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).ListKeysAsync(resourceGroupName, accountName), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -359,7 +359,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<StorageAccountKeys> ListKeysAsync(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<StorageAccountKeys> ListKeysAsync(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.ListKeysWithHttpMessagesAsync(resourceGroupName, accountName, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -408,7 +408,7 @@ namespace Petstore
             /// <param name='resourceGroupName'>
             /// The name of the resource group within the user's subscription.
             /// </param>
-            public static System.Collections.Generic.IEnumerable<StorageAccount> ListByResourceGroup(this IStorageAccountsOperations operations, System.String resourceGroupName)
+            public static System.Collections.Generic.IEnumerable<StorageAccount> ListByResourceGroup(this IStorageAccountsOperations operations, string resourceGroupName)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).ListByResourceGroupAsync(resourceGroupName), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -427,7 +427,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<System.Collections.Generic.IEnumerable<StorageAccount>> ListByResourceGroupAsync(this IStorageAccountsOperations operations, System.String resourceGroupName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<System.Collections.Generic.IEnumerable<StorageAccount>> ListByResourceGroupAsync(this IStorageAccountsOperations operations, string resourceGroupName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.ListByResourceGroupWithHttpMessagesAsync(resourceGroupName, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -453,7 +453,7 @@ namespace Petstore
             /// Specifies name of the key which should be regenerated. key1 or key2 for
             /// the default keys
             /// </param>
-            public static StorageAccountKeys RegenerateKey(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, StorageAccountRegenerateKeyParameters regenerateKey)
+            public static StorageAccountKeys RegenerateKey(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountRegenerateKeyParameters regenerateKey)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).RegenerateKeyAsync(resourceGroupName, accountName, regenerateKey), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -479,7 +479,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<StorageAccountKeys> RegenerateKeyAsync(this IStorageAccountsOperations operations, System.String resourceGroupName, System.String accountName, StorageAccountRegenerateKeyParameters regenerateKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<StorageAccountKeys> RegenerateKeyAsync(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountRegenerateKeyParameters regenerateKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.RegenerateKeyWithHttpMessagesAsync(resourceGroupName, accountName, regenerateKey, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/Samples/azure-storage/Azure.CSharp/StorageManagementClient.cs
+++ b/Samples/azure-storage/Azure.CSharp/StorageManagementClient.cs
@@ -35,29 +35,29 @@ namespace Petstore
         /// subscription. The subscription ID forms part of the URI for every service
         /// call.
         /// </summary>
-        public System.String SubscriptionId { get; set; }
+        public string SubscriptionId { get; set; }
 
         /// <summary>
         /// Client Api Version.
         /// </summary>
-        public System.String ApiVersion { get; private set; }
+        public string ApiVersion { get; private set; }
 
         /// <summary>
         /// Gets or sets the preferred language for the response.
         /// </summary>
-        public System.String AcceptLanguage { get; set; }
+        public string AcceptLanguage { get; set; }
 
         /// <summary>
         /// Gets or sets the retry timeout in seconds for Long Running Operations.
         /// Default value is 30.
         /// </summary>
-        public System.Int32? LongRunningOperationRetryTimeout { get; set; }
+        public int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
         /// When set to true a unique x-ms-client-request-id value is generated and
         /// included in each request. Default is true.
         /// </summary>
-        public System.Boolean? GenerateClientRequestId { get; set; }
+        public bool? GenerateClientRequestId { get; set; }
 
         /// <summary>
         /// Gets the IStorageAccountsOperations.

--- a/Samples/azure-storage/Azure.Java.Fluent/implementation/StorageAccountInner.java
+++ b/Samples/azure-storage/Azure.Java.Fluent/implementation/StorageAccountInner.java
@@ -5,7 +5,6 @@ package petstore.implementation;
 
 import petstore.StorageAccountProperties;
 import com.microsoft.azure.Resource;
-import com.microsoft.azure.Resource;
 
 /**
  * The storage account.

--- a/Samples/azure-storage/Azure.NodeJS/operations/index.d.ts
+++ b/Samples/azure-storage/Azure.NodeJS/operations/index.d.ts
@@ -20,7 +20,7 @@ export interface StorageAccounts {
      * specified resource group. Storage account names must be between 3 and 24
      * characters in length and use numbers and lower-case letters only.
      * 
-     * @param {string} [accountName.name]
+     * @param {string} accountName.name
      * 
      * @param {string} [accountName.type]
      * 
@@ -52,14 +52,14 @@ export interface StorageAccounts {
      * @param {object} parameters The parameters to provide for the created
      * account.
      * 
-     * @param {string} [parameters.location] Resource location
+     * @param {string} parameters.location Resource location
      * 
      * @param {object} [parameters.tags] Resource tags
      * 
      * @param {object} [parameters.properties]
      * 
-     * @param {string} [parameters.properties.accountType] Gets or sets the
-     * account type. Possible values include: 'Standard_LRS', 'Standard_ZRS',
+     * @param {string} parameters.properties.accountType Gets or sets the account
+     * type. Possible values include: 'Standard_LRS', 'Standard_ZRS',
      * 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
      * 
      * @param {object} [options] Optional Parameters.
@@ -90,14 +90,14 @@ export interface StorageAccounts {
      * @param {object} parameters The parameters to provide for the created
      * account.
      * 
-     * @param {string} [parameters.location] Resource location
+     * @param {string} parameters.location Resource location
      * 
      * @param {object} [parameters.tags] Resource tags
      * 
      * @param {object} [parameters.properties]
      * 
-     * @param {string} [parameters.properties.accountType] Gets or sets the
-     * account type. Possible values include: 'Standard_LRS', 'Standard_ZRS',
+     * @param {string} parameters.properties.accountType Gets or sets the account
+     * type. Possible values include: 'Standard_LRS', 'Standard_ZRS',
      * 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
      * 
      * @param {object} [options] Optional Parameters.
@@ -194,7 +194,7 @@ export interface StorageAccounts {
      * is supported per storage account at this time. To clear the existing
      * custom domain, use an empty string for the custom domain name property.
      * 
-     * @param {string} [parameters.properties.customDomain.name] Gets or sets the
+     * @param {string} parameters.properties.customDomain.name Gets or sets the
      * custom domain name. Name is the CNAME source.
      * 
      * @param {boolean} [parameters.properties.customDomain.useSubDomain]
@@ -277,7 +277,7 @@ export interface StorageAccounts {
      * @param {object} regenerateKey Specifies name of the key which should be
      * regenerated. key1 or key2 for the default keys
      * 
-     * @param {string} [regenerateKey.keyName]
+     * @param {string} regenerateKey.keyName
      * 
      * @param {object} [options] Optional Parameters.
      * 

--- a/Samples/azure-storage/Azure.NodeJS/operations/storageAccounts.js
+++ b/Samples/azure-storage/Azure.NodeJS/operations/storageAccounts.js
@@ -29,7 +29,7 @@ function StorageAccounts(client) {
  * specified resource group. Storage account names must be between 3 and 24
  * characters in length and use numbers and lower-case letters only.
  * 
- * @param {string} [accountName.name]
+ * @param {string} accountName.name
  * 
  * @param {string} [accountName.type]
  * 
@@ -83,14 +83,14 @@ StorageAccounts.prototype.checkNameAvailability = function (accountName, options
   var requestUrl = this.client.baseUri +
                    '//subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability';
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -201,14 +201,14 @@ StorageAccounts.prototype.checkNameAvailability = function (accountName, options
  * @param {object} parameters The parameters to provide for the created
  * account.
  * 
- * @param {string} [parameters.location] Resource location
+ * @param {string} parameters.location Resource location
  * 
  * @param {object} [parameters.tags] Resource tags
  * 
  * @param {object} [parameters.properties]
  * 
- * @param {string} [parameters.properties.accountType] Gets or sets the
- * account type. Possible values include: 'Standard_LRS', 'Standard_ZRS',
+ * @param {string} parameters.properties.accountType Gets or sets the account
+ * type. Possible values include: 'Standard_LRS', 'Standard_ZRS',
  * 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
  * 
  * @param {object} [options] Optional Parameters.
@@ -296,14 +296,14 @@ StorageAccounts.prototype.create = function (resourceGroupName, accountName, par
  * @param {object} parameters The parameters to provide for the created
  * account.
  * 
- * @param {string} [parameters.location] Resource location
+ * @param {string} parameters.location Resource location
  * 
  * @param {object} [parameters.tags] Resource tags
  * 
  * @param {object} [parameters.properties]
  * 
- * @param {string} [parameters.properties.accountType] Gets or sets the
- * account type. Possible values include: 'Standard_LRS', 'Standard_ZRS',
+ * @param {string} parameters.properties.accountType Gets or sets the account
+ * type. Possible values include: 'Standard_LRS', 'Standard_ZRS',
  * 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
  * 
  * @param {object} [options] Optional Parameters.
@@ -373,14 +373,14 @@ StorageAccounts.prototype.beginCreate = function (resourceGroupName, accountName
   requestUrl = requestUrl.replace('{resourceGroupName}', encodeURIComponent(resourceGroupName));
   requestUrl = requestUrl.replace('{accountName}', encodeURIComponent(accountName));
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -546,14 +546,14 @@ StorageAccounts.prototype.deleteMethod = function (resourceGroupName, accountNam
   requestUrl = requestUrl.replace('{resourceGroupName}', encodeURIComponent(resourceGroupName));
   requestUrl = requestUrl.replace('{accountName}', encodeURIComponent(accountName));
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -687,14 +687,14 @@ StorageAccounts.prototype.getProperties = function (resourceGroupName, accountNa
   requestUrl = requestUrl.replace('{resourceGroupName}', encodeURIComponent(resourceGroupName));
   requestUrl = requestUrl.replace('{accountName}', encodeURIComponent(accountName));
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -812,7 +812,7 @@ StorageAccounts.prototype.getProperties = function (resourceGroupName, accountNa
  * is supported per storage account at this time. To clear the existing
  * custom domain, use an empty string for the custom domain name property.
  * 
- * @param {string} [parameters.properties.customDomain.name] Gets or sets the
+ * @param {string} parameters.properties.customDomain.name Gets or sets the
  * custom domain name. Name is the CNAME source.
  * 
  * @param {boolean} [parameters.properties.customDomain.useSubDomain]
@@ -886,14 +886,14 @@ StorageAccounts.prototype.update = function (resourceGroupName, accountName, par
   requestUrl = requestUrl.replace('{resourceGroupName}', encodeURIComponent(resourceGroupName));
   requestUrl = requestUrl.replace('{accountName}', encodeURIComponent(accountName));
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -1057,14 +1057,14 @@ StorageAccounts.prototype.listKeys = function (resourceGroupName, accountName, o
   requestUrl = requestUrl.replace('{resourceGroupName}', encodeURIComponent(resourceGroupName));
   requestUrl = requestUrl.replace('{accountName}', encodeURIComponent(accountName));
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -1194,14 +1194,14 @@ StorageAccounts.prototype.list = function (options, callback) {
   var requestUrl = this.client.baseUri +
                    '//subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts';
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -1339,14 +1339,14 @@ StorageAccounts.prototype.listByResourceGroup = function (resourceGroupName, opt
                    '//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts';
   requestUrl = requestUrl.replace('{resourceGroupName}', encodeURIComponent(resourceGroupName));
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -1438,7 +1438,7 @@ StorageAccounts.prototype.listByResourceGroup = function (resourceGroupName, opt
  * @param {object} regenerateKey Specifies name of the key which should be
  * regenerated. key1 or key2 for the default keys
  * 
- * @param {string} [regenerateKey.keyName]
+ * @param {string} regenerateKey.keyName
  * 
  * @param {object} [options] Optional Parameters.
  * 
@@ -1507,14 +1507,14 @@ StorageAccounts.prototype.regenerateKey = function (resourceGroupName, accountNa
   requestUrl = requestUrl.replace('{resourceGroupName}', encodeURIComponent(resourceGroupName));
   requestUrl = requestUrl.replace('{accountName}', encodeURIComponent(accountName));
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();

--- a/Samples/azure-storage/Azure.NodeJS/operations/usageOperations.js
+++ b/Samples/azure-storage/Azure.NodeJS/operations/usageOperations.js
@@ -72,14 +72,14 @@ UsageOperations.prototype.list = function (options, callback) {
   var requestUrl = this.client.baseUri +
                    '//subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages';
   requestUrl = requestUrl.replace('{subscriptionId}', encodeURIComponent(this.client.subscriptionId));
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   queryParameters.push('api-version=' + encodeURIComponent(this.client.apiVersion));
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();

--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
@@ -5,8 +5,8 @@ module Petstore
   # A service client - single point of access to the REST API.
   #
   class StorageManagementClient < MsRestAzure::AzureServiceClient
-    include MsRest::Serialization
     include MsRestAzure
+    include MsRestAzure::Serialization
 
     # @return [String] the base URI of the service.
     attr_accessor :base_url

--- a/Samples/petstore/CSharp/ISwaggerPetstore.cs
+++ b/Samples/petstore/CSharp/ISwaggerPetstore.cs
@@ -41,7 +41,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> AddPetUsingByteArrayWithHttpMessagesAsync(System.String body = default(System.String), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> AddPetUsingByteArrayWithHttpMessagesAsync(string body = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Add a new pet to the store
@@ -90,7 +90,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Pet>>> FindPetsByStatusWithHttpMessagesAsync(System.Collections.Generic.IList<System.String> status = default(System.Collections.Generic.IList<System.String>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Pet>>> FindPetsByStatusWithHttpMessagesAsync(System.Collections.Generic.IList<string> status = default(System.Collections.Generic.IList<string>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Finds Pets by tags
@@ -108,7 +108,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Pet>>> FindPetsByTagsWithHttpMessagesAsync(System.Collections.Generic.IList<System.String> tags = default(System.Collections.Generic.IList<System.String>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Pet>>> FindPetsByTagsWithHttpMessagesAsync(System.Collections.Generic.IList<string> tags = default(System.Collections.Generic.IList<string>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Fake endpoint to test byte array return by 'Find pet by ID'
@@ -126,7 +126,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.String>> FindPetsWithByteArrayWithHttpMessagesAsync(System.Int64 petId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<string>> FindPetsWithByteArrayWithHttpMessagesAsync(long petId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -144,7 +144,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Pet>> GetPetByIdWithHttpMessagesAsync(System.Int64 petId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Pet>> GetPetByIdWithHttpMessagesAsync(long petId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Updates a pet in the store with form data
@@ -164,7 +164,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UpdatePetWithFormWithHttpMessagesAsync(System.String petId, System.String name = default(System.String), System.String status = default(System.String), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UpdatePetWithFormWithHttpMessagesAsync(string petId, string name = default(string), string status = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Deletes a pet
@@ -180,7 +180,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeletePetWithHttpMessagesAsync(System.Int64 petId, System.String apiKey = default(System.String), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeletePetWithHttpMessagesAsync(long petId, string apiKey = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -200,7 +200,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UploadFileWithHttpMessagesAsync(System.Int64 petId, System.String additionalMetadata = default(System.String), System.IO.Stream file = default(System.IO.Stream), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UploadFileWithHttpMessagesAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Returns pet inventories by status
@@ -214,7 +214,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<System.String, System.Int32?>>> GetInventoryWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, int?>>> GetInventoryWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -246,7 +246,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Order>> GetOrderByIdWithHttpMessagesAsync(System.String orderId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Order>> GetOrderByIdWithHttpMessagesAsync(string orderId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Delete purchase order by ID
@@ -264,7 +264,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeleteOrderWithHttpMessagesAsync(System.String orderId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeleteOrderWithHttpMessagesAsync(string orderId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Create user
@@ -326,7 +326,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.String>> LoginUserWithHttpMessagesAsync(System.String username = default(System.String), System.String password = default(System.String), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<string>> LoginUserWithHttpMessagesAsync(string username = default(string), string password = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Logs out current logged in user session
@@ -351,7 +351,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<User>> GetUserByNameWithHttpMessagesAsync(System.String username, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<User>> GetUserByNameWithHttpMessagesAsync(string username, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Updated user
@@ -371,7 +371,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UpdateUserWithHttpMessagesAsync(System.String username, User body = default(User), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UpdateUserWithHttpMessagesAsync(string username, User body = default(User), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Delete user
@@ -388,7 +388,7 @@ namespace Petstore
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeleteUserWithHttpMessagesAsync(System.String username, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeleteUserWithHttpMessagesAsync(string username, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
     }
 }

--- a/Samples/petstore/CSharp/Models/Category.cs
+++ b/Samples/petstore/CSharp/Models/Category.cs
@@ -13,7 +13,7 @@ namespace Petstore.Models
         /// <summary>
         /// Initializes a new instance of the Category class.
         /// </summary>
-        public Category(System.Int64? id = default(System.Int64?), System.String name = default(System.String))
+        public Category(long? id = default(long?), string name = default(string))
         {
             Id = id;
             Name = name;
@@ -22,12 +22,12 @@ namespace Petstore.Models
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
-        public System.Int64? Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
-        public System.String Name { get; set; }
+        public string Name { get; set; }
 
     }
 }

--- a/Samples/petstore/CSharp/Models/Order.cs
+++ b/Samples/petstore/CSharp/Models/Order.cs
@@ -15,7 +15,7 @@ namespace Petstore.Models
         /// </summary>
         /// <param name="status">Order Status. Possible values include:
         /// 'placed', 'approved', 'delivered'</param>
-        public Order(System.Int64? id = default(System.Int64?), System.Int64? petId = default(System.Int64?), System.Int32? quantity = default(System.Int32?), System.DateTime? shipDate = default(System.DateTime?), System.String status = default(System.String), System.Boolean? complete = default(System.Boolean?))
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), System.DateTime? shipDate = default(System.DateTime?), string status = default(string), bool? complete = default(bool?))
         {
             Id = id;
             PetId = petId;
@@ -28,17 +28,17 @@ namespace Petstore.Models
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
-        public System.Int64? Id { get; private set; }
+        public long? Id { get; private set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "petId")]
-        public System.Int64? PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "quantity")]
-        public System.Int32? Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// </summary>
@@ -50,12 +50,12 @@ namespace Petstore.Models
         /// 'approved', 'delivered'
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "status")]
-        public System.String Status { get; set; }
+        public string Status { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "complete")]
-        public System.Boolean? Complete { get; set; }
+        public bool? Complete { get; set; }
 
     }
 }

--- a/Samples/petstore/CSharp/Models/Pet.cs
+++ b/Samples/petstore/CSharp/Models/Pet.cs
@@ -22,7 +22,7 @@ namespace Petstore.Models
         /// <param name="id">The id of the pet.</param>
         /// <param name="status">pet status in the store. Possible values
         /// include: 'available', 'pending', 'sold'</param>
-        public Pet(System.String name, System.Collections.Generic.IList<System.String> photoUrls, System.Int64? id = default(System.Int64?), Category category = default(Category), System.Collections.Generic.IList<Tag> tags = default(System.Collections.Generic.IList<Tag>), System.String status = default(System.String))
+        public Pet(string name, System.Collections.Generic.IList<string> photoUrls, long? id = default(long?), Category category = default(Category), System.Collections.Generic.IList<Tag> tags = default(System.Collections.Generic.IList<Tag>), string status = default(string))
         {
             Id = id;
             Category = category;
@@ -39,7 +39,7 @@ namespace Petstore.Models
         /// A more detailed description of the id of the pet.
         /// </remarks>
         [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
-        public System.Int64? Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// </summary>
@@ -49,12 +49,12 @@ namespace Petstore.Models
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
-        public System.String Name { get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "photoUrls")]
-        public System.Collections.Generic.IList<System.String> PhotoUrls { get; set; }
+        public System.Collections.Generic.IList<string> PhotoUrls { get; set; }
 
         /// <summary>
         /// </summary>
@@ -66,7 +66,7 @@ namespace Petstore.Models
         /// 'available', 'pending', 'sold'
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "status")]
-        public System.String Status { get; set; }
+        public string Status { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/Samples/petstore/CSharp/Models/Tag.cs
+++ b/Samples/petstore/CSharp/Models/Tag.cs
@@ -13,7 +13,7 @@ namespace Petstore.Models
         /// <summary>
         /// Initializes a new instance of the Tag class.
         /// </summary>
-        public Tag(System.Int64? id = default(System.Int64?), System.String name = default(System.String))
+        public Tag(long? id = default(long?), string name = default(string))
         {
             Id = id;
             Name = name;
@@ -22,12 +22,12 @@ namespace Petstore.Models
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
-        public System.Int64? Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
-        public System.String Name { get; set; }
+        public string Name { get; set; }
 
     }
 }

--- a/Samples/petstore/CSharp/Models/User.cs
+++ b/Samples/petstore/CSharp/Models/User.cs
@@ -14,7 +14,7 @@ namespace Petstore.Models
         /// Initializes a new instance of the User class.
         /// </summary>
         /// <param name="userStatus">User Status</param>
-        public User(System.Int64? id = default(System.Int64?), System.String username = default(System.String), System.String firstName = default(System.String), System.String lastName = default(System.String), System.String email = default(System.String), System.String password = default(System.String), System.String phone = default(System.String), System.Int32? userStatus = default(System.Int32?))
+        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?))
         {
             Id = id;
             Username = username;
@@ -29,43 +29,43 @@ namespace Petstore.Models
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
-        public System.Int64? Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "username")]
-        public System.String Username { get; set; }
+        public string Username { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "firstName")]
-        public System.String FirstName { get; set; }
+        public string FirstName { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "lastName")]
-        public System.String LastName { get; set; }
+        public string LastName { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "email")]
-        public System.String Email { get; set; }
+        public string Email { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "password")]
-        public System.String Password { get; set; }
+        public string Password { get; set; }
 
         /// <summary>
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "phone")]
-        public System.String Phone { get; set; }
+        public string Phone { get; set; }
 
         /// <summary>
         /// Gets or sets user Status
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "userStatus")]
-        public System.Int32? UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
     }
 }

--- a/Samples/petstore/CSharp/SwaggerPetstore.cs
+++ b/Samples/petstore/CSharp/SwaggerPetstore.cs
@@ -154,7 +154,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> AddPetUsingByteArrayWithHttpMessagesAsync(System.String body = default(System.String), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> AddPetUsingByteArrayWithHttpMessagesAsync(string body = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -493,7 +493,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Pet>>> FindPetsByStatusWithHttpMessagesAsync(System.Collections.Generic.IList<System.String> status = default(System.Collections.Generic.IList<System.String>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Pet>>> FindPetsByStatusWithHttpMessagesAsync(System.Collections.Generic.IList<string> status = default(System.Collections.Generic.IList<string>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -628,7 +628,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Pet>>> FindPetsByTagsWithHttpMessagesAsync(System.Collections.Generic.IList<System.String> tags = default(System.Collections.Generic.IList<System.String>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Pet>>> FindPetsByTagsWithHttpMessagesAsync(System.Collections.Generic.IList<string> tags = default(System.Collections.Generic.IList<string>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -763,7 +763,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.String>> FindPetsWithByteArrayWithHttpMessagesAsync(System.Int64 petId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<string>> FindPetsWithByteArrayWithHttpMessagesAsync(long petId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -837,7 +837,7 @@ namespace Petstore
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.HttpOperationResponse<System.String>();
+            var _result = new Microsoft.Rest.HttpOperationResponse<string>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             // Deserialize Response
@@ -846,7 +846,7 @@ namespace Petstore
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<System.String>(_responseContent, this.DeserializationSettings);
+                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<string>(_responseContent, this.DeserializationSettings);
                 }
                 catch (Newtonsoft.Json.JsonException ex)
                 {
@@ -890,7 +890,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Pet>> GetPetByIdWithHttpMessagesAsync(System.Int64 petId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Pet>> GetPetByIdWithHttpMessagesAsync(long petId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -1019,7 +1019,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UpdatePetWithFormWithHttpMessagesAsync(System.String petId, System.String name = default(System.String), System.String status = default(System.String), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UpdatePetWithFormWithHttpMessagesAsync(string petId, string name = default(string), string status = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (petId == null)
             {
@@ -1141,7 +1141,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeletePetWithHttpMessagesAsync(System.Int64 petId, System.String apiKey = default(System.String), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeletePetWithHttpMessagesAsync(long petId, string apiKey = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -1258,7 +1258,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UploadFileWithHttpMessagesAsync(System.Int64 petId, System.String additionalMetadata = default(System.String), System.IO.Stream file = default(System.IO.Stream), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UploadFileWithHttpMessagesAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -1386,7 +1386,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<System.String, System.Int32?>>> GetInventoryWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, int?>>> GetInventoryWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -1458,7 +1458,7 @@ namespace Petstore
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<System.String, System.Int32?>>();
+            var _result = new Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, int?>>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             // Deserialize Response
@@ -1467,7 +1467,7 @@ namespace Petstore
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<System.Collections.Generic.IDictionary<System.String, System.Int32?>>(_responseContent, this.DeserializationSettings);
+                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<System.Collections.Generic.IDictionary<string, int?>>(_responseContent, this.DeserializationSettings);
                 }
                 catch (Newtonsoft.Json.JsonException ex)
                 {
@@ -1642,7 +1642,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Order>> GetOrderByIdWithHttpMessagesAsync(System.String orderId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Order>> GetOrderByIdWithHttpMessagesAsync(string orderId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (orderId == null)
             {
@@ -1773,7 +1773,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeleteOrderWithHttpMessagesAsync(System.String orderId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeleteOrderWithHttpMessagesAsync(string orderId, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (orderId == null)
             {
@@ -2209,7 +2209,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.String>> LoginUserWithHttpMessagesAsync(System.String username = default(System.String), System.String password = default(System.String), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<string>> LoginUserWithHttpMessagesAsync(string username = default(string), string password = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
@@ -2296,7 +2296,7 @@ namespace Petstore
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.HttpOperationResponse<System.String>();
+            var _result = new Microsoft.Rest.HttpOperationResponse<string>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             // Deserialize Response
@@ -2305,7 +2305,7 @@ namespace Petstore
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<System.String>(_responseContent, this.DeserializationSettings);
+                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<string>(_responseContent, this.DeserializationSettings);
                 }
                 catch (Newtonsoft.Json.JsonException ex)
                 {
@@ -2445,7 +2445,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<User>> GetUserByNameWithHttpMessagesAsync(System.String username, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<User>> GetUserByNameWithHttpMessagesAsync(string username, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (username == null)
             {
@@ -2578,7 +2578,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UpdateUserWithHttpMessagesAsync(System.String username, User body = default(User), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> UpdateUserWithHttpMessagesAsync(string username, User body = default(User), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (username == null)
             {
@@ -2697,7 +2697,7 @@ namespace Petstore
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeleteUserWithHttpMessagesAsync(System.String username, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> DeleteUserWithHttpMessagesAsync(string username, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (username == null)
             {

--- a/Samples/petstore/CSharp/SwaggerPetstoreExtensions.cs
+++ b/Samples/petstore/CSharp/SwaggerPetstoreExtensions.cs
@@ -19,7 +19,7 @@ namespace Petstore
             /// <param name='body'>
             /// Pet object in the form of byte array
             /// </param>
-            public static void AddPetUsingByteArray(this ISwaggerPetstore operations, System.String body = default(System.String))
+            public static void AddPetUsingByteArray(this ISwaggerPetstore operations, string body = default(string))
             {
                 System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).AddPetUsingByteArrayAsync(body), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None,  System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -37,7 +37,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task AddPetUsingByteArrayAsync(this ISwaggerPetstore operations, System.String body = default(System.String), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task AddPetUsingByteArrayAsync(this ISwaggerPetstore operations, string body = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 await operations.AddPetUsingByteArrayWithHttpMessagesAsync(body, null, cancellationToken).ConfigureAwait(false);
             }
@@ -124,7 +124,7 @@ namespace Petstore
             /// <param name='status'>
             /// Status values that need to be considered for filter
             /// </param>
-            public static System.Collections.Generic.IList<Pet> FindPetsByStatus(this ISwaggerPetstore operations, System.Collections.Generic.IList<System.String> status = default(System.Collections.Generic.IList<System.String>))
+            public static System.Collections.Generic.IList<Pet> FindPetsByStatus(this ISwaggerPetstore operations, System.Collections.Generic.IList<string> status = default(System.Collections.Generic.IList<string>))
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).FindPetsByStatusAsync(status), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -144,7 +144,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<System.Collections.Generic.IList<Pet>> FindPetsByStatusAsync(this ISwaggerPetstore operations, System.Collections.Generic.IList<System.String> status = default(System.Collections.Generic.IList<System.String>), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<System.Collections.Generic.IList<Pet>> FindPetsByStatusAsync(this ISwaggerPetstore operations, System.Collections.Generic.IList<string> status = default(System.Collections.Generic.IList<string>), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.FindPetsByStatusWithHttpMessagesAsync(status, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -165,7 +165,7 @@ namespace Petstore
             /// <param name='tags'>
             /// Tags to filter by
             /// </param>
-            public static System.Collections.Generic.IList<Pet> FindPetsByTags(this ISwaggerPetstore operations, System.Collections.Generic.IList<System.String> tags = default(System.Collections.Generic.IList<System.String>))
+            public static System.Collections.Generic.IList<Pet> FindPetsByTags(this ISwaggerPetstore operations, System.Collections.Generic.IList<string> tags = default(System.Collections.Generic.IList<string>))
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).FindPetsByTagsAsync(tags), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -186,7 +186,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<System.Collections.Generic.IList<Pet>> FindPetsByTagsAsync(this ISwaggerPetstore operations, System.Collections.Generic.IList<System.String> tags = default(System.Collections.Generic.IList<System.String>), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<System.Collections.Generic.IList<Pet>> FindPetsByTagsAsync(this ISwaggerPetstore operations, System.Collections.Generic.IList<string> tags = default(System.Collections.Generic.IList<string>), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.FindPetsByTagsWithHttpMessagesAsync(tags, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -207,7 +207,7 @@ namespace Petstore
             /// <param name='petId'>
             /// ID of pet that needs to be fetched
             /// </param>
-            public static System.String FindPetsWithByteArray(this ISwaggerPetstore operations, System.Int64 petId)
+            public static string FindPetsWithByteArray(this ISwaggerPetstore operations, long petId)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).FindPetsWithByteArrayAsync(petId), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -228,7 +228,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<System.String> FindPetsWithByteArrayAsync(this ISwaggerPetstore operations, System.Int64 petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<string> FindPetsWithByteArrayAsync(this ISwaggerPetstore operations, long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.FindPetsWithByteArrayWithHttpMessagesAsync(petId, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -249,7 +249,7 @@ namespace Petstore
             /// <param name='petId'>
             /// ID of pet that needs to be fetched
             /// </param>
-            public static Pet GetPetById(this ISwaggerPetstore operations, System.Int64 petId)
+            public static Pet GetPetById(this ISwaggerPetstore operations, long petId)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).GetPetByIdAsync(petId), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -270,7 +270,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(this ISwaggerPetstore operations, System.Int64 petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(this ISwaggerPetstore operations, long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.GetPetByIdWithHttpMessagesAsync(petId, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -293,7 +293,7 @@ namespace Petstore
             /// <param name='status'>
             /// Updated status of the pet
             /// </param>
-            public static void UpdatePetWithForm(this ISwaggerPetstore operations, System.String petId, System.String name = default(System.String), System.String status = default(System.String))
+            public static void UpdatePetWithForm(this ISwaggerPetstore operations, string petId, string name = default(string), string status = default(string))
             {
                 System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).UpdatePetWithFormAsync(petId, name, status), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None,  System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -316,7 +316,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task UpdatePetWithFormAsync(this ISwaggerPetstore operations, System.String petId, System.String name = default(System.String), System.String status = default(System.String), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task UpdatePetWithFormAsync(this ISwaggerPetstore operations, string petId, string name = default(string), string status = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 await operations.UpdatePetWithFormWithHttpMessagesAsync(petId, name, status, null, cancellationToken).ConfigureAwait(false);
             }
@@ -332,7 +332,7 @@ namespace Petstore
             /// </param>
             /// <param name='apiKey'>
             /// </param>
-            public static void DeletePet(this ISwaggerPetstore operations, System.Int64 petId, System.String apiKey = default(System.String))
+            public static void DeletePet(this ISwaggerPetstore operations, long petId, string apiKey = default(string))
             {
                 System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).DeletePetAsync(petId, apiKey), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None,  System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -351,7 +351,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task DeletePetAsync(this ISwaggerPetstore operations, System.Int64 petId, System.String apiKey = default(System.String), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task DeletePetAsync(this ISwaggerPetstore operations, long petId, string apiKey = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 await operations.DeletePetWithHttpMessagesAsync(petId, apiKey, null, cancellationToken).ConfigureAwait(false);
             }
@@ -371,7 +371,7 @@ namespace Petstore
             /// <param name='file'>
             /// file to upload
             /// </param>
-            public static void UploadFile(this ISwaggerPetstore operations, System.Int64 petId, System.String additionalMetadata = default(System.String), System.IO.Stream file = default(System.IO.Stream))
+            public static void UploadFile(this ISwaggerPetstore operations, long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
             {
                 System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).UploadFileAsync(petId, additionalMetadata, file), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None,  System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -394,7 +394,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task UploadFileAsync(this ISwaggerPetstore operations, System.Int64 petId, System.String additionalMetadata = default(System.String), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task UploadFileAsync(this ISwaggerPetstore operations, long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 await operations.UploadFileWithHttpMessagesAsync(petId, additionalMetadata, file, null, cancellationToken).ConfigureAwait(false);
             }
@@ -408,7 +408,7 @@ namespace Petstore
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
-            public static System.Collections.Generic.IDictionary<System.String, System.Int32?> GetInventory(this ISwaggerPetstore operations)
+            public static System.Collections.Generic.IDictionary<string, int?> GetInventory(this ISwaggerPetstore operations)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).GetInventoryAsync(), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -425,7 +425,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<System.String, System.Int32?>> GetInventoryAsync(this ISwaggerPetstore operations, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, int?>> GetInventoryAsync(this ISwaggerPetstore operations, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.GetInventoryWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false))
                 {
@@ -480,7 +480,7 @@ namespace Petstore
             /// <param name='orderId'>
             /// ID of pet that needs to be fetched
             /// </param>
-            public static Order GetOrderById(this ISwaggerPetstore operations, System.String orderId)
+            public static Order GetOrderById(this ISwaggerPetstore operations, string orderId)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).GetOrderByIdAsync(orderId), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -501,7 +501,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(this ISwaggerPetstore operations, System.String orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(this ISwaggerPetstore operations, string orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.GetOrderByIdWithHttpMessagesAsync(orderId, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -522,7 +522,7 @@ namespace Petstore
             /// <param name='orderId'>
             /// ID of the order that needs to be deleted
             /// </param>
-            public static void DeleteOrder(this ISwaggerPetstore operations, System.String orderId)
+            public static void DeleteOrder(this ISwaggerPetstore operations, string orderId)
             {
                 System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).DeleteOrderAsync(orderId), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None,  System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -543,7 +543,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task DeleteOrderAsync(this ISwaggerPetstore operations, System.String orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task DeleteOrderAsync(this ISwaggerPetstore operations, string orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 await operations.DeleteOrderWithHttpMessagesAsync(orderId, null, cancellationToken).ConfigureAwait(false);
             }
@@ -659,7 +659,7 @@ namespace Petstore
             /// <param name='password'>
             /// The password for login in clear text
             /// </param>
-            public static System.String LoginUser(this ISwaggerPetstore operations, System.String username = default(System.String), System.String password = default(System.String))
+            public static string LoginUser(this ISwaggerPetstore operations, string username = default(string), string password = default(string))
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).LoginUserAsync(username, password), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -679,7 +679,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<System.String> LoginUserAsync(this ISwaggerPetstore operations, System.String username = default(System.String), System.String password = default(System.String), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<string> LoginUserAsync(this ISwaggerPetstore operations, string username = default(string), string password = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.LoginUserWithHttpMessagesAsync(username, password, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -721,7 +721,7 @@ namespace Petstore
             /// <param name='username'>
             /// The name that needs to be fetched. Use user1 for testing.
             /// </param>
-            public static User GetUserByName(this ISwaggerPetstore operations, System.String username)
+            public static User GetUserByName(this ISwaggerPetstore operations, string username)
             {
                 return System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).GetUserByNameAsync(username), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -738,7 +738,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<User> GetUserByNameAsync(this ISwaggerPetstore operations, System.String username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task<User> GetUserByNameAsync(this ISwaggerPetstore operations, string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 using (var _result = await operations.GetUserByNameWithHttpMessagesAsync(username, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -761,7 +761,7 @@ namespace Petstore
             /// <param name='body'>
             /// Updated user object
             /// </param>
-            public static void UpdateUser(this ISwaggerPetstore operations, System.String username, User body = default(User))
+            public static void UpdateUser(this ISwaggerPetstore operations, string username, User body = default(User))
             {
                 System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).UpdateUserAsync(username, body), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None,  System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -784,7 +784,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task UpdateUserAsync(this ISwaggerPetstore operations, System.String username, User body = default(User), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task UpdateUserAsync(this ISwaggerPetstore operations, string username, User body = default(User), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 await operations.UpdateUserWithHttpMessagesAsync(username, body, null, cancellationToken).ConfigureAwait(false);
             }
@@ -801,7 +801,7 @@ namespace Petstore
             /// <param name='username'>
             /// The name that needs to be deleted
             /// </param>
-            public static void DeleteUser(this ISwaggerPetstore operations, System.String username)
+            public static void DeleteUser(this ISwaggerPetstore operations, string username)
             {
                 System.Threading.Tasks.Task.Factory.StartNew(s => ((ISwaggerPetstore)s).DeleteUserAsync(username), operations, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None,  System.Threading.Tasks.TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -821,7 +821,7 @@ namespace Petstore
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task DeleteUserAsync(this ISwaggerPetstore operations, System.String username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async System.Threading.Tasks.Task DeleteUserAsync(this ISwaggerPetstore operations, string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
             {
                 await operations.DeleteUserWithHttpMessagesAsync(username, null, cancellationToken).ConfigureAwait(false);
             }

--- a/Samples/petstore/NodeJS/swaggerPetstore.d.ts
+++ b/Samples/petstore/NodeJS/swaggerPetstore.d.ts
@@ -61,9 +61,9 @@ declare class SwaggerPetstore {
          * 
          * @param {string} [options.body.category.name]
          * 
-         * @param {string} [options.body.name]
+         * @param {string} options.body.name
          * 
-         * @param {array} [options.body.photoUrls]
+         * @param {array} options.body.photoUrls
          * 
          * @param {array} [options.body.tags]
          * 
@@ -96,9 +96,9 @@ declare class SwaggerPetstore {
          * 
          * @param {string} [options.body.category.name]
          * 
-         * @param {string} [options.body.name]
+         * @param {string} options.body.name
          * 
-         * @param {array} [options.body.photoUrls]
+         * @param {array} options.body.photoUrls
          * 
          * @param {array} [options.body.tags]
          * 

--- a/Samples/petstore/NodeJS/swaggerPetstore.js
+++ b/Samples/petstore/NodeJS/swaggerPetstore.js
@@ -186,9 +186,9 @@ SwaggerPetstore.prototype.addPetUsingByteArray = function (options, callback) {
  * 
  * @param {string} [options.body.category.name]
  * 
- * @param {string} [options.body.name]
+ * @param {string} options.body.name
  * 
- * @param {array} [options.body.photoUrls]
+ * @param {array} options.body.photoUrls
  * 
  * @param {array} [options.body.tags]
  * 
@@ -309,9 +309,9 @@ SwaggerPetstore.prototype.addPet = function (options, callback) {
  * 
  * @param {string} [options.body.category.name]
  * 
- * @param {string} [options.body.name]
+ * @param {string} options.body.name
  * 
- * @param {array} [options.body.photoUrls]
+ * @param {array} options.body.photoUrls
  * 
  * @param {array} [options.body.tags]
  * 
@@ -466,6 +466,9 @@ SwaggerPetstore.prototype.findPetsByStatus = function (options, callback) {
   // Construct URL
   var requestUrl = this.baseUri +
                    '//pet/findByStatus';
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   if (status !== null && status !== undefined) {
     queryParameters.push('status=' + encodeURIComponent(status.join(',')));
@@ -473,9 +476,6 @@ SwaggerPetstore.prototype.findPetsByStatus = function (options, callback) {
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -609,6 +609,9 @@ SwaggerPetstore.prototype.findPetsByTags = function (options, callback) {
   // Construct URL
   var requestUrl = this.baseUri +
                    '//pet/findByTags';
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   if (tags !== null && tags !== undefined) {
     queryParameters.push('tags=' + encodeURIComponent(tags.join(',')));
@@ -616,9 +619,6 @@ SwaggerPetstore.prototype.findPetsByTags = function (options, callback) {
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();
@@ -2168,6 +2168,9 @@ SwaggerPetstore.prototype.loginUser = function (options, callback) {
   // Construct URL
   var requestUrl = this.baseUri +
                    '//user/login';
+  // trim all duplicate forward slashes in the url
+  var regex = /([^:]\/)\/+/gi;
+  requestUrl = requestUrl.replace(regex, '$1');
   var queryParameters = [];
   if (username !== null && username !== undefined) {
     queryParameters.push('username=' + encodeURIComponent(username));
@@ -2178,9 +2181,6 @@ SwaggerPetstore.prototype.loginUser = function (options, callback) {
   if (queryParameters.length > 0) {
     requestUrl += '?' + queryParameters.join('&');
   }
-  // trim all duplicate forward slashes in the url
-  var regex = /([^:]\/)\/+/gi;
-  requestUrl = requestUrl.replace(regex, '$1');
 
   // Create HTTP transport objects
   var httpRequest = new WebResource();

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure.rb
@@ -9,6 +9,7 @@ require 'ms_rest_azure/version'
 require 'ms_rest_azure/credentials/application_token_provider.rb'
 
 require 'ms_rest_azure/resource.rb'
+require 'ms_rest_azure/serialization.rb'
 require 'ms_rest_azure/sub_resource.rb'
 require 'ms_rest_azure/cloud_error_data.rb'
 require 'ms_rest_azure/azure_operation_error.rb'
@@ -18,4 +19,5 @@ require 'ms_rest_azure/polling_state.rb'
 require 'ms_rest_azure/active_directory_service_settings.rb'
 require 'ms_rest_azure/azure_service_client.rb'
 
-module MsRestAzure; end
+module MsRestAzure end
+module MsRestAzure::Serialization end

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/serialization.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/serialization.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
+module MsRestAzure
+  # Base module for Azure Ruby serialization and deserialization.
+  #
+  # Provides methods to serialize Ruby object into Ruby Hash and
+  # to deserialize Ruby Hash into Ruby object.
+  module Serialization
+    include MsRest::Serialization
+
+    private
+
+    #
+    # Builds serializer
+    #
+    def build_serializer
+      Serialization.new(self)
+    end
+
+    #
+    # Class to handle serialization & deserialization.
+    #
+    class Serialization < MsRest::Serialization::Serialization
+
+      #
+      # Retrieves model of the model_name
+      #
+      # @param model_name [String] Name of the model to retrieve.
+      #
+      def get_model(model_name)
+        begin
+          Object.const_get(@context.class.to_s.split('::')[0...-1].join('::') + "::Models::#{model_name}")
+        rescue NameError
+          # Look into MsRestAzure namespace if model name not found in the ARM's models namespace
+          Object.const_get("MsRestAzure::#{model_name}")
+        end
+      end
+
+    end
+  end
+end

--- a/src/client/Ruby/ms-rest-azure/spec/resource_spec.rb
+++ b/src/client/Ruby/ms-rest-azure/spec/resource_spec.rb
@@ -5,18 +5,18 @@
 require 'rspec'
 require 'ms_rest_azure'
 
-module MsRestAzure
+module MsRestAzureTest
   class Helper
-    include MsRest::Serialization
+    include MsRestAzure::Serialization
   end
 
-  describe Resource do
+  describe 'Resource' do
     before (:all) do
       @helper = Helper.new
     end
 
     it 'should serialize Resource correctly' do
-      resource = Resource.new
+      resource = MsRestAzure::Resource.new
       resource.id = 'id'
       resource.name = 'name'
       resource.type = 'type'
@@ -26,8 +26,7 @@ module MsRestAzure
         'tag2' => 'tag2_value'
       }
 
-      allow_any_instance_of(MsRest::Serialization::Serialization).to receive(:get_model).and_return(Resource)
-      res = @helper.serialize(Resource.mapper(), resource, 'resource')
+      res = @helper.serialize(MsRestAzure::Resource.mapper(), resource, 'resource')
 
       expect(res).to be_a(Hash)
       expect(res['id']).to eq('id')
@@ -47,10 +46,9 @@ module MsRestAzure
         }
       }
 
-      allow_any_instance_of(MsRest::Serialization::Serialization).to receive(:get_model).and_return(Resource)
-      res = @helper.deserialize(Resource.mapper(), resource_hash, 'resource_hash')
+      res = @helper.deserialize(MsRestAzure::Resource.mapper(), resource_hash, 'resource_hash')
 
-      expect(res).to be_a(Resource)
+      expect(res).to be_a(MsRestAzure::Resource)
       expect(res.id).to eq('id')
       expect(res.name).to eq('name')
       expect(res.type).to eq('type')

--- a/src/client/Ruby/ms-rest-azure/spec/sub_resource_spec.rb
+++ b/src/client/Ruby/ms-rest-azure/spec/sub_resource_spec.rb
@@ -5,22 +5,21 @@
 require 'rspec'
 require 'ms_rest_azure'
 
-module MsRestAzure
+module MsRestAzureTest
   class Helper
-    include MsRest::Serialization
+    include MsRestAzure::Serialization
   end
 
-  describe SubResource do
+  describe 'Sub Resource' do
     before (:all) do
       @helper = Helper.new
     end
 
     it 'should serialize SubResource correctly' do
-      sub_resource = SubResource.new
+      sub_resource = MsRestAzure::SubResource.new
       sub_resource.id = 'the_id'
 
-      allow_any_instance_of(MsRest::Serialization::Serialization).to receive(:get_model).and_return(SubResource)
-      sub_resource_serialized = @helper.serialize(SubResource.mapper(), sub_resource, 'sub_resource')
+      sub_resource_serialized = @helper.serialize(MsRestAzure::SubResource.mapper(), sub_resource, 'sub_resource')
 
       expect(sub_resource_serialized).to be_a(Hash)
       expect(sub_resource_serialized['id']).to eq('the_id')
@@ -30,10 +29,9 @@ module MsRestAzure
       sub_resource_hash = {
           'id' => 'the_id'
       }
-      allow_any_instance_of(MsRest::Serialization::Serialization).to receive(:get_model).and_return(SubResource)
-      sub_resource = @helper.deserialize(SubResource.mapper(), sub_resource_hash, 'sub_resource_hash')
+      sub_resource = @helper.deserialize(MsRestAzure::SubResource.mapper(), sub_resource_hash, 'sub_resource_hash')
 
-      expect(sub_resource).to be_a(SubResource)
+      expect(sub_resource).to be_a(MsRestAzure::SubResource)
       expect(sub_resource.id).to eq('the_id')
     end
   end

--- a/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb
@@ -16,8 +16,7 @@ module MsRest
     # @param object_name [String] Name of the deserialized object.
     #
     def deserialize(mapper, response_body, object_name)
-      serialization = Serialization.new(self)
-      serialization.deserialize(mapper, response_body, object_name)
+      build_serializer.deserialize(mapper, response_body, object_name)
     end
 
     #
@@ -28,8 +27,16 @@ module MsRest
     # @param object_name [String] Name of the serialized object.
     #
     def serialize(mapper, object, object_name)
-      serialization = Serialization.new(self)
-      serialization.serialize(mapper, object, object_name)
+      build_serializer.serialize(mapper, object, object_name)
+    end
+
+    private
+
+    #
+    # Builds serializer
+    #
+    def build_serializer
+      Serialization.new(self)
     end
 
     #

--- a/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureServiceClientTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureServiceClientTemplateModel.cs
@@ -34,7 +34,7 @@ namespace AutoRest.Ruby.Azure.TemplateModels
             get
             {
                 return new List<string>
-				{
+                {
                     "MsRestAzure"
                 };
             }
@@ -48,6 +48,17 @@ namespace AutoRest.Ruby.Azure.TemplateModels
             get
             {
                 return "MsRestAzure::AzureServiceClient";
+            }
+        }
+
+        /// <summary>
+        /// Gets the serializer type of the client.
+        /// </summary>
+        public override string IncludeSerializer
+        {
+            get
+            {
+                return "include MsRestAzure::Serialization";
             }
         }
     }

--- a/src/generator/AutoRest.Ruby.Tests/RspecTests/query_spec.rb
+++ b/src/generator/AutoRest.Ruby.Tests/RspecTests/query_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-$: << 'RspecTests/url_query'
+$: << 'RspecTests/Generated/url_query'
 
 require 'rspec'
 require 'generated/url'

--- a/src/generator/AutoRest.Ruby/TemplateModels/ServiceClientTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby/TemplateModels/ServiceClientTemplateModel.cs
@@ -61,5 +61,16 @@ namespace AutoRest.Ruby.TemplateModels
                 return "MsRest::ServiceClient";
             }
         }
+
+        /// <summary>
+        /// Gets the serializer type of the client.
+        /// </summary>
+        public virtual string IncludeSerializer
+        {
+            get
+            {
+                return "include MsRest::Serialization";
+            }
+        }
     }
 }

--- a/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
@@ -11,11 +11,11 @@ module @Settings.Namespace
   #
   class @Model.Name < @Model.BaseType
 
-    include MsRest::Serialization
 @foreach (var include in Model.Includes)
 {
     @:include @include
 }
+    @Model.IncludeSerializer
     @EmptyLine
 
     # @@return [String] the base URI of the service.


### PR DESCRIPTION
This separation helps overriding the [get_model](https://github.com/Azure/autorest/blob/master/src/client/Ruby/ms-rest/lib/ms_rest/serialization.rb#L386) and override implementation to be Azure specific serialization/deserialization. 

This addresses issue https://github.com/Azure/azure-sdk-for-ruby/issues/407