### PR TITLE
GetDerivedType should consider only the derived types of the provided base type

### DIFF
--- a/src/client/Microsoft.Rest.ClientRuntime.Tests/Resources/Animal.cs
+++ b/src/client/Microsoft.Rest.ClientRuntime.Tests/Resources/Animal.cs
@@ -31,6 +31,13 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
     }
 
     [JsonObject("siamese")]
+    public class Martian : Alien
+    {
+        [JsonProperty("robot")]
+        public string Robot { get; set; }
+    }
+
+    [JsonObject("siamese")]
     public class Siamese : Cat
     {
         [JsonProperty("color")]

--- a/src/client/Microsoft.Rest.ClientRuntime/Serialization/PolymorphicJsonConverter.cs
+++ b/src/client/Microsoft.Rest.ClientRuntime/Serialization/PolymorphicJsonConverter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Rest.Serialization
                 throw new ArgumentNullException("baseType");
             }
             foreach (TypeInfo type in baseType.GetTypeInfo().Assembly.DefinedTypes
-                .Where(t => t.Namespace == baseType.Namespace && t != baseType.GetTypeInfo()))
+                .Where(t => t.Namespace == baseType.Namespace && t != baseType.GetTypeInfo() && t.IsSubclassOf(baseType)))
             {
                 string typeName = type.Name;
                 if (type.GetCustomAttributes<JsonObjectAttribute>().Any())


### PR DESCRIPTION
Issue related to this PR: https://github.com/Azure/autorest/issues/1351

I've verified that this patch fixes the issue.