### PR TITLE
Add Operations Config documentation page to Python msrest

### DIFF
--- a/src/client/Python/msrest/doc/conf.py
+++ b/src/client/Python/msrest/doc/conf.py
@@ -15,6 +15,7 @@
 import sys
 import os
 import pip
+import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -107,6 +108,7 @@ autoclass_content = 'both'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 #html_theme_options = {'collapsiblesidebar': True}
 
 # Activate the theme.
@@ -114,6 +116,7 @@ autoclass_content = 'both'
 #import sphinx_bootstrap_theme
 #html_theme = 'bootstrap'
 #html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/src/client/Python/msrest/doc/index.rst
+++ b/src/client/Python/msrest/doc/index.rst
@@ -62,3 +62,4 @@ Indices and tables
   :glob:
 
   msrest
+  operation_config

--- a/src/client/Python/msrest/doc/operation_config.rst
+++ b/src/client/Python/msrest/doc/operation_config.rst
@@ -1,0 +1,21 @@
+.. _optionsforoperations:
+
+Operation config
+================
+
+Methods on operations have extra parameters which can be provided in the kwargs. This is called `operation_config`.
+
+The list of operation configuration is:
+
+=============== ==== ====
+Parameter name  Type Role
+=============== ==== ====
+verify          bool
+cert            str
+timeout         int
+allow_redirects bool
+max_redirects   int
+proxies         dict
+use_env_proxies bool whether to read proxy settings from local env vars
+retries         int  number of retries
+=============== ==== ====

--- a/src/client/Python/msrest/doc/requirements.txt
+++ b/src/client/Python/msrest/doc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
Just a new documentation page, content from @annatisch.