### PR TITLE
Adding pageable validation rules and tests

### DIFF
--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/pageable-nextlink-not-modeled.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/pageable-nextlink-not-modeled.json
@@ -1,0 +1,56 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "PageablePropertiesNotModeled",
+    "description": "The properties needed for pageable are not modeled",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "post": {
+        "operationId": "PostFoo",
+        "summary": "Foo path",
+        "description": "Foo operation ",
+        "x-ms-pageable": {
+          "nextLinkName": "bar"
+        },
+        "responses": {
+          "200": {
+            "description": "A pageable response",
+            "schema": {
+              "$ref": "#/definitions/Pageable"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pageable": {
+      "type": "object",
+      "description": "Pageable object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "foo": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/pageable-no-200-response.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/pageable-no-200-response.json
@@ -1,0 +1,56 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "PageableNo200Response",
+    "description": "The 200 response code is not modeled for a pageable operation",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "post": {
+        "operationId": "PostFoo",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "x-ms-pageable": {
+          "nextLinkName": "bar"
+        },
+        "responses": {
+          "200": {
+            "description": "A pageable response",
+            "schema": {
+              "$ref": "#/definitions/Pageable"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pageable": {
+      "type": "object",
+      "description": "Pageable object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "foo": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -28,7 +28,7 @@ namespace AutoRest.Swagger.Tests
         internal static void AssertOnlyValidationMessage(this IEnumerable<ValidationMessage> messages, Type validationType)
         {
             // checks that the collection has one item, and that it is the correct message type.
-            Assert.Collection(messages , message => Assert.Equal(validationType, message.Type));
+            Assert.Collection(messages, message => Assert.Equal(validationType, message.Type));
         }
 
         internal static void AssertOnlyValidationMessage(this IEnumerable<ValidationMessage> messages, Type validationType, int count)
@@ -135,7 +135,7 @@ namespace AutoRest.Swagger.Tests
         public void InvalidConstraintValidation()
         {
             var messages = ValidateSwagger(Path.Combine("Swagger", "swagger-validation.json"));
-            messages.AssertOnlyValidationWarning(typeof(InvalidConstraint),18);
+            messages.AssertOnlyValidationWarning(typeof(InvalidConstraint), 18);
         }
 
         [Fact]
@@ -164,6 +164,20 @@ namespace AutoRest.Swagger.Tests
         {
             var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "parameter-missing-description.json"));
             messages.AssertOnlyValidationMessage(typeof(ParameterDescriptionRequired));
+        }
+
+        [Fact]
+        public void PageableNextLinkNotModeledValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "pageable-nextlink-not-modeled.json"));
+            messages.AssertOnlyValidationMessage(typeof(NextLinkPropertyMustExist));
+        }
+
+        [Fact]
+        public void Pageable200ResponseNotModeledValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "pageable-no-200-response.json"));
+            messages.Any(m => m.Type == typeof(PageableRequires200Response));
         }
     }
 }

--- a/src/modeler/AutoRest.Swagger/Model/SwaggerBase.cs
+++ b/src/modeler/AutoRest.Swagger/Model/SwaggerBase.cs
@@ -22,6 +22,8 @@ namespace AutoRest.Swagger.Model
         /// </summary>
         [JsonExtensionData]
         [CollectionRule(typeof(NonEmptyClientName))]
