### PR TITLE
Making SchemaResolver more flexible

### DIFF
--- a/src/modeler/AutoRest.Swagger/Validation/SwaggerModelValidationExtensions.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/SwaggerModelValidationExtensions.cs
@@ -9,5 +9,23 @@ namespace AutoRest.Swagger.Validation
         {
             return context?.Root as ServiceDefinition;
         }
+
+        /// <summary>
+        /// Traverses <paramref name="context"/> to find the first ancestor of type <paramref name="T"/>
+        /// </summary>
+        /// <typeparam name="T">The type of value to find</typeparam>
+        /// <param name="context"></param>
+        /// <returns>The first ancestor of type T or null</returns>
+        public static T GetFirstAncestor<T>(this RuleContext context) where T : class
+        {
+            var current = context;
+            T value = context.Value as T;
+            while (current != null && value == null)
+            {
+                value = current.Value as T;
+                current = current.Parent;
+            }
+            return value;
+        }
     }
 }


### PR DESCRIPTION
Making `SchemaResolver` usable outside of a `SwaggerModeler`. This will be used in validation rules to unwrap references for a given schema, letting us look at all parameters/definitions, either local or referenced in rules (other PRs to come).

- Adding a constructor to instantiate it without a modeler (which was only used to get the `Modeler.ServiceDefinition`). Useful when we only have a `ServiceDefinition` (which has all the info to dereference)
- Exposing the `FindProperty()` method that finds a property by name in a schema's inheritence chain. Standardizing the naming so that you can call this by schema $ref string or with the actual schema
- Tweaking the method documentation for `FindProperty()`, because references to "ancestor" or "parent" come from the usage of the class in `SwaggerModeler`. The actual logic of the method searches the referenced schema, as well as its ancestors.
- Also adding an extension method to make it easy to get the first ancestor of a given type from the context when writing a validation rule.