### PR TITLE
Generate specific return type when a method has multiple responses of the same primary type

### DIFF
--- a/src/core/AutoRest.Core/ClientModel/PrimaryType.cs
+++ b/src/core/AutoRest.Core/ClientModel/PrimaryType.cs
@@ -52,6 +52,34 @@ namespace AutoRest.Core.ClientModel
         public override string ToString()
         {
             return Name;
-        }        
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to this object based on the Type.
+        /// </summary>
+        /// <param name="obj">The object to compare with this object.</param>
+        /// <returns>true if the specified object is equal to this object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            var modelType = obj as PrimaryType;
+
+            if (modelType != null)
+            {
+                return modelType.Type == Type;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Serves as a hash function based on Type.
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return Type.GetHashCode();
+        }
     }
 }

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-multiple-string-responses.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-multiple-string-responses.json
@@ -1,0 +1,43 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "v1",
+    "title": "Test generated return type when a method has multiple responses of the same primary type"
+  },
+  "host": "rest.example.com:443",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/string": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "operationId": "Test_GetString",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json",
+          "application/xml",
+          "text/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerTests.cs
@@ -761,5 +761,21 @@ namespace AutoRest.Swagger.Tests
             Assert.True(dictionaryProperty.SupportsAdditionalProperties);
 
         }
+
+        [Fact]
+        public void TestReturnTypeOfMultipleStringResponses()
+        {
+            Modeler modeler = new SwaggerModeler(new Settings
+            {
+                Namespace = "Test",
+                Input = Path.Combine("Swagger", "swagger-multiple-string-responses.json")
+            });
+            var clientModel = modeler.Build();
+
+            Assert.NotNull(clientModel);
+            Assert.IsType<PrimaryType>(clientModel.Methods.First().ReturnType.Body);
+            var returnType = (PrimaryType) clientModel.Methods.First().ReturnType.Body;
+            Assert.Equal(KnownPrimaryType.String, returnType.Type);
+        }
     }
 }


### PR DESCRIPTION
If a method has multiple responses all of the same primary type (like string) then this change will generate a return type of that primary type instead of Object.

Older versions did this but between 0.14.0 and 0.15.0 AutoRest started generating an Object return type.