### PR TITLE
Python: Make AzureOperationPoller thread a daemon thread

### DIFF
--- a/src/client/Python/msrestazure/msrestazure/azure_operation.py
+++ b/src/client/Python/msrestazure/msrestazure/azure_operation.py
@@ -395,6 +395,7 @@ class AzureOperationPoller(object):
         self._done = threading.Event()
         self._thread = threading.Thread(
             target=self._start, args=(send_cmd, update_cmd, output_cmd))
+        self._thread.daemon = True
         self._thread.start()
 
     def _start(self, send_cmd, update_cmd, output_cmd):


### PR DESCRIPTION
See item #1378. This PR doesn't make the use of daemon threads configurable, but that is an option too. This is the simplest fix. 