+        [CollectionRule(typeof(NextLinkPropertyMustExist))]
+        [CollectionRule(typeof(PageableRequires200Response))]
         public Dictionary<string, object> Extensions { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Validation/ExtensionRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ExtensionRule.cs
@@ -3,15 +3,12 @@
 
 using AutoRest.Core.Validation;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 
 namespace AutoRest.Swagger.Validation
 {
     /// <summary>
-    /// A rule that validates objects of type <typeparamref name="T"/>
+    /// A rule that validates extensions (e.g. x-ms-pageable)
     /// </summary>
-    /// <typeparam name="T">The type of the object to validate</typeparam>
     public abstract class ExtensionRule : Rule
     {
         protected abstract string ExtensionName { get; }
@@ -24,6 +21,7 @@ namespace AutoRest.Swagger.Validation
         public override IEnumerable<ValidationMessage> GetValidationMessages(object entity, RuleContext context)
         {
             object[] formatParams;
+            // Only try to validate an object with this extension rule if the extension name matches the key
             if (context.Key == ExtensionName && !IsValid(entity, context, out formatParams))
             {
                 yield return new ValidationMessage(this, formatParams);

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/NextLinkPropertyMustExist.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/NextLinkPropertyMustExist.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Logging;
+using AutoRest.Core.Validation;
+using Newtonsoft.Json.Linq;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class NextLinkPropertyMustExist : PageableExtensionRule
+    {
+        private const string ExtensionNextLinkPropertyName = "nextLinkName";
+
+        /// <summary>
+        /// An x-ms-pageable extension passes this rule if the value for nextLinkName refers to a string property
+        /// that exists on the schema for the 200 response of the parent operation.
+        /// </summary>
+        /// <param name="pageable"></param>
+        /// <param name="context"></param>
+        /// <param name="formatParameters"></param>
+        /// <returns></returns>
+        public override bool IsValid(object pageable, RuleContext context, out object[] formatParameters)
+        {
+            // Get the name of the property defined by nextLinkName in the spec
+            var nextLinkPropertyName = (pageable as JContainer)?[ExtensionNextLinkPropertyName]?.ToString();
+            if (!string.IsNullOrEmpty(nextLinkPropertyName))
+            {
+                // Get the list of properties defined for the 200 response schema
+                var schemaProperties = Get200ResponseSchema(context)?.Properties;
+
+                // Fail the rule if there's no property that has the name specified by nextLinkName
+                if (schemaProperties == null || !schemaProperties.ContainsKey(nextLinkPropertyName))
+                {
+                    formatParameters = new string[] { nextLinkPropertyName };
+                    return false;
+                }
+            }
+            formatParameters = new string[0];
+            return true;
+        }
+
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => "The property '{0}' specified by nextLinkName does not exist in the 200 response schema.";
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override LogEntrySeverity Severity => LogEntrySeverity.Warning;
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/PageableExtensionRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/PageableExtensionRule.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Logging;
+using AutoRest.Core.Validation;
+using AutoRest.Swagger.Model;
+using System.Collections.Generic;
+
+namespace AutoRest.Swagger.Validation
+{
+    internal static class PageableExtensions
+    {
+        public static T GetValueOrNull<T>(this Dictionary<string, T> dictionary, string key)
+        {
+            T value = default(T);
+            if (dictionary != null)
+            {
+                dictionary.TryGetValue(key, out value);
+            }
+            return value;
+        }
+    }
+
+    public abstract class PageableExtensionRule : ExtensionRule
+    {
+        protected override string ExtensionName => "x-ms-pageable";
+
+        protected static Schema Get200ResponseSchema(RuleContext context)
+        {
+            OperationResponse response = context?.GetFirstAncestor<Operation>()?.Responses?.GetValueOrNull("200");
+            if (response == null)
+            {
+                return null;
+            }
+            var resolver = new SchemaResolver(context?.GetServiceDefinition());
+            return resolver.Unwrap(response.Schema);
+        }
+
+        public abstract override string MessageTemplate { get; }
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public abstract override LogEntrySeverity Severity { get; }
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/PageableRequires200Response.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/PageableRequires200Response.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Logging;
+using AutoRest.Core.Validation;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class PageableRequires200Response : PageableExtensionRule
+    {
+        /// <summary>
+        /// An x-ms-pageable extension passes this rule if the operation that this extension is defined on has a 200
+        /// response defined
+        /// </summary>
+        /// <param name="pageable"></param>
+        /// <param name="context"></param>
+        /// <param name="formatParameters"></param>
+        /// <returns></returns>
+        public override bool IsValid(object pageable, RuleContext context) => Get200ResponseSchema(context) != null;
+
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => "A response for the 200 HTTP status code must be defined to use x-ms-pageable";
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override LogEntrySeverity Severity => LogEntrySeverity.Warning;
+    }
+}


### PR DESCRIPTION
Enforced rules:
- Using `x-ms-pageable` requires a 200 response defined
- The value specified by `nextLinkName` property in `x-ms-pageable` must refer to a property that exists

- Adding a base class for Extension rules to make it easy to write rules to validate extensions
- Adding a base class for Pageable rules to make it easy to write rules to validate `x-ms-pageable` 