### PR TITLE
Fix Node.js Infinite Request Wrap Stack Overflow

### DIFF
--- a/src/client/NodeJS/ms-rest/lib/requestPipeline.js
+++ b/src/client/NodeJS/ms-rest/lib/requestPipeline.js
@@ -83,11 +83,11 @@ exports.createWithSink = function(sink) {
 exports.requestLibrarySink = function (requestOptions) {
 
   return function (options, callback) {
-    request = request.defaults(requestOptions);
+    var defaultRequest = request.defaults(requestOptions);
     var requestStream;
     var bodyStream;
     if (options.headersOnly) {
-      var requestHeaderStream = request(options);
+      var requestHeaderStream = defaultRequest(options);
       requestHeaderStream.on('error', function (err) {
         return callback(err);
       });
@@ -101,9 +101,9 @@ exports.requestLibrarySink = function (requestOptions) {
       if (options.body && typeof options.body.pipe === 'function') {
         bodyStream = options.body;
         options.body = null;
-        requestStream = bodyStream.pipe(request(options));
+        requestStream = bodyStream.pipe(defaultRequest(options));
       } else {
-        requestStream = request(options);
+        requestStream = defaultRequest(options);
       }
       requestStream.on('error', function (err) {
         return callback(err);
@@ -115,12 +115,12 @@ exports.requestLibrarySink = function (requestOptions) {
     } else if (options.body && typeof options.body.pipe === 'function') {
       bodyStream = options.body;
       options.body = null;
-      return bodyStream.pipe(request(options, function (err, response, body) {
+      return bodyStream.pipe(defaultRequest(options, function (err, response, body) {
         if (err) { return callback(err); }
         return callback(null, response, body);
       }));
     } else {
-      return request(options, function (err, response, body) {
+      return defaultRequest(options, function (err, response, body) {
         if (err) { return callback(err); }
         return callback(null, response, body);
       });


### PR DESCRIPTION
Hey there. There isn't a contributing document so I'm not sure what specific information you need.

We're hitting [this issue](https://github.com/Azure/autorest/issues/919) A LOT and its causing big problems as it basically causes an unrecoverable error in our backend workers. This is on the latest version of `ms-rest`.

The issue happens when you call azure node.js sdk calls enough (think within the thousands of requests). Because you are wrapping the global `request` module within this module every time a client calls `requestLibrarySink` it adds an [additional layer on the stack](https://github.com/request/request/blob/v2.72.0/index.js#L84).

So you should just use a new variable every time you call `request.defaults`. This prevents the stack from getting too big.