### PR TITLE
Updating runtime authentication library due to signing issue

### DIFF
--- a/src/client/Microsoft.Rest.ClientRuntime.Azure.Authentication/Properties/AssemblyInfo.cs
+++ b/src/client/Microsoft.Rest.ClientRuntime.Azure.Authentication/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Rest Azure Client Runtime Authentication")]
 [assembly: AssemblyDescription("Client authentication infrastructure for Azure client libraries.")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.7.0")]
+[assembly: AssemblyFileVersion("2.2.8.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]

--- a/src/client/Microsoft.Rest.ClientRuntime.Azure.Authentication/project.json
+++ b/src/client/Microsoft.Rest.ClientRuntime.Azure.Authentication/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.7-preview",
+  "version": "2.2.8-preview",
   "title": "Authentication for Azure Management Clients",
   "description": "Provides ADAL based authentication for Azure management client libraries \nSupported Platforms:\n  -   Portable Class Libraries\n  -   .NET Framework 4.5\n  -   Windows 8\n  -   Windows Phone 8.1\n  -   DotNet Core",
   "authors": [ "Microsoft" ],

--- a/src/client/Microsoft.Rest.ClientRuntime.Azure.Tests/project.json
+++ b/src/client/Microsoft.Rest.ClientRuntime.Azure.Tests/project.json
@@ -23,7 +23,7 @@
     }, 
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Microsoft.Rest.ClientRuntime.Azure": "[3.3.2,4.0.0)",
-    "Microsoft.Rest.ClientRuntime.Azure.Authentication": "[2.2.7-preview,3.0.0)",
+    "Microsoft.Rest.ClientRuntime.Azure.Authentication": "[2.2.8-preview,3.0.0)",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }

--- a/src/client/Microsoft.Rest.ClientRuntime.Tests/project.json
+++ b/src/client/Microsoft.Rest.ClientRuntime.Tests/project.json
@@ -23,7 +23,7 @@
     }, 
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Microsoft.Rest.ClientRuntime.Azure": "[3.3.2,4.0.0)",
-    "Microsoft.Rest.ClientRuntime.Azure.Authentication": "[2.2.7-preview,3.0.0)",
+    "Microsoft.Rest.ClientRuntime.Azure.Authentication": "[2.2.8-preview,3.0.0)",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }


### PR DESCRIPTION
This is solely about updating the version so we can sign and publish the package.