### PR TITLE
Remove ServiceResponse<> wrappers in most methods

### DIFF
--- a/src/client/Java/azure-client-runtime/src/main/java/com/microsoft/azure/AzureServiceCall.java
+++ b/src/client/Java/azure-client-runtime/src/main/java/com/microsoft/azure/AzureServiceCall.java
@@ -117,7 +117,7 @@ public final class AzureServiceCall<T> extends ServiceCall<T> {
                 }
             }
             if (behavior == ListOperationCallback.PagingBehavior.STOP || serviceResponse.getBody().getNextPageLink() == null) {
-                serviceCall.set(new ServiceResponse<>(lastResponse.getBody().getItems(), lastResponse.getResponse()));
+                serviceCall.set(lastResponse.getBody().getItems());
             } else {
                 serviceCall.setSubscription(next.call(serviceResponse.getBody().getNextPageLink()).single().subscribe(this));
             }

--- a/src/client/Java/azure-client-runtime/src/main/java/com/microsoft/azure/ListOperationCallback.java
+++ b/src/client/Java/azure-client-runtime/src/main/java/com/microsoft/azure/ListOperationCallback.java
@@ -8,7 +8,6 @@
 package com.microsoft.azure;
 
 import com.microsoft.rest.ServiceCallback;
-import com.microsoft.rest.ServiceResponse;
 
 import java.util.List;
 
@@ -71,7 +70,7 @@ public abstract class ListOperationCallback<E> extends ServiceCallback<List<E>> 
     }
 
     @Override
-    public void success(ServiceResponse<List<E>> result) {
+    public void success(List<E> result) {
         success();
     }
 

--- a/src/client/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceCall.java
+++ b/src/client/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceCall.java
@@ -20,7 +20,7 @@ import rx.functions.Action1;
  *
  * @param <T> the type of the returning object
  */
-public class ServiceCall<T> extends AbstractFuture<ServiceResponse<T>> {
+public class ServiceCall<T> extends AbstractFuture<T> {
     /**
      * The Retrofit method invocation.
      */
@@ -43,7 +43,7 @@ public class ServiceCall<T> extends AbstractFuture<ServiceResponse<T>> {
             .subscribe(new Action1<ServiceResponse<T>>() {
                 @Override
                 public void call(ServiceResponse<T> t) {
-                    serviceCall.set(t);
+                    serviceCall.set(t.getBody());
                 }
             }, new Action1<Throwable>() {
                 @Override
@@ -70,9 +70,9 @@ public class ServiceCall<T> extends AbstractFuture<ServiceResponse<T>> {
                 @Override
                 public void call(ServiceResponse<T> t) {
                     if (callback != null) {
-                        callback.success(t);
+                        callback.success(t.getBody());
                     }
-                    serviceCall.set(t);
+                    serviceCall.set(t.getBody());
                 }
             }, new Action1<Throwable>() {
                 @Override
@@ -103,9 +103,9 @@ public class ServiceCall<T> extends AbstractFuture<ServiceResponse<T>> {
                 @Override
                 public void call(ServiceResponse<T> t) {
                     if (callback != null) {
-                        callback.success(t);
+                        callback.success(t.getBody());
                     }
-                    serviceCall.set(t);
+                    serviceCall.set(t.getBody());
                 }
             }, new Action1<Throwable>() {
                 @Override

--- a/src/client/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceCallback.java
+++ b/src/client/Java/client-runtime/src/main/java/com/microsoft/rest/ServiceCallback.java
@@ -23,7 +23,7 @@ public abstract class ServiceCallback<T> {
     /**
      * Override this method to handle successful REST call results.
      *
-     * @param result the ServiceResponse holding the response.
+     * @param result the result object.
      */
-    public abstract void success(ServiceResponse<T> result);
+    public abstract void success(T result);
 }

--- a/src/client/Python/msrest/doc/conf.py
+++ b/src/client/Python/msrest/doc/conf.py
@@ -15,6 +15,7 @@
 import sys
 import os
 import pip
+import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -107,6 +108,7 @@ autoclass_content = 'both'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 #html_theme_options = {'collapsiblesidebar': True}
 
 # Activate the theme.
@@ -114,6 +116,7 @@ autoclass_content = 'both'
 #import sphinx_bootstrap_theme
 #html_theme = 'bootstrap'
 #html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/src/client/Python/msrest/doc/index.rst
+++ b/src/client/Python/msrest/doc/index.rst
@@ -62,3 +62,4 @@ Indices and tables
   :glob:
 
   msrest
+  operation_config

--- a/src/client/Python/msrest/doc/operation_config.rst
+++ b/src/client/Python/msrest/doc/operation_config.rst
@@ -1,0 +1,21 @@
+.. _optionsforoperations:
+
+Operation config
+================
+
+Methods on operations have extra parameters which can be provided in the kwargs. This is called `operation_config`.
+
+The list of operation configuration is:
+
+=============== ==== ====
+Parameter name  Type Role
+=============== ==== ====
+verify          bool
+cert            str
+timeout         int
+allow_redirects bool
+max_redirects   int
+proxies         dict
+use_env_proxies bool whether to read proxy settings from local env vars
+retries         int  number of retries
+=============== ==== ====

--- a/src/client/Python/msrest/doc/requirements.txt
+++ b/src/client/Python/msrest/doc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsInner.java
@@ -109,7 +109,7 @@ public final class ParameterGroupingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -179,7 +179,7 @@ public final class ParameterGroupingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -213,7 +213,7 @@ public final class ParameterGroupingsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void postOptional(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) throws ErrorException, IOException {
-        postOptionalWithServiceResponseAsync().toBlocking().single().getBody();
+        postOptionalWithServiceResponseAsync(parameterGroupingPostOptionalParameters).toBlocking().single().getBody();
     }
 
     /**
@@ -230,6 +230,7 @@ public final class ParameterGroupingsInner {
     /**
      * Post a bunch of optional parameters grouped.
      *
+     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) {
@@ -238,7 +239,7 @@ public final class ParameterGroupingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -309,7 +310,7 @@ public final class ParameterGroupingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -347,7 +348,7 @@ public final class ParameterGroupingsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void postMultiParamGroups(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException {
-        postMultiParamGroupsWithServiceResponseAsync().toBlocking().single().getBody();
+        postMultiParamGroupsWithServiceResponseAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup).toBlocking().single().getBody();
     }
 
     /**
@@ -365,6 +366,8 @@ public final class ParameterGroupingsInner {
     /**
      * Post parameters from multiple different parameter groups.
      *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postMultiParamGroupsAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) {
@@ -373,7 +376,7 @@ public final class ParameterGroupingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -454,7 +457,7 @@ public final class ParameterGroupingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -488,7 +491,7 @@ public final class ParameterGroupingsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void postSharedParameterGroupObject(FirstParameterGroupInner firstParameterGroup) throws ErrorException, IOException {
-        postSharedParameterGroupObjectWithServiceResponseAsync().toBlocking().single().getBody();
+        postSharedParameterGroupObjectWithServiceResponseAsync(firstParameterGroup).toBlocking().single().getBody();
     }
 
     /**
@@ -505,6 +508,7 @@ public final class ParameterGroupingsInner {
     /**
      * Post parameters with a shared parameter group object.
      *
+     * @param firstParameterGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postSharedParameterGroupObjectAsync(FirstParameterGroupInner firstParameterGroup) {
@@ -513,7 +517,7 @@ public final class ParameterGroupingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsInner.java
@@ -81,10 +81,9 @@ public final class ParameterGroupingsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postRequired(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredAsync(parameterGroupingPostRequiredParameters).toBlocking().single();
+    public void postRequired(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) throws ErrorException, IOException, IllegalArgumentException {
+        postRequiredWithServiceResponseAsync(parameterGroupingPostRequiredParameters).toBlocking().single().getBody();
     }
 
     /**
@@ -95,7 +94,7 @@ public final class ParameterGroupingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postRequiredAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postRequiredAsync(parameterGroupingPostRequiredParameters), serviceCallback);
+        return ServiceCall.create(postRequiredWithServiceResponseAsync(parameterGroupingPostRequiredParameters), serviceCallback);
     }
 
     /**
@@ -104,7 +103,22 @@ public final class ParameterGroupingsInner {
      * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postRequiredAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) {
+    public Observable<Void> postRequiredAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) {
+        return postRequiredWithServiceResponseAsync(parameterGroupingPostRequiredParameters).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post a bunch of required parameters grouped.
+     *
+     * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postRequiredWithServiceResponseAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) {
         if (parameterGroupingPostRequiredParameters == null) {
             throw new IllegalArgumentException("Parameter parameterGroupingPostRequiredParameters is required and cannot be null.");
         }
@@ -139,10 +153,9 @@ public final class ParameterGroupingsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptional() throws ErrorException, IOException {
-        return postOptionalAsync().toBlocking().single();
+    public void postOptional() throws ErrorException, IOException {
+        postOptionalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -152,7 +165,7 @@ public final class ParameterGroupingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -160,7 +173,21 @@ public final class ParameterGroupingsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalAsync() {
+    public Observable<Void> postOptionalAsync() {
+        return postOptionalWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalWithServiceResponseAsync() {
         final ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters = null;
         String customHeader = null;
         Integer query = null;
@@ -184,10 +211,9 @@ public final class ParameterGroupingsInner {
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptional(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) throws ErrorException, IOException {
-        return postOptionalAsync(parameterGroupingPostOptionalParameters).toBlocking().single();
+    public void postOptional(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) throws ErrorException, IOException {
+        postOptionalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -198,7 +224,21 @@ public final class ParameterGroupingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalAsync(parameterGroupingPostOptionalParameters), serviceCallback);
+        return ServiceCall.create(postOptionalWithServiceResponseAsync(parameterGroupingPostOptionalParameters), serviceCallback);
+    }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) {
+        return postOptionalWithServiceResponseAsync(parameterGroupingPostOptionalParameters).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -207,7 +247,7 @@ public final class ParameterGroupingsInner {
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) {
+    public Observable<ServiceResponse<Void>> postOptionalWithServiceResponseAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) {
         Validator.validate(parameterGroupingPostOptionalParameters);
         String customHeader = null;
         if (parameterGroupingPostOptionalParameters != null) {
@@ -243,10 +283,9 @@ public final class ParameterGroupingsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMultiParamGroups() throws ErrorException, IOException {
-        return postMultiParamGroupsAsync().toBlocking().single();
+    public void postMultiParamGroups() throws ErrorException, IOException {
+        postMultiParamGroupsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -256,7 +295,7 @@ public final class ParameterGroupingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMultiParamGroupsAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMultiParamGroupsAsync(), serviceCallback);
+        return ServiceCall.create(postMultiParamGroupsWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -264,7 +303,21 @@ public final class ParameterGroupingsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMultiParamGroupsAsync() {
+    public Observable<Void> postMultiParamGroupsAsync() {
+        return postMultiParamGroupsWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMultiParamGroupsWithServiceResponseAsync() {
         final FirstParameterGroupInner firstParameterGroup = null;
         final ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup = null;
         String headerOne = null;
@@ -292,10 +345,9 @@ public final class ParameterGroupingsInner {
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMultiParamGroups(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException {
-        return postMultiParamGroupsAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup).toBlocking().single();
+    public void postMultiParamGroups(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException {
+        postMultiParamGroupsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -307,7 +359,21 @@ public final class ParameterGroupingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMultiParamGroupsAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMultiParamGroupsAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup), serviceCallback);
+        return ServiceCall.create(postMultiParamGroupsWithServiceResponseAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup), serviceCallback);
+    }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postMultiParamGroupsAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+        return postMultiParamGroupsWithServiceResponseAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -317,7 +383,7 @@ public final class ParameterGroupingsInner {
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMultiParamGroupsAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+    public Observable<ServiceResponse<Void>> postMultiParamGroupsWithServiceResponseAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) {
         Validator.validate(firstParameterGroup);
         Validator.validate(parameterGroupingPostMultiParamGroupsSecondParamGroup);
         String headerOne = null;
@@ -362,10 +428,9 @@ public final class ParameterGroupingsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postSharedParameterGroupObject() throws ErrorException, IOException {
-        return postSharedParameterGroupObjectAsync().toBlocking().single();
+    public void postSharedParameterGroupObject() throws ErrorException, IOException {
+        postSharedParameterGroupObjectWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -375,7 +440,7 @@ public final class ParameterGroupingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postSharedParameterGroupObjectAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postSharedParameterGroupObjectAsync(), serviceCallback);
+        return ServiceCall.create(postSharedParameterGroupObjectWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -383,7 +448,21 @@ public final class ParameterGroupingsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsync() {
+    public Observable<Void> postSharedParameterGroupObjectAsync() {
+        return postSharedParameterGroupObjectWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postSharedParameterGroupObjectWithServiceResponseAsync() {
         final FirstParameterGroupInner firstParameterGroup = null;
         String headerOne = null;
         Integer queryOne = null;
@@ -407,10 +486,9 @@ public final class ParameterGroupingsInner {
      * @param firstParameterGroup Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postSharedParameterGroupObject(FirstParameterGroupInner firstParameterGroup) throws ErrorException, IOException {
-        return postSharedParameterGroupObjectAsync(firstParameterGroup).toBlocking().single();
+    public void postSharedParameterGroupObject(FirstParameterGroupInner firstParameterGroup) throws ErrorException, IOException {
+        postSharedParameterGroupObjectWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -421,7 +499,21 @@ public final class ParameterGroupingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postSharedParameterGroupObjectAsync(FirstParameterGroupInner firstParameterGroup, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postSharedParameterGroupObjectAsync(firstParameterGroup), serviceCallback);
+        return ServiceCall.create(postSharedParameterGroupObjectWithServiceResponseAsync(firstParameterGroup), serviceCallback);
+    }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postSharedParameterGroupObjectAsync(FirstParameterGroupInner firstParameterGroup) {
+        return postSharedParameterGroupObjectWithServiceResponseAsync(firstParameterGroup).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -430,7 +522,7 @@ public final class ParameterGroupingsInner {
      * @param firstParameterGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsync(FirstParameterGroupInner firstParameterGroup) {
+    public Observable<ServiceResponse<Void>> postSharedParameterGroupObjectWithServiceResponseAsync(FirstParameterGroupInner firstParameterGroup) {
         Validator.validate(firstParameterGroup);
         String headerOne = null;
         if (firstParameterGroup != null) {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
@@ -188,10 +188,10 @@ public final class AutoRestReportServiceForAzureImpl extends AzureServiceClient 
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
-    public ServiceResponse<Map<String, Integer>> getReport() throws ErrorException, IOException {
-        return getReportAsync().toBlocking().single();
+    public Map<String, Integer> getReport() throws ErrorException, IOException {
+        return getReportWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -201,7 +201,7 @@ public final class AutoRestReportServiceForAzureImpl extends AzureServiceClient 
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getReportAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getReportAsync(), serviceCallback);
+        return ServiceCall.create(getReportWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -209,7 +209,21 @@ public final class AutoRestReportServiceForAzureImpl extends AzureServiceClient 
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getReportAsync() {
+    public Observable<Map<String, Integer>> getReportAsync() {
+        return getReportWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get test coverage report.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Integer>>> getReportWithServiceResponseAsync() {
         return service.getReport(this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
@@ -215,7 +215,7 @@ public final class AutoRestReportServiceForAzureImpl extends AzureServiceClient 
             public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -238,7 +238,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -270,7 +270,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void putArray(List<ResourceInner> resourceArray) throws ErrorException, IOException {
-        putArrayWithServiceResponseAsync().toBlocking().single().getBody();
+        putArrayWithServiceResponseAsync(resourceArray).toBlocking().single().getBody();
     }
 
     /**
@@ -287,6 +287,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
     /**
      * Put External Resource as an Array.
      *
+     * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putArrayAsync(List<ResourceInner> resourceArray) {
@@ -295,7 +296,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -359,7 +360,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public List<FlattenedProductInner> call(ServiceResponse<List<FlattenedProductInner>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -420,7 +421,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -452,7 +453,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void putDictionary(Map<String, FlattenedProductInner> resourceDictionary) throws ErrorException, IOException {
-        putDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
+        putDictionaryWithServiceResponseAsync(resourceDictionary).toBlocking().single().getBody();
     }
 
     /**
@@ -469,6 +470,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
     /**
      * Put External Resource as a Dictionary.
      *
+     * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDictionaryAsync(Map<String, FlattenedProductInner> resourceDictionary) {
@@ -477,7 +479,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -541,7 +543,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Map<String, FlattenedProductInner> call(ServiceResponse<Map<String, FlattenedProductInner>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -602,7 +604,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -634,7 +636,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void putResourceCollection(ResourceCollectionInner resourceComplexObject) throws ErrorException, IOException {
-        putResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
+        putResourceCollectionWithServiceResponseAsync(resourceComplexObject).toBlocking().single().getBody();
     }
 
     /**
@@ -651,6 +653,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
     /**
      * Put External Resource as a ResourceCollection.
      *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putResourceCollectionAsync(ResourceCollectionInner resourceComplexObject) {
@@ -659,7 +662,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -723,7 +726,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public ResourceCollectionInner call(ServiceResponse<ResourceCollectionInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -212,10 +212,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putArray() throws ErrorException, IOException {
-        return putArrayAsync().toBlocking().single();
+    public void putArray() throws ErrorException, IOException {
+        putArrayWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -225,7 +224,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayAsync(), serviceCallback);
+        return ServiceCall.create(putArrayWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -233,7 +232,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayAsync() {
+    public Observable<Void> putArrayAsync() {
+        return putArrayWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync() {
         final List<ResourceInner> resourceArray = null;
         return service.putArray(resourceArray, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -255,10 +268,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceArray External Resource as an Array to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putArray(List<ResourceInner> resourceArray) throws ErrorException, IOException {
-        return putArrayAsync(resourceArray).toBlocking().single();
+    public void putArray(List<ResourceInner> resourceArray) throws ErrorException, IOException {
+        putArrayWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -269,7 +281,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayAsync(List<ResourceInner> resourceArray, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayAsync(resourceArray), serviceCallback);
+        return ServiceCall.create(putArrayWithServiceResponseAsync(resourceArray), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putArrayAsync(List<ResourceInner> resourceArray) {
+        return putArrayWithServiceResponseAsync(resourceArray).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -278,7 +304,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayAsync(List<ResourceInner> resourceArray) {
+    public Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync(List<ResourceInner> resourceArray) {
         Validator.validate(resourceArray);
         return service.putArray(resourceArray, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -306,10 +332,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;FlattenedProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;FlattenedProductInner&gt; object if successful.
      */
-    public ServiceResponse<List<FlattenedProductInner>> getArray() throws ErrorException, IOException {
-        return getArrayAsync().toBlocking().single();
+    public List<FlattenedProductInner> getArray() throws ErrorException, IOException {
+        return getArrayWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -319,7 +345,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<FlattenedProductInner>> getArrayAsync(final ServiceCallback<List<FlattenedProductInner>> serviceCallback) {
-        return ServiceCall.create(getArrayAsync(), serviceCallback);
+        return ServiceCall.create(getArrayWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -327,7 +353,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the observable to the List&lt;FlattenedProductInner&gt; object
      */
-    public Observable<ServiceResponse<List<FlattenedProductInner>>> getArrayAsync() {
+    public Observable<List<FlattenedProductInner>> getArrayAsync() {
+        return getArrayWithServiceResponseAsync().map(new Func1<ServiceResponse<List<FlattenedProductInner>>, List<FlattenedProductInner>>() {
+            @Override
+            public List<FlattenedProductInner> call(ServiceResponse<List<FlattenedProductInner>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @return the observable to the List&lt;FlattenedProductInner&gt; object
+     */
+    public Observable<ServiceResponse<List<FlattenedProductInner>>> getArrayWithServiceResponseAsync() {
         return service.getArray(this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<FlattenedProductInner>>>>() {
                 @Override
@@ -354,10 +394,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDictionary() throws ErrorException, IOException {
-        return putDictionaryAsync().toBlocking().single();
+    public void putDictionary() throws ErrorException, IOException {
+        putDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -367,7 +406,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryAsync(), serviceCallback);
+        return ServiceCall.create(putDictionaryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -375,7 +414,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryAsync() {
+    public Observable<Void> putDictionaryAsync() {
+        return putDictionaryWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync() {
         final Map<String, FlattenedProductInner> resourceDictionary = null;
         return service.putDictionary(resourceDictionary, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -397,10 +450,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceDictionary External Resource as a Dictionary to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDictionary(Map<String, FlattenedProductInner> resourceDictionary) throws ErrorException, IOException {
-        return putDictionaryAsync(resourceDictionary).toBlocking().single();
+    public void putDictionary(Map<String, FlattenedProductInner> resourceDictionary) throws ErrorException, IOException {
+        putDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -411,7 +463,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryAsync(Map<String, FlattenedProductInner> resourceDictionary, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryAsync(resourceDictionary), serviceCallback);
+        return ServiceCall.create(putDictionaryWithServiceResponseAsync(resourceDictionary), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putDictionaryAsync(Map<String, FlattenedProductInner> resourceDictionary) {
+        return putDictionaryWithServiceResponseAsync(resourceDictionary).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -420,7 +486,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryAsync(Map<String, FlattenedProductInner> resourceDictionary) {
+    public Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync(Map<String, FlattenedProductInner> resourceDictionary) {
         Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -448,10 +514,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, FlattenedProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, FlattenedProductInner&gt; object if successful.
      */
-    public ServiceResponse<Map<String, FlattenedProductInner>> getDictionary() throws ErrorException, IOException {
-        return getDictionaryAsync().toBlocking().single();
+    public Map<String, FlattenedProductInner> getDictionary() throws ErrorException, IOException {
+        return getDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -461,7 +527,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, FlattenedProductInner>> getDictionaryAsync(final ServiceCallback<Map<String, FlattenedProductInner>> serviceCallback) {
-        return ServiceCall.create(getDictionaryAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -469,7 +535,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the observable to the Map&lt;String, FlattenedProductInner&gt; object
      */
-    public Observable<ServiceResponse<Map<String, FlattenedProductInner>>> getDictionaryAsync() {
+    public Observable<Map<String, FlattenedProductInner>> getDictionaryAsync() {
+        return getDictionaryWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, FlattenedProductInner>>, Map<String, FlattenedProductInner>>() {
+            @Override
+            public Map<String, FlattenedProductInner> call(ServiceResponse<Map<String, FlattenedProductInner>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @return the observable to the Map&lt;String, FlattenedProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, FlattenedProductInner>>> getDictionaryWithServiceResponseAsync() {
         return service.getDictionary(this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, FlattenedProductInner>>>>() {
                 @Override
@@ -496,10 +576,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putResourceCollection() throws ErrorException, IOException {
-        return putResourceCollectionAsync().toBlocking().single();
+    public void putResourceCollection() throws ErrorException, IOException {
+        putResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -509,7 +588,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putResourceCollectionAsync(), serviceCallback);
+        return ServiceCall.create(putResourceCollectionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -517,7 +596,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putResourceCollectionAsync() {
+    public Observable<Void> putResourceCollectionAsync() {
+        return putResourceCollectionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync() {
         final ResourceCollectionInner resourceComplexObject = null;
         return service.putResourceCollection(resourceComplexObject, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -539,10 +632,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putResourceCollection(ResourceCollectionInner resourceComplexObject) throws ErrorException, IOException {
-        return putResourceCollectionAsync(resourceComplexObject).toBlocking().single();
+    public void putResourceCollection(ResourceCollectionInner resourceComplexObject) throws ErrorException, IOException {
+        putResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -553,7 +645,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putResourceCollectionAsync(ResourceCollectionInner resourceComplexObject, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putResourceCollectionAsync(resourceComplexObject), serviceCallback);
+        return ServiceCall.create(putResourceCollectionWithServiceResponseAsync(resourceComplexObject), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putResourceCollectionAsync(ResourceCollectionInner resourceComplexObject) {
+        return putResourceCollectionWithServiceResponseAsync(resourceComplexObject).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -562,7 +668,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putResourceCollectionAsync(ResourceCollectionInner resourceComplexObject) {
+    public Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync(ResourceCollectionInner resourceComplexObject) {
         Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -590,10 +696,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ResourceCollectionInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ResourceCollectionInner object if successful.
      */
-    public ServiceResponse<ResourceCollectionInner> getResourceCollection() throws ErrorException, IOException {
-        return getResourceCollectionAsync().toBlocking().single();
+    public ResourceCollectionInner getResourceCollection() throws ErrorException, IOException {
+        return getResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -603,7 +709,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ResourceCollectionInner> getResourceCollectionAsync(final ServiceCallback<ResourceCollectionInner> serviceCallback) {
-        return ServiceCall.create(getResourceCollectionAsync(), serviceCallback);
+        return ServiceCall.create(getResourceCollectionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -611,7 +717,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the observable to the ResourceCollectionInner object
      */
-    public Observable<ServiceResponse<ResourceCollectionInner>> getResourceCollectionAsync() {
+    public Observable<ResourceCollectionInner> getResourceCollectionAsync() {
+        return getResourceCollectionWithServiceResponseAsync().map(new Func1<ServiceResponse<ResourceCollectionInner>, ResourceCollectionInner>() {
+            @Override
+            public ResourceCollectionInner call(ServiceResponse<ResourceCollectionInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @return the observable to the ResourceCollectionInner object
+     */
+    public Observable<ServiceResponse<ResourceCollectionInner>> getResourceCollectionWithServiceResponseAsync() {
         return service.getResourceCollection(this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ResourceCollectionInner>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsInner.java
@@ -77,10 +77,9 @@ public final class ApiVersionDefaultsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return getMethodGlobalValidAsync().toBlocking().single();
+    public void getMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        getMethodGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -90,7 +89,7 @@ public final class ApiVersionDefaultsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(getMethodGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -98,7 +97,21 @@ public final class ApiVersionDefaultsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodGlobalValidAsync() {
+    public Observable<Void> getMethodGlobalValidAsync() {
+        return getMethodGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodGlobalValidWithServiceResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
@@ -129,10 +142,9 @@ public final class ApiVersionDefaultsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException {
-        return getMethodGlobalNotProvidedValidAsync().toBlocking().single();
+    public void getMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException {
+        getMethodGlobalNotProvidedValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -142,7 +154,7 @@ public final class ApiVersionDefaultsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodGlobalNotProvidedValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodGlobalNotProvidedValidAsync(), serviceCallback);
+        return ServiceCall.create(getMethodGlobalNotProvidedValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -150,7 +162,21 @@ public final class ApiVersionDefaultsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodGlobalNotProvidedValidAsync() {
+    public Observable<Void> getMethodGlobalNotProvidedValidAsync() {
+        return getMethodGlobalNotProvidedValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodGlobalNotProvidedValidWithServiceResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
@@ -181,10 +207,9 @@ public final class ApiVersionDefaultsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return getPathGlobalValidAsync().toBlocking().single();
+    public void getPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        getPathGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -194,7 +219,7 @@ public final class ApiVersionDefaultsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getPathGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getPathGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(getPathGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -202,7 +227,21 @@ public final class ApiVersionDefaultsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getPathGlobalValidAsync() {
+    public Observable<Void> getPathGlobalValidAsync() {
+        return getPathGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getPathGlobalValidWithServiceResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
@@ -233,10 +272,9 @@ public final class ApiVersionDefaultsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return getSwaggerGlobalValidAsync().toBlocking().single();
+    public void getSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        getSwaggerGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -246,7 +284,7 @@ public final class ApiVersionDefaultsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getSwaggerGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getSwaggerGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(getSwaggerGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -254,7 +292,21 @@ public final class ApiVersionDefaultsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getSwaggerGlobalValidAsync() {
+    public Observable<Void> getSwaggerGlobalValidAsync() {
+        return getSwaggerGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getSwaggerGlobalValidWithServiceResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsInner.java
@@ -103,7 +103,7 @@ public final class ApiVersionDefaultsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -168,7 +168,7 @@ public final class ApiVersionDefaultsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -233,7 +233,7 @@ public final class ApiVersionDefaultsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -298,7 +298,7 @@ public final class ApiVersionDefaultsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsInner.java
@@ -76,10 +76,9 @@ public final class ApiVersionLocalsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodLocalValid() throws ErrorException, IOException {
-        return getMethodLocalValidAsync().toBlocking().single();
+    public void getMethodLocalValid() throws ErrorException, IOException {
+        getMethodLocalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -89,7 +88,7 @@ public final class ApiVersionLocalsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodLocalValidAsync(), serviceCallback);
+        return ServiceCall.create(getMethodLocalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -97,7 +96,21 @@ public final class ApiVersionLocalsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodLocalValidAsync() {
+    public Observable<Void> getMethodLocalValidAsync() {
+        return getMethodLocalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodLocalValidWithServiceResponseAsync() {
         final String apiVersion = "2.0";
         return service.getMethodLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -125,10 +138,9 @@ public final class ApiVersionLocalsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodLocalNull() throws ErrorException, IOException {
-        return getMethodLocalNullAsync().toBlocking().single();
+    public void getMethodLocalNull() throws ErrorException, IOException {
+        getMethodLocalNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -138,7 +150,7 @@ public final class ApiVersionLocalsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodLocalNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodLocalNullAsync(), serviceCallback);
+        return ServiceCall.create(getMethodLocalNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -146,7 +158,21 @@ public final class ApiVersionLocalsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodLocalNullAsync() {
+    public Observable<Void> getMethodLocalNullAsync() {
+        return getMethodLocalNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodLocalNullWithServiceResponseAsync() {
         final String apiVersion = null;
         return service.getMethodLocalNull(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -168,10 +194,9 @@ public final class ApiVersionLocalsInner {
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodLocalNull(String apiVersion) throws ErrorException, IOException {
-        return getMethodLocalNullAsync(apiVersion).toBlocking().single();
+    public void getMethodLocalNull(String apiVersion) throws ErrorException, IOException {
+        getMethodLocalNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -182,7 +207,21 @@ public final class ApiVersionLocalsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodLocalNullAsync(String apiVersion, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodLocalNullAsync(apiVersion), serviceCallback);
+        return ServiceCall.create(getMethodLocalNullWithServiceResponseAsync(apiVersion), serviceCallback);
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getMethodLocalNullAsync(String apiVersion) {
+        return getMethodLocalNullWithServiceResponseAsync(apiVersion).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -191,7 +230,7 @@ public final class ApiVersionLocalsInner {
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodLocalNullAsync(String apiVersion) {
+    public Observable<ServiceResponse<Void>> getMethodLocalNullWithServiceResponseAsync(String apiVersion) {
         return service.getMethodLocalNull(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -218,10 +257,9 @@ public final class ApiVersionLocalsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getPathLocalValid() throws ErrorException, IOException {
-        return getPathLocalValidAsync().toBlocking().single();
+    public void getPathLocalValid() throws ErrorException, IOException {
+        getPathLocalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -231,7 +269,7 @@ public final class ApiVersionLocalsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getPathLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getPathLocalValidAsync(), serviceCallback);
+        return ServiceCall.create(getPathLocalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -239,7 +277,21 @@ public final class ApiVersionLocalsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getPathLocalValidAsync() {
+    public Observable<Void> getPathLocalValidAsync() {
+        return getPathLocalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getPathLocalValidWithServiceResponseAsync() {
         final String apiVersion = "2.0";
         return service.getPathLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -267,10 +319,9 @@ public final class ApiVersionLocalsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getSwaggerLocalValid() throws ErrorException, IOException {
-        return getSwaggerLocalValidAsync().toBlocking().single();
+    public void getSwaggerLocalValid() throws ErrorException, IOException {
+        getSwaggerLocalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -280,7 +331,7 @@ public final class ApiVersionLocalsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getSwaggerLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getSwaggerLocalValidAsync(), serviceCallback);
+        return ServiceCall.create(getSwaggerLocalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -288,7 +339,21 @@ public final class ApiVersionLocalsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getSwaggerLocalValidAsync() {
+    public Observable<Void> getSwaggerLocalValidAsync() {
+        return getSwaggerLocalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getSwaggerLocalValidWithServiceResponseAsync() {
         final String apiVersion = "2.0";
         return service.getSwaggerLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsInner.java
@@ -102,7 +102,7 @@ public final class ApiVersionLocalsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -164,7 +164,7 @@ public final class ApiVersionLocalsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -196,7 +196,7 @@ public final class ApiVersionLocalsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void getMethodLocalNull(String apiVersion) throws ErrorException, IOException {
-        getMethodLocalNullWithServiceResponseAsync().toBlocking().single().getBody();
+        getMethodLocalNullWithServiceResponseAsync(apiVersion).toBlocking().single().getBody();
     }
 
     /**
@@ -213,6 +213,7 @@ public final class ApiVersionLocalsInner {
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
+     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getMethodLocalNullAsync(String apiVersion) {
@@ -221,7 +222,7 @@ public final class ApiVersionLocalsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -283,7 +284,7 @@ public final class ApiVersionLocalsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -345,7 +346,7 @@ public final class ApiVersionLocalsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/HeadersInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/HeadersInner.java
@@ -70,10 +70,9 @@ public final class HeadersInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeadersInner> customNamedRequestId(String fooClientRequestId) throws ErrorException, IOException, IllegalArgumentException {
-        return customNamedRequestIdAsync(fooClientRequestId).toBlocking().single();
+    public void customNamedRequestId(String fooClientRequestId) throws ErrorException, IOException, IllegalArgumentException {
+        customNamedRequestIdWithServiceResponseAsync(fooClientRequestId).toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +83,7 @@ public final class HeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> customNamedRequestIdAsync(String fooClientRequestId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(customNamedRequestIdAsync(fooClientRequestId), serviceCallback);
+        return ServiceCall.createWithHeaders(customNamedRequestIdWithServiceResponseAsync(fooClientRequestId), serviceCallback);
     }
 
     /**
@@ -93,7 +92,22 @@ public final class HeadersInner {
      * @param fooClientRequestId The fooRequestId
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeadersInner>> customNamedRequestIdAsync(String fooClientRequestId) {
+    public Observable<Void> customNamedRequestIdAsync(String fooClientRequestId) {
+        return customNamedRequestIdWithServiceResponseAsync(fooClientRequestId).map(new Func1<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeadersInner>> customNamedRequestIdWithServiceResponseAsync(String fooClientRequestId) {
         if (fooClientRequestId == null) {
             throw new IllegalArgumentException("Parameter fooClientRequestId is required and cannot be null.");
         }
@@ -125,10 +139,9 @@ public final class HeadersInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeadersInner> customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) throws ErrorException, IOException, IllegalArgumentException {
-        return customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters).toBlocking().single();
+    public void customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) throws ErrorException, IOException, IllegalArgumentException {
+        customNamedRequestIdParamGroupingWithServiceResponseAsync(headerCustomNamedRequestIdParamGroupingParameters).toBlocking().single().getBody();
     }
 
     /**
@@ -139,7 +152,7 @@ public final class HeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters), serviceCallback);
+        return ServiceCall.createWithHeaders(customNamedRequestIdParamGroupingWithServiceResponseAsync(headerCustomNamedRequestIdParamGroupingParameters), serviceCallback);
     }
 
     /**
@@ -148,7 +161,22 @@ public final class HeadersInner {
      * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeadersInner>> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) {
+    public Observable<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) {
+        return customNamedRequestIdParamGroupingWithServiceResponseAsync(headerCustomNamedRequestIdParamGroupingParameters).map(new Func1<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
+     *
+     * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeadersInner>> customNamedRequestIdParamGroupingWithServiceResponseAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) {
         if (headerCustomNamedRequestIdParamGroupingParameters == null) {
             throw new IllegalArgumentException("Parameter headerCustomNamedRequestIdParamGroupingParameters is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/HeadersInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/HeadersInner.java
@@ -98,7 +98,7 @@ public final class HeadersInner {
             public Void call(ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -167,7 +167,7 @@ public final class HeadersInner {
             public Void call(ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/OdatasInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/OdatasInner.java
@@ -64,10 +64,9 @@ public final class OdatasInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getWithFilter() throws ErrorException, IOException {
-        return getWithFilterAsync().toBlocking().single();
+    public void getWithFilter() throws ErrorException, IOException {
+        getWithFilterWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -77,7 +76,7 @@ public final class OdatasInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getWithFilterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getWithFilterAsync(), serviceCallback);
+        return ServiceCall.create(getWithFilterWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -85,7 +84,21 @@ public final class OdatasInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getWithFilterAsync() {
+    public Observable<Void> getWithFilterAsync() {
+        return getWithFilterWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getWithFilterWithServiceResponseAsync() {
         final String filter = null;
         final Integer top = null;
         final String orderby = null;
@@ -111,10 +124,9 @@ public final class OdatasInner {
      * @param orderby The orderby parameter with value id.
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException {
-        return getWithFilterAsync(filter, top, orderby).toBlocking().single();
+    public void getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException {
+        getWithFilterWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -127,7 +139,21 @@ public final class OdatasInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getWithFilterAsync(String filter, Integer top, String orderby, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getWithFilterAsync(filter, top, orderby), serviceCallback);
+        return ServiceCall.create(getWithFilterWithServiceResponseAsync(filter, top, orderby), serviceCallback);
+    }
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getWithFilterAsync(String filter, Integer top, String orderby) {
+        return getWithFilterWithServiceResponseAsync(filter, top, orderby).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -138,7 +164,7 @@ public final class OdatasInner {
      * @param orderby The orderby parameter with value id.
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getWithFilterAsync(String filter, Integer top, String orderby) {
+    public Observable<ServiceResponse<Void>> getWithFilterWithServiceResponseAsync(String filter, Integer top, String orderby) {
         return service.getWithFilter(filter, top, orderby, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/OdatasInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/OdatasInner.java
@@ -90,7 +90,7 @@ public final class OdatasInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -126,7 +126,7 @@ public final class OdatasInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException {
-        getWithFilterWithServiceResponseAsync().toBlocking().single().getBody();
+        getWithFilterWithServiceResponseAsync(filter, top, orderby).toBlocking().single().getBody();
     }
 
     /**
@@ -145,6 +145,9 @@ public final class OdatasInner {
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
+     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
+     * @param top The top parameter with value 10.
+     * @param orderby The orderby parameter with value id.
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getWithFilterAsync(String filter, Integer top, String orderby) {
@@ -153,7 +156,7 @@ public final class OdatasInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsInner.java
@@ -91,10 +91,9 @@ public final class SkipUrlEncodingsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException {
-        return getMethodPathValidAsync(unencodedPathParam).toBlocking().single();
+    public void getMethodPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException {
+        getMethodPathValidWithServiceResponseAsync(unencodedPathParam).toBlocking().single().getBody();
     }
 
     /**
@@ -105,7 +104,7 @@ public final class SkipUrlEncodingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodPathValidAsync(String unencodedPathParam, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodPathValidAsync(unencodedPathParam), serviceCallback);
+        return ServiceCall.create(getMethodPathValidWithServiceResponseAsync(unencodedPathParam), serviceCallback);
     }
 
     /**
@@ -114,7 +113,22 @@ public final class SkipUrlEncodingsInner {
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodPathValidAsync(String unencodedPathParam) {
+    public Observable<Void> getMethodPathValidAsync(String unencodedPathParam) {
+        return getMethodPathValidWithServiceResponseAsync(unencodedPathParam).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodPathValidWithServiceResponseAsync(String unencodedPathParam) {
         if (unencodedPathParam == null) {
             throw new IllegalArgumentException("Parameter unencodedPathParam is required and cannot be null.");
         }
@@ -146,10 +160,9 @@ public final class SkipUrlEncodingsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getPathPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException {
-        return getPathPathValidAsync(unencodedPathParam).toBlocking().single();
+    public void getPathPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException {
+        getPathPathValidWithServiceResponseAsync(unencodedPathParam).toBlocking().single().getBody();
     }
 
     /**
@@ -160,7 +173,7 @@ public final class SkipUrlEncodingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getPathPathValidAsync(String unencodedPathParam, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getPathPathValidAsync(unencodedPathParam), serviceCallback);
+        return ServiceCall.create(getPathPathValidWithServiceResponseAsync(unencodedPathParam), serviceCallback);
     }
 
     /**
@@ -169,7 +182,22 @@ public final class SkipUrlEncodingsInner {
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getPathPathValidAsync(String unencodedPathParam) {
+    public Observable<Void> getPathPathValidAsync(String unencodedPathParam) {
+        return getPathPathValidWithServiceResponseAsync(unencodedPathParam).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getPathPathValidWithServiceResponseAsync(String unencodedPathParam) {
         if (unencodedPathParam == null) {
             throw new IllegalArgumentException("Parameter unencodedPathParam is required and cannot be null.");
         }
@@ -199,10 +227,9 @@ public final class SkipUrlEncodingsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getSwaggerPathValid() throws ErrorException, IOException {
-        return getSwaggerPathValidAsync().toBlocking().single();
+    public void getSwaggerPathValid() throws ErrorException, IOException {
+        getSwaggerPathValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -212,7 +239,7 @@ public final class SkipUrlEncodingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getSwaggerPathValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getSwaggerPathValidAsync(), serviceCallback);
+        return ServiceCall.create(getSwaggerPathValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -220,7 +247,21 @@ public final class SkipUrlEncodingsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getSwaggerPathValidAsync() {
+    public Observable<Void> getSwaggerPathValidAsync() {
+        return getSwaggerPathValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getSwaggerPathValidWithServiceResponseAsync() {
         final String unencodedPathParam = "path1/path2/path3";
         return service.getSwaggerPathValid(unencodedPathParam, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -250,10 +291,9 @@ public final class SkipUrlEncodingsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException {
-        return getMethodQueryValidAsync(q1).toBlocking().single();
+    public void getMethodQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException {
+        getMethodQueryValidWithServiceResponseAsync(q1).toBlocking().single().getBody();
     }
 
     /**
@@ -264,7 +304,7 @@ public final class SkipUrlEncodingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodQueryValidAsync(String q1, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodQueryValidAsync(q1), serviceCallback);
+        return ServiceCall.create(getMethodQueryValidWithServiceResponseAsync(q1), serviceCallback);
     }
 
     /**
@@ -273,7 +313,22 @@ public final class SkipUrlEncodingsInner {
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodQueryValidAsync(String q1) {
+    public Observable<Void> getMethodQueryValidAsync(String q1) {
+        return getMethodQueryValidWithServiceResponseAsync(q1).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodQueryValidWithServiceResponseAsync(String q1) {
         if (q1 == null) {
             throw new IllegalArgumentException("Parameter q1 is required and cannot be null.");
         }
@@ -303,10 +358,9 @@ public final class SkipUrlEncodingsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodQueryNull() throws ErrorException, IOException {
-        return getMethodQueryNullAsync().toBlocking().single();
+    public void getMethodQueryNull() throws ErrorException, IOException {
+        getMethodQueryNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -316,7 +370,7 @@ public final class SkipUrlEncodingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodQueryNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodQueryNullAsync(), serviceCallback);
+        return ServiceCall.create(getMethodQueryNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -324,7 +378,21 @@ public final class SkipUrlEncodingsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodQueryNullAsync() {
+    public Observable<Void> getMethodQueryNullAsync() {
+        return getMethodQueryNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodQueryNullWithServiceResponseAsync() {
         final String q1 = null;
         return service.getMethodQueryNull(q1, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -346,10 +414,9 @@ public final class SkipUrlEncodingsInner {
      * @param q1 Unencoded query parameter with value null
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodQueryNull(String q1) throws ErrorException, IOException {
-        return getMethodQueryNullAsync(q1).toBlocking().single();
+    public void getMethodQueryNull(String q1) throws ErrorException, IOException {
+        getMethodQueryNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -360,7 +427,21 @@ public final class SkipUrlEncodingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodQueryNullAsync(String q1, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodQueryNullAsync(q1), serviceCallback);
+        return ServiceCall.create(getMethodQueryNullWithServiceResponseAsync(q1), serviceCallback);
+    }
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getMethodQueryNullAsync(String q1) {
+        return getMethodQueryNullWithServiceResponseAsync(q1).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -369,7 +450,7 @@ public final class SkipUrlEncodingsInner {
      * @param q1 Unencoded query parameter with value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodQueryNullAsync(String q1) {
+    public Observable<ServiceResponse<Void>> getMethodQueryNullWithServiceResponseAsync(String q1) {
         return service.getMethodQueryNull(q1, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -398,10 +479,9 @@ public final class SkipUrlEncodingsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getPathQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException {
-        return getPathQueryValidAsync(q1).toBlocking().single();
+    public void getPathQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException {
+        getPathQueryValidWithServiceResponseAsync(q1).toBlocking().single().getBody();
     }
 
     /**
@@ -412,7 +492,7 @@ public final class SkipUrlEncodingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getPathQueryValidAsync(String q1, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getPathQueryValidAsync(q1), serviceCallback);
+        return ServiceCall.create(getPathQueryValidWithServiceResponseAsync(q1), serviceCallback);
     }
 
     /**
@@ -421,7 +501,22 @@ public final class SkipUrlEncodingsInner {
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getPathQueryValidAsync(String q1) {
+    public Observable<Void> getPathQueryValidAsync(String q1) {
+        return getPathQueryValidWithServiceResponseAsync(q1).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getPathQueryValidWithServiceResponseAsync(String q1) {
         if (q1 == null) {
             throw new IllegalArgumentException("Parameter q1 is required and cannot be null.");
         }
@@ -451,10 +546,9 @@ public final class SkipUrlEncodingsInner {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getSwaggerQueryValid() throws ErrorException, IOException {
-        return getSwaggerQueryValidAsync().toBlocking().single();
+    public void getSwaggerQueryValid() throws ErrorException, IOException {
+        getSwaggerQueryValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -464,7 +558,7 @@ public final class SkipUrlEncodingsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getSwaggerQueryValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getSwaggerQueryValidAsync(), serviceCallback);
+        return ServiceCall.create(getSwaggerQueryValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -472,7 +566,21 @@ public final class SkipUrlEncodingsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getSwaggerQueryValidAsync() {
+    public Observable<Void> getSwaggerQueryValidAsync() {
+        return getSwaggerQueryValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getSwaggerQueryValidWithServiceResponseAsync() {
         final String q1 = "value1&q2=value2&q3=value3";
         return service.getSwaggerQueryValid(q1, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsInner.java
@@ -119,7 +119,7 @@ public final class SkipUrlEncodingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -188,7 +188,7 @@ public final class SkipUrlEncodingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -253,7 +253,7 @@ public final class SkipUrlEncodingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -319,7 +319,7 @@ public final class SkipUrlEncodingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -384,7 +384,7 @@ public final class SkipUrlEncodingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -416,7 +416,7 @@ public final class SkipUrlEncodingsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void getMethodQueryNull(String q1) throws ErrorException, IOException {
-        getMethodQueryNullWithServiceResponseAsync().toBlocking().single().getBody();
+        getMethodQueryNullWithServiceResponseAsync(q1).toBlocking().single().getBody();
     }
 
     /**
@@ -433,6 +433,7 @@ public final class SkipUrlEncodingsInner {
     /**
      * Get method with unencoded query parameter with value null.
      *
+     * @param q1 Unencoded query parameter with value null
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getMethodQueryNullAsync(String q1) {
@@ -441,7 +442,7 @@ public final class SkipUrlEncodingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -507,7 +508,7 @@ public final class SkipUrlEncodingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -572,7 +573,7 @@ public final class SkipUrlEncodingsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsInner.java
@@ -108,7 +108,7 @@ public final class SubscriptionInCredentialsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -173,7 +173,7 @@ public final class SubscriptionInCredentialsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -238,7 +238,7 @@ public final class SubscriptionInCredentialsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -306,7 +306,7 @@ public final class SubscriptionInCredentialsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -371,7 +371,7 @@ public final class SubscriptionInCredentialsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsInner.java
@@ -82,10 +82,9 @@ public final class SubscriptionInCredentialsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodGlobalValidAsync().toBlocking().single();
+    public void postMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        postMethodGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -95,7 +94,7 @@ public final class SubscriptionInCredentialsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(postMethodGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -103,7 +102,21 @@ public final class SubscriptionInCredentialsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodGlobalValidAsync() {
+    public Observable<Void> postMethodGlobalValidAsync() {
+        return postMethodGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodGlobalValidWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -134,10 +147,9 @@ public final class SubscriptionInCredentialsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodGlobalNull() throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodGlobalNullAsync().toBlocking().single();
+    public void postMethodGlobalNull() throws ErrorException, IOException, IllegalArgumentException {
+        postMethodGlobalNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -147,7 +159,7 @@ public final class SubscriptionInCredentialsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodGlobalNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodGlobalNullAsync(), serviceCallback);
+        return ServiceCall.create(postMethodGlobalNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -155,7 +167,21 @@ public final class SubscriptionInCredentialsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodGlobalNullAsync() {
+    public Observable<Void> postMethodGlobalNullAsync() {
+        return postMethodGlobalNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodGlobalNullWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -186,10 +212,9 @@ public final class SubscriptionInCredentialsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodGlobalNotProvidedValidAsync().toBlocking().single();
+    public void postMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException {
+        postMethodGlobalNotProvidedValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -199,7 +224,7 @@ public final class SubscriptionInCredentialsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodGlobalNotProvidedValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodGlobalNotProvidedValidAsync(), serviceCallback);
+        return ServiceCall.create(postMethodGlobalNotProvidedValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -207,7 +232,21 @@ public final class SubscriptionInCredentialsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodGlobalNotProvidedValidAsync() {
+    public Observable<Void> postMethodGlobalNotProvidedValidAsync() {
+        return postMethodGlobalNotProvidedValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodGlobalNotProvidedValidWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -241,10 +280,9 @@ public final class SubscriptionInCredentialsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return postPathGlobalValidAsync().toBlocking().single();
+    public void postPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        postPathGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -254,7 +292,7 @@ public final class SubscriptionInCredentialsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postPathGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postPathGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(postPathGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -262,7 +300,21 @@ public final class SubscriptionInCredentialsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postPathGlobalValidAsync() {
+    public Observable<Void> postPathGlobalValidAsync() {
+        return postPathGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postPathGlobalValidWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -293,10 +345,9 @@ public final class SubscriptionInCredentialsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return postSwaggerGlobalValidAsync().toBlocking().single();
+    public void postSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        postSwaggerGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -306,7 +357,7 @@ public final class SubscriptionInCredentialsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postSwaggerGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postSwaggerGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(postSwaggerGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -314,7 +365,21 @@ public final class SubscriptionInCredentialsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postSwaggerGlobalValidAsync() {
+    public Observable<Void> postSwaggerGlobalValidAsync() {
+        return postSwaggerGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postSwaggerGlobalValidWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsInner.java
@@ -78,10 +78,9 @@ public final class SubscriptionInMethodsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodLocalValidAsync(subscriptionId).toBlocking().single();
+    public void postMethodLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
+        postMethodLocalValidWithServiceResponseAsync(subscriptionId).toBlocking().single().getBody();
     }
 
     /**
@@ -92,7 +91,7 @@ public final class SubscriptionInMethodsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodLocalValidAsync(subscriptionId), serviceCallback);
+        return ServiceCall.create(postMethodLocalValidWithServiceResponseAsync(subscriptionId), serviceCallback);
     }
 
     /**
@@ -101,7 +100,22 @@ public final class SubscriptionInMethodsInner {
      * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodLocalValidAsync(String subscriptionId) {
+    public Observable<Void> postMethodLocalValidAsync(String subscriptionId) {
+        return postMethodLocalValidWithServiceResponseAsync(subscriptionId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodLocalValidWithServiceResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
@@ -133,10 +147,9 @@ public final class SubscriptionInMethodsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodLocalNull(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodLocalNullAsync(subscriptionId).toBlocking().single();
+    public void postMethodLocalNull(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
+        postMethodLocalNullWithServiceResponseAsync(subscriptionId).toBlocking().single().getBody();
     }
 
     /**
@@ -147,7 +160,7 @@ public final class SubscriptionInMethodsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodLocalNullAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodLocalNullAsync(subscriptionId), serviceCallback);
+        return ServiceCall.create(postMethodLocalNullWithServiceResponseAsync(subscriptionId), serviceCallback);
     }
 
     /**
@@ -156,7 +169,22 @@ public final class SubscriptionInMethodsInner {
      * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodLocalNullAsync(String subscriptionId) {
+    public Observable<Void> postMethodLocalNullAsync(String subscriptionId) {
+        return postMethodLocalNullWithServiceResponseAsync(subscriptionId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodLocalNullWithServiceResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
@@ -188,10 +216,9 @@ public final class SubscriptionInMethodsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postPathLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
-        return postPathLocalValidAsync(subscriptionId).toBlocking().single();
+    public void postPathLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
+        postPathLocalValidWithServiceResponseAsync(subscriptionId).toBlocking().single().getBody();
     }
 
     /**
@@ -202,7 +229,7 @@ public final class SubscriptionInMethodsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postPathLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postPathLocalValidAsync(subscriptionId), serviceCallback);
+        return ServiceCall.create(postPathLocalValidWithServiceResponseAsync(subscriptionId), serviceCallback);
     }
 
     /**
@@ -211,7 +238,22 @@ public final class SubscriptionInMethodsInner {
      * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postPathLocalValidAsync(String subscriptionId) {
+    public Observable<Void> postPathLocalValidAsync(String subscriptionId) {
+        return postPathLocalValidWithServiceResponseAsync(subscriptionId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postPathLocalValidWithServiceResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
@@ -243,10 +285,9 @@ public final class SubscriptionInMethodsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postSwaggerLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
-        return postSwaggerLocalValidAsync(subscriptionId).toBlocking().single();
+    public void postSwaggerLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
+        postSwaggerLocalValidWithServiceResponseAsync(subscriptionId).toBlocking().single().getBody();
     }
 
     /**
@@ -257,7 +298,7 @@ public final class SubscriptionInMethodsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postSwaggerLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postSwaggerLocalValidAsync(subscriptionId), serviceCallback);
+        return ServiceCall.create(postSwaggerLocalValidWithServiceResponseAsync(subscriptionId), serviceCallback);
     }
 
     /**
@@ -266,7 +307,22 @@ public final class SubscriptionInMethodsInner {
      * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postSwaggerLocalValidAsync(String subscriptionId) {
+    public Observable<Void> postSwaggerLocalValidAsync(String subscriptionId) {
+        return postSwaggerLocalValidWithServiceResponseAsync(subscriptionId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postSwaggerLocalValidWithServiceResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsInner.java
@@ -106,7 +106,7 @@ public final class SubscriptionInMethodsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -175,7 +175,7 @@ public final class SubscriptionInMethodsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -244,7 +244,7 @@ public final class SubscriptionInMethodsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -313,7 +313,7 @@ public final class SubscriptionInMethodsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsInner.java
@@ -68,10 +68,9 @@ public final class XMsClientRequestIdsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get() throws CloudException, IOException {
-        return getAsync().toBlocking().single();
+    public void get() throws CloudException, IOException {
+        getWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -81,7 +80,7 @@ public final class XMsClientRequestIdsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getAsync(), serviceCallback);
+        return ServiceCall.create(getWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -89,7 +88,21 @@ public final class XMsClientRequestIdsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getAsync() {
+    public Observable<Void> getAsync() {
+        return getWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getWithServiceResponseAsync() {
         return service.get(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -117,10 +130,9 @@ public final class XMsClientRequestIdsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramGet(String xMsClientRequestId) throws ErrorException, IOException, IllegalArgumentException {
-        return paramGetAsync(xMsClientRequestId).toBlocking().single();
+    public void paramGet(String xMsClientRequestId) throws ErrorException, IOException, IllegalArgumentException {
+        paramGetWithServiceResponseAsync(xMsClientRequestId).toBlocking().single().getBody();
     }
 
     /**
@@ -131,7 +143,7 @@ public final class XMsClientRequestIdsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramGetAsync(String xMsClientRequestId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramGetAsync(xMsClientRequestId), serviceCallback);
+        return ServiceCall.create(paramGetWithServiceResponseAsync(xMsClientRequestId), serviceCallback);
     }
 
     /**
@@ -140,7 +152,22 @@ public final class XMsClientRequestIdsInner {
      * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramGetAsync(String xMsClientRequestId) {
+    public Observable<Void> paramGetAsync(String xMsClientRequestId) {
+        return paramGetWithServiceResponseAsync(xMsClientRequestId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramGetWithServiceResponseAsync(String xMsClientRequestId) {
         if (xMsClientRequestId == null) {
             throw new IllegalArgumentException("Parameter xMsClientRequestId is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsInner.java
@@ -94,7 +94,7 @@ public final class XMsClientRequestIdsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -158,7 +158,7 @@ public final class XMsClientRequestIdsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsInner.java
@@ -66,10 +66,9 @@ public final class PathsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException {
-        return getEmptyAsync(accountName).toBlocking().single();
+    public void getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException {
+        getEmptyWithServiceResponseAsync(accountName).toBlocking().single().getBody();
     }
 
     /**
@@ -80,7 +79,7 @@ public final class PathsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getEmptyAsync(String accountName, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(accountName), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(accountName), serviceCallback);
     }
 
     /**
@@ -89,7 +88,22 @@ public final class PathsInner {
      * @param accountName Account Name
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getEmptyAsync(String accountName) {
+    public Observable<Void> getEmptyAsync(String accountName) {
+        return getEmptyWithServiceResponseAsync(accountName).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String accountName) {
         if (accountName == null) {
             throw new IllegalArgumentException("Parameter accountName is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsInner.java
@@ -94,7 +94,7 @@ public final class PathsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/head/implementation/HttpSuccessInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/head/implementation/HttpSuccessInner.java
@@ -70,10 +70,10 @@ public final class HttpSuccessInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
-    public ServiceResponse<Boolean> head200() throws CloudException, IOException {
-        return head200Async().toBlocking().single();
+    public boolean head200() throws CloudException, IOException {
+        return head200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -83,7 +83,7 @@ public final class HttpSuccessInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> head200Async(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(head200Async(), serviceCallback);
+        return ServiceCall.create(head200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -91,7 +91,21 @@ public final class HttpSuccessInner {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> head200Async() {
+    public Observable<Boolean> head200Async() {
+        return head200WithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> head200WithServiceResponseAsync() {
         return service.head200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -119,10 +133,10 @@ public final class HttpSuccessInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
-    public ServiceResponse<Boolean> head204() throws CloudException, IOException {
-        return head204Async().toBlocking().single();
+    public boolean head204() throws CloudException, IOException {
+        return head204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -132,7 +146,7 @@ public final class HttpSuccessInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> head204Async(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(head204Async(), serviceCallback);
+        return ServiceCall.create(head204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -140,7 +154,21 @@ public final class HttpSuccessInner {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> head204Async() {
+    public Observable<Boolean> head204Async() {
+        return head204WithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> head204WithServiceResponseAsync() {
         return service.head204(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -168,10 +196,10 @@ public final class HttpSuccessInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
-    public ServiceResponse<Boolean> head404() throws CloudException, IOException {
-        return head404Async().toBlocking().single();
+    public boolean head404() throws CloudException, IOException {
+        return head404WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -181,7 +209,7 @@ public final class HttpSuccessInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> head404Async(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(head404Async(), serviceCallback);
+        return ServiceCall.create(head404WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -189,7 +217,21 @@ public final class HttpSuccessInner {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> head404Async() {
+    public Observable<Boolean> head404Async() {
+        return head404WithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> head404WithServiceResponseAsync() {
         return service.head404(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Boolean>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/head/implementation/HttpSuccessInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/head/implementation/HttpSuccessInner.java
@@ -97,7 +97,7 @@ public final class HttpSuccessInner {
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -160,7 +160,7 @@ public final class HttpSuccessInner {
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -223,7 +223,7 @@ public final class HttpSuccessInner {
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsInner.java
@@ -96,7 +96,7 @@ public final class HeadExceptionsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -156,7 +156,7 @@ public final class HeadExceptionsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -216,7 +216,7 @@ public final class HeadExceptionsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsInner.java
@@ -70,10 +70,9 @@ public final class HeadExceptionsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head200() throws CloudException, IOException {
-        return head200Async().toBlocking().single();
+    public void head200() throws CloudException, IOException {
+        head200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -83,7 +82,7 @@ public final class HeadExceptionsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head200Async(), serviceCallback);
+        return ServiceCall.create(head200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -91,7 +90,21 @@ public final class HeadExceptionsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head200Async() {
+    public Observable<Void> head200Async() {
+        return head200WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head200WithServiceResponseAsync() {
         return service.head200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -117,10 +130,9 @@ public final class HeadExceptionsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head204() throws CloudException, IOException {
-        return head204Async().toBlocking().single();
+    public void head204() throws CloudException, IOException {
+        head204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -130,7 +142,7 @@ public final class HeadExceptionsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head204Async(), serviceCallback);
+        return ServiceCall.create(head204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -138,7 +150,21 @@ public final class HeadExceptionsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head204Async() {
+    public Observable<Void> head204Async() {
+        return head204WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head204WithServiceResponseAsync() {
         return service.head204(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -164,10 +190,9 @@ public final class HeadExceptionsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head404() throws CloudException, IOException {
-        return head404Async().toBlocking().single();
+    public void head404() throws CloudException, IOException {
+        head404WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -177,7 +202,7 @@ public final class HeadExceptionsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head404Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head404Async(), serviceCallback);
+        return ServiceCall.create(head404WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -185,7 +210,21 @@ public final class HeadExceptionsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head404Async() {
+    public Observable<Void> head404Async() {
+        return head404WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head404WithServiceResponseAsync() {
         return service.head404(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LRORetrysInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LRORetrysInner.java
@@ -171,7 +171,7 @@ public final class LRORetrysInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -244,7 +244,7 @@ public final class LRORetrysInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -277,7 +277,7 @@ public final class LRORetrysInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -294,6 +294,7 @@ public final class LRORetrysInner {
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product) {
@@ -302,7 +303,7 @@ public final class LRORetrysInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -391,7 +392,7 @@ public final class LRORetrysInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -464,7 +465,7 @@ public final class LRORetrysInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -497,7 +498,7 @@ public final class LRORetrysInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -514,6 +515,7 @@ public final class LRORetrysInner {
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRelativeRetrySucceededAsync(ProductInner product) {
@@ -522,7 +524,7 @@ public final class LRORetrysInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -632,7 +634,7 @@ public final class LRORetrysInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -739,7 +741,7 @@ public final class LRORetrysInner {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -845,7 +847,7 @@ public final class LRORetrysInner {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -929,7 +931,7 @@ public final class LRORetrysInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
+        post202Retry200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1001,7 +1003,7 @@ public final class LRORetrysInner {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1033,7 +1035,7 @@ public final class LRORetrysInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202Retry200(ProductInner product) throws CloudException, IOException {
-        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202Retry200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1050,6 +1052,7 @@ public final class LRORetrysInner {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202Retry200Async(ProductInner product) {
@@ -1058,7 +1061,7 @@ public final class LRORetrysInner {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1144,7 +1147,7 @@ public final class LRORetrysInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1216,7 +1219,7 @@ public final class LRORetrysInner {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1248,7 +1251,7 @@ public final class LRORetrysInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1265,6 +1268,7 @@ public final class LRORetrysInner {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetrySucceededAsync(ProductInner product) {
@@ -1273,7 +1277,7 @@ public final class LRORetrysInner {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LRORetrysInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LRORetrysInner.java
@@ -121,10 +121,10 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async().toBlocking().last();
+    public ProductInner put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -134,7 +134,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -142,7 +142,21 @@ public final class LRORetrysInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200Async() {
+    public Observable<ProductInner> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -154,10 +168,10 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async(product).toBlocking().last();
+    public ProductInner put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -168,7 +182,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -177,7 +191,22 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200Async(ProductInner product) {
+    public Observable<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -188,10 +217,10 @@ public final class LRORetrysInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut201CreatingSucceeded200() throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async().toBlocking().single();
+    public ProductInner beginPut201CreatingSucceeded200() throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -201,7 +230,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -209,7 +238,21 @@ public final class LRORetrysInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200Async() {
+    public Observable<ProductInner> beginPut201CreatingSucceeded200Async() {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -231,10 +274,10 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async(product).toBlocking().single();
+    public ProductInner beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -245,7 +288,21 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product) {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -254,7 +311,7 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -284,10 +341,10 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> putAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetrySucceededAsync().toBlocking().last();
+    public ProductInner putAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -297,7 +354,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -305,7 +362,21 @@ public final class LRORetrysInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>> putAsyncRelativeRetrySucceededAsync() {
+    public Observable<ProductInner> putAsyncRelativeRetrySucceededAsync() {
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>> putAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LRORetrysPutAsyncRelativeRetrySucceededHeadersInner.class);
@@ -317,10 +388,10 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> putAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetrySucceededAsync(product).toBlocking().last();
+    public ProductInner putAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -331,7 +402,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -340,7 +411,22 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>> putAsyncRelativeRetrySucceededAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncRelativeRetrySucceededAsync(ProductInner product) {
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>> putAsyncRelativeRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LRORetrysPutAsyncRelativeRetrySucceededHeadersInner.class);
@@ -351,10 +437,10 @@ public final class LRORetrysInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> beginPutAsyncRelativeRetrySucceeded() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetrySucceededAsync().toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetrySucceeded() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -364,7 +450,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -372,7 +458,21 @@ public final class LRORetrysInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>> beginPutAsyncRelativeRetrySucceededAsync() {
+    public Observable<ProductInner> beginPutAsyncRelativeRetrySucceededAsync() {
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>> beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>>>() {
@@ -394,10 +494,10 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> beginPutAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetrySucceededAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -408,7 +508,21 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRelativeRetrySucceededAsync(ProductInner product) {
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -417,7 +531,7 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>> beginPutAsyncRelativeRetrySucceededAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>> beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysPutAsyncRelativeRetrySucceededHeadersInner>>>() {
@@ -446,10 +560,10 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner> deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException {
-        return deleteProvisioning202Accepted200SucceededAsync().toBlocking().last();
+    public ProductInner deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException {
+        return deleteProvisioning202Accepted200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -459,7 +573,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> deleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteProvisioning202Accepted200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -467,7 +581,21 @@ public final class LRORetrysInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner>> deleteProvisioning202Accepted200SucceededAsync() {
+    public Observable<ProductInner> deleteProvisioning202Accepted200SucceededAsync() {
+        return deleteProvisioning202Accepted200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner>> deleteProvisioning202Accepted200SucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner.class);
     }
@@ -477,10 +605,10 @@ public final class LRORetrysInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner> beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException {
-        return beginDeleteProvisioning202Accepted200SucceededAsync().toBlocking().single();
+    public ProductInner beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException {
+        return beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -490,7 +618,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginDeleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -498,7 +626,21 @@ public final class LRORetrysInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner>> beginDeleteProvisioning202Accepted200SucceededAsync() {
+    public Observable<ProductInner> beginDeleteProvisioning202Accepted200SucceededAsync() {
+        return beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner>> beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync() {
         return service.beginDeleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner>>>() {
                 @Override
@@ -527,10 +669,9 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner> delete202Retry200() throws CloudException, IOException, InterruptedException {
-        return delete202Retry200Async().toBlocking().last();
+    public void delete202Retry200() throws CloudException, IOException, InterruptedException {
+        delete202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -540,7 +681,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -548,7 +689,21 @@ public final class LRORetrysInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner>> delete202Retry200Async() {
+    public Observable<Void> delete202Retry200Async() {
+        return delete202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner>> delete202Retry200WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202Retry200(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysDelete202Retry200HeadersInner.class);
     }
@@ -558,10 +713,9 @@ public final class LRORetrysInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner> beginDelete202Retry200() throws CloudException, IOException {
-        return beginDelete202Retry200Async().toBlocking().single();
+    public void beginDelete202Retry200() throws CloudException, IOException {
+        beginDelete202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -571,7 +725,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -579,7 +733,21 @@ public final class LRORetrysInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner>> beginDelete202Retry200Async() {
+    public Observable<Void> beginDelete202Retry200Async() {
+        return beginDelete202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner>> beginDelete202Retry200WithServiceResponseAsync() {
         return service.beginDelete202Retry200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200HeadersInner>>>() {
                 @Override
@@ -607,10 +775,9 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner> deleteAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetrySucceededAsync().toBlocking().last();
+    public void deleteAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -620,7 +787,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -628,7 +795,21 @@ public final class LRORetrysInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner>> deleteAsyncRelativeRetrySucceededAsync() {
+    public Observable<Void> deleteAsyncRelativeRetrySucceededAsync() {
+        return deleteAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner>> deleteAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner.class);
     }
@@ -638,10 +819,9 @@ public final class LRORetrysInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner> beginDeleteAsyncRelativeRetrySucceeded() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetrySucceededAsync().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetrySucceeded() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -651,7 +831,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -659,7 +839,21 @@ public final class LRORetrysInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner>> beginDeleteAsyncRelativeRetrySucceededAsync() {
+    public Observable<Void> beginDeleteAsyncRelativeRetrySucceededAsync() {
+        return beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner>> beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner>>>() {
                 @Override
@@ -687,10 +881,9 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> post202Retry200() throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async().toBlocking().last();
+    public void post202Retry200() throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -700,7 +893,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -708,7 +901,21 @@ public final class LRORetrysInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>> post202Retry200Async() {
+    public Observable<Void> post202Retry200Async() {
+        return post202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>> post202Retry200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysPost202Retry200HeadersInner.class);
@@ -720,10 +927,9 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async(product).toBlocking().last();
+    public void post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -734,7 +940,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -743,7 +949,22 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>> post202Retry200Async(ProductInner product) {
+    public Observable<Void> post202Retry200Async(ProductInner product) {
+        return post202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>> post202Retry200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysPost202Retry200HeadersInner.class);
@@ -754,10 +975,9 @@ public final class LRORetrysInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> beginPost202Retry200() throws CloudException, IOException {
-        return beginPost202Retry200Async().toBlocking().single();
+    public void beginPost202Retry200() throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -767,7 +987,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -775,7 +995,21 @@ public final class LRORetrysInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>> beginPost202Retry200Async() {
+    public Observable<Void> beginPost202Retry200Async() {
+        return beginPost202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>> beginPost202Retry200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>>>() {
@@ -797,10 +1031,9 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> beginPost202Retry200(ProductInner product) throws CloudException, IOException {
-        return beginPost202Retry200Async(product).toBlocking().single();
+    public void beginPost202Retry200(ProductInner product) throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -811,7 +1044,21 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202Retry200Async(ProductInner product) {
+        return beginPost202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -820,7 +1067,7 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>> beginPost202Retry200Async(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>> beginPost202Retry200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200HeadersInner>>>() {
@@ -849,10 +1096,9 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> postAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetrySucceededAsync().toBlocking().last();
+    public void postAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -862,7 +1108,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -870,7 +1116,21 @@ public final class LRORetrysInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>> postAsyncRelativeRetrySucceededAsync() {
+    public Observable<Void> postAsyncRelativeRetrySucceededAsync() {
+        return postAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>> postAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysPostAsyncRelativeRetrySucceededHeadersInner.class);
@@ -882,10 +1142,9 @@ public final class LRORetrysInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> postAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetrySucceededAsync(product).toBlocking().last();
+    public void postAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -896,7 +1155,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetrySucceededAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -905,7 +1164,22 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>> postAsyncRelativeRetrySucceededAsync(ProductInner product) {
+    public Observable<Void> postAsyncRelativeRetrySucceededAsync(ProductInner product) {
+        return postAsyncRelativeRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>> postAsyncRelativeRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysPostAsyncRelativeRetrySucceededHeadersInner.class);
@@ -916,10 +1190,9 @@ public final class LRORetrysInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> beginPostAsyncRelativeRetrySucceeded() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetrySucceededAsync().toBlocking().single();
+    public void beginPostAsyncRelativeRetrySucceeded() throws CloudException, IOException {
+        beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -929,7 +1202,7 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -937,7 +1210,21 @@ public final class LRORetrysInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>> beginPostAsyncRelativeRetrySucceededAsync() {
+    public Observable<Void> beginPostAsyncRelativeRetrySucceededAsync() {
+        return beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>> beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>>>() {
@@ -959,10 +1246,9 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> beginPostAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetrySucceededAsync(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetrySucceeded(ProductInner product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -973,7 +1259,21 @@ public final class LRORetrysInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetrySucceededAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetrySucceededAsync(ProductInner product) {
+        return beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -982,7 +1282,7 @@ public final class LRORetrysInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>> beginPostAsyncRelativeRetrySucceededAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>> beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeadersInner>>>() {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROSADsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROSADsInner.java
@@ -273,10 +273,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> putNonRetry400() throws CloudException, IOException, InterruptedException {
-        return putNonRetry400Async().toBlocking().last();
+    public ProductInner putNonRetry400() throws CloudException, IOException, InterruptedException {
+        return putNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -286,7 +286,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putNonRetry400Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(putNonRetry400Async(), serviceCallback);
+        return ServiceCall.create(putNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -294,7 +294,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> putNonRetry400Async() {
+    public Observable<ProductInner> putNonRetry400Async() {
+        return putNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> putNonRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -306,10 +320,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> putNonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry400Async(product).toBlocking().last();
+    public ProductInner putNonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -320,7 +334,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putNonRetry400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(putNonRetry400Async(product), serviceCallback);
+        return ServiceCall.create(putNonRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -329,7 +343,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> putNonRetry400Async(ProductInner product) {
+    public Observable<ProductInner> putNonRetry400Async(ProductInner product) {
+        return putNonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> putNonRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -340,10 +369,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPutNonRetry400() throws CloudException, IOException {
-        return beginPutNonRetry400Async().toBlocking().single();
+    public ProductInner beginPutNonRetry400() throws CloudException, IOException {
+        return beginPutNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -353,7 +382,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutNonRetry400Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry400Async(), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -361,7 +390,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry400Async() {
+    public Observable<ProductInner> beginPutNonRetry400Async() {
+        return beginPutNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -383,10 +426,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPutNonRetry400(ProductInner product) throws CloudException, IOException {
-        return beginPutNonRetry400Async(product).toBlocking().single();
+    public ProductInner beginPutNonRetry400(ProductInner product) throws CloudException, IOException {
+        return beginPutNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -397,7 +440,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutNonRetry400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry400Async(product), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutNonRetry400Async(ProductInner product) {
+        return beginPutNonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -406,7 +463,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry400Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -436,10 +493,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> putNonRetry201Creating400() throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400Async().toBlocking().last();
+    public ProductInner putNonRetry201Creating400() throws CloudException, IOException, InterruptedException {
+        return putNonRetry201Creating400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -449,7 +506,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putNonRetry201Creating400Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(putNonRetry201Creating400Async(), serviceCallback);
+        return ServiceCall.create(putNonRetry201Creating400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -457,7 +514,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> putNonRetry201Creating400Async() {
+    public Observable<ProductInner> putNonRetry201Creating400Async() {
+        return putNonRetry201Creating400WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> putNonRetry201Creating400WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -469,10 +540,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> putNonRetry201Creating400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400Async(product).toBlocking().last();
+    public ProductInner putNonRetry201Creating400(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putNonRetry201Creating400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -483,7 +554,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putNonRetry201Creating400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(putNonRetry201Creating400Async(product), serviceCallback);
+        return ServiceCall.create(putNonRetry201Creating400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -492,7 +563,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> putNonRetry201Creating400Async(ProductInner product) {
+    public Observable<ProductInner> putNonRetry201Creating400Async(ProductInner product) {
+        return putNonRetry201Creating400WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> putNonRetry201Creating400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -503,10 +589,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPutNonRetry201Creating400() throws CloudException, IOException {
-        return beginPutNonRetry201Creating400Async().toBlocking().single();
+    public ProductInner beginPutNonRetry201Creating400() throws CloudException, IOException {
+        return beginPutNonRetry201Creating400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -516,7 +602,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutNonRetry201Creating400Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry201Creating400Async(), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry201Creating400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -524,7 +610,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry201Creating400Async() {
+    public Observable<ProductInner> beginPutNonRetry201Creating400Async() {
+        return beginPutNonRetry201Creating400WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry201Creating400WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -546,10 +646,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPutNonRetry201Creating400(ProductInner product) throws CloudException, IOException {
-        return beginPutNonRetry201Creating400Async(product).toBlocking().single();
+    public ProductInner beginPutNonRetry201Creating400(ProductInner product) throws CloudException, IOException {
+        return beginPutNonRetry201Creating400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -560,7 +660,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutNonRetry201Creating400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry201Creating400Async(product), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry201Creating400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutNonRetry201Creating400Async(ProductInner product) {
+        return beginPutNonRetry201Creating400WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -569,7 +683,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry201Creating400Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry201Creating400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -599,10 +713,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> putNonRetry201Creating400InvalidJson() throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400InvalidJsonAsync().toBlocking().last();
+    public ProductInner putNonRetry201Creating400InvalidJson() throws CloudException, IOException, InterruptedException {
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -612,7 +726,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putNonRetry201Creating400InvalidJsonAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(putNonRetry201Creating400InvalidJsonAsync(), serviceCallback);
+        return ServiceCall.create(putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -620,7 +734,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> putNonRetry201Creating400InvalidJsonAsync() {
+    public Observable<ProductInner> putNonRetry201Creating400InvalidJsonAsync() {
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> putNonRetry201Creating400InvalidJsonWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -632,10 +760,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> putNonRetry201Creating400InvalidJson(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400InvalidJsonAsync(product).toBlocking().last();
+    public ProductInner putNonRetry201Creating400InvalidJson(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -646,7 +774,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putNonRetry201Creating400InvalidJsonAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(putNonRetry201Creating400InvalidJsonAsync(product), serviceCallback);
+        return ServiceCall.create(putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -655,7 +783,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> putNonRetry201Creating400InvalidJsonAsync(ProductInner product) {
+    public Observable<ProductInner> putNonRetry201Creating400InvalidJsonAsync(ProductInner product) {
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -666,10 +809,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPutNonRetry201Creating400InvalidJson() throws CloudException, IOException {
-        return beginPutNonRetry201Creating400InvalidJsonAsync().toBlocking().single();
+    public ProductInner beginPutNonRetry201Creating400InvalidJson() throws CloudException, IOException {
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -679,7 +822,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutNonRetry201Creating400InvalidJsonAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry201Creating400InvalidJsonAsync(), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -687,7 +830,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry201Creating400InvalidJsonAsync() {
+    public Observable<ProductInner> beginPutNonRetry201Creating400InvalidJsonAsync() {
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -709,10 +866,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPutNonRetry201Creating400InvalidJson(ProductInner product) throws CloudException, IOException {
-        return beginPutNonRetry201Creating400InvalidJsonAsync(product).toBlocking().single();
+    public ProductInner beginPutNonRetry201Creating400InvalidJson(ProductInner product) throws CloudException, IOException {
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -723,7 +880,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutNonRetry201Creating400InvalidJsonAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry201Creating400InvalidJsonAsync(product), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutNonRetry201Creating400InvalidJsonAsync(ProductInner product) {
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -732,7 +903,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry201Creating400InvalidJsonAsync(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -762,10 +933,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> putAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetry400Async().toBlocking().last();
+    public ProductInner putAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -775,7 +946,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetry400Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -783,7 +954,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>> putAsyncRelativeRetry400Async() {
+    public Observable<ProductInner> putAsyncRelativeRetry400Async() {
+        return putAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>> putAsyncRelativeRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetry400HeadersInner.class);
@@ -795,10 +980,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> putAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetry400Async(product).toBlocking().last();
+    public ProductInner putAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -809,7 +994,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetry400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -818,7 +1003,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>> putAsyncRelativeRetry400Async(ProductInner product) {
+    public Observable<ProductInner> putAsyncRelativeRetry400Async(ProductInner product) {
+        return putAsyncRelativeRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>> putAsyncRelativeRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetry400HeadersInner.class);
@@ -829,10 +1029,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> beginPutAsyncRelativeRetry400() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetry400Async().toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetry400() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -842,7 +1042,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetry400Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -850,7 +1050,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>> beginPutAsyncRelativeRetry400Async() {
+    public Observable<ProductInner> beginPutAsyncRelativeRetry400Async() {
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>> beginPutAsyncRelativeRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>>>() {
@@ -872,10 +1086,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> beginPutAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetry400Async(product).toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -886,7 +1100,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetry400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRelativeRetry400Async(ProductInner product) {
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -895,7 +1123,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>> beginPutAsyncRelativeRetry400Async(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>> beginPutAsyncRelativeRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner>>>() {
@@ -924,10 +1152,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner> deleteNonRetry400() throws CloudException, IOException, InterruptedException {
-        return deleteNonRetry400Async().toBlocking().last();
+    public void deleteNonRetry400() throws CloudException, IOException, InterruptedException {
+        deleteNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -937,7 +1164,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteNonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -945,7 +1172,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner>> deleteNonRetry400Async() {
+    public Observable<Void> deleteNonRetry400Async() {
+        return deleteNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner>> deleteNonRetry400WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteNonRetry400(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteNonRetry400HeadersInner.class);
     }
@@ -955,10 +1196,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner> beginDeleteNonRetry400() throws CloudException, IOException {
-        return beginDeleteNonRetry400Async().toBlocking().single();
+    public void beginDeleteNonRetry400() throws CloudException, IOException {
+        beginDeleteNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -968,7 +1208,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteNonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -976,7 +1216,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner>> beginDeleteNonRetry400Async() {
+    public Observable<Void> beginDeleteNonRetry400Async() {
+        return beginDeleteNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner>> beginDeleteNonRetry400WithServiceResponseAsync() {
         return service.beginDeleteNonRetry400(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner>>>() {
                 @Override
@@ -1004,10 +1258,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner> delete202NonRetry400() throws CloudException, IOException, InterruptedException {
-        return delete202NonRetry400Async().toBlocking().last();
+    public void delete202NonRetry400() throws CloudException, IOException, InterruptedException {
+        delete202NonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1017,7 +1270,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202NonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202NonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1025,7 +1278,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner>> delete202NonRetry400Async() {
+    public Observable<Void> delete202NonRetry400Async() {
+        return delete202NonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner>> delete202NonRetry400WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202NonRetry400(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDelete202NonRetry400HeadersInner.class);
     }
@@ -1035,10 +1302,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner> beginDelete202NonRetry400() throws CloudException, IOException {
-        return beginDelete202NonRetry400Async().toBlocking().single();
+    public void beginDelete202NonRetry400() throws CloudException, IOException {
+        beginDelete202NonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1048,7 +1314,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202NonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202NonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1056,7 +1322,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner>> beginDelete202NonRetry400Async() {
+    public Observable<Void> beginDelete202NonRetry400Async() {
+        return beginDelete202NonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner>> beginDelete202NonRetry400WithServiceResponseAsync() {
         return service.beginDelete202NonRetry400(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner>>>() {
                 @Override
@@ -1084,10 +1364,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner> deleteAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetry400Async().toBlocking().last();
+    public void deleteAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1097,7 +1376,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1105,7 +1384,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner>> deleteAsyncRelativeRetry400Async() {
+    public Observable<Void> deleteAsyncRelativeRetry400Async() {
+        return deleteAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner>> deleteAsyncRelativeRetry400WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetry400(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteAsyncRelativeRetry400HeadersInner.class);
     }
@@ -1115,10 +1408,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner> beginDeleteAsyncRelativeRetry400() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetry400Async().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetry400() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1128,7 +1420,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1136,7 +1428,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner>> beginDeleteAsyncRelativeRetry400Async() {
+    public Observable<Void> beginDeleteAsyncRelativeRetry400Async() {
+        return beginDeleteAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner>> beginDeleteAsyncRelativeRetry400WithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetry400(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner>>>() {
                 @Override
@@ -1164,10 +1470,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> postNonRetry400() throws CloudException, IOException, InterruptedException {
-        return postNonRetry400Async().toBlocking().last();
+    public void postNonRetry400() throws CloudException, IOException, InterruptedException {
+        postNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1177,7 +1482,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postNonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(postNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1185,7 +1490,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>> postNonRetry400Async() {
+    public Observable<Void> postNonRetry400Async() {
+        return postNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>> postNonRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostNonRetry400HeadersInner.class);
@@ -1197,10 +1516,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> postNonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postNonRetry400Async(product).toBlocking().last();
+    public void postNonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1211,7 +1529,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postNonRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postNonRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postNonRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1220,7 +1538,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>> postNonRetry400Async(ProductInner product) {
+    public Observable<Void> postNonRetry400Async(ProductInner product) {
+        return postNonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>> postNonRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostNonRetry400HeadersInner.class);
@@ -1231,10 +1564,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> beginPostNonRetry400() throws CloudException, IOException {
-        return beginPostNonRetry400Async().toBlocking().single();
+    public void beginPostNonRetry400() throws CloudException, IOException {
+        beginPostNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1244,7 +1576,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostNonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1252,7 +1584,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>> beginPostNonRetry400Async() {
+    public Observable<Void> beginPostNonRetry400Async() {
+        return beginPostNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>> beginPostNonRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>>>() {
@@ -1274,10 +1620,9 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> beginPostNonRetry400(ProductInner product) throws CloudException, IOException {
-        return beginPostNonRetry400Async(product).toBlocking().single();
+    public void beginPostNonRetry400(ProductInner product) throws CloudException, IOException {
+        beginPostNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1288,7 +1633,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostNonRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostNonRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostNonRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostNonRetry400Async(ProductInner product) {
+        return beginPostNonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1297,7 +1656,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>> beginPostNonRetry400Async(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>> beginPostNonRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner>>>() {
@@ -1326,10 +1685,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> post202NonRetry400() throws CloudException, IOException, InterruptedException {
-        return post202NonRetry400Async().toBlocking().last();
+    public void post202NonRetry400() throws CloudException, IOException, InterruptedException {
+        post202NonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1339,7 +1697,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1347,7 +1705,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>> post202NonRetry400Async() {
+    public Observable<Void> post202NonRetry400Async() {
+        return post202NonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>> post202NonRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.post202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202NonRetry400HeadersInner.class);
@@ -1359,10 +1731,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> post202NonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return post202NonRetry400Async(product).toBlocking().last();
+    public void post202NonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
+        post202NonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1373,7 +1744,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202NonRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NonRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NonRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1382,7 +1753,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>> post202NonRetry400Async(ProductInner product) {
+    public Observable<Void> post202NonRetry400Async(ProductInner product) {
+        return post202NonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>> post202NonRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202NonRetry400HeadersInner.class);
@@ -1393,10 +1779,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> beginPost202NonRetry400() throws CloudException, IOException {
-        return beginPost202NonRetry400Async().toBlocking().single();
+    public void beginPost202NonRetry400() throws CloudException, IOException {
+        beginPost202NonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1406,7 +1791,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1414,7 +1799,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>> beginPost202NonRetry400Async() {
+    public Observable<Void> beginPost202NonRetry400Async() {
+        return beginPost202NonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>> beginPost202NonRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPost202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>>>() {
@@ -1436,10 +1835,9 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> beginPost202NonRetry400(ProductInner product) throws CloudException, IOException {
-        return beginPost202NonRetry400Async(product).toBlocking().single();
+    public void beginPost202NonRetry400(ProductInner product) throws CloudException, IOException {
+        beginPost202NonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1450,7 +1848,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202NonRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NonRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NonRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202NonRetry400Async(ProductInner product) {
+        return beginPost202NonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1459,7 +1871,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>> beginPost202NonRetry400Async(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>> beginPost202NonRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPost202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner>>>() {
@@ -1488,10 +1900,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> postAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetry400Async().toBlocking().last();
+    public void postAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1501,7 +1912,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1509,7 +1920,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>> postAsyncRelativeRetry400Async() {
+    public Observable<Void> postAsyncRelativeRetry400Async() {
+        return postAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>> postAsyncRelativeRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetry400HeadersInner.class);
@@ -1521,10 +1946,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> postAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetry400Async(product).toBlocking().last();
+    public void postAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1535,7 +1959,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1544,7 +1968,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>> postAsyncRelativeRetry400Async(ProductInner product) {
+    public Observable<Void> postAsyncRelativeRetry400Async(ProductInner product) {
+        return postAsyncRelativeRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>> postAsyncRelativeRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetry400HeadersInner.class);
@@ -1555,10 +1994,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> beginPostAsyncRelativeRetry400() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetry400Async().toBlocking().single();
+    public void beginPostAsyncRelativeRetry400() throws CloudException, IOException {
+        beginPostAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1568,7 +2006,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1576,7 +2014,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>> beginPostAsyncRelativeRetry400Async() {
+    public Observable<Void> beginPostAsyncRelativeRetry400Async() {
+        return beginPostAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>> beginPostAsyncRelativeRetry400WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>>>() {
@@ -1598,10 +2050,9 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> beginPostAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetry400Async(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1612,7 +2063,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetry400Async(ProductInner product) {
+        return beginPostAsyncRelativeRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1621,7 +2086,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>> beginPostAsyncRelativeRetry400Async(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>> beginPostAsyncRelativeRetry400WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner>>>() {
@@ -1650,10 +2115,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> putError201NoProvisioningStatePayload() throws CloudException, IOException, InterruptedException {
-        return putError201NoProvisioningStatePayloadAsync().toBlocking().last();
+    public ProductInner putError201NoProvisioningStatePayload() throws CloudException, IOException, InterruptedException {
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1663,7 +2128,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putError201NoProvisioningStatePayloadAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(putError201NoProvisioningStatePayloadAsync(), serviceCallback);
+        return ServiceCall.create(putError201NoProvisioningStatePayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1671,7 +2136,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> putError201NoProvisioningStatePayloadAsync() {
+    public Observable<ProductInner> putError201NoProvisioningStatePayloadAsync() {
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> putError201NoProvisioningStatePayloadWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -1683,10 +2162,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> putError201NoProvisioningStatePayload(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putError201NoProvisioningStatePayloadAsync(product).toBlocking().last();
+    public ProductInner putError201NoProvisioningStatePayload(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1697,7 +2176,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putError201NoProvisioningStatePayloadAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(putError201NoProvisioningStatePayloadAsync(product), serviceCallback);
+        return ServiceCall.create(putError201NoProvisioningStatePayloadWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1706,7 +2185,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> putError201NoProvisioningStatePayloadAsync(ProductInner product) {
+    public Observable<ProductInner> putError201NoProvisioningStatePayloadAsync(ProductInner product) {
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> putError201NoProvisioningStatePayloadWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -1717,10 +2211,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPutError201NoProvisioningStatePayload() throws CloudException, IOException {
-        return beginPutError201NoProvisioningStatePayloadAsync().toBlocking().single();
+    public ProductInner beginPutError201NoProvisioningStatePayload() throws CloudException, IOException {
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1730,7 +2224,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutError201NoProvisioningStatePayloadAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutError201NoProvisioningStatePayloadAsync(), serviceCallback);
+        return ServiceCall.create(beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1738,7 +2232,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPutError201NoProvisioningStatePayloadAsync() {
+    public Observable<ProductInner> beginPutError201NoProvisioningStatePayloadAsync() {
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1760,10 +2268,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPutError201NoProvisioningStatePayload(ProductInner product) throws CloudException, IOException {
-        return beginPutError201NoProvisioningStatePayloadAsync(product).toBlocking().single();
+    public ProductInner beginPutError201NoProvisioningStatePayload(ProductInner product) throws CloudException, IOException {
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1774,7 +2282,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutError201NoProvisioningStatePayloadAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutError201NoProvisioningStatePayloadAsync(product), serviceCallback);
+        return ServiceCall.create(beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutError201NoProvisioningStatePayloadAsync(ProductInner product) {
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1783,7 +2305,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPutError201NoProvisioningStatePayloadAsync(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1813,10 +2335,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> putAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusAsync().toBlocking().last();
+    public ProductInner putAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1826,7 +2348,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetryNoStatusAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1834,7 +2356,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>> putAsyncRelativeRetryNoStatusAsync() {
+    public Observable<ProductInner> putAsyncRelativeRetryNoStatusAsync() {
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>> putAsyncRelativeRetryNoStatusWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetryNoStatusHeadersInner.class);
@@ -1846,10 +2382,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> putAsyncRelativeRetryNoStatus(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusAsync(product).toBlocking().last();
+    public ProductInner putAsyncRelativeRetryNoStatus(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1860,7 +2396,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetryNoStatusAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1869,7 +2405,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>> putAsyncRelativeRetryNoStatusAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncRelativeRetryNoStatusAsync(ProductInner product) {
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>> putAsyncRelativeRetryNoStatusWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetryNoStatusHeadersInner.class);
@@ -1880,10 +2431,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> beginPutAsyncRelativeRetryNoStatus() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusAsync().toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetryNoStatus() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1893,7 +2444,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetryNoStatusAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1901,7 +2452,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>> beginPutAsyncRelativeRetryNoStatusAsync() {
+    public Observable<ProductInner> beginPutAsyncRelativeRetryNoStatusAsync() {
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>> beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>>>() {
@@ -1923,10 +2488,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> beginPutAsyncRelativeRetryNoStatus(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetryNoStatus(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1937,7 +2502,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetryNoStatusAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRelativeRetryNoStatusAsync(ProductInner product) {
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1946,7 +2525,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>> beginPutAsyncRelativeRetryNoStatusAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>> beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner>>>() {
@@ -1975,10 +2554,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> putAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusPayloadAsync().toBlocking().last();
+    public ProductInner putAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1988,7 +2567,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusPayloadAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1996,7 +2575,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>> putAsyncRelativeRetryNoStatusPayloadAsync() {
+    public Observable<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync() {
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>> putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner.class);
@@ -2008,10 +2601,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> putAsyncRelativeRetryNoStatusPayload(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusPayloadAsync(product).toBlocking().last();
+    public ProductInner putAsyncRelativeRetryNoStatusPayload(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2022,7 +2615,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusPayloadAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2031,7 +2624,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>> putAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product) {
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>> putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner.class);
@@ -2042,10 +2650,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> beginPutAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusPayloadAsync().toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2055,7 +2663,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetryNoStatusPayloadAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusPayloadAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2063,7 +2671,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>> beginPutAsyncRelativeRetryNoStatusPayloadAsync() {
+    public Observable<ProductInner> beginPutAsyncRelativeRetryNoStatusPayloadAsync() {
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>> beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>>>() {
@@ -2085,10 +2707,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> beginPutAsyncRelativeRetryNoStatusPayload(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusPayloadAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetryNoStatusPayload(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2099,7 +2721,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusPayloadAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product) {
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2108,7 +2744,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>> beginPutAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>> beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner>>>() {
@@ -2137,10 +2773,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponse object if successful.
      */
-    public ServiceResponse<Void> delete204Succeeded() throws CloudException, IOException, InterruptedException {
-        return delete204SucceededAsync().toBlocking().last();
+    public void delete204Succeeded() throws CloudException, IOException, InterruptedException {
+        delete204SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2150,7 +2785,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete204SucceededAsync(), serviceCallback);
+        return ServiceCall.create(delete204SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2158,7 +2793,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Void>> delete204SucceededAsync() {
+    public Observable<Void> delete204SucceededAsync() {
+        return delete204SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Void>> delete204SucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete204Succeeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<Void>() { }.getType());
     }
@@ -2168,10 +2817,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> beginDelete204Succeeded() throws CloudException, IOException {
-        return beginDelete204SucceededAsync().toBlocking().single();
+    public void beginDelete204Succeeded() throws CloudException, IOException {
+        beginDelete204SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2181,7 +2829,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(beginDelete204SucceededAsync(), serviceCallback);
+        return ServiceCall.create(beginDelete204SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2189,7 +2837,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> beginDelete204SucceededAsync() {
+    public Observable<Void> beginDelete204SucceededAsync() {
+        return beginDelete204SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> beginDelete204SucceededWithServiceResponseAsync() {
         return service.beginDelete204Succeeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -2217,10 +2879,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner> deleteAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetryNoStatusAsync().toBlocking().last();
+    public void deleteAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2230,7 +2891,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2238,7 +2899,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner>> deleteAsyncRelativeRetryNoStatusAsync() {
+    public Observable<Void> deleteAsyncRelativeRetryNoStatusAsync() {
+        return deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner>> deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetryNoStatus(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner.class);
     }
@@ -2248,10 +2923,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner> beginDeleteAsyncRelativeRetryNoStatus() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetryNoStatusAsync().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetryNoStatus() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2261,7 +2935,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2269,7 +2943,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner>> beginDeleteAsyncRelativeRetryNoStatusAsync() {
+    public Observable<Void> beginDeleteAsyncRelativeRetryNoStatusAsync() {
+        return beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner>> beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetryNoStatus(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner>>>() {
                 @Override
@@ -2297,10 +2985,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> post202NoLocation() throws CloudException, IOException, InterruptedException {
-        return post202NoLocationAsync().toBlocking().last();
+    public void post202NoLocation() throws CloudException, IOException, InterruptedException {
+        post202NoLocationWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2310,7 +2997,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202NoLocationAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NoLocationAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NoLocationWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2318,7 +3005,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>> post202NoLocationAsync() {
+    public Observable<Void> post202NoLocationAsync() {
+        return post202NoLocationWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>> post202NoLocationWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.post202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202NoLocationHeadersInner.class);
@@ -2330,10 +3031,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> post202NoLocation(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return post202NoLocationAsync(product).toBlocking().last();
+    public void post202NoLocation(ProductInner product) throws CloudException, IOException, InterruptedException {
+        post202NoLocationWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2344,7 +3044,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202NoLocationAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NoLocationAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NoLocationWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2353,7 +3053,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>> post202NoLocationAsync(ProductInner product) {
+    public Observable<Void> post202NoLocationAsync(ProductInner product) {
+        return post202NoLocationWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>> post202NoLocationWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202NoLocationHeadersInner.class);
@@ -2364,10 +3079,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> beginPost202NoLocation() throws CloudException, IOException {
-        return beginPost202NoLocationAsync().toBlocking().single();
+    public void beginPost202NoLocation() throws CloudException, IOException {
+        beginPost202NoLocationWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2377,7 +3091,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202NoLocationAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NoLocationAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NoLocationWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2385,7 +3099,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>> beginPost202NoLocationAsync() {
+    public Observable<Void> beginPost202NoLocationAsync() {
+        return beginPost202NoLocationWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>> beginPost202NoLocationWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPost202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>>>() {
@@ -2407,10 +3135,9 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> beginPost202NoLocation(ProductInner product) throws CloudException, IOException {
-        return beginPost202NoLocationAsync(product).toBlocking().single();
+    public void beginPost202NoLocation(ProductInner product) throws CloudException, IOException {
+        beginPost202NoLocationWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2421,7 +3148,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202NoLocationAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NoLocationAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NoLocationWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202NoLocationAsync(ProductInner product) {
+        return beginPost202NoLocationWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2430,7 +3171,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>> beginPost202NoLocationAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>> beginPost202NoLocationWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPost202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner>>>() {
@@ -2459,10 +3200,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> postAsyncRelativeRetryNoPayload() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryNoPayloadAsync().toBlocking().last();
+    public void postAsyncRelativeRetryNoPayload() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2472,7 +3212,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryNoPayloadAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryNoPayloadAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2480,7 +3220,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>> postAsyncRelativeRetryNoPayloadAsync() {
+    public Observable<Void> postAsyncRelativeRetryNoPayloadAsync() {
+        return postAsyncRelativeRetryNoPayloadWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>> postAsyncRelativeRetryNoPayloadWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner.class);
@@ -2492,10 +3246,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> postAsyncRelativeRetryNoPayload(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryNoPayloadAsync(product).toBlocking().last();
+    public void postAsyncRelativeRetryNoPayload(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2506,7 +3259,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryNoPayloadAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryNoPayloadAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2515,7 +3268,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>> postAsyncRelativeRetryNoPayloadAsync(ProductInner product) {
+    public Observable<Void> postAsyncRelativeRetryNoPayloadAsync(ProductInner product) {
+        return postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>> postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner.class);
@@ -2526,10 +3294,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> beginPostAsyncRelativeRetryNoPayload() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryNoPayloadAsync().toBlocking().single();
+    public void beginPostAsyncRelativeRetryNoPayload() throws CloudException, IOException {
+        beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2539,7 +3306,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryNoPayloadAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryNoPayloadAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2547,7 +3314,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>> beginPostAsyncRelativeRetryNoPayloadAsync() {
+    public Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync() {
+        return beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>> beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>>>() {
@@ -2569,10 +3350,9 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> beginPostAsyncRelativeRetryNoPayload(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryNoPayloadAsync(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetryNoPayload(ProductInner product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2583,7 +3363,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryNoPayloadAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryNoPayloadAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync(ProductInner product) {
+        return beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2592,7 +3386,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>> beginPostAsyncRelativeRetryNoPayloadAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>> beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner>>>() {
@@ -2621,10 +3415,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put200InvalidJson() throws CloudException, IOException, InterruptedException {
-        return put200InvalidJsonAsync().toBlocking().last();
+    public ProductInner put200InvalidJson() throws CloudException, IOException, InterruptedException {
+        return put200InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2634,7 +3428,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200InvalidJsonAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200InvalidJsonAsync(), serviceCallback);
+        return ServiceCall.create(put200InvalidJsonWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2642,7 +3436,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200InvalidJsonAsync() {
+    public Observable<ProductInner> put200InvalidJsonAsync() {
+        return put200InvalidJsonWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200InvalidJsonWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -2654,10 +3462,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put200InvalidJson(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200InvalidJsonAsync(product).toBlocking().last();
+    public ProductInner put200InvalidJson(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put200InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2668,7 +3476,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200InvalidJsonAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200InvalidJsonAsync(product), serviceCallback);
+        return ServiceCall.create(put200InvalidJsonWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2677,7 +3485,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200InvalidJsonAsync(ProductInner product) {
+    public Observable<ProductInner> put200InvalidJsonAsync(ProductInner product) {
+        return put200InvalidJsonWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200InvalidJsonWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -2688,10 +3511,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200InvalidJson() throws CloudException, IOException {
-        return beginPut200InvalidJsonAsync().toBlocking().single();
+    public ProductInner beginPut200InvalidJson() throws CloudException, IOException {
+        return beginPut200InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2701,7 +3524,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200InvalidJsonAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200InvalidJsonAsync(), serviceCallback);
+        return ServiceCall.create(beginPut200InvalidJsonWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2709,7 +3532,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200InvalidJsonAsync() {
+    public Observable<ProductInner> beginPut200InvalidJsonAsync() {
+        return beginPut200InvalidJsonWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut200InvalidJsonWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -2731,10 +3568,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200InvalidJson(ProductInner product) throws CloudException, IOException {
-        return beginPut200InvalidJsonAsync(product).toBlocking().single();
+    public ProductInner beginPut200InvalidJson(ProductInner product) throws CloudException, IOException {
+        return beginPut200InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2745,7 +3582,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200InvalidJsonAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200InvalidJsonAsync(product), serviceCallback);
+        return ServiceCall.create(beginPut200InvalidJsonWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut200InvalidJsonAsync(ProductInner product) {
+        return beginPut200InvalidJsonWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2754,7 +3605,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200InvalidJsonAsync(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut200InvalidJsonWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -2784,10 +3635,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> putAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidHeaderAsync().toBlocking().last();
+    public ProductInner putAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2797,7 +3648,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2805,7 +3656,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>> putAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync() {
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>> putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner.class);
@@ -2817,10 +3682,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> putAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().last();
+    public ProductInner putAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2831,7 +3696,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2840,7 +3705,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>> putAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>> putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner.class);
@@ -2851,10 +3731,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> beginPutAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidHeaderAsync().toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2864,7 +3744,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2872,7 +3752,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>> beginPutAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<ProductInner> beginPutAsyncRelativeRetryInvalidHeaderAsync() {
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>> beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>>>() {
@@ -2894,10 +3788,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> beginPutAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2908,7 +3802,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2917,7 +3825,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>> beginPutAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>> beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner>>>() {
@@ -2946,10 +3854,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> putAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().last();
+    public ProductInner putAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2959,7 +3867,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2967,7 +3875,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>> putAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>> putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner.class);
@@ -2979,10 +3901,10 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> putAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().last();
+    public ProductInner putAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2993,7 +3915,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3002,7 +3924,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>> putAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>> putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner.class);
@@ -3013,10 +3950,10 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> beginPutAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3026,7 +3963,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3034,7 +3971,21 @@ public final class LROSADsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginPutAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<ProductInner> beginPutAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>>>() {
@@ -3056,10 +4007,10 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> beginPutAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3070,7 +4021,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3079,7 +4044,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner>>>() {
@@ -3108,10 +4073,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner> delete202RetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return delete202RetryInvalidHeaderAsync().toBlocking().last();
+    public void delete202RetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        delete202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3121,7 +4085,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202RetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202RetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3129,7 +4093,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner>> delete202RetryInvalidHeaderAsync() {
+    public Observable<Void> delete202RetryInvalidHeaderAsync() {
+        return delete202RetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner>> delete202RetryInvalidHeaderWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202RetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDelete202RetryInvalidHeaderHeadersInner.class);
     }
@@ -3139,10 +4117,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner> beginDelete202RetryInvalidHeader() throws CloudException, IOException {
-        return beginDelete202RetryInvalidHeaderAsync().toBlocking().single();
+    public void beginDelete202RetryInvalidHeader() throws CloudException, IOException {
+        beginDelete202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3152,7 +4129,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202RetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202RetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3160,7 +4137,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner>> beginDelete202RetryInvalidHeaderAsync() {
+    public Observable<Void> beginDelete202RetryInvalidHeaderAsync() {
+        return beginDelete202RetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner>> beginDelete202RetryInvalidHeaderWithServiceResponseAsync() {
         return service.beginDelete202RetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner>>>() {
                 @Override
@@ -3188,10 +4179,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner> deleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetryInvalidHeaderAsync().toBlocking().last();
+    public void deleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3201,7 +4191,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3209,7 +4199,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner>> deleteAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Void> deleteAsyncRelativeRetryInvalidHeaderAsync() {
+        return deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner>> deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner.class);
     }
@@ -3219,10 +4223,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner> beginDeleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetryInvalidHeaderAsync().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3232,7 +4235,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3240,7 +4243,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner>> beginDeleteAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Void> beginDeleteAsyncRelativeRetryInvalidHeaderAsync() {
+        return beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner>> beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner>>>() {
                 @Override
@@ -3268,10 +4285,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner> deleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().last();
+    public void deleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3281,7 +4297,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3289,7 +4305,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner>> deleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner>> deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetryInvalidJsonPolling(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner.class);
     }
@@ -3299,10 +4329,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner> beginDeleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3312,7 +4341,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3320,7 +4349,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Void> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetryInvalidJsonPolling(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner>>>() {
                 @Override
@@ -3348,10 +4391,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> post202RetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return post202RetryInvalidHeaderAsync().toBlocking().last();
+    public void post202RetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        post202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3361,7 +4403,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202RetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202RetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3369,7 +4411,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>> post202RetryInvalidHeaderAsync() {
+    public Observable<Void> post202RetryInvalidHeaderAsync() {
+        return post202RetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>> post202RetryInvalidHeaderWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.post202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202RetryInvalidHeaderHeadersInner.class);
@@ -3381,10 +4437,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> post202RetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return post202RetryInvalidHeaderAsync(product).toBlocking().last();
+    public void post202RetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
+        post202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3395,7 +4450,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202RetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202RetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202RetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3404,7 +4459,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>> post202RetryInvalidHeaderAsync(ProductInner product) {
+    public Observable<Void> post202RetryInvalidHeaderAsync(ProductInner product) {
+        return post202RetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>> post202RetryInvalidHeaderWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202RetryInvalidHeaderHeadersInner.class);
@@ -3415,10 +4485,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> beginPost202RetryInvalidHeader() throws CloudException, IOException {
-        return beginPost202RetryInvalidHeaderAsync().toBlocking().single();
+    public void beginPost202RetryInvalidHeader() throws CloudException, IOException {
+        beginPost202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3428,7 +4497,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202RetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202RetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3436,7 +4505,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>> beginPost202RetryInvalidHeaderAsync() {
+    public Observable<Void> beginPost202RetryInvalidHeaderAsync() {
+        return beginPost202RetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>> beginPost202RetryInvalidHeaderWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPost202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>>>() {
@@ -3458,10 +4541,9 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> beginPost202RetryInvalidHeader(ProductInner product) throws CloudException, IOException {
-        return beginPost202RetryInvalidHeaderAsync(product).toBlocking().single();
+    public void beginPost202RetryInvalidHeader(ProductInner product) throws CloudException, IOException {
+        beginPost202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3472,7 +4554,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202RetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202RetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202RetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202RetryInvalidHeaderAsync(ProductInner product) {
+        return beginPost202RetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3481,7 +4577,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>> beginPost202RetryInvalidHeaderAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>> beginPost202RetryInvalidHeaderWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPost202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner>>>() {
@@ -3510,10 +4606,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> postAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryInvalidHeaderAsync().toBlocking().last();
+    public void postAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3523,7 +4618,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3531,7 +4626,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>> postAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Void> postAsyncRelativeRetryInvalidHeaderAsync() {
+        return postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>> postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner.class);
@@ -3543,10 +4652,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> postAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().last();
+    public void postAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3557,7 +4665,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3566,7 +4674,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>> postAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+    public Observable<Void> postAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+        return postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>> postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner.class);
@@ -3577,10 +4700,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> beginPostAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryInvalidHeaderAsync().toBlocking().single();
+    public void beginPostAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
+        beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3590,7 +4712,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3598,7 +4720,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>> beginPostAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync() {
+        return beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>> beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>>>() {
@@ -3620,10 +4756,9 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> beginPostAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3634,7 +4769,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+        return beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3643,7 +4792,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>> beginPostAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>> beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner>>>() {
@@ -3672,10 +4821,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> postAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().last();
+    public void postAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3685,7 +4833,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3693,7 +4841,21 @@ public final class LROSADsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>> postAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Void> postAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>> postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner.class);
@@ -3705,10 +4867,9 @@ public final class LROSADsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> postAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().last();
+    public void postAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3719,7 +4880,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3728,7 +4889,22 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>> postAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+    public Observable<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+        return postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>> postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner.class);
@@ -3739,10 +4915,9 @@ public final class LROSADsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> beginPostAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().single();
+    public void beginPostAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
+        beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3752,7 +4927,7 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3760,7 +4935,21 @@ public final class LROSADsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginPostAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>>>() {
@@ -3782,10 +4971,9 @@ public final class LROSADsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> beginPostAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3796,7 +4984,21 @@ public final class LROSADsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+        return beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3805,7 +5007,7 @@ public final class LROSADsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>> beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner>>>() {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROSADsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROSADsInner.java
@@ -323,7 +323,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putNonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        return putNonRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -396,7 +396,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -429,7 +429,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutNonRetry400(ProductInner product) throws CloudException, IOException {
-        return beginPutNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNonRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -446,6 +446,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutNonRetry400Async(ProductInner product) {
@@ -454,7 +455,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -543,7 +544,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putNonRetry201Creating400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400WithServiceResponseAsync().toBlocking().last().getBody();
+        return putNonRetry201Creating400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -616,7 +617,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -649,7 +650,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutNonRetry201Creating400(ProductInner product) throws CloudException, IOException {
-        return beginPutNonRetry201Creating400WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNonRetry201Creating400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -666,6 +667,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutNonRetry201Creating400Async(ProductInner product) {
@@ -674,7 +676,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -763,7 +765,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putNonRetry201Creating400InvalidJson(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -836,7 +838,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -869,7 +871,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutNonRetry201Creating400InvalidJson(ProductInner product) throws CloudException, IOException {
-        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -886,6 +888,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutNonRetry201Creating400InvalidJsonAsync(ProductInner product) {
@@ -894,7 +897,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -983,7 +986,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1056,7 +1059,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1089,7 +1092,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1106,6 +1109,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRelativeRetry400Async(ProductInner product) {
@@ -1114,7 +1118,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1222,7 +1226,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1328,7 +1332,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1434,7 +1438,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1518,7 +1522,7 @@ public final class LROSADsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postNonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        postNonRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1590,7 +1594,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1622,7 +1626,7 @@ public final class LROSADsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostNonRetry400(ProductInner product) throws CloudException, IOException {
-        beginPostNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostNonRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1639,6 +1643,7 @@ public final class LROSADsInner {
     /**
      * Long running post request, service returns a 400 with no error body.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostNonRetry400Async(ProductInner product) {
@@ -1647,7 +1652,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1733,7 +1738,7 @@ public final class LROSADsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202NonRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        post202NonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        post202NonRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1805,7 +1810,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1837,7 +1842,7 @@ public final class LROSADsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202NonRetry400(ProductInner product) throws CloudException, IOException {
-        beginPost202NonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202NonRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1854,6 +1859,7 @@ public final class LROSADsInner {
     /**
      * Long running post request, service returns a 202 with a location header.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202NonRetry400Async(ProductInner product) {
@@ -1862,7 +1868,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1948,7 +1954,7 @@ public final class LROSADsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2020,7 +2026,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2052,7 +2058,7 @@ public final class LROSADsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetry400(ProductInner product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2069,6 +2075,7 @@ public final class LROSADsInner {
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetry400Async(ProductInner product) {
@@ -2077,7 +2084,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2165,7 +2172,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putError201NoProvisioningStatePayload(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().last().getBody();
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2238,7 +2245,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2271,7 +2278,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutError201NoProvisioningStatePayload(ProductInner product) throws CloudException, IOException {
-        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2288,6 +2295,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutError201NoProvisioningStatePayloadAsync(ProductInner product) {
@@ -2296,7 +2304,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2385,7 +2393,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRelativeRetryNoStatus(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2458,7 +2466,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2491,7 +2499,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRelativeRetryNoStatus(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2508,6 +2516,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRelativeRetryNoStatusAsync(ProductInner product) {
@@ -2516,7 +2525,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2604,7 +2613,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRelativeRetryNoStatusPayload(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2677,7 +2686,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2710,7 +2719,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRelativeRetryNoStatusPayload(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2727,6 +2736,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product) {
@@ -2735,7 +2745,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2843,7 +2853,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2949,7 +2959,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3033,7 +3043,7 @@ public final class LROSADsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202NoLocation(ProductInner product) throws CloudException, IOException, InterruptedException {
-        post202NoLocationWithServiceResponseAsync().toBlocking().last().getBody();
+        post202NoLocationWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3105,7 +3115,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3137,7 +3147,7 @@ public final class LROSADsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202NoLocation(ProductInner product) throws CloudException, IOException {
-        beginPost202NoLocationWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202NoLocationWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3154,6 +3164,7 @@ public final class LROSADsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202NoLocationAsync(ProductInner product) {
@@ -3162,7 +3173,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3248,7 +3259,7 @@ public final class LROSADsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetryNoPayload(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3320,7 +3331,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3352,7 +3363,7 @@ public final class LROSADsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetryNoPayload(ProductInner product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3369,6 +3380,7 @@ public final class LROSADsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync(ProductInner product) {
@@ -3377,7 +3389,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3465,7 +3477,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put200InvalidJson(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
+        return put200InvalidJsonWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3538,7 +3550,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3571,7 +3583,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut200InvalidJson(ProductInner product) throws CloudException, IOException {
-        return beginPut200InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200InvalidJsonWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3588,6 +3600,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut200InvalidJsonAsync(ProductInner product) {
@@ -3596,7 +3609,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3685,7 +3698,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3758,7 +3771,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3791,7 +3804,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3808,6 +3821,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
@@ -3816,7 +3830,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3904,7 +3918,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3977,7 +3991,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4010,7 +4024,7 @@ public final class LROSADsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4027,6 +4041,7 @@ public final class LROSADsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
@@ -4035,7 +4050,7 @@ public final class LROSADsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4143,7 +4158,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4249,7 +4264,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4355,7 +4370,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4439,7 +4454,7 @@ public final class LROSADsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202RetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
-        post202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
+        post202RetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -4511,7 +4526,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4543,7 +4558,7 @@ public final class LROSADsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202RetryInvalidHeader(ProductInner product) throws CloudException, IOException {
-        beginPost202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202RetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4560,6 +4575,7 @@ public final class LROSADsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202RetryInvalidHeaderAsync(ProductInner product) {
@@ -4568,7 +4584,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4654,7 +4670,7 @@ public final class LROSADsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -4726,7 +4742,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4758,7 +4774,7 @@ public final class LROSADsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetryInvalidHeader(ProductInner product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4775,6 +4791,7 @@ public final class LROSADsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
@@ -4783,7 +4800,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4869,7 +4886,7 @@ public final class LROSADsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -4941,7 +4958,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4973,7 +4990,7 @@ public final class LROSADsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetryInvalidJsonPolling(ProductInner product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4990,6 +5007,7 @@ public final class LROSADsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
@@ -4998,7 +5016,7 @@ public final class LROSADsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersInner.java
@@ -146,7 +146,7 @@ public final class LROsCustomHeadersInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -219,7 +219,7 @@ public final class LROsCustomHeadersInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -252,7 +252,7 @@ public final class LROsCustomHeadersInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -269,6 +269,7 @@ public final class LROsCustomHeadersInner {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRetrySucceededAsync(ProductInner product) {
@@ -277,7 +278,7 @@ public final class LROsCustomHeadersInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -365,7 +366,7 @@ public final class LROsCustomHeadersInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -438,7 +439,7 @@ public final class LROsCustomHeadersInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -471,7 +472,7 @@ public final class LROsCustomHeadersInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -488,6 +489,7 @@ public final class LROsCustomHeadersInner {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product) {
@@ -496,7 +498,7 @@ public final class LROsCustomHeadersInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -583,7 +585,7 @@ public final class LROsCustomHeadersInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
+        post202Retry200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -655,7 +657,7 @@ public final class LROsCustomHeadersInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -687,7 +689,7 @@ public final class LROsCustomHeadersInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202Retry200(ProductInner product) throws CloudException, IOException {
-        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202Retry200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -704,6 +706,7 @@ public final class LROsCustomHeadersInner {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202Retry200Async(ProductInner product) {
@@ -712,7 +715,7 @@ public final class LROsCustomHeadersInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -798,7 +801,7 @@ public final class LROsCustomHeadersInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -870,7 +873,7 @@ public final class LROsCustomHeadersInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -902,7 +905,7 @@ public final class LROsCustomHeadersInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -919,6 +922,7 @@ public final class LROsCustomHeadersInner {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRetrySucceededAsync(ProductInner product) {
@@ -927,7 +931,7 @@ public final class LROsCustomHeadersInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersInner.java
@@ -96,10 +96,10 @@ public final class LROsCustomHeadersInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededAsync().toBlocking().last();
+    public ProductInner putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -109,7 +109,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -117,7 +117,21 @@ public final class LROsCustomHeadersInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>> putAsyncRetrySucceededAsync() {
+    public Observable<ProductInner> putAsyncRetrySucceededAsync() {
+        return putAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>> putAsyncRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsCustomHeaderPutAsyncRetrySucceededHeadersInner.class);
@@ -129,10 +143,10 @@ public final class LROsCustomHeadersInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> putAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededAsync(product).toBlocking().last();
+    public ProductInner putAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -143,7 +157,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -152,7 +166,22 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>> putAsyncRetrySucceededAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncRetrySucceededAsync(ProductInner product) {
+        return putAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>> putAsyncRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsCustomHeaderPutAsyncRetrySucceededHeadersInner.class);
@@ -163,10 +192,10 @@ public final class LROsCustomHeadersInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> beginPutAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededAsync().toBlocking().single();
+    public ProductInner beginPutAsyncRetrySucceeded() throws CloudException, IOException {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -176,7 +205,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -184,7 +213,21 @@ public final class LROsCustomHeadersInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>> beginPutAsyncRetrySucceededAsync() {
+    public Observable<ProductInner> beginPutAsyncRetrySucceededAsync() {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>> beginPutAsyncRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>>>() {
@@ -206,10 +249,10 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> beginPutAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -220,7 +263,21 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRetrySucceededAsync(ProductInner product) {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -229,7 +286,7 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>> beginPutAsyncRetrySucceededAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>> beginPutAsyncRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsCustomHeaderPutAsyncRetrySucceededHeadersInner>>>() {
@@ -258,10 +315,10 @@ public final class LROsCustomHeadersInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async().toBlocking().last();
+    public ProductInner put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -271,7 +328,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -279,7 +336,21 @@ public final class LROsCustomHeadersInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200Async() {
+    public Observable<ProductInner> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -291,10 +362,10 @@ public final class LROsCustomHeadersInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async(product).toBlocking().last();
+    public ProductInner put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -305,7 +376,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -314,7 +385,22 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200Async(ProductInner product) {
+    public Observable<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -325,10 +411,10 @@ public final class LROsCustomHeadersInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut201CreatingSucceeded200() throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async().toBlocking().single();
+    public ProductInner beginPut201CreatingSucceeded200() throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -338,7 +424,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -346,7 +432,21 @@ public final class LROsCustomHeadersInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200Async() {
+    public Observable<ProductInner> beginPut201CreatingSucceeded200Async() {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -368,10 +468,10 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async(product).toBlocking().single();
+    public ProductInner beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -382,7 +482,21 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product) {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -391,7 +505,7 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -421,10 +535,9 @@ public final class LROsCustomHeadersInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> post202Retry200() throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async().toBlocking().last();
+    public void post202Retry200() throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -434,7 +547,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -442,7 +555,21 @@ public final class LROsCustomHeadersInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>> post202Retry200Async() {
+    public Observable<Void> post202Retry200Async() {
+        return post202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>> post202Retry200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsCustomHeaderPost202Retry200HeadersInner.class);
@@ -454,10 +581,9 @@ public final class LROsCustomHeadersInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async(product).toBlocking().last();
+    public void post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -468,7 +594,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -477,7 +603,22 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>> post202Retry200Async(ProductInner product) {
+    public Observable<Void> post202Retry200Async(ProductInner product) {
+        return post202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>> post202Retry200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsCustomHeaderPost202Retry200HeadersInner.class);
@@ -488,10 +629,9 @@ public final class LROsCustomHeadersInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> beginPost202Retry200() throws CloudException, IOException {
-        return beginPost202Retry200Async().toBlocking().single();
+    public void beginPost202Retry200() throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -501,7 +641,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -509,7 +649,21 @@ public final class LROsCustomHeadersInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>> beginPost202Retry200Async() {
+    public Observable<Void> beginPost202Retry200Async() {
+        return beginPost202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>> beginPost202Retry200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>>>() {
@@ -531,10 +685,9 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> beginPost202Retry200(ProductInner product) throws CloudException, IOException {
-        return beginPost202Retry200Async(product).toBlocking().single();
+    public void beginPost202Retry200(ProductInner product) throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -545,7 +698,21 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202Retry200Async(ProductInner product) {
+        return beginPost202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -554,7 +721,7 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>> beginPost202Retry200Async(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>> beginPost202Retry200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200HeadersInner>>>() {
@@ -583,10 +750,9 @@ public final class LROsCustomHeadersInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededAsync().toBlocking().last();
+    public void postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -596,7 +762,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -604,7 +770,21 @@ public final class LROsCustomHeadersInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>> postAsyncRetrySucceededAsync() {
+    public Observable<Void> postAsyncRetrySucceededAsync() {
+        return postAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>> postAsyncRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsCustomHeaderPostAsyncRetrySucceededHeadersInner.class);
@@ -616,10 +796,9 @@ public final class LROsCustomHeadersInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> postAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededAsync(product).toBlocking().last();
+    public void postAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -630,7 +809,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -639,7 +818,22 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>> postAsyncRetrySucceededAsync(ProductInner product) {
+    public Observable<Void> postAsyncRetrySucceededAsync(ProductInner product) {
+        return postAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>> postAsyncRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsCustomHeaderPostAsyncRetrySucceededHeadersInner.class);
@@ -650,10 +844,9 @@ public final class LROsCustomHeadersInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> beginPostAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededAsync().toBlocking().single();
+    public void beginPostAsyncRetrySucceeded() throws CloudException, IOException {
+        beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -663,7 +856,7 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -671,7 +864,21 @@ public final class LROsCustomHeadersInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>> beginPostAsyncRetrySucceededAsync() {
+    public Observable<Void> beginPostAsyncRetrySucceededAsync() {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>> beginPostAsyncRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>>>() {
@@ -693,10 +900,9 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> beginPostAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededAsync(product).toBlocking().single();
+    public void beginPostAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
+        beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -707,7 +913,21 @@ public final class LROsCustomHeadersInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRetrySucceededAsync(ProductInner product) {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -716,7 +936,7 @@ public final class LROsCustomHeadersInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>> beginPostAsyncRetrySucceededAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>> beginPostAsyncRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeadersInner>>>() {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROsInner.java
@@ -403,7 +403,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put200Succeeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return put200SucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -476,7 +476,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -509,7 +509,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut200Succeeded(ProductInner product) throws CloudException, IOException {
-        return beginPut200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200SucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -526,6 +526,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut200SucceededAsync(ProductInner product) {
@@ -534,7 +535,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -623,7 +624,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put200SucceededNoState(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200SucceededNoStateWithServiceResponseAsync().toBlocking().last().getBody();
+        return put200SucceededNoStateWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -696,7 +697,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -729,7 +730,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut200SucceededNoState(ProductInner product) throws CloudException, IOException {
-        return beginPut200SucceededNoStateWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200SucceededNoStateWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -746,6 +747,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut200SucceededNoStateAsync(ProductInner product) {
@@ -754,7 +756,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -842,7 +844,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put202Retry200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -915,7 +917,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -948,7 +950,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut202Retry200(ProductInner product) throws CloudException, IOException {
-        return beginPut202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut202Retry200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -965,6 +967,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut202Retry200Async(ProductInner product) {
@@ -973,7 +976,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1061,7 +1064,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1134,7 +1137,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1167,7 +1170,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1184,6 +1187,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product) {
@@ -1192,7 +1196,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1281,7 +1285,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put200UpdatingSucceeded204(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().last().getBody();
+        return put200UpdatingSucceeded204WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1354,7 +1358,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1387,7 +1391,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut200UpdatingSucceeded204(ProductInner product) throws CloudException, IOException {
-        return beginPut200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1404,6 +1408,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut200UpdatingSucceeded204Async(ProductInner product) {
@@ -1412,7 +1417,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1500,7 +1505,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put201CreatingFailed200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingFailed200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put201CreatingFailed200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1573,7 +1578,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1606,7 +1611,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut201CreatingFailed200(ProductInner product) throws CloudException, IOException {
-        return beginPut201CreatingFailed200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut201CreatingFailed200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1623,6 +1628,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut201CreatingFailed200Async(ProductInner product) {
@@ -1631,7 +1637,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1720,7 +1726,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner put200Acceptedcanceled200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200Acceptedcanceled200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put200Acceptedcanceled200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1793,7 +1799,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1826,7 +1832,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPut200Acceptedcanceled200(ProductInner product) throws CloudException, IOException {
-        return beginPut200Acceptedcanceled200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1843,6 +1849,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPut200Acceptedcanceled200Async(ProductInner product) {
@@ -1851,7 +1858,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponse<ProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1939,7 +1946,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putNoHeaderInRetry(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
+        return putNoHeaderInRetryWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2012,7 +2019,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2045,7 +2052,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutNoHeaderInRetry(ProductInner product) throws CloudException, IOException {
-        return beginPutNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNoHeaderInRetryWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2062,6 +2069,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutNoHeaderInRetryAsync(ProductInner product) {
@@ -2070,7 +2078,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2158,7 +2166,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2231,7 +2239,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2264,7 +2272,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2281,6 +2289,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRetrySucceededAsync(ProductInner product) {
@@ -2289,7 +2298,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2377,7 +2386,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncNoRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2450,7 +2459,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2483,7 +2492,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2500,6 +2509,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncNoRetrySucceededAsync(ProductInner product) {
@@ -2508,7 +2518,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2596,7 +2606,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncRetryFailed(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRetryFailedWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2669,7 +2679,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2702,7 +2712,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncRetryFailed(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRetryFailedWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2719,6 +2729,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncRetryFailedAsync(ProductInner product) {
@@ -2727,7 +2738,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2815,7 +2826,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncNoRetrycanceled(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncNoRetrycanceledWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2888,7 +2899,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2921,7 +2932,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncNoRetrycanceled(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2938,6 +2949,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncNoRetrycanceledAsync(ProductInner product) {
@@ -2946,7 +2958,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3034,7 +3046,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner putAsyncNoHeaderInRetry(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3107,7 +3119,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3140,7 +3152,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPutAsyncNoHeaderInRetry(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3157,6 +3169,7 @@ public final class LROsInner {
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPutAsyncNoHeaderInRetryAsync(ProductInner product) {
@@ -3165,7 +3178,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3253,7 +3266,7 @@ public final class LROsInner {
      * @return the SkuInner object if successful.
      */
     public SkuInner putNonResource(SkuInner sku) throws CloudException, IOException, InterruptedException {
-        return putNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
+        return putNonResourceWithServiceResponseAsync(sku).toBlocking().last().getBody();
     }
 
     /**
@@ -3326,7 +3339,7 @@ public final class LROsInner {
             public SkuInner call(ServiceResponse<SkuInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3359,7 +3372,7 @@ public final class LROsInner {
      * @return the SkuInner object if successful.
      */
     public SkuInner beginPutNonResource(SkuInner sku) throws CloudException, IOException {
-        return beginPutNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNonResourceWithServiceResponseAsync(sku).toBlocking().single().getBody();
     }
 
     /**
@@ -3376,6 +3389,7 @@ public final class LROsInner {
     /**
      * Long running put request with non resource.
      *
+     * @param sku sku to put
      * @return the observable to the SkuInner object
      */
     public Observable<SkuInner> beginPutNonResourceAsync(SkuInner sku) {
@@ -3384,7 +3398,7 @@ public final class LROsInner {
             public SkuInner call(ServiceResponse<SkuInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3472,7 +3486,7 @@ public final class LROsInner {
      * @return the SkuInner object if successful.
      */
     public SkuInner putAsyncNonResource(SkuInner sku) throws CloudException, IOException, InterruptedException {
-        return putAsyncNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncNonResourceWithServiceResponseAsync(sku).toBlocking().last().getBody();
     }
 
     /**
@@ -3545,7 +3559,7 @@ public final class LROsInner {
             public SkuInner call(ServiceResponse<SkuInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3578,7 +3592,7 @@ public final class LROsInner {
      * @return the SkuInner object if successful.
      */
     public SkuInner beginPutAsyncNonResource(SkuInner sku) throws CloudException, IOException {
-        return beginPutAsyncNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncNonResourceWithServiceResponseAsync(sku).toBlocking().single().getBody();
     }
 
     /**
@@ -3595,6 +3609,7 @@ public final class LROsInner {
     /**
      * Long running put request with non resource.
      *
+     * @param sku Sku to put
      * @return the observable to the SkuInner object
      */
     public Observable<SkuInner> beginPutAsyncNonResourceAsync(SkuInner sku) {
@@ -3603,7 +3618,7 @@ public final class LROsInner {
             public SkuInner call(ServiceResponse<SkuInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3691,7 +3706,7 @@ public final class LROsInner {
      * @return the SubProductInner object if successful.
      */
     public SubProductInner putSubResource(SubProductInner product) throws CloudException, IOException, InterruptedException {
-        return putSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
+        return putSubResourceWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3764,7 +3779,7 @@ public final class LROsInner {
             public SubProductInner call(ServiceResponse<SubProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3797,7 +3812,7 @@ public final class LROsInner {
      * @return the SubProductInner object if successful.
      */
     public SubProductInner beginPutSubResource(SubProductInner product) throws CloudException, IOException {
-        return beginPutSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutSubResourceWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3814,6 +3829,7 @@ public final class LROsInner {
     /**
      * Long running put request with sub resource.
      *
+     * @param product Sub Product to put
      * @return the observable to the SubProductInner object
      */
     public Observable<SubProductInner> beginPutSubResourceAsync(SubProductInner product) {
@@ -3822,7 +3838,7 @@ public final class LROsInner {
             public SubProductInner call(ServiceResponse<SubProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3910,7 +3926,7 @@ public final class LROsInner {
      * @return the SubProductInner object if successful.
      */
     public SubProductInner putAsyncSubResource(SubProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncSubResourceWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3983,7 +3999,7 @@ public final class LROsInner {
             public SubProductInner call(ServiceResponse<SubProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4016,7 +4032,7 @@ public final class LROsInner {
      * @return the SubProductInner object if successful.
      */
     public SubProductInner beginPutAsyncSubResource(SubProductInner product) throws CloudException, IOException {
-        return beginPutAsyncSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncSubResourceWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4033,6 +4049,7 @@ public final class LROsInner {
     /**
      * Long running put request with sub resource.
      *
+     * @param product Sub Product to put
      * @return the observable to the SubProductInner object
      */
     public Observable<SubProductInner> beginPutAsyncSubResourceAsync(SubProductInner product) {
@@ -4041,7 +4058,7 @@ public final class LROsInner {
             public SubProductInner call(ServiceResponse<SubProductInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4151,7 +4168,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4260,7 +4277,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4369,7 +4386,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4476,7 +4493,7 @@ public final class LROsInner {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4584,7 +4601,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4693,7 +4710,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4800,7 +4817,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4907,7 +4924,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5014,7 +5031,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5120,7 +5137,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5226,7 +5243,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5332,7 +5349,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5440,7 +5457,7 @@ public final class LROsInner {
             public SkuInner call(ServiceResponse<SkuInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5525,7 +5542,7 @@ public final class LROsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
+        post202Retry200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -5597,7 +5614,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5629,7 +5646,7 @@ public final class LROsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202Retry200(ProductInner product) throws CloudException, IOException {
-        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202Retry200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -5646,6 +5663,7 @@ public final class LROsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202Retry200Async(ProductInner product) {
@@ -5654,7 +5672,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5742,7 +5760,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner post202NoRetry204(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return post202NoRetry204WithServiceResponseAsync().toBlocking().last().getBody();
+        return post202NoRetry204WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -5815,7 +5833,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5848,7 +5866,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPost202NoRetry204(ProductInner product) throws CloudException, IOException {
-        return beginPost202NoRetry204WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPost202NoRetry204WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -5865,6 +5883,7 @@ public final class LROsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPost202NoRetry204Async(ProductInner product) {
@@ -5873,7 +5892,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5961,7 +5980,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner postAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return postAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -6034,7 +6053,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6067,7 +6086,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPostAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -6084,6 +6103,7 @@ public final class LROsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPostAsyncRetrySucceededAsync(ProductInner product) {
@@ -6092,7 +6112,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6181,7 +6201,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner postAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return postAsyncNoRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -6254,7 +6274,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6287,7 +6307,7 @@ public final class LROsInner {
      * @return the ProductInner object if successful.
      */
     public ProductInner beginPostAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -6304,6 +6324,7 @@ public final class LROsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the ProductInner object
      */
     public Observable<ProductInner> beginPostAsyncNoRetrySucceededAsync(ProductInner product) {
@@ -6312,7 +6333,7 @@ public final class LROsInner {
             public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6399,7 +6420,7 @@ public final class LROsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRetryFailed(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRetryFailedWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -6471,7 +6492,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6503,7 +6524,7 @@ public final class LROsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRetryFailed(ProductInner product) throws CloudException, IOException {
-        beginPostAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRetryFailedWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -6520,6 +6541,7 @@ public final class LROsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRetryFailedAsync(ProductInner product) {
@@ -6528,7 +6550,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6614,7 +6636,7 @@ public final class LROsInner {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRetrycanceled(ProductInner product) throws CloudException, IOException, InterruptedException {
-        postAsyncRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRetrycanceledWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -6686,7 +6708,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6718,7 +6740,7 @@ public final class LROsInner {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRetrycanceled(ProductInner product) throws CloudException, IOException {
-        beginPostAsyncRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRetrycanceledWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -6735,6 +6757,7 @@ public final class LROsInner {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRetrycanceledAsync(ProductInner product) {
@@ -6743,7 +6766,7 @@ public final class LROsInner {
             public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/lro/implementation/LROsInner.java
@@ -353,10 +353,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put200Succeeded() throws CloudException, IOException, InterruptedException {
-        return put200SucceededAsync().toBlocking().last();
+    public ProductInner put200Succeeded() throws CloudException, IOException, InterruptedException {
+        return put200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -366,7 +366,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200SucceededAsync(), serviceCallback);
+        return ServiceCall.create(put200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -374,7 +374,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200SucceededAsync() {
+    public Observable<ProductInner> put200SucceededAsync() {
+        return put200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200SucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -386,10 +400,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put200Succeeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200SucceededAsync(product).toBlocking().last();
+    public ProductInner put200Succeeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -400,7 +414,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200SucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200SucceededAsync(product), serviceCallback);
+        return ServiceCall.create(put200SucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -409,7 +423,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200SucceededAsync(ProductInner product) {
+    public Observable<ProductInner> put200SucceededAsync(ProductInner product) {
+        return put200SucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200SucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -420,10 +449,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200Succeeded() throws CloudException, IOException {
-        return beginPut200SucceededAsync().toBlocking().single();
+    public ProductInner beginPut200Succeeded() throws CloudException, IOException {
+        return beginPut200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -433,7 +462,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200SucceededAsync(), serviceCallback);
+        return ServiceCall.create(beginPut200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -441,7 +470,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200SucceededAsync() {
+    public Observable<ProductInner> beginPut200SucceededAsync() {
+        return beginPut200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut200SucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -463,10 +506,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200Succeeded(ProductInner product) throws CloudException, IOException {
-        return beginPut200SucceededAsync(product).toBlocking().single();
+    public ProductInner beginPut200Succeeded(ProductInner product) throws CloudException, IOException {
+        return beginPut200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -477,7 +520,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200SucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200SucceededAsync(product), serviceCallback);
+        return ServiceCall.create(beginPut200SucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut200SucceededAsync(ProductInner product) {
+        return beginPut200SucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -486,7 +543,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200SucceededAsync(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut200SucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -516,10 +573,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put200SucceededNoState() throws CloudException, IOException, InterruptedException {
-        return put200SucceededNoStateAsync().toBlocking().last();
+    public ProductInner put200SucceededNoState() throws CloudException, IOException, InterruptedException {
+        return put200SucceededNoStateWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -529,7 +586,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200SucceededNoStateAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200SucceededNoStateAsync(), serviceCallback);
+        return ServiceCall.create(put200SucceededNoStateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -537,7 +594,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200SucceededNoStateAsync() {
+    public Observable<ProductInner> put200SucceededNoStateAsync() {
+        return put200SucceededNoStateWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200SucceededNoStateWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -549,10 +620,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put200SucceededNoState(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200SucceededNoStateAsync(product).toBlocking().last();
+    public ProductInner put200SucceededNoState(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put200SucceededNoStateWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -563,7 +634,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200SucceededNoStateAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200SucceededNoStateAsync(product), serviceCallback);
+        return ServiceCall.create(put200SucceededNoStateWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -572,7 +643,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200SucceededNoStateAsync(ProductInner product) {
+    public Observable<ProductInner> put200SucceededNoStateAsync(ProductInner product) {
+        return put200SucceededNoStateWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200SucceededNoStateWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -583,10 +669,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200SucceededNoState() throws CloudException, IOException {
-        return beginPut200SucceededNoStateAsync().toBlocking().single();
+    public ProductInner beginPut200SucceededNoState() throws CloudException, IOException {
+        return beginPut200SucceededNoStateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -596,7 +682,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200SucceededNoStateAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200SucceededNoStateAsync(), serviceCallback);
+        return ServiceCall.create(beginPut200SucceededNoStateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -604,7 +690,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200SucceededNoStateAsync() {
+    public Observable<ProductInner> beginPut200SucceededNoStateAsync() {
+        return beginPut200SucceededNoStateWithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut200SucceededNoStateWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -626,10 +726,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200SucceededNoState(ProductInner product) throws CloudException, IOException {
-        return beginPut200SucceededNoStateAsync(product).toBlocking().single();
+    public ProductInner beginPut200SucceededNoState(ProductInner product) throws CloudException, IOException {
+        return beginPut200SucceededNoStateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -640,7 +740,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200SucceededNoStateAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200SucceededNoStateAsync(product), serviceCallback);
+        return ServiceCall.create(beginPut200SucceededNoStateWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut200SucceededNoStateAsync(ProductInner product) {
+        return beginPut200SucceededNoStateWithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -649,7 +763,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200SucceededNoStateAsync(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut200SucceededNoStateWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -678,10 +792,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put202Retry200() throws CloudException, IOException, InterruptedException {
-        return put202Retry200Async().toBlocking().last();
+    public ProductInner put202Retry200() throws CloudException, IOException, InterruptedException {
+        return put202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -691,7 +805,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put202Retry200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put202Retry200Async(), serviceCallback);
+        return ServiceCall.create(put202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -699,7 +813,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put202Retry200Async() {
+    public Observable<ProductInner> put202Retry200Async() {
+        return put202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put202Retry200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -711,10 +839,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put202Retry200Async(product).toBlocking().last();
+    public ProductInner put202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -725,7 +853,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put202Retry200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put202Retry200Async(product), serviceCallback);
+        return ServiceCall.create(put202Retry200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -734,7 +862,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put202Retry200Async(ProductInner product) {
+    public Observable<ProductInner> put202Retry200Async(ProductInner product) {
+        return put202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put202Retry200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -745,10 +888,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut202Retry200() throws CloudException, IOException {
-        return beginPut202Retry200Async().toBlocking().single();
+    public ProductInner beginPut202Retry200() throws CloudException, IOException {
+        return beginPut202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -758,7 +901,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut202Retry200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut202Retry200Async(), serviceCallback);
+        return ServiceCall.create(beginPut202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -766,7 +909,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut202Retry200Async() {
+    public Observable<ProductInner> beginPut202Retry200Async() {
+        return beginPut202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut202Retry200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -788,10 +945,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut202Retry200(ProductInner product) throws CloudException, IOException {
-        return beginPut202Retry200Async(product).toBlocking().single();
+    public ProductInner beginPut202Retry200(ProductInner product) throws CloudException, IOException {
+        return beginPut202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -802,7 +959,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut202Retry200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut202Retry200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut202Retry200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut202Retry200Async(ProductInner product) {
+        return beginPut202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -811,7 +982,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut202Retry200Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut202Retry200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -840,10 +1011,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async().toBlocking().last();
+    public ProductInner put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -853,7 +1024,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -861,7 +1032,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200Async() {
+    public Observable<ProductInner> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -873,10 +1058,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async(product).toBlocking().last();
+    public ProductInner put201CreatingSucceeded200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -887,7 +1072,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -896,7 +1081,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200Async(ProductInner product) {
+    public Observable<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put201CreatingSucceeded200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -907,10 +1107,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut201CreatingSucceeded200() throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async().toBlocking().single();
+    public ProductInner beginPut201CreatingSucceeded200() throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -920,7 +1120,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -928,7 +1128,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200Async() {
+    public Observable<ProductInner> beginPut201CreatingSucceeded200Async() {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -950,10 +1164,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async(product).toBlocking().single();
+    public ProductInner beginPut201CreatingSucceeded200(ProductInner product) throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -964,7 +1178,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut201CreatingSucceeded200Async(ProductInner product) {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -973,7 +1201,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingSucceeded200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1003,10 +1231,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put200UpdatingSucceeded204() throws CloudException, IOException, InterruptedException {
-        return put200UpdatingSucceeded204Async().toBlocking().last();
+    public ProductInner put200UpdatingSucceeded204() throws CloudException, IOException, InterruptedException {
+        return put200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1016,7 +1244,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200UpdatingSucceeded204Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200UpdatingSucceeded204Async(), serviceCallback);
+        return ServiceCall.create(put200UpdatingSucceeded204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1024,7 +1252,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200UpdatingSucceeded204Async() {
+    public Observable<ProductInner> put200UpdatingSucceeded204Async() {
+        return put200UpdatingSucceeded204WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200UpdatingSucceeded204WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -1036,10 +1278,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put200UpdatingSucceeded204(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200UpdatingSucceeded204Async(product).toBlocking().last();
+    public ProductInner put200UpdatingSucceeded204(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1050,7 +1292,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200UpdatingSucceeded204Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200UpdatingSucceeded204Async(product), serviceCallback);
+        return ServiceCall.create(put200UpdatingSucceeded204WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1059,7 +1301,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200UpdatingSucceeded204Async(ProductInner product) {
+    public Observable<ProductInner> put200UpdatingSucceeded204Async(ProductInner product) {
+        return put200UpdatingSucceeded204WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200UpdatingSucceeded204WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -1070,10 +1327,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200UpdatingSucceeded204() throws CloudException, IOException {
-        return beginPut200UpdatingSucceeded204Async().toBlocking().single();
+    public ProductInner beginPut200UpdatingSucceeded204() throws CloudException, IOException {
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1083,7 +1340,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200UpdatingSucceeded204Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200UpdatingSucceeded204Async(), serviceCallback);
+        return ServiceCall.create(beginPut200UpdatingSucceeded204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1091,7 +1348,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200UpdatingSucceeded204Async() {
+    public Observable<ProductInner> beginPut200UpdatingSucceeded204Async() {
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut200UpdatingSucceeded204WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1113,10 +1384,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200UpdatingSucceeded204(ProductInner product) throws CloudException, IOException {
-        return beginPut200UpdatingSucceeded204Async(product).toBlocking().single();
+    public ProductInner beginPut200UpdatingSucceeded204(ProductInner product) throws CloudException, IOException {
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1127,7 +1398,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200UpdatingSucceeded204Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200UpdatingSucceeded204Async(product), serviceCallback);
+        return ServiceCall.create(beginPut200UpdatingSucceeded204WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut200UpdatingSucceeded204Async(ProductInner product) {
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1136,7 +1421,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200UpdatingSucceeded204Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut200UpdatingSucceeded204WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1165,10 +1450,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put201CreatingFailed200() throws CloudException, IOException, InterruptedException {
-        return put201CreatingFailed200Async().toBlocking().last();
+    public ProductInner put201CreatingFailed200() throws CloudException, IOException, InterruptedException {
+        return put201CreatingFailed200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1178,7 +1463,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put201CreatingFailed200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put201CreatingFailed200Async(), serviceCallback);
+        return ServiceCall.create(put201CreatingFailed200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1186,7 +1471,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put201CreatingFailed200Async() {
+    public Observable<ProductInner> put201CreatingFailed200Async() {
+        return put201CreatingFailed200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put201CreatingFailed200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -1198,10 +1497,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put201CreatingFailed200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingFailed200Async(product).toBlocking().last();
+    public ProductInner put201CreatingFailed200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put201CreatingFailed200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1212,7 +1511,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put201CreatingFailed200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put201CreatingFailed200Async(product), serviceCallback);
+        return ServiceCall.create(put201CreatingFailed200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1221,7 +1520,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put201CreatingFailed200Async(ProductInner product) {
+    public Observable<ProductInner> put201CreatingFailed200Async(ProductInner product) {
+        return put201CreatingFailed200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put201CreatingFailed200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -1232,10 +1546,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut201CreatingFailed200() throws CloudException, IOException {
-        return beginPut201CreatingFailed200Async().toBlocking().single();
+    public ProductInner beginPut201CreatingFailed200() throws CloudException, IOException {
+        return beginPut201CreatingFailed200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1245,7 +1559,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut201CreatingFailed200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingFailed200Async(), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingFailed200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1253,7 +1567,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingFailed200Async() {
+    public Observable<ProductInner> beginPut201CreatingFailed200Async() {
+        return beginPut201CreatingFailed200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingFailed200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1275,10 +1603,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut201CreatingFailed200(ProductInner product) throws CloudException, IOException {
-        return beginPut201CreatingFailed200Async(product).toBlocking().single();
+    public ProductInner beginPut201CreatingFailed200(ProductInner product) throws CloudException, IOException {
+        return beginPut201CreatingFailed200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1289,7 +1617,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut201CreatingFailed200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingFailed200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingFailed200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut201CreatingFailed200Async(ProductInner product) {
+        return beginPut201CreatingFailed200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1298,7 +1640,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingFailed200Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut201CreatingFailed200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1328,10 +1670,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponse<ProductInner> put200Acceptedcanceled200() throws CloudException, IOException, InterruptedException {
-        return put200Acceptedcanceled200Async().toBlocking().last();
+    public ProductInner put200Acceptedcanceled200() throws CloudException, IOException, InterruptedException {
+        return put200Acceptedcanceled200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1341,7 +1683,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200Acceptedcanceled200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200Acceptedcanceled200Async(), serviceCallback);
+        return ServiceCall.create(put200Acceptedcanceled200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1349,7 +1691,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200Acceptedcanceled200Async() {
+    public Observable<ProductInner> put200Acceptedcanceled200Async() {
+        return put200Acceptedcanceled200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200Acceptedcanceled200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.put200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -1361,10 +1717,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponse if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> put200Acceptedcanceled200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return put200Acceptedcanceled200Async(product).toBlocking().last();
+    public ProductInner put200Acceptedcanceled200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return put200Acceptedcanceled200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1375,7 +1731,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> put200Acceptedcanceled200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(put200Acceptedcanceled200Async(product), serviceCallback);
+        return ServiceCall.create(put200Acceptedcanceled200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1384,7 +1740,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<ProductInner>> put200Acceptedcanceled200Async(ProductInner product) {
+    public Observable<ProductInner> put200Acceptedcanceled200Async(ProductInner product) {
+        return put200Acceptedcanceled200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<ProductInner>> put200Acceptedcanceled200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
@@ -1395,10 +1766,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200Acceptedcanceled200() throws CloudException, IOException {
-        return beginPut200Acceptedcanceled200Async().toBlocking().single();
+    public ProductInner beginPut200Acceptedcanceled200() throws CloudException, IOException {
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1408,7 +1779,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200Acceptedcanceled200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200Acceptedcanceled200Async(), serviceCallback);
+        return ServiceCall.create(beginPut200Acceptedcanceled200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1416,7 +1787,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200Acceptedcanceled200Async() {
+    public Observable<ProductInner> beginPut200Acceptedcanceled200Async() {
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync().map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponse<ProductInner>> beginPut200Acceptedcanceled200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPut200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1438,10 +1823,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponse<ProductInner> beginPut200Acceptedcanceled200(ProductInner product) throws CloudException, IOException {
-        return beginPut200Acceptedcanceled200Async(product).toBlocking().single();
+    public ProductInner beginPut200Acceptedcanceled200(ProductInner product) throws CloudException, IOException {
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1452,7 +1837,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPut200Acceptedcanceled200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.create(beginPut200Acceptedcanceled200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut200Acceptedcanceled200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPut200Acceptedcanceled200Async(ProductInner product) {
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<ProductInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponse<ProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1461,7 +1860,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponse<ProductInner>> beginPut200Acceptedcanceled200Async(ProductInner product) {
+    public Observable<ServiceResponse<ProductInner>> beginPut200Acceptedcanceled200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPut200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ProductInner>>>() {
@@ -1490,10 +1889,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> putNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
-        return putNoHeaderInRetryAsync().toBlocking().last();
+    public ProductInner putNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
+        return putNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1503,7 +1902,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putNoHeaderInRetryAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1511,7 +1910,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>> putNoHeaderInRetryAsync() {
+    public Observable<ProductInner> putNoHeaderInRetryAsync() {
+        return putNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>> putNoHeaderInRetryWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutNoHeaderInRetryHeadersInner.class);
@@ -1523,10 +1936,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> putNoHeaderInRetry(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putNoHeaderInRetryAsync(product).toBlocking().last();
+    public ProductInner putNoHeaderInRetry(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1537,7 +1950,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putNoHeaderInRetryAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putNoHeaderInRetryAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putNoHeaderInRetryWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1546,7 +1959,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>> putNoHeaderInRetryAsync(ProductInner product) {
+    public Observable<ProductInner> putNoHeaderInRetryAsync(ProductInner product) {
+        return putNoHeaderInRetryWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>> putNoHeaderInRetryWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutNoHeaderInRetryHeadersInner.class);
@@ -1557,10 +1985,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> beginPutNoHeaderInRetry() throws CloudException, IOException {
-        return beginPutNoHeaderInRetryAsync().toBlocking().single();
+    public ProductInner beginPutNoHeaderInRetry() throws CloudException, IOException {
+        return beginPutNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1570,7 +1998,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutNoHeaderInRetryAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1578,7 +2006,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>> beginPutNoHeaderInRetryAsync() {
+    public Observable<ProductInner> beginPutNoHeaderInRetryAsync() {
+        return beginPutNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>> beginPutNoHeaderInRetryWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>>>() {
@@ -1600,10 +2042,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> beginPutNoHeaderInRetry(ProductInner product) throws CloudException, IOException {
-        return beginPutNoHeaderInRetryAsync(product).toBlocking().single();
+    public ProductInner beginPutNoHeaderInRetry(ProductInner product) throws CloudException, IOException {
+        return beginPutNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1614,7 +2056,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutNoHeaderInRetryAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutNoHeaderInRetryAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutNoHeaderInRetryWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutNoHeaderInRetryAsync(ProductInner product) {
+        return beginPutNoHeaderInRetryWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1623,7 +2079,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>> beginPutNoHeaderInRetryAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>> beginPutNoHeaderInRetryWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutNoHeaderInRetryHeadersInner>>>() {
@@ -1652,10 +2108,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededAsync().toBlocking().last();
+    public ProductInner putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1665,7 +2121,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1673,7 +2129,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>> putAsyncRetrySucceededAsync() {
+    public Observable<ProductInner> putAsyncRetrySucceededAsync() {
+        return putAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>> putAsyncRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncRetrySucceededHeadersInner.class);
@@ -1685,10 +2155,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> putAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededAsync(product).toBlocking().last();
+    public ProductInner putAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1699,7 +2169,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1708,7 +2178,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>> putAsyncRetrySucceededAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncRetrySucceededAsync(ProductInner product) {
+        return putAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>> putAsyncRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncRetrySucceededHeadersInner.class);
@@ -1719,10 +2204,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> beginPutAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededAsync().toBlocking().single();
+    public ProductInner beginPutAsyncRetrySucceeded() throws CloudException, IOException {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1732,7 +2217,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1740,7 +2225,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>> beginPutAsyncRetrySucceededAsync() {
+    public Observable<ProductInner> beginPutAsyncRetrySucceededAsync() {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>> beginPutAsyncRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>>>() {
@@ -1762,10 +2261,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> beginPutAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1776,7 +2275,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRetrySucceededAsync(ProductInner product) {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1785,7 +2298,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>> beginPutAsyncRetrySucceededAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>> beginPutAsyncRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetrySucceededHeadersInner>>>() {
@@ -1814,10 +2327,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> putAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrySucceededAsync().toBlocking().last();
+    public ProductInner putAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return putAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1827,7 +2340,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncNoRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1835,7 +2348,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>> putAsyncNoRetrySucceededAsync() {
+    public Observable<ProductInner> putAsyncNoRetrySucceededAsync() {
+        return putAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>> putAsyncNoRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncNoRetrySucceededHeadersInner.class);
@@ -1847,10 +2374,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> putAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrySucceededAsync(product).toBlocking().last();
+    public ProductInner putAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1861,7 +2388,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncNoRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1870,7 +2397,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>> putAsyncNoRetrySucceededAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncNoRetrySucceededAsync(ProductInner product) {
+        return putAsyncNoRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>> putAsyncNoRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncNoRetrySucceededHeadersInner.class);
@@ -1881,10 +2423,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> beginPutAsyncNoRetrySucceeded() throws CloudException, IOException {
-        return beginPutAsyncNoRetrySucceededAsync().toBlocking().single();
+    public ProductInner beginPutAsyncNoRetrySucceeded() throws CloudException, IOException {
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1894,7 +2436,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncNoRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1902,7 +2444,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>> beginPutAsyncNoRetrySucceededAsync() {
+    public Observable<ProductInner> beginPutAsyncNoRetrySucceededAsync() {
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>> beginPutAsyncNoRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>>>() {
@@ -1924,10 +2480,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> beginPutAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncNoRetrySucceededAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1938,7 +2494,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncNoRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncNoRetrySucceededAsync(ProductInner product) {
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1947,7 +2517,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>> beginPutAsyncNoRetrySucceededAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>> beginPutAsyncNoRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrySucceededHeadersInner>>>() {
@@ -1976,10 +2546,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> putAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
-        return putAsyncRetryFailedAsync().toBlocking().last();
+    public ProductInner putAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
+        return putAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1989,7 +2559,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRetryFailedAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1997,7 +2567,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>> putAsyncRetryFailedAsync() {
+    public Observable<ProductInner> putAsyncRetryFailedAsync() {
+        return putAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>> putAsyncRetryFailedWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncRetryFailedHeadersInner.class);
@@ -2009,10 +2593,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> putAsyncRetryFailed(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetryFailedAsync(product).toBlocking().last();
+    public ProductInner putAsyncRetryFailed(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2023,7 +2607,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncRetryFailedAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetryFailedAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetryFailedWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2032,7 +2616,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>> putAsyncRetryFailedAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncRetryFailedAsync(ProductInner product) {
+        return putAsyncRetryFailedWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>> putAsyncRetryFailedWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncRetryFailedHeadersInner.class);
@@ -2043,10 +2642,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> beginPutAsyncRetryFailed() throws CloudException, IOException {
-        return beginPutAsyncRetryFailedAsync().toBlocking().single();
+    public ProductInner beginPutAsyncRetryFailed() throws CloudException, IOException {
+        return beginPutAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2056,7 +2655,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRetryFailedAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2064,7 +2663,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>> beginPutAsyncRetryFailedAsync() {
+    public Observable<ProductInner> beginPutAsyncRetryFailedAsync() {
+        return beginPutAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>> beginPutAsyncRetryFailedWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>>>() {
@@ -2086,10 +2699,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> beginPutAsyncRetryFailed(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncRetryFailedAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncRetryFailed(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2100,7 +2713,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncRetryFailedAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetryFailedAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetryFailedWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncRetryFailedAsync(ProductInner product) {
+        return beginPutAsyncRetryFailedWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2109,7 +2736,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>> beginPutAsyncRetryFailedAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>> beginPutAsyncRetryFailedWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncRetryFailedHeadersInner>>>() {
@@ -2138,10 +2765,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> putAsyncNoRetrycanceled() throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrycanceledAsync().toBlocking().last();
+    public ProductInner putAsyncNoRetrycanceled() throws CloudException, IOException, InterruptedException {
+        return putAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2151,7 +2778,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncNoRetrycanceledAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2159,7 +2786,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>> putAsyncNoRetrycanceledAsync() {
+    public Observable<ProductInner> putAsyncNoRetrycanceledAsync() {
+        return putAsyncNoRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>> putAsyncNoRetrycanceledWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncNoRetrycanceledHeadersInner.class);
@@ -2171,10 +2812,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> putAsyncNoRetrycanceled(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrycanceledAsync(product).toBlocking().last();
+    public ProductInner putAsyncNoRetrycanceled(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2185,7 +2826,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncNoRetrycanceledAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoRetrycanceledAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoRetrycanceledWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2194,7 +2835,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>> putAsyncNoRetrycanceledAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncNoRetrycanceledAsync(ProductInner product) {
+        return putAsyncNoRetrycanceledWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>> putAsyncNoRetrycanceledWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncNoRetrycanceledHeadersInner.class);
@@ -2205,10 +2861,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> beginPutAsyncNoRetrycanceled() throws CloudException, IOException {
-        return beginPutAsyncNoRetrycanceledAsync().toBlocking().single();
+    public ProductInner beginPutAsyncNoRetrycanceled() throws CloudException, IOException {
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2218,7 +2874,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncNoRetrycanceledAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2226,7 +2882,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>> beginPutAsyncNoRetrycanceledAsync() {
+    public Observable<ProductInner> beginPutAsyncNoRetrycanceledAsync() {
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>> beginPutAsyncNoRetrycanceledWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>>>() {
@@ -2248,10 +2918,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> beginPutAsyncNoRetrycanceled(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncNoRetrycanceledAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncNoRetrycanceled(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2262,7 +2932,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncNoRetrycanceledAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrycanceledAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrycanceledWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncNoRetrycanceledAsync(ProductInner product) {
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2271,7 +2955,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>> beginPutAsyncNoRetrycanceledAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>> beginPutAsyncNoRetrycanceledWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoRetrycanceledHeadersInner>>>() {
@@ -2300,10 +2984,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> putAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
-        return putAsyncNoHeaderInRetryAsync().toBlocking().last();
+    public ProductInner putAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2313,7 +2997,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncNoHeaderInRetryAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2321,7 +3005,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>> putAsyncNoHeaderInRetryAsync() {
+    public Observable<ProductInner> putAsyncNoHeaderInRetryAsync() {
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>> putAsyncNoHeaderInRetryWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncNoHeaderInRetryHeadersInner.class);
@@ -2333,10 +3031,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> putAsyncNoHeaderInRetry(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoHeaderInRetryAsync(product).toBlocking().last();
+    public ProductInner putAsyncNoHeaderInRetry(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2347,7 +3045,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> putAsyncNoHeaderInRetryAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoHeaderInRetryAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoHeaderInRetryWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2356,7 +3054,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>> putAsyncNoHeaderInRetryAsync(ProductInner product) {
+    public Observable<ProductInner> putAsyncNoHeaderInRetryAsync(ProductInner product) {
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>> putAsyncNoHeaderInRetryWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPutAsyncNoHeaderInRetryHeadersInner.class);
@@ -2367,10 +3080,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> beginPutAsyncNoHeaderInRetry() throws CloudException, IOException {
-        return beginPutAsyncNoHeaderInRetryAsync().toBlocking().single();
+    public ProductInner beginPutAsyncNoHeaderInRetry() throws CloudException, IOException {
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2380,7 +3093,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncNoHeaderInRetryAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2388,7 +3101,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>> beginPutAsyncNoHeaderInRetryAsync() {
+    public Observable<ProductInner> beginPutAsyncNoHeaderInRetryAsync() {
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>> beginPutAsyncNoHeaderInRetryWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPutAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>>>() {
@@ -2410,10 +3137,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> beginPutAsyncNoHeaderInRetry(ProductInner product) throws CloudException, IOException {
-        return beginPutAsyncNoHeaderInRetryAsync(product).toBlocking().single();
+    public ProductInner beginPutAsyncNoHeaderInRetry(ProductInner product) throws CloudException, IOException {
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2424,7 +3151,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPutAsyncNoHeaderInRetryAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoHeaderInRetryAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPutAsyncNoHeaderInRetryAsync(ProductInner product) {
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2433,7 +3174,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>> beginPutAsyncNoHeaderInRetryAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>> beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPutAsyncNoHeaderInRetryHeadersInner>>>() {
@@ -2462,10 +3203,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SkuInner object wrapped in ServiceResponse if successful.
+     * @return the SkuInner object  if successful.
      */
-    public ServiceResponse<SkuInner> putNonResource() throws CloudException, IOException, InterruptedException {
-        return putNonResourceAsync().toBlocking().last();
+    public SkuInner putNonResource() throws CloudException, IOException, InterruptedException {
+        return putNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2475,7 +3216,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> putNonResourceAsync(final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(putNonResourceAsync(), serviceCallback);
+        return ServiceCall.create(putNonResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2483,7 +3224,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SkuInner>> putNonResourceAsync() {
+    public Observable<SkuInner> putNonResourceAsync() {
+        return putNonResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SkuInner>> putNonResourceWithServiceResponseAsync() {
         final SkuInner sku = null;
         Observable<Response<ResponseBody>> observable = service.putNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SkuInner>() { }.getType());
@@ -2495,10 +3250,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SkuInner object wrapped in ServiceResponse if successful.
+     * @return the SkuInner object if successful.
      */
-    public ServiceResponse<SkuInner> putNonResource(SkuInner sku) throws CloudException, IOException, InterruptedException {
-        return putNonResourceAsync(sku).toBlocking().last();
+    public SkuInner putNonResource(SkuInner sku) throws CloudException, IOException, InterruptedException {
+        return putNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2509,7 +3264,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> putNonResourceAsync(SkuInner sku, final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(putNonResourceAsync(sku), serviceCallback);
+        return ServiceCall.create(putNonResourceWithServiceResponseAsync(sku), serviceCallback);
     }
 
     /**
@@ -2518,7 +3273,22 @@ public final class LROsInner {
      * @param sku sku to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SkuInner>> putNonResourceAsync(SkuInner sku) {
+    public Observable<SkuInner> putNonResourceAsync(SkuInner sku) {
+        return putNonResourceWithServiceResponseAsync(sku).map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SkuInner>> putNonResourceWithServiceResponseAsync(SkuInner sku) {
         Validator.validate(sku);
         Observable<Response<ResponseBody>> observable = service.putNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SkuInner>() { }.getType());
@@ -2529,10 +3299,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SkuInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SkuInner object if successful.
      */
-    public ServiceResponse<SkuInner> beginPutNonResource() throws CloudException, IOException {
-        return beginPutNonResourceAsync().toBlocking().single();
+    public SkuInner beginPutNonResource() throws CloudException, IOException {
+        return beginPutNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2542,7 +3312,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> beginPutNonResourceAsync(final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(beginPutNonResourceAsync(), serviceCallback);
+        return ServiceCall.create(beginPutNonResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2550,7 +3320,21 @@ public final class LROsInner {
      *
      * @return the observable to the SkuInner object
      */
-    public Observable<ServiceResponse<SkuInner>> beginPutNonResourceAsync() {
+    public Observable<SkuInner> beginPutNonResourceAsync() {
+        return beginPutNonResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable to the SkuInner object
+     */
+    public Observable<ServiceResponse<SkuInner>> beginPutNonResourceWithServiceResponseAsync() {
         final SkuInner sku = null;
         return service.beginPutNonResource(sku, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SkuInner>>>() {
@@ -2572,10 +3356,10 @@ public final class LROsInner {
      * @param sku sku to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SkuInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SkuInner object if successful.
      */
-    public ServiceResponse<SkuInner> beginPutNonResource(SkuInner sku) throws CloudException, IOException {
-        return beginPutNonResourceAsync(sku).toBlocking().single();
+    public SkuInner beginPutNonResource(SkuInner sku) throws CloudException, IOException {
+        return beginPutNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2586,7 +3370,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> beginPutNonResourceAsync(SkuInner sku, final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(beginPutNonResourceAsync(sku), serviceCallback);
+        return ServiceCall.create(beginPutNonResourceWithServiceResponseAsync(sku), serviceCallback);
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable to the SkuInner object
+     */
+    public Observable<SkuInner> beginPutNonResourceAsync(SkuInner sku) {
+        return beginPutNonResourceWithServiceResponseAsync(sku).map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2595,7 +3393,7 @@ public final class LROsInner {
      * @param sku sku to put
      * @return the observable to the SkuInner object
      */
-    public Observable<ServiceResponse<SkuInner>> beginPutNonResourceAsync(SkuInner sku) {
+    public Observable<ServiceResponse<SkuInner>> beginPutNonResourceWithServiceResponseAsync(SkuInner sku) {
         Validator.validate(sku);
         return service.beginPutNonResource(sku, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SkuInner>>>() {
@@ -2624,10 +3422,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SkuInner object wrapped in ServiceResponse if successful.
+     * @return the SkuInner object  if successful.
      */
-    public ServiceResponse<SkuInner> putAsyncNonResource() throws CloudException, IOException, InterruptedException {
-        return putAsyncNonResourceAsync().toBlocking().last();
+    public SkuInner putAsyncNonResource() throws CloudException, IOException, InterruptedException {
+        return putAsyncNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2637,7 +3435,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> putAsyncNonResourceAsync(final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(putAsyncNonResourceAsync(), serviceCallback);
+        return ServiceCall.create(putAsyncNonResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2645,7 +3443,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SkuInner>> putAsyncNonResourceAsync() {
+    public Observable<SkuInner> putAsyncNonResourceAsync() {
+        return putAsyncNonResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SkuInner>> putAsyncNonResourceWithServiceResponseAsync() {
         final SkuInner sku = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SkuInner>() { }.getType());
@@ -2657,10 +3469,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SkuInner object wrapped in ServiceResponse if successful.
+     * @return the SkuInner object if successful.
      */
-    public ServiceResponse<SkuInner> putAsyncNonResource(SkuInner sku) throws CloudException, IOException, InterruptedException {
-        return putAsyncNonResourceAsync(sku).toBlocking().last();
+    public SkuInner putAsyncNonResource(SkuInner sku) throws CloudException, IOException, InterruptedException {
+        return putAsyncNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2671,7 +3483,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> putAsyncNonResourceAsync(SkuInner sku, final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(putAsyncNonResourceAsync(sku), serviceCallback);
+        return ServiceCall.create(putAsyncNonResourceWithServiceResponseAsync(sku), serviceCallback);
     }
 
     /**
@@ -2680,7 +3492,22 @@ public final class LROsInner {
      * @param sku Sku to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SkuInner>> putAsyncNonResourceAsync(SkuInner sku) {
+    public Observable<SkuInner> putAsyncNonResourceAsync(SkuInner sku) {
+        return putAsyncNonResourceWithServiceResponseAsync(sku).map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SkuInner>> putAsyncNonResourceWithServiceResponseAsync(SkuInner sku) {
         Validator.validate(sku);
         Observable<Response<ResponseBody>> observable = service.putAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SkuInner>() { }.getType());
@@ -2691,10 +3518,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SkuInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SkuInner object if successful.
      */
-    public ServiceResponse<SkuInner> beginPutAsyncNonResource() throws CloudException, IOException {
-        return beginPutAsyncNonResourceAsync().toBlocking().single();
+    public SkuInner beginPutAsyncNonResource() throws CloudException, IOException {
+        return beginPutAsyncNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2704,7 +3531,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> beginPutAsyncNonResourceAsync(final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(beginPutAsyncNonResourceAsync(), serviceCallback);
+        return ServiceCall.create(beginPutAsyncNonResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2712,7 +3539,21 @@ public final class LROsInner {
      *
      * @return the observable to the SkuInner object
      */
-    public Observable<ServiceResponse<SkuInner>> beginPutAsyncNonResourceAsync() {
+    public Observable<SkuInner> beginPutAsyncNonResourceAsync() {
+        return beginPutAsyncNonResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable to the SkuInner object
+     */
+    public Observable<ServiceResponse<SkuInner>> beginPutAsyncNonResourceWithServiceResponseAsync() {
         final SkuInner sku = null;
         return service.beginPutAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SkuInner>>>() {
@@ -2734,10 +3575,10 @@ public final class LROsInner {
      * @param sku Sku to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SkuInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SkuInner object if successful.
      */
-    public ServiceResponse<SkuInner> beginPutAsyncNonResource(SkuInner sku) throws CloudException, IOException {
-        return beginPutAsyncNonResourceAsync(sku).toBlocking().single();
+    public SkuInner beginPutAsyncNonResource(SkuInner sku) throws CloudException, IOException {
+        return beginPutAsyncNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2748,7 +3589,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> beginPutAsyncNonResourceAsync(SkuInner sku, final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(beginPutAsyncNonResourceAsync(sku), serviceCallback);
+        return ServiceCall.create(beginPutAsyncNonResourceWithServiceResponseAsync(sku), serviceCallback);
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable to the SkuInner object
+     */
+    public Observable<SkuInner> beginPutAsyncNonResourceAsync(SkuInner sku) {
+        return beginPutAsyncNonResourceWithServiceResponseAsync(sku).map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2757,7 +3612,7 @@ public final class LROsInner {
      * @param sku Sku to put
      * @return the observable to the SkuInner object
      */
-    public Observable<ServiceResponse<SkuInner>> beginPutAsyncNonResourceAsync(SkuInner sku) {
+    public Observable<ServiceResponse<SkuInner>> beginPutAsyncNonResourceWithServiceResponseAsync(SkuInner sku) {
         Validator.validate(sku);
         return service.beginPutAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SkuInner>>>() {
@@ -2786,10 +3641,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProductInner object wrapped in ServiceResponse if successful.
+     * @return the SubProductInner object  if successful.
      */
-    public ServiceResponse<SubProductInner> putSubResource() throws CloudException, IOException, InterruptedException {
-        return putSubResourceAsync().toBlocking().last();
+    public SubProductInner putSubResource() throws CloudException, IOException, InterruptedException {
+        return putSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2799,7 +3654,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProductInner> putSubResourceAsync(final ServiceCallback<SubProductInner> serviceCallback) {
-        return ServiceCall.create(putSubResourceAsync(), serviceCallback);
+        return ServiceCall.create(putSubResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2807,7 +3662,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SubProductInner>> putSubResourceAsync() {
+    public Observable<SubProductInner> putSubResourceAsync() {
+        return putSubResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SubProductInner>, SubProductInner>() {
+            @Override
+            public SubProductInner call(ServiceResponse<SubProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SubProductInner>> putSubResourceWithServiceResponseAsync() {
         final SubProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SubProductInner>() { }.getType());
@@ -2819,10 +3688,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProductInner object wrapped in ServiceResponse if successful.
+     * @return the SubProductInner object if successful.
      */
-    public ServiceResponse<SubProductInner> putSubResource(SubProductInner product) throws CloudException, IOException, InterruptedException {
-        return putSubResourceAsync(product).toBlocking().last();
+    public SubProductInner putSubResource(SubProductInner product) throws CloudException, IOException, InterruptedException {
+        return putSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2833,7 +3702,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProductInner> putSubResourceAsync(SubProductInner product, final ServiceCallback<SubProductInner> serviceCallback) {
-        return ServiceCall.create(putSubResourceAsync(product), serviceCallback);
+        return ServiceCall.create(putSubResourceWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2842,7 +3711,22 @@ public final class LROsInner {
      * @param product Sub Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SubProductInner>> putSubResourceAsync(SubProductInner product) {
+    public Observable<SubProductInner> putSubResourceAsync(SubProductInner product) {
+        return putSubResourceWithServiceResponseAsync(product).map(new Func1<ServiceResponse<SubProductInner>, SubProductInner>() {
+            @Override
+            public SubProductInner call(ServiceResponse<SubProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SubProductInner>> putSubResourceWithServiceResponseAsync(SubProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SubProductInner>() { }.getType());
@@ -2853,10 +3737,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProductInner object if successful.
      */
-    public ServiceResponse<SubProductInner> beginPutSubResource() throws CloudException, IOException {
-        return beginPutSubResourceAsync().toBlocking().single();
+    public SubProductInner beginPutSubResource() throws CloudException, IOException {
+        return beginPutSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2866,7 +3750,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProductInner> beginPutSubResourceAsync(final ServiceCallback<SubProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutSubResourceAsync(), serviceCallback);
+        return ServiceCall.create(beginPutSubResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2874,7 +3758,21 @@ public final class LROsInner {
      *
      * @return the observable to the SubProductInner object
      */
-    public Observable<ServiceResponse<SubProductInner>> beginPutSubResourceAsync() {
+    public Observable<SubProductInner> beginPutSubResourceAsync() {
+        return beginPutSubResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SubProductInner>, SubProductInner>() {
+            @Override
+            public SubProductInner call(ServiceResponse<SubProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable to the SubProductInner object
+     */
+    public Observable<ServiceResponse<SubProductInner>> beginPutSubResourceWithServiceResponseAsync() {
         final SubProductInner product = null;
         return service.beginPutSubResource(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SubProductInner>>>() {
@@ -2896,10 +3794,10 @@ public final class LROsInner {
      * @param product Sub Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProductInner object if successful.
      */
-    public ServiceResponse<SubProductInner> beginPutSubResource(SubProductInner product) throws CloudException, IOException {
-        return beginPutSubResourceAsync(product).toBlocking().single();
+    public SubProductInner beginPutSubResource(SubProductInner product) throws CloudException, IOException {
+        return beginPutSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2910,7 +3808,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProductInner> beginPutSubResourceAsync(SubProductInner product, final ServiceCallback<SubProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutSubResourceAsync(product), serviceCallback);
+        return ServiceCall.create(beginPutSubResourceWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable to the SubProductInner object
+     */
+    public Observable<SubProductInner> beginPutSubResourceAsync(SubProductInner product) {
+        return beginPutSubResourceWithServiceResponseAsync(product).map(new Func1<ServiceResponse<SubProductInner>, SubProductInner>() {
+            @Override
+            public SubProductInner call(ServiceResponse<SubProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2919,7 +3831,7 @@ public final class LROsInner {
      * @param product Sub Product to put
      * @return the observable to the SubProductInner object
      */
-    public Observable<ServiceResponse<SubProductInner>> beginPutSubResourceAsync(SubProductInner product) {
+    public Observable<ServiceResponse<SubProductInner>> beginPutSubResourceWithServiceResponseAsync(SubProductInner product) {
         Validator.validate(product);
         return service.beginPutSubResource(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SubProductInner>>>() {
@@ -2948,10 +3860,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProductInner object wrapped in ServiceResponse if successful.
+     * @return the SubProductInner object  if successful.
      */
-    public ServiceResponse<SubProductInner> putAsyncSubResource() throws CloudException, IOException, InterruptedException {
-        return putAsyncSubResourceAsync().toBlocking().last();
+    public SubProductInner putAsyncSubResource() throws CloudException, IOException, InterruptedException {
+        return putAsyncSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2961,7 +3873,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProductInner> putAsyncSubResourceAsync(final ServiceCallback<SubProductInner> serviceCallback) {
-        return ServiceCall.create(putAsyncSubResourceAsync(), serviceCallback);
+        return ServiceCall.create(putAsyncSubResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2969,7 +3881,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SubProductInner>> putAsyncSubResourceAsync() {
+    public Observable<SubProductInner> putAsyncSubResourceAsync() {
+        return putAsyncSubResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SubProductInner>, SubProductInner>() {
+            @Override
+            public SubProductInner call(ServiceResponse<SubProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SubProductInner>> putAsyncSubResourceWithServiceResponseAsync() {
         final SubProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SubProductInner>() { }.getType());
@@ -2981,10 +3907,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProductInner object wrapped in ServiceResponse if successful.
+     * @return the SubProductInner object if successful.
      */
-    public ServiceResponse<SubProductInner> putAsyncSubResource(SubProductInner product) throws CloudException, IOException, InterruptedException {
-        return putAsyncSubResourceAsync(product).toBlocking().last();
+    public SubProductInner putAsyncSubResource(SubProductInner product) throws CloudException, IOException, InterruptedException {
+        return putAsyncSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2995,7 +3921,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProductInner> putAsyncSubResourceAsync(SubProductInner product, final ServiceCallback<SubProductInner> serviceCallback) {
-        return ServiceCall.create(putAsyncSubResourceAsync(product), serviceCallback);
+        return ServiceCall.create(putAsyncSubResourceWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3004,7 +3930,22 @@ public final class LROsInner {
      * @param product Sub Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SubProductInner>> putAsyncSubResourceAsync(SubProductInner product) {
+    public Observable<SubProductInner> putAsyncSubResourceAsync(SubProductInner product) {
+        return putAsyncSubResourceWithServiceResponseAsync(product).map(new Func1<ServiceResponse<SubProductInner>, SubProductInner>() {
+            @Override
+            public SubProductInner call(ServiceResponse<SubProductInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SubProductInner>> putAsyncSubResourceWithServiceResponseAsync(SubProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SubProductInner>() { }.getType());
@@ -3015,10 +3956,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProductInner object if successful.
      */
-    public ServiceResponse<SubProductInner> beginPutAsyncSubResource() throws CloudException, IOException {
-        return beginPutAsyncSubResourceAsync().toBlocking().single();
+    public SubProductInner beginPutAsyncSubResource() throws CloudException, IOException {
+        return beginPutAsyncSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3028,7 +3969,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProductInner> beginPutAsyncSubResourceAsync(final ServiceCallback<SubProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutAsyncSubResourceAsync(), serviceCallback);
+        return ServiceCall.create(beginPutAsyncSubResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3036,7 +3977,21 @@ public final class LROsInner {
      *
      * @return the observable to the SubProductInner object
      */
-    public Observable<ServiceResponse<SubProductInner>> beginPutAsyncSubResourceAsync() {
+    public Observable<SubProductInner> beginPutAsyncSubResourceAsync() {
+        return beginPutAsyncSubResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SubProductInner>, SubProductInner>() {
+            @Override
+            public SubProductInner call(ServiceResponse<SubProductInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable to the SubProductInner object
+     */
+    public Observable<ServiceResponse<SubProductInner>> beginPutAsyncSubResourceWithServiceResponseAsync() {
         final SubProductInner product = null;
         return service.beginPutAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SubProductInner>>>() {
@@ -3058,10 +4013,10 @@ public final class LROsInner {
      * @param product Sub Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProductInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProductInner object if successful.
      */
-    public ServiceResponse<SubProductInner> beginPutAsyncSubResource(SubProductInner product) throws CloudException, IOException {
-        return beginPutAsyncSubResourceAsync(product).toBlocking().single();
+    public SubProductInner beginPutAsyncSubResource(SubProductInner product) throws CloudException, IOException {
+        return beginPutAsyncSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3072,7 +4027,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProductInner> beginPutAsyncSubResourceAsync(SubProductInner product, final ServiceCallback<SubProductInner> serviceCallback) {
-        return ServiceCall.create(beginPutAsyncSubResourceAsync(product), serviceCallback);
+        return ServiceCall.create(beginPutAsyncSubResourceWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable to the SubProductInner object
+     */
+    public Observable<SubProductInner> beginPutAsyncSubResourceAsync(SubProductInner product) {
+        return beginPutAsyncSubResourceWithServiceResponseAsync(product).map(new Func1<ServiceResponse<SubProductInner>, SubProductInner>() {
+            @Override
+            public SubProductInner call(ServiceResponse<SubProductInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3081,7 +4050,7 @@ public final class LROsInner {
      * @param product Sub Product to put
      * @return the observable to the SubProductInner object
      */
-    public Observable<ServiceResponse<SubProductInner>> beginPutAsyncSubResourceAsync(SubProductInner product) {
+    public Observable<ServiceResponse<SubProductInner>> beginPutAsyncSubResourceWithServiceResponseAsync(SubProductInner product) {
         Validator.validate(product);
         return service.beginPutAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SubProductInner>>>() {
@@ -3110,10 +4079,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner> deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException {
-        return deleteProvisioning202Accepted200SucceededAsync().toBlocking().last();
+    public ProductInner deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException {
+        return deleteProvisioning202Accepted200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3123,7 +4092,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> deleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteProvisioning202Accepted200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3131,7 +4100,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner>> deleteProvisioning202Accepted200SucceededAsync() {
+    public Observable<ProductInner> deleteProvisioning202Accepted200SucceededAsync() {
+        return deleteProvisioning202Accepted200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner>> deleteProvisioning202Accepted200SucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsDeleteProvisioning202Accepted200SucceededHeadersInner.class);
     }
@@ -3141,10 +4124,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner> beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException {
-        return beginDeleteProvisioning202Accepted200SucceededAsync().toBlocking().single();
+    public ProductInner beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException {
+        return beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3154,7 +4137,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginDeleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3162,7 +4145,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner>> beginDeleteProvisioning202Accepted200SucceededAsync() {
+    public Observable<ProductInner> beginDeleteProvisioning202Accepted200SucceededAsync() {
+        return beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner>> beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync() {
         return service.beginDeleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Accepted200SucceededHeadersInner>>>() {
                 @Override
@@ -3191,10 +4188,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner> deleteProvisioning202DeletingFailed200() throws CloudException, IOException, InterruptedException {
-        return deleteProvisioning202DeletingFailed200Async().toBlocking().last();
+    public ProductInner deleteProvisioning202DeletingFailed200() throws CloudException, IOException, InterruptedException {
+        return deleteProvisioning202DeletingFailed200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3204,7 +4201,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> deleteProvisioning202DeletingFailed200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteProvisioning202DeletingFailed200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteProvisioning202DeletingFailed200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3212,7 +4209,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner>> deleteProvisioning202DeletingFailed200Async() {
+    public Observable<ProductInner> deleteProvisioning202DeletingFailed200Async() {
+        return deleteProvisioning202DeletingFailed200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner>> deleteProvisioning202DeletingFailed200WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteProvisioning202DeletingFailed200(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsDeleteProvisioning202DeletingFailed200HeadersInner.class);
     }
@@ -3222,10 +4233,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner> beginDeleteProvisioning202DeletingFailed200() throws CloudException, IOException {
-        return beginDeleteProvisioning202DeletingFailed200Async().toBlocking().single();
+    public ProductInner beginDeleteProvisioning202DeletingFailed200() throws CloudException, IOException {
+        return beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3235,7 +4246,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginDeleteProvisioning202DeletingFailed200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteProvisioning202DeletingFailed200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3243,7 +4254,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner>> beginDeleteProvisioning202DeletingFailed200Async() {
+    public Observable<ProductInner> beginDeleteProvisioning202DeletingFailed200Async() {
+        return beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner>> beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync() {
         return service.beginDeleteProvisioning202DeletingFailed200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202DeletingFailed200HeadersInner>>>() {
                 @Override
@@ -3272,10 +4297,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner> deleteProvisioning202Deletingcanceled200() throws CloudException, IOException, InterruptedException {
-        return deleteProvisioning202Deletingcanceled200Async().toBlocking().last();
+    public ProductInner deleteProvisioning202Deletingcanceled200() throws CloudException, IOException, InterruptedException {
+        return deleteProvisioning202Deletingcanceled200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3285,7 +4310,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> deleteProvisioning202Deletingcanceled200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteProvisioning202Deletingcanceled200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteProvisioning202Deletingcanceled200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3293,7 +4318,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner>> deleteProvisioning202Deletingcanceled200Async() {
+    public Observable<ProductInner> deleteProvisioning202Deletingcanceled200Async() {
+        return deleteProvisioning202Deletingcanceled200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner>> deleteProvisioning202Deletingcanceled200WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteProvisioning202Deletingcanceled200(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsDeleteProvisioning202Deletingcanceled200HeadersInner.class);
     }
@@ -3303,10 +4342,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner> beginDeleteProvisioning202Deletingcanceled200() throws CloudException, IOException {
-        return beginDeleteProvisioning202Deletingcanceled200Async().toBlocking().single();
+    public ProductInner beginDeleteProvisioning202Deletingcanceled200() throws CloudException, IOException {
+        return beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3316,7 +4355,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginDeleteProvisioning202Deletingcanceled200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Deletingcanceled200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3324,7 +4363,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner>> beginDeleteProvisioning202Deletingcanceled200Async() {
+    public Observable<ProductInner> beginDeleteProvisioning202Deletingcanceled200Async() {
+        return beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner>> beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync() {
         return service.beginDeleteProvisioning202Deletingcanceled200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsDeleteProvisioning202Deletingcanceled200HeadersInner>>>() {
                 @Override
@@ -3353,10 +4406,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponse object if successful.
      */
-    public ServiceResponse<Void> delete204Succeeded() throws CloudException, IOException, InterruptedException {
-        return delete204SucceededAsync().toBlocking().last();
+    public void delete204Succeeded() throws CloudException, IOException, InterruptedException {
+        delete204SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3366,7 +4418,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete204SucceededAsync(), serviceCallback);
+        return ServiceCall.create(delete204SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3374,7 +4426,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Void>> delete204SucceededAsync() {
+    public Observable<Void> delete204SucceededAsync() {
+        return delete204SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Void>> delete204SucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete204Succeeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<Void>() { }.getType());
     }
@@ -3384,10 +4450,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> beginDelete204Succeeded() throws CloudException, IOException {
-        return beginDelete204SucceededAsync().toBlocking().single();
+    public void beginDelete204Succeeded() throws CloudException, IOException {
+        beginDelete204SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3397,7 +4462,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(beginDelete204SucceededAsync(), serviceCallback);
+        return ServiceCall.create(beginDelete204SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3405,7 +4470,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> beginDelete204SucceededAsync() {
+    public Observable<Void> beginDelete204SucceededAsync() {
+        return beginDelete204SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> beginDelete204SucceededWithServiceResponseAsync() {
         return service.beginDelete204Succeeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -3433,10 +4512,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner> delete202Retry200() throws CloudException, IOException, InterruptedException {
-        return delete202Retry200Async().toBlocking().last();
+    public ProductInner delete202Retry200() throws CloudException, IOException, InterruptedException {
+        return delete202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3446,7 +4525,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> delete202Retry200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3454,7 +4533,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner>> delete202Retry200Async() {
+    public Observable<ProductInner> delete202Retry200Async() {
+        return delete202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner>> delete202Retry200WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202Retry200(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsDelete202Retry200HeadersInner.class);
     }
@@ -3464,10 +4557,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner> beginDelete202Retry200() throws CloudException, IOException {
-        return beginDelete202Retry200Async().toBlocking().single();
+    public ProductInner beginDelete202Retry200() throws CloudException, IOException {
+        return beginDelete202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3477,7 +4570,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginDelete202Retry200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3485,7 +4578,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner>> beginDelete202Retry200Async() {
+    public Observable<ProductInner> beginDelete202Retry200Async() {
+        return beginDelete202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner>> beginDelete202Retry200WithServiceResponseAsync() {
         return service.beginDelete202Retry200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202Retry200HeadersInner>>>() {
                 @Override
@@ -3514,10 +4621,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner> delete202NoRetry204() throws CloudException, IOException, InterruptedException {
-        return delete202NoRetry204Async().toBlocking().last();
+    public ProductInner delete202NoRetry204() throws CloudException, IOException, InterruptedException {
+        return delete202NoRetry204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3527,7 +4634,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> delete202NoRetry204Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202NoRetry204Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202NoRetry204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3535,7 +4642,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner>> delete202NoRetry204Async() {
+    public Observable<ProductInner> delete202NoRetry204Async() {
+        return delete202NoRetry204WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner>> delete202NoRetry204WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202NoRetry204(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsDelete202NoRetry204HeadersInner.class);
     }
@@ -3545,10 +4666,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner> beginDelete202NoRetry204() throws CloudException, IOException {
-        return beginDelete202NoRetry204Async().toBlocking().single();
+    public ProductInner beginDelete202NoRetry204() throws CloudException, IOException {
+        return beginDelete202NoRetry204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3558,7 +4679,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginDelete202NoRetry204Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202NoRetry204Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202NoRetry204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3566,7 +4687,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner>> beginDelete202NoRetry204Async() {
+    public Observable<ProductInner> beginDelete202NoRetry204Async() {
+        return beginDelete202NoRetry204WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner>> beginDelete202NoRetry204WithServiceResponseAsync() {
         return service.beginDelete202NoRetry204(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsDelete202NoRetry204HeadersInner>>>() {
                 @Override
@@ -3595,10 +4730,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner> deleteNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
-        return deleteNoHeaderInRetryAsync().toBlocking().last();
+    public void deleteNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
+        deleteNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3608,7 +4742,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3616,7 +4750,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner>> deleteNoHeaderInRetryAsync() {
+    public Observable<Void> deleteNoHeaderInRetryAsync() {
+        return deleteNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner>> deleteNoHeaderInRetryWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteNoHeaderInRetryHeadersInner.class);
     }
@@ -3626,10 +4774,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner> beginDeleteNoHeaderInRetry() throws CloudException, IOException {
-        return beginDeleteNoHeaderInRetryAsync().toBlocking().single();
+    public void beginDeleteNoHeaderInRetry() throws CloudException, IOException {
+        beginDeleteNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3639,7 +4786,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3647,7 +4794,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner>> beginDeleteNoHeaderInRetryAsync() {
+    public Observable<Void> beginDeleteNoHeaderInRetryAsync() {
+        return beginDeleteNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner>> beginDeleteNoHeaderInRetryWithServiceResponseAsync() {
         return service.beginDeleteNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeadersInner>>>() {
                 @Override
@@ -3676,10 +4837,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner> deleteAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncNoHeaderInRetryAsync().toBlocking().last();
+    public void deleteAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
+        deleteAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3689,7 +4849,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3697,7 +4857,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner>> deleteAsyncNoHeaderInRetryAsync() {
+    public Observable<Void> deleteAsyncNoHeaderInRetryAsync() {
+        return deleteAsyncNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner>> deleteAsyncNoHeaderInRetryWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncNoHeaderInRetryHeadersInner.class);
     }
@@ -3707,10 +4881,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner> beginDeleteAsyncNoHeaderInRetry() throws CloudException, IOException {
-        return beginDeleteAsyncNoHeaderInRetryAsync().toBlocking().single();
+    public void beginDeleteAsyncNoHeaderInRetry() throws CloudException, IOException {
+        beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3720,7 +4893,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3728,7 +4901,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner>> beginDeleteAsyncNoHeaderInRetryAsync() {
+    public Observable<Void> beginDeleteAsyncNoHeaderInRetryAsync() {
+        return beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner>> beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync() {
         return service.beginDeleteAsyncNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeadersInner>>>() {
                 @Override
@@ -3757,10 +4944,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner> deleteAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRetrySucceededAsync().toBlocking().last();
+    public void deleteAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3770,7 +4956,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3778,7 +4964,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner>> deleteAsyncRetrySucceededAsync() {
+    public Observable<Void> deleteAsyncRetrySucceededAsync() {
+        return deleteAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner>> deleteAsyncRetrySucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncRetrySucceededHeadersInner.class);
     }
@@ -3788,10 +4988,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner> beginDeleteAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginDeleteAsyncRetrySucceededAsync().toBlocking().single();
+    public void beginDeleteAsyncRetrySucceeded() throws CloudException, IOException {
+        beginDeleteAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3801,7 +5000,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3809,7 +5008,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner>> beginDeleteAsyncRetrySucceededAsync() {
+    public Observable<Void> beginDeleteAsyncRetrySucceededAsync() {
+        return beginDeleteAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner>> beginDeleteAsyncRetrySucceededWithServiceResponseAsync() {
         return service.beginDeleteAsyncRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeadersInner>>>() {
                 @Override
@@ -3837,10 +5050,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner> deleteAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncNoRetrySucceededAsync().toBlocking().last();
+    public void deleteAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        deleteAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3850,7 +5062,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncNoRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3858,7 +5070,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner>> deleteAsyncNoRetrySucceededAsync() {
+    public Observable<Void> deleteAsyncNoRetrySucceededAsync() {
+        return deleteAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner>> deleteAsyncNoRetrySucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncNoRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncNoRetrySucceededHeadersInner.class);
     }
@@ -3868,10 +5094,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner> beginDeleteAsyncNoRetrySucceeded() throws CloudException, IOException {
-        return beginDeleteAsyncNoRetrySucceededAsync().toBlocking().single();
+    public void beginDeleteAsyncNoRetrySucceeded() throws CloudException, IOException {
+        beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3881,7 +5106,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncNoRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3889,7 +5114,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner>> beginDeleteAsyncNoRetrySucceededAsync() {
+    public Observable<Void> beginDeleteAsyncNoRetrySucceededAsync() {
+        return beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner>> beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync() {
         return service.beginDeleteAsyncNoRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeadersInner>>>() {
                 @Override
@@ -3917,10 +5156,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner> deleteAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRetryFailedAsync().toBlocking().last();
+    public void deleteAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3930,7 +5168,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3938,7 +5176,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner>> deleteAsyncRetryFailedAsync() {
+    public Observable<Void> deleteAsyncRetryFailedAsync() {
+        return deleteAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner>> deleteAsyncRetryFailedWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRetryFailed(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncRetryFailedHeadersInner.class);
     }
@@ -3948,10 +5200,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner> beginDeleteAsyncRetryFailed() throws CloudException, IOException {
-        return beginDeleteAsyncRetryFailedAsync().toBlocking().single();
+    public void beginDeleteAsyncRetryFailed() throws CloudException, IOException {
+        beginDeleteAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3961,7 +5212,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3969,7 +5220,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner>> beginDeleteAsyncRetryFailedAsync() {
+    public Observable<Void> beginDeleteAsyncRetryFailedAsync() {
+        return beginDeleteAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner>> beginDeleteAsyncRetryFailedWithServiceResponseAsync() {
         return service.beginDeleteAsyncRetryFailed(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeadersInner>>>() {
                 @Override
@@ -3997,10 +5262,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner> deleteAsyncRetrycanceled() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRetrycanceledAsync().toBlocking().last();
+    public void deleteAsyncRetrycanceled() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4010,7 +5274,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4018,7 +5282,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner>> deleteAsyncRetrycanceledAsync() {
+    public Observable<Void> deleteAsyncRetrycanceledAsync() {
+        return deleteAsyncRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner>> deleteAsyncRetrycanceledWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRetrycanceled(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncRetrycanceledHeadersInner.class);
     }
@@ -4028,10 +5306,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner> beginDeleteAsyncRetrycanceled() throws CloudException, IOException {
-        return beginDeleteAsyncRetrycanceledAsync().toBlocking().single();
+    public void beginDeleteAsyncRetrycanceled() throws CloudException, IOException {
+        beginDeleteAsyncRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4041,7 +5318,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4049,7 +5326,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner>> beginDeleteAsyncRetrycanceledAsync() {
+    public Observable<Void> beginDeleteAsyncRetrycanceledAsync() {
+        return beginDeleteAsyncRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner>> beginDeleteAsyncRetrycanceledWithServiceResponseAsync() {
         return service.beginDeleteAsyncRetrycanceled(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeadersInner>>>() {
                 @Override
@@ -4077,10 +5368,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SkuInner object wrapped in ServiceResponse if successful.
+     * @return the SkuInner object if successful.
      */
-    public ServiceResponse<SkuInner> post200WithPayload() throws CloudException, IOException, InterruptedException {
-        return post200WithPayloadAsync().toBlocking().last();
+    public SkuInner post200WithPayload() throws CloudException, IOException, InterruptedException {
+        return post200WithPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4090,7 +5381,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> post200WithPayloadAsync(final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(post200WithPayloadAsync(), serviceCallback);
+        return ServiceCall.create(post200WithPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4098,7 +5389,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SkuInner>> post200WithPayloadAsync() {
+    public Observable<SkuInner> post200WithPayloadAsync() {
+        return post200WithPayloadWithServiceResponseAsync().map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SkuInner>> post200WithPayloadWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.post200WithPayload(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<SkuInner>() { }.getType());
     }
@@ -4108,10 +5413,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SkuInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SkuInner object if successful.
      */
-    public ServiceResponse<SkuInner> beginPost200WithPayload() throws CloudException, IOException {
-        return beginPost200WithPayloadAsync().toBlocking().single();
+    public SkuInner beginPost200WithPayload() throws CloudException, IOException {
+        return beginPost200WithPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4121,7 +5426,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SkuInner> beginPost200WithPayloadAsync(final ServiceCallback<SkuInner> serviceCallback) {
-        return ServiceCall.create(beginPost200WithPayloadAsync(), serviceCallback);
+        return ServiceCall.create(beginPost200WithPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4129,7 +5434,21 @@ public final class LROsInner {
      *
      * @return the observable to the SkuInner object
      */
-    public Observable<ServiceResponse<SkuInner>> beginPost200WithPayloadAsync() {
+    public Observable<SkuInner> beginPost200WithPayloadAsync() {
+        return beginPost200WithPayloadWithServiceResponseAsync().map(new Func1<ServiceResponse<SkuInner>, SkuInner>() {
+            @Override
+            public SkuInner call(ServiceResponse<SkuInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @return the observable to the SkuInner object
+     */
+    public Observable<ServiceResponse<SkuInner>> beginPost200WithPayloadWithServiceResponseAsync() {
         return service.beginPost200WithPayload(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SkuInner>>>() {
                 @Override
@@ -4158,10 +5477,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> post202Retry200() throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async().toBlocking().last();
+    public void post202Retry200() throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4171,7 +5489,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4179,7 +5497,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>> post202Retry200Async() {
+    public Observable<Void> post202Retry200Async() {
+        return post202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>> post202Retry200WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPost202Retry200HeadersInner.class);
@@ -4191,10 +5523,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async(product).toBlocking().last();
+    public void post202Retry200(ProductInner product) throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4205,7 +5536,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4214,7 +5545,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>> post202Retry200Async(ProductInner product) {
+    public Observable<Void> post202Retry200Async(ProductInner product) {
+        return post202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>> post202Retry200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPost202Retry200HeadersInner.class);
@@ -4225,10 +5571,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> beginPost202Retry200() throws CloudException, IOException {
-        return beginPost202Retry200Async().toBlocking().single();
+    public void beginPost202Retry200() throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4238,7 +5583,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4246,7 +5591,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>> beginPost202Retry200Async() {
+    public Observable<Void> beginPost202Retry200Async() {
+        return beginPost202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>> beginPost202Retry200WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>>>() {
@@ -4268,10 +5627,9 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> beginPost202Retry200(ProductInner product) throws CloudException, IOException {
-        return beginPost202Retry200Async(product).toBlocking().single();
+    public void beginPost202Retry200(ProductInner product) throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4282,7 +5640,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202Retry200Async(ProductInner product) {
+        return beginPost202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4291,7 +5663,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>> beginPost202Retry200Async(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>> beginPost202Retry200WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200HeadersInner>>>() {
@@ -4320,10 +5692,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> post202NoRetry204() throws CloudException, IOException, InterruptedException {
-        return post202NoRetry204Async().toBlocking().last();
+    public ProductInner post202NoRetry204() throws CloudException, IOException, InterruptedException {
+        return post202NoRetry204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4333,7 +5705,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> post202NoRetry204Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NoRetry204Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NoRetry204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4341,7 +5713,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>> post202NoRetry204Async() {
+    public Observable<ProductInner> post202NoRetry204Async() {
+        return post202NoRetry204WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>> post202NoRetry204WithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.post202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPost202NoRetry204HeadersInner.class);
@@ -4353,10 +5739,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> post202NoRetry204(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return post202NoRetry204Async(product).toBlocking().last();
+    public ProductInner post202NoRetry204(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return post202NoRetry204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4367,7 +5753,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> post202NoRetry204Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NoRetry204Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NoRetry204WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4376,7 +5762,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>> post202NoRetry204Async(ProductInner product) {
+    public Observable<ProductInner> post202NoRetry204Async(ProductInner product) {
+        return post202NoRetry204WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>> post202NoRetry204WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPost202NoRetry204HeadersInner.class);
@@ -4387,10 +5788,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> beginPost202NoRetry204() throws CloudException, IOException {
-        return beginPost202NoRetry204Async().toBlocking().single();
+    public ProductInner beginPost202NoRetry204() throws CloudException, IOException {
+        return beginPost202NoRetry204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4400,7 +5801,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPost202NoRetry204Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NoRetry204Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NoRetry204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4408,7 +5809,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>> beginPost202NoRetry204Async() {
+    public Observable<ProductInner> beginPost202NoRetry204Async() {
+        return beginPost202NoRetry204WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>> beginPost202NoRetry204WithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPost202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>>>() {
@@ -4430,10 +5845,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> beginPost202NoRetry204(ProductInner product) throws CloudException, IOException {
-        return beginPost202NoRetry204Async(product).toBlocking().single();
+    public ProductInner beginPost202NoRetry204(ProductInner product) throws CloudException, IOException {
+        return beginPost202NoRetry204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4444,7 +5859,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPost202NoRetry204Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NoRetry204Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NoRetry204WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPost202NoRetry204Async(ProductInner product) {
+        return beginPost202NoRetry204WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4453,7 +5882,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>> beginPost202NoRetry204Async(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>> beginPost202NoRetry204WithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPost202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPost202NoRetry204HeadersInner>>>() {
@@ -4482,10 +5911,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededAsync().toBlocking().last();
+    public ProductInner postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4495,7 +5924,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> postAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4503,7 +5932,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>> postAsyncRetrySucceededAsync() {
+    public Observable<ProductInner> postAsyncRetrySucceededAsync() {
+        return postAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>> postAsyncRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPostAsyncRetrySucceededHeadersInner.class);
@@ -4515,10 +5958,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> postAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededAsync(product).toBlocking().last();
+    public ProductInner postAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4529,7 +5972,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> postAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4538,7 +5981,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>> postAsyncRetrySucceededAsync(ProductInner product) {
+    public Observable<ProductInner> postAsyncRetrySucceededAsync(ProductInner product) {
+        return postAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>> postAsyncRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPostAsyncRetrySucceededHeadersInner.class);
@@ -4549,10 +6007,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> beginPostAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededAsync().toBlocking().single();
+    public ProductInner beginPostAsyncRetrySucceeded() throws CloudException, IOException {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4562,7 +6020,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPostAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4570,7 +6028,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>> beginPostAsyncRetrySucceededAsync() {
+    public Observable<ProductInner> beginPostAsyncRetrySucceededAsync() {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>> beginPostAsyncRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>>>() {
@@ -4592,10 +6064,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> beginPostAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededAsync(product).toBlocking().single();
+    public ProductInner beginPostAsyncRetrySucceeded(ProductInner product) throws CloudException, IOException {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4606,7 +6078,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPostAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPostAsyncRetrySucceededAsync(ProductInner product) {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4615,7 +6101,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>> beginPostAsyncRetrySucceededAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>> beginPostAsyncRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncRetrySucceededHeadersInner>>>() {
@@ -4645,10 +6131,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object  if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> postAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return postAsyncNoRetrySucceededAsync().toBlocking().last();
+    public ProductInner postAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return postAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4658,7 +6144,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> postAsyncNoRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4666,7 +6152,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>> postAsyncNoRetrySucceededAsync() {
+    public Observable<ProductInner> postAsyncNoRetrySucceededAsync() {
+        return postAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>> postAsyncNoRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPostAsyncNoRetrySucceededHeadersInner.class);
@@ -4678,10 +6178,10 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ProductInner object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> postAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncNoRetrySucceededAsync(product).toBlocking().last();
+    public ProductInner postAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException, InterruptedException {
+        return postAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4692,7 +6192,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> postAsyncNoRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncNoRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncNoRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4701,7 +6201,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>> postAsyncNoRetrySucceededAsync(ProductInner product) {
+    public Observable<ProductInner> postAsyncNoRetrySucceededAsync(ProductInner product) {
+        return postAsyncNoRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>> postAsyncNoRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<ProductInner>() { }.getType(), LROsPostAsyncNoRetrySucceededHeadersInner.class);
@@ -4712,10 +6227,10 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> beginPostAsyncNoRetrySucceeded() throws CloudException, IOException {
-        return beginPostAsyncNoRetrySucceededAsync().toBlocking().single();
+    public ProductInner beginPostAsyncNoRetrySucceeded() throws CloudException, IOException {
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4725,7 +6240,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPostAsyncNoRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4733,7 +6248,21 @@ public final class LROsInner {
      *
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>> beginPostAsyncNoRetrySucceededAsync() {
+    public Observable<ProductInner> beginPostAsyncNoRetrySucceededAsync() {
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>> beginPostAsyncNoRetrySucceededWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>>>() {
@@ -4755,10 +6284,10 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ProductInner object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the ProductInner object if successful.
      */
-    public ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> beginPostAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncNoRetrySucceededAsync(product).toBlocking().single();
+    public ProductInner beginPostAsyncNoRetrySucceeded(ProductInner product) throws CloudException, IOException {
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4769,7 +6298,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ProductInner> beginPostAsyncNoRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncNoRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncNoRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the ProductInner object
+     */
+    public Observable<ProductInner> beginPostAsyncNoRetrySucceededAsync(ProductInner product) {
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>, ProductInner>() {
+            @Override
+            public ProductInner call(ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4778,7 +6321,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable to the ProductInner object
      */
-    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>> beginPostAsyncNoRetrySucceededAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>> beginPostAsyncNoRetrySucceededWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<ProductInner, LROsPostAsyncNoRetrySucceededHeadersInner>>>() {
@@ -4808,10 +6351,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> postAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
-        return postAsyncRetryFailedAsync().toBlocking().last();
+    public void postAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
+        postAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4821,7 +6363,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4829,7 +6371,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>> postAsyncRetryFailedAsync() {
+    public Observable<Void> postAsyncRetryFailedAsync() {
+        return postAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>> postAsyncRetryFailedWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPostAsyncRetryFailedHeadersInner.class);
@@ -4841,10 +6397,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> postAsyncRetryFailed(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetryFailedAsync(product).toBlocking().last();
+    public void postAsyncRetryFailed(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4855,7 +6410,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetryFailedAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetryFailedAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetryFailedWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4864,7 +6419,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>> postAsyncRetryFailedAsync(ProductInner product) {
+    public Observable<Void> postAsyncRetryFailedAsync(ProductInner product) {
+        return postAsyncRetryFailedWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>> postAsyncRetryFailedWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPostAsyncRetryFailedHeadersInner.class);
@@ -4875,10 +6445,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> beginPostAsyncRetryFailed() throws CloudException, IOException {
-        return beginPostAsyncRetryFailedAsync().toBlocking().single();
+    public void beginPostAsyncRetryFailed() throws CloudException, IOException {
+        beginPostAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4888,7 +6457,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4896,7 +6465,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>> beginPostAsyncRetryFailedAsync() {
+    public Observable<Void> beginPostAsyncRetryFailedAsync() {
+        return beginPostAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>> beginPostAsyncRetryFailedWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>>>() {
@@ -4918,10 +6501,9 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> beginPostAsyncRetryFailed(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRetryFailedAsync(product).toBlocking().single();
+    public void beginPostAsyncRetryFailed(ProductInner product) throws CloudException, IOException {
+        beginPostAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4932,7 +6514,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetryFailedAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetryFailedAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetryFailedWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRetryFailedAsync(ProductInner product) {
+        return beginPostAsyncRetryFailedWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4941,7 +6537,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>> beginPostAsyncRetryFailedAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>> beginPostAsyncRetryFailedWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeadersInner>>>() {
@@ -4970,10 +6566,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> postAsyncRetrycanceled() throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrycanceledAsync().toBlocking().last();
+    public void postAsyncRetrycanceled() throws CloudException, IOException, InterruptedException {
+        postAsyncRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4983,7 +6578,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4991,7 +6586,21 @@ public final class LROsInner {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>> postAsyncRetrycanceledAsync() {
+    public Observable<Void> postAsyncRetrycanceledAsync() {
+        return postAsyncRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>> postAsyncRetrycanceledWithServiceResponseAsync() {
         final ProductInner product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPostAsyncRetrycanceledHeadersInner.class);
@@ -5003,10 +6612,9 @@ public final class LROsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> postAsyncRetrycanceled(ProductInner product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrycanceledAsync(product).toBlocking().last();
+    public void postAsyncRetrycanceled(ProductInner product) throws CloudException, IOException, InterruptedException {
+        postAsyncRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -5017,7 +6625,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetrycanceledAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrycanceledAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrycanceledWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -5026,7 +6634,22 @@ public final class LROsInner {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>> postAsyncRetrycanceledAsync(ProductInner product) {
+    public Observable<Void> postAsyncRetrycanceledAsync(ProductInner product) {
+        return postAsyncRetrycanceledWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>> postAsyncRetrycanceledWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPostAsyncRetrycanceledHeadersInner.class);
@@ -5037,10 +6660,9 @@ public final class LROsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> beginPostAsyncRetrycanceled() throws CloudException, IOException {
-        return beginPostAsyncRetrycanceledAsync().toBlocking().single();
+    public void beginPostAsyncRetrycanceled() throws CloudException, IOException {
+        beginPostAsyncRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -5050,7 +6672,7 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -5058,7 +6680,21 @@ public final class LROsInner {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>> beginPostAsyncRetrycanceledAsync() {
+    public Observable<Void> beginPostAsyncRetrycanceledAsync() {
+        return beginPostAsyncRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>> beginPostAsyncRetrycanceledWithServiceResponseAsync() {
         final ProductInner product = null;
         return service.beginPostAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>>>() {
@@ -5080,10 +6716,9 @@ public final class LROsInner {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> beginPostAsyncRetrycanceled(ProductInner product) throws CloudException, IOException {
-        return beginPostAsyncRetrycanceledAsync(product).toBlocking().single();
+    public void beginPostAsyncRetrycanceled(ProductInner product) throws CloudException, IOException {
+        beginPostAsyncRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -5094,7 +6729,21 @@ public final class LROsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetrycanceledAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrycanceledAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrycanceledWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRetrycanceledAsync(ProductInner product) {
+        return beginPostAsyncRetrycanceledWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -5103,7 +6752,7 @@ public final class LROsInner {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>> beginPostAsyncRetrycanceledAsync(ProductInner product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>> beginPostAsyncRetrycanceledWithServiceResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.beginPostAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeadersInner>>>() {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/paging/implementation/PagingsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/paging/implementation/PagingsInner.java
@@ -138,9 +138,9 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getSinglePages() throws CloudException, IOException {
+    public PagedList<ProductInner> getSinglePages() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getSinglePagesSinglePageAsync().toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -171,7 +171,7 @@ public final class PagingsInner {
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getSinglePagesAsync() {
         return getSinglePagesWithServiceResponseAsync()
@@ -186,7 +186,7 @@ public final class PagingsInner {
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesWithServiceResponseAsync() {
         return getSinglePagesSinglePageAsync()
@@ -205,7 +205,7 @@ public final class PagingsInner {
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesSinglePageAsync() {
         return service.getSinglePages(this.client.acceptLanguage(), this.client.userAgent())
@@ -234,9 +234,9 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePages() throws CloudException, IOException {
+    public PagedList<ProductInner> getMultiplePages() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesSinglePageAsync().toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -267,7 +267,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesAsync() {
         return getMultiplePagesWithServiceResponseAsync()
@@ -282,7 +282,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithServiceResponseAsync() {
         return getMultiplePagesSinglePageAsync()
@@ -301,7 +301,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesSinglePageAsync() {
         final String clientRequestId = null;
@@ -329,9 +329,9 @@ public final class PagingsInner {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) throws CloudException, IOException {
+    public PagedList<ProductInner> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -366,7 +366,7 @@ public final class PagingsInner {
      *
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
         return getMultiplePagesWithServiceResponseAsync(clientRequestId, pagingGetMultiplePagesOptions)
@@ -383,7 +383,7 @@ public final class PagingsInner {
      *
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
         return getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions)
@@ -404,7 +404,7 @@ public final class PagingsInner {
      *
     ServiceResponse<PageImpl<ProductInner>> * @param clientRequestId the String value
     ServiceResponse<PageImpl<ProductInner>> * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesSinglePageAsync(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
         Validator.validate(pagingGetMultiplePagesOptions);
@@ -442,9 +442,9 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getOdataMultiplePages() throws CloudException, IOException {
+    public PagedList<ProductInner> getOdataMultiplePages() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getOdataMultiplePagesSinglePageAsync().toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -475,7 +475,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getOdataMultiplePagesAsync() {
         return getOdataMultiplePagesWithServiceResponseAsync()
@@ -490,7 +490,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesWithServiceResponseAsync() {
         return getOdataMultiplePagesSinglePageAsync()
@@ -509,7 +509,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesSinglePageAsync() {
         final String clientRequestId = null;
@@ -537,9 +537,9 @@ public final class PagingsInner {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) throws CloudException, IOException {
+    public PagedList<ProductInner> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -574,7 +574,7 @@ public final class PagingsInner {
      *
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesWithServiceResponseAsync(clientRequestId, pagingGetOdataMultiplePagesOptions)
@@ -591,7 +591,7 @@ public final class PagingsInner {
      *
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions)
@@ -612,7 +612,7 @@ public final class PagingsInner {
      *
     ServiceResponse<PageImpl1<ProductInner>> * @param clientRequestId the String value
     ServiceResponse<PageImpl1<ProductInner>> * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesSinglePageAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
         Validator.validate(pagingGetOdataMultiplePagesOptions);
@@ -652,9 +652,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -693,7 +693,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) {
         return getMultiplePagesWithOffsetWithServiceResponseAsync(pagingGetMultiplePagesWithOffsetOptions)
@@ -709,7 +709,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions)
@@ -732,7 +732,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetSinglePageAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) {
         if (pagingGetMultiplePagesWithOffsetOptions == null) {
@@ -765,9 +765,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -808,7 +808,7 @@ public final class PagingsInner {
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @param clientRequestId the String value
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
         return getMultiplePagesWithOffsetWithServiceResponseAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
@@ -825,7 +825,7 @@ public final class PagingsInner {
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @param clientRequestId the String value
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
@@ -849,7 +849,7 @@ public final class PagingsInner {
      *
     ServiceResponse<PageImpl<ProductInner>> * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
     ServiceResponse<PageImpl<ProductInner>> * @param clientRequestId the String value
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetSinglePageAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
         if (pagingGetMultiplePagesWithOffsetOptions == null) {
@@ -885,9 +885,9 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesRetryFirst() throws CloudException, IOException {
+    public PagedList<ProductInner> getMultiplePagesRetryFirst() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesRetryFirstSinglePageAsync().toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -918,7 +918,7 @@ public final class PagingsInner {
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesRetryFirstAsync() {
         return getMultiplePagesRetryFirstWithServiceResponseAsync()
@@ -933,7 +933,7 @@ public final class PagingsInner {
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetryFirstWithServiceResponseAsync() {
         return getMultiplePagesRetryFirstSinglePageAsync()
@@ -952,7 +952,7 @@ public final class PagingsInner {
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetryFirstSinglePageAsync() {
         return service.getMultiplePagesRetryFirst(this.client.acceptLanguage(), this.client.userAgent())
@@ -981,9 +981,9 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesRetrySecond() throws CloudException, IOException {
+    public PagedList<ProductInner> getMultiplePagesRetrySecond() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesRetrySecondSinglePageAsync().toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1014,7 +1014,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesRetrySecondAsync() {
         return getMultiplePagesRetrySecondWithServiceResponseAsync()
@@ -1029,7 +1029,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetrySecondWithServiceResponseAsync() {
         return getMultiplePagesRetrySecondSinglePageAsync()
@@ -1048,7 +1048,7 @@ public final class PagingsInner {
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetrySecondSinglePageAsync() {
         return service.getMultiplePagesRetrySecond(this.client.acceptLanguage(), this.client.userAgent())
@@ -1077,9 +1077,9 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getSinglePagesFailure() throws CloudException, IOException {
+    public PagedList<ProductInner> getSinglePagesFailure() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getSinglePagesFailureSinglePageAsync().toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1110,7 +1110,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives a 400 on the first call.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getSinglePagesFailureAsync() {
         return getSinglePagesFailureWithServiceResponseAsync()
@@ -1125,7 +1125,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives a 400 on the first call.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesFailureWithServiceResponseAsync() {
         return getSinglePagesFailureSinglePageAsync()
@@ -1144,7 +1144,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives a 400 on the first call.
      *
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesFailureSinglePageAsync() {
         return service.getSinglePagesFailure(this.client.acceptLanguage(), this.client.userAgent())
@@ -1173,9 +1173,9 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesFailure() throws CloudException, IOException {
+    public PagedList<ProductInner> getMultiplePagesFailure() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesFailureSinglePageAsync().toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1206,7 +1206,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives a 400 on the second call.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesFailureAsync() {
         return getMultiplePagesFailureWithServiceResponseAsync()
@@ -1221,7 +1221,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives a 400 on the second call.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureWithServiceResponseAsync() {
         return getMultiplePagesFailureSinglePageAsync()
@@ -1240,7 +1240,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives a 400 on the second call.
      *
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureSinglePageAsync() {
         return service.getMultiplePagesFailure(this.client.acceptLanguage(), this.client.userAgent())
@@ -1269,9 +1269,9 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesFailureUri() throws CloudException, IOException {
+    public PagedList<ProductInner> getMultiplePagesFailureUri() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesFailureUriSinglePageAsync().toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1302,7 +1302,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives an invalid nextLink.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesFailureUriAsync() {
         return getMultiplePagesFailureUriWithServiceResponseAsync()
@@ -1317,7 +1317,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives an invalid nextLink.
      *
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureUriWithServiceResponseAsync() {
         return getMultiplePagesFailureUriSinglePageAsync()
@@ -1336,7 +1336,7 @@ public final class PagingsInner {
     /**
      * A paging operation that receives an invalid nextLink.
      *
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureUriSinglePageAsync() {
         return service.getMultiplePagesFailureUri(this.client.acceptLanguage(), this.client.userAgent())
@@ -1367,9 +1367,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getSinglePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1403,7 +1403,7 @@ public final class PagingsInner {
      * A paging operation that finishes on the first call without a nextlink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getSinglePagesNextAsync(final String nextPageLink) {
         return getSinglePagesNextWithServiceResponseAsync(nextPageLink)
@@ -1419,7 +1419,7 @@ public final class PagingsInner {
      * A paging operation that finishes on the first call without a nextlink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getSinglePagesNextSinglePageAsync(nextPageLink)
@@ -1439,7 +1439,7 @@ public final class PagingsInner {
      * A paging operation that finishes on the first call without a nextlink.
      *
     ServiceResponse<PageImpl<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -1473,9 +1473,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1509,7 +1509,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesNextAsync(final String nextPageLink) {
         return getMultiplePagesNextWithServiceResponseAsync(nextPageLink)
@@ -1525,7 +1525,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesNextSinglePageAsync(nextPageLink)
@@ -1545,7 +1545,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -1578,9 +1578,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1618,7 +1618,7 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
         return getMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions)
@@ -1636,7 +1636,7 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
         return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions)
@@ -1658,7 +1658,7 @@ public final class PagingsInner {
     ServiceResponse<PageImpl<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
     ServiceResponse<PageImpl<ProductInner>> * @param clientRequestId the String value
     ServiceResponse<PageImpl<ProductInner>> * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesNextSinglePageAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
         if (nextPageLink == null) {
@@ -1701,9 +1701,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getOdataMultiplePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1737,7 +1737,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getOdataMultiplePagesNextAsync(final String nextPageLink) {
         return getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink)
@@ -1753,7 +1753,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getOdataMultiplePagesNextSinglePageAsync(nextPageLink)
@@ -1773,7 +1773,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -1806,9 +1806,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1846,7 +1846,7 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions)
@@ -1864,7 +1864,7 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions)
@@ -1886,7 +1886,7 @@ public final class PagingsInner {
     ServiceResponse<PageImpl1<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
     ServiceResponse<PageImpl1<ProductInner>> * @param clientRequestId the String value
     ServiceResponse<PageImpl1<ProductInner>> * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesNextSinglePageAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
         if (nextPageLink == null) {
@@ -1929,9 +1929,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -1965,7 +1965,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink) {
         return getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink)
@@ -1981,7 +1981,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink)
@@ -2001,7 +2001,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2034,9 +2034,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -2074,7 +2074,7 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) {
         return getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions)
@@ -2092,7 +2092,7 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) {
         return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions)
@@ -2114,7 +2114,7 @@ public final class PagingsInner {
     ServiceResponse<PageImpl<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
     ServiceResponse<PageImpl<ProductInner>> * @param clientRequestId the String value
     ServiceResponse<PageImpl<ProductInner>> * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetNextSinglePageAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) {
         if (nextPageLink == null) {
@@ -2157,9 +2157,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -2193,7 +2193,7 @@ public final class PagingsInner {
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink) {
         return getMultiplePagesRetryFirstNextWithServiceResponseAsync(nextPageLink)
@@ -2209,7 +2209,7 @@ public final class PagingsInner {
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetryFirstNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink)
@@ -2229,7 +2229,7 @@ public final class PagingsInner {
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
     ServiceResponse<PageImpl<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetryFirstNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2263,9 +2263,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -2299,7 +2299,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink) {
         return getMultiplePagesRetrySecondNextWithServiceResponseAsync(nextPageLink)
@@ -2315,7 +2315,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetrySecondNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink)
@@ -2335,7 +2335,7 @@ public final class PagingsInner {
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
     ServiceResponse<PageImpl<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetrySecondNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2369,9 +2369,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getSinglePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -2405,7 +2405,7 @@ public final class PagingsInner {
      * A paging operation that receives a 400 on the first call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getSinglePagesFailureNextAsync(final String nextPageLink) {
         return getSinglePagesFailureNextWithServiceResponseAsync(nextPageLink)
@@ -2421,7 +2421,7 @@ public final class PagingsInner {
      * A paging operation that receives a 400 on the first call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesFailureNextWithServiceResponseAsync(final String nextPageLink) {
         return getSinglePagesFailureNextSinglePageAsync(nextPageLink)
@@ -2441,7 +2441,7 @@ public final class PagingsInner {
      * A paging operation that receives a 400 on the first call.
      *
     ServiceResponse<PageImpl<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesFailureNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2475,9 +2475,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -2511,7 +2511,7 @@ public final class PagingsInner {
      * A paging operation that receives a 400 on the second call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesFailureNextAsync(final String nextPageLink) {
         return getMultiplePagesFailureNextWithServiceResponseAsync(nextPageLink)
@@ -2527,7 +2527,7 @@ public final class PagingsInner {
      * A paging operation that receives a 400 on the second call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesFailureNextSinglePageAsync(nextPageLink)
@@ -2547,7 +2547,7 @@ public final class PagingsInner {
      * A paging operation that receives a 400 on the second call.
      *
     ServiceResponse<PageImpl<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2581,9 +2581,9 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object if successful.
+     * @return the PagedList&lt;ProductInner&gt; object if successful.
      */
-    public List<ProductInner> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<ProductInner> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<ProductInner>(response.getBody()) {
             @Override
@@ -2617,7 +2617,7 @@ public final class PagingsInner {
      * A paging operation that receives an invalid nextLink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<Page<ProductInner>> getMultiplePagesFailureUriNextAsync(final String nextPageLink) {
         return getMultiplePagesFailureUriNextWithServiceResponseAsync(nextPageLink)
@@ -2633,7 +2633,7 @@ public final class PagingsInner {
      * A paging operation that receives an invalid nextLink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;ProductInner&gt; object
+     * @return the observable to the PagedList&lt;ProductInner&gt; object
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureUriNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink)
@@ -2653,7 +2653,7 @@ public final class PagingsInner {
      * A paging operation that receives an invalid nextLink.
      *
     ServiceResponse<PageImpl<ProductInner>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureUriNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/paging/implementation/PagingsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/paging/implementation/PagingsInner.java
@@ -138,17 +138,16 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getSinglePages() throws CloudException, IOException {
+    public List<ProductInner> getSinglePages() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getSinglePagesSinglePageAsync().toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getSinglePagesNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -174,13 +173,31 @@ public final class PagingsInner {
      *
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesAsync() {
+    public Observable<Page<ProductInner>> getSinglePagesAsync() {
+        return getSinglePagesWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesWithServiceResponseAsync() {
         return getSinglePagesSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getSinglePagesNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getSinglePagesNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -217,17 +234,16 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePages() throws CloudException, IOException {
+    public List<ProductInner> getMultiplePages() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesSinglePageAsync().toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -253,13 +269,31 @@ public final class PagingsInner {
      *
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesAsync() {
+    public Observable<Page<ProductInner>> getMultiplePagesAsync() {
+        return getMultiplePagesWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithServiceResponseAsync() {
         return getMultiplePagesSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -295,17 +329,16 @@ public final class PagingsInner {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) throws CloudException, IOException {
+    public List<ProductInner> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -335,13 +368,33 @@ public final class PagingsInner {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
+    public Observable<Page<ProductInner>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
+        return getMultiplePagesWithServiceResponseAsync(clientRequestId, pagingGetMultiplePagesOptions)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
         return getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions));
                 }
             });
     }
@@ -389,17 +442,16 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getOdataMultiplePages() throws CloudException, IOException {
+    public List<ProductInner> getOdataMultiplePages() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getOdataMultiplePagesSinglePageAsync().toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -425,13 +477,31 @@ public final class PagingsInner {
      *
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesAsync() {
+    public Observable<Page<ProductInner>> getOdataMultiplePagesAsync() {
+        return getOdataMultiplePagesWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesWithServiceResponseAsync() {
         return getOdataMultiplePagesSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -467,17 +537,16 @@ public final class PagingsInner {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) throws CloudException, IOException {
+    public List<ProductInner> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -507,13 +576,33 @@ public final class PagingsInner {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
+    public Observable<Page<ProductInner>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
+        return getOdataMultiplePagesWithServiceResponseAsync(clientRequestId, pagingGetOdataMultiplePagesOptions)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
                 }
             });
     }
@@ -563,11 +652,11 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions = new PagingGetMultiplePagesWithOffsetNextOptionsInner();
@@ -576,7 +665,6 @@ public final class PagingsInner {
                 return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, null, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -607,16 +695,35 @@ public final class PagingsInner {
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) {
+    public Observable<Page<ProductInner>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) {
+        return getMultiplePagesWithOffsetWithServiceResponseAsync(pagingGetMultiplePagesWithOffsetOptions)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
                     PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions = new PagingGetMultiplePagesWithOffsetNextOptionsInner();
                     pagingGetMultiplePagesWithOffsetNextOptions.withMaxresults(pagingGetMultiplePagesWithOffsetOptions.maxresults());
                     pagingGetMultiplePagesWithOffsetNextOptions.withTimeout(pagingGetMultiplePagesWithOffsetOptions.timeout());
-                    return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, null, pagingGetMultiplePagesWithOffsetNextOptions);
+                    return Observable.just(page).concatWith(getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, null, pagingGetMultiplePagesWithOffsetNextOptions));
                 }
             });
     }
@@ -658,11 +765,11 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions = new PagingGetMultiplePagesWithOffsetNextOptionsInner();
@@ -671,7 +778,6 @@ public final class PagingsInner {
                 return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -704,16 +810,36 @@ public final class PagingsInner {
      * @param clientRequestId the String value
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
+    public Observable<Page<ProductInner>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
+        return getMultiplePagesWithOffsetWithServiceResponseAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @param clientRequestId the String value
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptionsInner pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
                     PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions = new PagingGetMultiplePagesWithOffsetNextOptionsInner();
                     pagingGetMultiplePagesWithOffsetNextOptions.withMaxresults(pagingGetMultiplePagesWithOffsetOptions.maxresults());
                     pagingGetMultiplePagesWithOffsetNextOptions.withTimeout(pagingGetMultiplePagesWithOffsetOptions.timeout());
-                    return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions);
+                    return Observable.just(page).concatWith(getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions));
                 }
             });
     }
@@ -759,17 +885,16 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesRetryFirst() throws CloudException, IOException {
+    public List<ProductInner> getMultiplePagesRetryFirst() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesRetryFirstSinglePageAsync().toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -795,13 +920,31 @@ public final class PagingsInner {
      *
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetryFirstAsync() {
+    public Observable<Page<ProductInner>> getMultiplePagesRetryFirstAsync() {
+        return getMultiplePagesRetryFirstWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     *
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetryFirstWithServiceResponseAsync() {
         return getMultiplePagesRetryFirstSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesRetryFirstNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -838,17 +981,16 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesRetrySecond() throws CloudException, IOException {
+    public List<ProductInner> getMultiplePagesRetrySecond() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesRetrySecondSinglePageAsync().toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -874,13 +1016,31 @@ public final class PagingsInner {
      *
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetrySecondAsync() {
+    public Observable<Page<ProductInner>> getMultiplePagesRetrySecondAsync() {
+        return getMultiplePagesRetrySecondWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     *
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetrySecondWithServiceResponseAsync() {
         return getMultiplePagesRetrySecondSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesRetrySecondNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -917,17 +1077,16 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getSinglePagesFailure() throws CloudException, IOException {
+    public List<ProductInner> getSinglePagesFailure() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getSinglePagesFailureSinglePageAsync().toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getSinglePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -953,13 +1112,31 @@ public final class PagingsInner {
      *
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesFailureAsync() {
+    public Observable<Page<ProductInner>> getSinglePagesFailureAsync() {
+        return getSinglePagesFailureWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesFailureWithServiceResponseAsync() {
         return getSinglePagesFailureSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getSinglePagesFailureNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getSinglePagesFailureNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -996,17 +1173,16 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesFailure() throws CloudException, IOException {
+    public List<ProductInner> getMultiplePagesFailure() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesFailureSinglePageAsync().toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1032,13 +1208,31 @@ public final class PagingsInner {
      *
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureAsync() {
+    public Observable<Page<ProductInner>> getMultiplePagesFailureAsync() {
+        return getMultiplePagesFailureWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureWithServiceResponseAsync() {
         return getMultiplePagesFailureSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesFailureNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesFailureNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1075,17 +1269,16 @@ public final class PagingsInner {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesFailureUri() throws CloudException, IOException {
+    public List<ProductInner> getMultiplePagesFailureUri() throws CloudException, IOException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesFailureUriSinglePageAsync().toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1111,13 +1304,31 @@ public final class PagingsInner {
      *
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureUriAsync() {
+    public Observable<Page<ProductInner>> getMultiplePagesFailureUriAsync() {
+        return getMultiplePagesFailureUriWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureUriWithServiceResponseAsync() {
         return getMultiplePagesFailureUriSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesFailureUriNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1156,17 +1367,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getSinglePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getSinglePagesNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1195,13 +1405,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getSinglePagesNextAsync(final String nextPageLink) {
+        return getSinglePagesNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getSinglePagesNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getSinglePagesNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getSinglePagesNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1244,17 +1473,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1283,13 +1511,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getMultiplePagesNextAsync(final String nextPageLink) {
+        return getMultiplePagesNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -1331,17 +1578,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1374,13 +1620,34 @@ public final class PagingsInner {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
+    public Observable<Page<ProductInner>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
+        return getMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions) {
         return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions));
                 }
             });
     }
@@ -1434,17 +1701,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getOdataMultiplePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1473,13 +1739,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getOdataMultiplePagesNextAsync(final String nextPageLink) {
+        return getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getOdataMultiplePagesNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -1521,17 +1806,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1564,13 +1848,34 @@ public final class PagingsInner {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
+    public Observable<Page<ProductInner>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
+        return getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
                 }
             });
     }
@@ -1624,17 +1929,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1663,13 +1967,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink) {
+        return getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -1711,17 +2034,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1754,13 +2076,34 @@ public final class PagingsInner {
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) {
+    public Observable<Page<ProductInner>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) {
+        return getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptionsInner pagingGetMultiplePagesWithOffsetNextOptions) {
         return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions));
                 }
             });
     }
@@ -1814,17 +2157,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1853,13 +2195,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink) {
+        return getMultiplePagesRetryFirstNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetryFirstNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesRetryFirstNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1902,17 +2263,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1941,13 +2301,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink) {
+        return getMultiplePagesRetrySecondNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesRetrySecondNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesRetrySecondNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1990,17 +2369,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getSinglePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getSinglePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -2029,13 +2407,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesFailureNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getSinglePagesFailureNextAsync(final String nextPageLink) {
+        return getSinglePagesFailureNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getSinglePagesFailureNextWithServiceResponseAsync(final String nextPageLink) {
         return getSinglePagesFailureNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getSinglePagesFailureNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getSinglePagesFailureNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -2078,17 +2475,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -2117,13 +2513,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getMultiplePagesFailureNextAsync(final String nextPageLink) {
+        return getMultiplePagesFailureNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesFailureNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesFailureNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesFailureNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -2166,17 +2581,16 @@ public final class PagingsInner {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;ProductInner&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;ProductInner&gt; object if successful.
      */
-    public ServiceResponse<PagedList<ProductInner>> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<ProductInner> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<ProductInner>> response = getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<ProductInner> pagedList = new PagedList<ProductInner>(response.getBody()) {
+        return new PagedList<ProductInner>(response.getBody()) {
             @Override
             public Page<ProductInner> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<ProductInner>>(pagedList, response.getResponse());
     }
 
     /**
@@ -2205,13 +2619,32 @@ public final class PagingsInner {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;ProductInner&gt; object
      */
-    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureUriNextAsync(final String nextPageLink) {
+    public Observable<Page<ProductInner>> getMultiplePagesFailureUriNextAsync(final String nextPageLink) {
+        return getMultiplePagesFailureUriNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<ProductInner>>, Page<ProductInner>>() {
+                @Override
+                public Page<ProductInner> call(ServiceResponse<Page<ProductInner>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;ProductInner&gt; object
+     */
+    public Observable<ServiceResponse<Page<ProductInner>>> getMultiplePagesFailureUriNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<ProductInner>>, Observable<ServiceResponse<Page<ProductInner>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<ProductInner>>> call(ServiceResponse<Page<ProductInner>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesFailureUriNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsInner.java
@@ -67,10 +67,10 @@ public final class GroupsInner {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SampleResourceGroupInner object wrapped in {@link ServiceResponse} if successful.
+     * @return the SampleResourceGroupInner object if successful.
      */
-    public ServiceResponse<SampleResourceGroupInner> getSampleResourceGroup(String resourceGroupName) throws ErrorException, IOException, IllegalArgumentException {
-        return getSampleResourceGroupAsync(resourceGroupName).toBlocking().single();
+    public SampleResourceGroupInner getSampleResourceGroup(String resourceGroupName) throws ErrorException, IOException, IllegalArgumentException {
+        return getSampleResourceGroupWithServiceResponseAsync(resourceGroupName).toBlocking().single().getBody();
     }
 
     /**
@@ -81,7 +81,7 @@ public final class GroupsInner {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SampleResourceGroupInner> getSampleResourceGroupAsync(String resourceGroupName, final ServiceCallback<SampleResourceGroupInner> serviceCallback) {
-        return ServiceCall.create(getSampleResourceGroupAsync(resourceGroupName), serviceCallback);
+        return ServiceCall.create(getSampleResourceGroupWithServiceResponseAsync(resourceGroupName), serviceCallback);
     }
 
     /**
@@ -90,7 +90,22 @@ public final class GroupsInner {
      * @param resourceGroupName Resource Group name 'testgroup101'.
      * @return the observable to the SampleResourceGroupInner object
      */
-    public Observable<ServiceResponse<SampleResourceGroupInner>> getSampleResourceGroupAsync(String resourceGroupName) {
+    public Observable<SampleResourceGroupInner> getSampleResourceGroupAsync(String resourceGroupName) {
+        return getSampleResourceGroupWithServiceResponseAsync(resourceGroupName).map(new Func1<ServiceResponse<SampleResourceGroupInner>, SampleResourceGroupInner>() {
+            @Override
+            public SampleResourceGroupInner call(ServiceResponse<SampleResourceGroupInner> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Provides a resouce group with name 'testgroup101' and location 'West US'.
+     *
+     * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @return the observable to the SampleResourceGroupInner object
+     */
+    public Observable<ServiceResponse<SampleResourceGroupInner>> getSampleResourceGroupWithServiceResponseAsync(String resourceGroupName) {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsInner.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsInner.java
@@ -96,7 +96,7 @@ public final class GroupsInner {
             public SampleResourceGroupInner call(ServiceResponse<SampleResourceGroupInner> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurecustombaseuri/AzureCustomBaseUriTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurecustombaseuri/AzureCustomBaseUriTests.java
@@ -22,7 +22,7 @@ public class AzureCustomBaseUriTests {
     @Test
     public void getEmptyWithValidCustomUri() throws Exception {
         client.withHost("host:3000");
-        Assert.assertTrue(client.paths().getEmpty("local").getResponse().isSuccessful());
+        client.paths().getEmpty("local");
     }
 
     @Test

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azureparametergrouping/ParameterGroupingTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azureparametergrouping/ParameterGroupingTests.java
@@ -1,7 +1,5 @@
 package fixtures.azureparametergrouping;
 
-import com.microsoft.rest.ServiceResponse;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -27,7 +25,7 @@ public class ParameterGroupingTests {
         params.withPath("path");
         params.withQuery(21);
         params.withCustomHeader("header");
-        ServiceResponse<Void> group = client.parameterGroupings().postRequired(params);
+        client.parameterGroupings().postRequired(params);
     }
 
     @Test
@@ -35,7 +33,7 @@ public class ParameterGroupingTests {
         ParameterGroupingPostOptionalParametersInner params = new ParameterGroupingPostOptionalParametersInner();
         params.withQuery(21);
         params.withCustomHeader("header");
-        ServiceResponse<Void> group = client.parameterGroupings().postOptional(params);
+        client.parameterGroupings().postOptional(params);
     }
 
     @Test
@@ -46,7 +44,7 @@ public class ParameterGroupingTests {
         ParameterGroupingPostMultiParamGroupsSecondParamGroupInner second = new ParameterGroupingPostMultiParamGroupsSecondParamGroupInner();
         second.withHeaderTwo("header2");
         second.withQueryTwo(42);
-        ServiceResponse<Void> group = client.parameterGroupings().postMultiParamGroups(first, second);
+        client.parameterGroupings().postMultiParamGroups(first, second);
     }
 
     @Test
@@ -54,6 +52,6 @@ public class ParameterGroupingTests {
         FirstParameterGroupInner first = new FirstParameterGroupInner();
         first.withQueryOne(21);
         first.withHeaderOne("header");
-        ServiceResponse<Void> group = client.parameterGroupings().postSharedParameterGroupObject(first);
+        client.parameterGroupings().postSharedParameterGroupObject(first);
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurereport/CoverageReporter.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurereport/CoverageReporter.java
@@ -12,7 +12,7 @@ public final class CoverageReporter {
     private CoverageReporter() { }
 
     public static void main(String[] args) throws Exception {
-        Map<String, Integer> report = client.getReport().getBody();
+        Map<String, Integer> report = client.getReport();
 
         // Pending URL encoding
         report.put("AzureMethodQueryUrlEncoding", 1);

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/ApiVersionDefaultTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/ApiVersionDefaultTests.java
@@ -1,7 +1,5 @@
 package fixtures.azurespecials;
 
-import com.microsoft.rest.ServiceResponse;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -17,25 +15,21 @@ public class ApiVersionDefaultTests {
 
     @Test
     public void getMethodGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionDefaults().getMethodGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.apiVersionDefaults().getMethodGlobalValid();
     }
 
     @Test
     public void getMethodGlobalNotProvidedValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionDefaults().getMethodGlobalNotProvidedValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.apiVersionDefaults().getMethodGlobalNotProvidedValid();
     }
 
     @Test
     public void getPathGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionDefaults().getPathGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.apiVersionDefaults().getPathGlobalValid();
     }
 
     @Test
     public void getSwaggerGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionDefaults().getSwaggerGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.apiVersionDefaults().getSwaggerGlobalValid();
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/ApiVersionLocalTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/ApiVersionLocalTests.java
@@ -1,7 +1,5 @@
 package fixtures.azurespecials;
 
-import com.microsoft.rest.ServiceResponse;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -17,25 +15,21 @@ public class ApiVersionLocalTests {
 
     @Test
     public void getMethodLocalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionLocals().getMethodLocalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.apiVersionLocals().getMethodLocalValid();
     }
 
     @Test
     public void getMethodGlobalNotProvidedValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionLocals().getMethodLocalNull(null);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.apiVersionLocals().getMethodLocalNull(null);
     }
 
     @Test
     public void getPathGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionLocals().getPathLocalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.apiVersionLocals().getPathLocalValid();
     }
 
     @Test
     public void getSwaggerGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionLocals().getSwaggerLocalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.apiVersionLocals().getSwaggerLocalValid();
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/HeaderOperationsTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/HeaderOperationsTests.java
@@ -20,7 +20,7 @@ public class HeaderOperationsTests {
 
     @Test
     public void customNamedRequestId() throws Exception {
-        ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeadersInner> response = client.headers().customNamedRequestId("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
+        ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeadersInner> response = client.headers().customNamedRequestIdWithServiceResponseAsync("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0").toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
         Assert.assertEquals("123", response.getHeaders().fooRequestId());
     }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/SkipUrlEncodingTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/SkipUrlEncodingTests.java
@@ -1,8 +1,5 @@
 package fixtures.azurespecials;
 
-import com.microsoft.rest.ServiceResponse;
-
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -11,9 +8,6 @@ import fixtures.azurespecials.implementation.AutoRestAzureSpecialParametersTestC
 import fixtures.azurespecials.implementation.SkipUrlEncodingsInner;
 
 public class SkipUrlEncodingTests {
-    private static final int OK_STATUS_CODE = 200;
-    private static final int NOT_FOUND_STATUS_CODE = 404;
-
     private static String baseUrl = "http://localhost:3000";
     private static String unencodedPath = "path1/path2/path3";
     private static String unencodedQuery = "value1&q2=value2&q3=value3";
@@ -27,44 +21,37 @@ public class SkipUrlEncodingTests {
 
     @Test
     public void getMethodPathValid() throws Exception {
-        ServiceResponse<Void> response = client.getMethodPathValid(unencodedPath);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getMethodPathValid(unencodedPath);
     }
 
     @Test
     public void getPathPathValid() throws Exception {
-        ServiceResponse<Void> response = client.getPathPathValid(unencodedPath);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getPathPathValid(unencodedPath);
     }
 
     @Test
     public void getSwaggerPathValid() throws Exception {
-        ServiceResponse<Void> response = client.getSwaggerPathValid();
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getSwaggerPathValid();
     }
 
     @Ignore("Not supported by OkHttp: https://github.com/square/okhttp/issues/2623")
     public void getMethodQueryValid() throws Exception {
-        ServiceResponse<Void> response = client.getMethodQueryValid(unencodedQuery);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getMethodQueryValid(unencodedQuery);
     }
 
     @Ignore("Not supported by OkHttp: https://github.com/square/okhttp/issues/2623")
     public void getPathQueryValid() throws Exception {
-        ServiceResponse<Void> response = client.getPathQueryValid(unencodedQuery);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getPathQueryValid(unencodedQuery);
     }
 
     @Ignore("Not supported by OkHttp: https://github.com/square/okhttp/issues/2623")
     public void getSwaggerQueryValid() throws Exception {
-        ServiceResponse<Void> response = client.getSwaggerQueryValid();
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getSwaggerQueryValid();
     }
 
     @Test
     public void getMethodQueryNull() throws Exception {
-        ServiceResponse<Void> response = client.getMethodQueryNull(null);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getMethodQueryNull(null);
     }
 
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/SubscriptionInCredentialsTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/SubscriptionInCredentialsTests.java
@@ -2,10 +2,8 @@ package fixtures.azurespecials;
 
 import com.microsoft.azure.RequestIdHeaderInterceptor;
 import com.microsoft.azure.RestClient;
-import com.microsoft.rest.ServiceResponse;
 import com.microsoft.rest.credentials.TokenCredentials;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -29,25 +27,21 @@ public class SubscriptionInCredentialsTests {
 
     @Test
     public void postMethodGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInCredentials().postMethodGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInCredentials().postMethodGlobalValid();
     }
 
     @Test
     public void postMethodGlobalNotProvidedValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInCredentials().postMethodGlobalNotProvidedValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInCredentials().postMethodGlobalNotProvidedValid();
     }
 
     @Test
     public void postPathGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInCredentials().postPathGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInCredentials().postPathGlobalValid();
     }
 
     @Test
     public void postSwaggerGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInCredentials().postSwaggerGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInCredentials().postSwaggerGlobalValid();
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/SubscriptionInMethodTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/SubscriptionInMethodTests.java
@@ -2,7 +2,6 @@ package fixtures.azurespecials;
 
 import com.microsoft.azure.RequestIdHeaderInterceptor;
 import com.microsoft.azure.RestClient;
-import com.microsoft.rest.ServiceResponse;
 import com.microsoft.rest.credentials.TokenCredentials;
 
 import org.junit.Assert;
@@ -31,14 +30,13 @@ public class SubscriptionInMethodTests {
 
     @Test
     public void postMethodLocalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInMethods().postMethodLocalValid("1234-5678-9012-3456");
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInMethods().postMethodLocalValid("1234-5678-9012-3456");
     }
 
     @Test
     public void postMethodLocalNull() throws Exception {
         try {
-            ServiceResponse<Void> response = client.subscriptionInMethods().postMethodLocalNull(null);
+            client.subscriptionInMethods().postMethodLocalNull(null);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter subscriptionId is required"));
@@ -47,13 +45,11 @@ public class SubscriptionInMethodTests {
 
     @Test
     public void postPathLocalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInMethods().postPathLocalValid("1234-5678-9012-3456");
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInMethods().postPathLocalValid("1234-5678-9012-3456");
     }
 
     @Test
     public void postSwaggerLocalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInMethods().postSwaggerLocalValid("1234-5678-9012-3456");
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInMethods().postSwaggerLocalValid("1234-5678-9012-3456");
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/XMsClientRequestIdTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/azurespecials/XMsClientRequestIdTests.java
@@ -1,9 +1,7 @@
 package fixtures.azurespecials;
 
-import com.microsoft.rest.ServiceResponse;
 import com.microsoft.rest.credentials.TokenCredentials;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -22,17 +20,14 @@ public class XMsClientRequestIdTests {
 
     @Test
     public void get() throws Exception {
-        client.restClient().headers().removeHeader("x-ms-client-request-id");
         client.restClient().headers().addHeader("x-ms-client-request-id", "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
-        ServiceResponse<Void> response = client.xMsClientRequestIds().get();
+        client.xMsClientRequestIds().get();
         client.restClient().headers().removeHeader("x-ms-client-request-id");
-        Assert.assertEquals(200, response.getResponse().code());
     }
 
     @Test
     public void paramGet() throws Exception {
         client.restClient().headers().removeHeader("x-ms-client-request-id");
-        ServiceResponse<Void> response = client.xMsClientRequestIds().paramGet("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
-        Assert.assertEquals(200, response.getResponse().code());
+        client.xMsClientRequestIds().paramGet("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/head/HttpSuccessTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/head/HttpSuccessTests.java
@@ -16,16 +16,16 @@ public class HttpSuccessTests {
 
     @Test
     public void head200() throws Exception {
-        Assert.assertTrue(client.httpSuccess().head200().getBody());
+        Assert.assertTrue(client.httpSuccess().head200());
     }
 
     @Test
     public void head204() throws Exception {
-        Assert.assertTrue(client.httpSuccess().head204().getBody());
+        Assert.assertTrue(client.httpSuccess().head204());
     }
 
     @Test
     public void head404() throws Exception {
-        Assert.assertFalse(client.httpSuccess().head404().getBody());
+        Assert.assertFalse(client.httpSuccess().head404());
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/lro/LRORetrysTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/lro/LRORetrysTests.java
@@ -1,7 +1,5 @@
 package fixtures.lro;
 
-import com.microsoft.rest.ServiceResponse;
-
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -23,52 +21,45 @@ public class LRORetrysTests {
     public void put201CreatingSucceeded200() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lRORetrys().put201CreatingSucceeded200(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lRORetrys().put201CreatingSucceeded200(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putAsyncRelativeRetrySucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lRORetrys().putAsyncRelativeRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lRORetrys().putAsyncRelativeRetrySucceeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void deleteProvisioning202Accepted200Succeeded() throws Exception {
-        ServiceResponse<ProductInner> response = client.lRORetrys().deleteProvisioning202Accepted200Succeeded();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lRORetrys().deleteProvisioning202Accepted200Succeeded();
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void delete202Retry200() throws Exception {
-        ServiceResponse<Void> response = client.lRORetrys().delete202Retry200();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lRORetrys().delete202Retry200();
     }
 
     @Test
     public void deleteAsyncRelativeRetrySucceeded() throws Exception {
-        ServiceResponse<Void> response = client.lRORetrys().deleteAsyncRelativeRetrySucceeded();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lRORetrys().deleteAsyncRelativeRetrySucceeded();
     }
 
     @Test
     public void post202Retry200() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lRORetrys().post202Retry200(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lRORetrys().post202Retry200(product);
     }
 
     @Test
     public void postAsyncRelativeRetrySucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lRORetrys().postAsyncRelativeRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lRORetrys().postAsyncRelativeRetrySucceeded(product);
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/lro/LROSADsTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/lro/LROSADsTests.java
@@ -1,7 +1,6 @@
 package fixtures.lro;
 
 import com.microsoft.azure.CloudException;
-import com.microsoft.rest.ServiceResponse;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -26,7 +25,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().putNonRetry400(product);
+            client.lROSADs().putNonRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -38,7 +37,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().putNonRetry201Creating400(product);
+            client.lROSADs().putNonRetry201Creating400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -50,7 +49,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().putAsyncRelativeRetry400(product);
+            client.lROSADs().putAsyncRelativeRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -60,7 +59,7 @@ public class LROSADsTests {
     @Test
     public void deleteNonRetry400() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteNonRetry400();
+            client.lROSADs().deleteNonRetry400();
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -70,7 +69,7 @@ public class LROSADsTests {
     @Test
     public void delete202NonRetry400() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().delete202NonRetry400();
+            client.lROSADs().delete202NonRetry400();
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -80,7 +79,7 @@ public class LROSADsTests {
     @Test
     public void deleteAsyncRelativeRetry400() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteAsyncRelativeRetry400();
+            client.lROSADs().deleteAsyncRelativeRetry400();
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -92,7 +91,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postNonRetry400(product);
+            client.lROSADs().postNonRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -104,7 +103,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().post202NonRetry400(product);
+            client.lROSADs().post202NonRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -116,7 +115,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postAsyncRelativeRetry400(product);
+            client.lROSADs().postAsyncRelativeRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -128,7 +127,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().putError201NoProvisioningStatePayload(product);
+            client.lROSADs().putError201NoProvisioningStatePayload(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -141,7 +140,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().putAsyncRelativeRetryNoStatus(product);
+            client.lROSADs().putAsyncRelativeRetryNoStatus(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -154,7 +153,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().putAsyncRelativeRetryNoStatusPayload(product);
+            client.lROSADs().putAsyncRelativeRetryNoStatusPayload(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -164,14 +163,13 @@ public class LROSADsTests {
 
     @Test
     public void delete204Succeeded() throws Exception {
-        ServiceResponse<Void> response = client.lROSADs().delete204Succeeded();
-        Assert.assertEquals(204, response.getResponse().code());
+        client.lROSADs().delete204Succeeded();
     }
 
     @Test
     public void deleteAsyncRelativeRetryNoStatus() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteAsyncRelativeRetryNoStatus();
+            client.lROSADs().deleteAsyncRelativeRetryNoStatus();
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -184,7 +182,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().post202NoLocation(product);
+            client.lROSADs().post202NoLocation(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(202, ex.getResponse().code());
@@ -197,7 +195,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postAsyncRelativeRetryNoPayload(product);
+            client.lROSADs().postAsyncRelativeRetryNoPayload(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -210,7 +208,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().put200InvalidJson(product);
+            client.lROSADs().put200InvalidJson(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("Unexpected end-of-input"));
@@ -222,7 +220,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().putAsyncRelativeRetryInvalidHeader(product);
+            client.lROSADs().putAsyncRelativeRetryInvalidHeader(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -234,7 +232,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROSADs().putAsyncRelativeRetryInvalidJsonPolling(product);
+            client.lROSADs().putAsyncRelativeRetryInvalidJsonPolling(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("does not contain a valid body"));
@@ -244,7 +242,7 @@ public class LROSADsTests {
     @Test
     public void delete202RetryInvalidHeader() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().delete202RetryInvalidHeader();
+            client.lROSADs().delete202RetryInvalidHeader();
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -254,7 +252,7 @@ public class LROSADsTests {
     @Test
     public void deleteAsyncRelativeRetryInvalidHeader() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteAsyncRelativeRetryInvalidHeader();
+            client.lROSADs().deleteAsyncRelativeRetryInvalidHeader();
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -264,7 +262,7 @@ public class LROSADsTests {
     @Test
     public void deleteAsyncRelativeRetryInvalidJsonPolling() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteAsyncRelativeRetryInvalidJsonPolling();
+            client.lROSADs().deleteAsyncRelativeRetryInvalidJsonPolling();
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("does not contain a valid body"));
@@ -276,7 +274,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().post202RetryInvalidHeader(product);
+            client.lROSADs().post202RetryInvalidHeader(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -288,7 +286,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postAsyncRelativeRetryInvalidHeader(product);
+            client.lROSADs().postAsyncRelativeRetryInvalidHeader(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -300,7 +298,7 @@ public class LROSADsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postAsyncRelativeRetryInvalidJsonPolling(product);
+            client.lROSADs().postAsyncRelativeRetryInvalidJsonPolling(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("does not contain a valid body"));

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/lro/LROsCustomHeaderTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/lro/LROsCustomHeaderTests.java
@@ -1,7 +1,5 @@
 package fixtures.lro;
 
-import com.microsoft.rest.ServiceResponse;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -29,33 +27,29 @@ public class LROsCustomHeaderTests {
     public void putAsyncRetrySucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROsCustomHeaders().putAsyncRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROsCustomHeaders().putAsyncRetrySucceeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Ignore("Pending headermap")
     public void put201CreatingSucceeded200() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROsCustomHeaders().put201CreatingSucceeded200(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROsCustomHeaders().put201CreatingSucceeded200(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Ignore("Pending headermap")
     public void post202Retry200() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lROsCustomHeaders().post202Retry200(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROsCustomHeaders().post202Retry200(product);
     }
 
     @Ignore("Pending headermap")
     public void postAsyncRetrySucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lROsCustomHeaders().postAsyncRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROsCustomHeaders().postAsyncRetrySucceeded(product);
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/lro/LROsTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/lro/LROsTests.java
@@ -3,7 +3,6 @@ package fixtures.lro;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.RestClient;
 import com.microsoft.rest.ServiceCallback;
-import com.microsoft.rest.ServiceResponse;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,9 +39,8 @@ public class LROsTests {
     public void put200Succeeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().put200Succeeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().put200Succeeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
@@ -50,7 +48,7 @@ public class LROsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         Observable.from(client.lROs().put200SucceededAsync(product, null))
-                .subscribe(new Subscriber<ServiceResponse<ProductInner>>() {
+                .subscribe(new Subscriber<ProductInner>() {
                     @Override
                     public void onCompleted() {
                         System.out.println("completed");
@@ -62,8 +60,8 @@ public class LROsTests {
                     }
 
                     @Override
-                    public void onNext(ServiceResponse<ProductInner> productInnerServiceResponse) {
-                        System.out.println(productInnerServiceResponse.getBody().provisioningState());
+                    public void onNext(ProductInner productInnerServiceResponse) {
+                        System.out.println(productInnerServiceResponse.provisioningState());
                     }
                 });
         System.out.println("Checkpoint");
@@ -73,27 +71,24 @@ public class LROsTests {
     public void put200AsyncSucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().put200SucceededAsync(product, null).get();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().put200SucceededAsync(product, null).get();
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void put200SucceededNoState() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().put200SucceededNoState(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("100", response.getBody().id());
+        ProductInner response = client.lROs().put200SucceededNoState(product);
+        Assert.assertEquals("100", response.id());
     }
 
     @Test
     public void put202Retry200() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().put202Retry200(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("100", response.getBody().id());
+        ProductInner response = client.lROs().put202Retry200(product);
+        Assert.assertEquals("100", response.id());
     }
 
     @Ignore("Can cause flakiness - only run manually")
@@ -111,9 +106,8 @@ public class LROsTests {
             }
 
             @Override
-            public void success(ServiceResponse<ProductInner> result) {
-                Assert.assertEquals(200, result.getResponse().code());
-                Assert.assertEquals("100", result.getBody().id());
+            public void success(ProductInner result) {
+                Assert.assertEquals("100", result.id());
                 callbackTime[0] = System.currentTimeMillis();
                 lock.countDown();
             }
@@ -129,18 +123,16 @@ public class LROsTests {
     public void put201CreatingSucceeded200() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().put201CreatingSucceeded200(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().put201CreatingSucceeded200(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void put200UpdatingSucceeded204() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().put200UpdatingSucceeded204(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().put200UpdatingSucceeded204(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
@@ -148,7 +140,7 @@ public class LROsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROs().put201CreatingFailed200(product);
+            ProductInner response = client.lROs().put201CreatingFailed200(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Failed", e.getMessage());
@@ -160,7 +152,7 @@ public class LROsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROs().put200Acceptedcanceled200(product);
+            ProductInner response = client.lROs().put200Acceptedcanceled200(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Canceled", e.getMessage());
@@ -171,27 +163,24 @@ public class LROsTests {
     public void putNoHeaderInRetry() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().putNoHeaderInRetry(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().putNoHeaderInRetry(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putAsyncRetrySucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().putAsyncRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().putAsyncRetrySucceeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putAsyncNoRetrySucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().putAsyncNoRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().putAsyncNoRetrySucceeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
@@ -199,7 +188,7 @@ public class LROsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROs().putAsyncRetryFailed(product);
+            ProductInner response = client.lROs().putAsyncRetryFailed(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Failed", e.getMessage());
@@ -211,7 +200,7 @@ public class LROsTests {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
         try {
-            ServiceResponse<ProductInner> response = client.lROs().putAsyncNoRetrycanceled(product);
+            ProductInner response = client.lROs().putAsyncNoRetrycanceled(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Canceled", e.getMessage());
@@ -222,110 +211,95 @@ public class LROsTests {
     public void putAsyncNoHeaderInRetry() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().putAsyncNoHeaderInRetry(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().putAsyncNoHeaderInRetry(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putNonResource() throws Exception {
         SkuInner sku = new SkuInner();
-        ServiceResponse<SkuInner> response = client.lROs().putNonResource(sku);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("100", response.getBody().id());
+        SkuInner response = client.lROs().putNonResource(sku);
+        Assert.assertEquals("100", response.id());
     }
 
     @Test
     public void putAsyncNonResource() throws Exception {
         SkuInner sku = new SkuInner();
-        ServiceResponse<SkuInner> response = client.lROs().putAsyncNonResource(sku);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("100", response.getBody().id());
+        SkuInner response = client.lROs().putAsyncNonResource(sku);
+        Assert.assertEquals("100", response.id());
     }
 
     @Test
     public void putSubResource() throws Exception {
         SubProductInner subProduct = new SubProductInner();
-        ServiceResponse<SubProductInner> response = client.lROs().putSubResource(subProduct);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        SubProductInner response = client.lROs().putSubResource(subProduct);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putAsyncSubResource() throws Exception {
         SubProductInner subProduct = new SubProductInner();
-        ServiceResponse<SubProductInner> response = client.lROs().putAsyncSubResource(subProduct);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        SubProductInner response = client.lROs().putAsyncSubResource(subProduct);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void deleteProvisioning202Accepted200Succeeded() throws Exception {
-        ServiceResponse<ProductInner> response = client.lROs().deleteProvisioning202Accepted200Succeeded();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        ProductInner response = client.lROs().deleteProvisioning202Accepted200Succeeded();
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void deleteProvisioning202DeletingFailed200() throws Exception {
-        ServiceResponse<ProductInner> response = client.lROs().deleteProvisioning202DeletingFailed200();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Failed", response.getBody().provisioningState());
+        ProductInner response = client.lROs().deleteProvisioning202DeletingFailed200();
+        Assert.assertEquals("Failed", response.provisioningState());
     }
 
     @Test
     public void deleteProvisioning202Deletingcanceled200() throws Exception {
-        ServiceResponse<ProductInner> response = client.lROs().deleteProvisioning202Deletingcanceled200();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Canceled", response.getBody().provisioningState());
+        ProductInner response = client.lROs().deleteProvisioning202Deletingcanceled200();
+        Assert.assertEquals("Canceled", response.provisioningState());
     }
 
     @Test
     public void delete204Succeeded() throws Exception {
-        ServiceResponse<Void> response = client.lROs().delete204Succeeded();
-        Assert.assertEquals(204, response.getResponse().code());
+        client.lROs().delete204Succeeded();
     }
 
     @Test
     public void delete202Retry200() throws Exception {
-        ServiceResponse<ProductInner> response = client.lROs().delete202Retry200();
-        Assert.assertEquals(200, response.getResponse().code());
+        ProductInner response = client.lROs().delete202Retry200();
     }
 
     @Test
     public void delete202NoRetry204() throws Exception {
-        ServiceResponse<ProductInner> response = client.lROs().delete202NoRetry204();
-        Assert.assertEquals(204, response.getResponse().code());
+        ProductInner response = client.lROs().delete202NoRetry204();
     }
 
     @Test
     public void deleteNoHeaderInRetry() throws Exception {
-        ServiceResponse<Void> response = client.lROs().deleteNoHeaderInRetry();
-        Assert.assertEquals(204, response.getResponse().code());
+        client.lROs().deleteNoHeaderInRetry();
     }
 
     @Test
     public void deleteAsyncNoHeaderInRetry() throws Exception {
-        ServiceResponse<Void> response = client.lROs().deleteAsyncNoHeaderInRetry();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROs().deleteAsyncNoHeaderInRetry();
     }
 
     @Test
     public void deleteAsyncRetrySucceeded() throws Exception {
-        ServiceResponse<Void> response = client.lROs().deleteAsyncRetrySucceeded();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROs().deleteAsyncRetrySucceeded();
     }
 
     @Test
     public void deleteAsyncNoRetrySucceeded() throws Exception {
-        ServiceResponse<Void> response = client.lROs().deleteAsyncNoRetrySucceeded();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROs().deleteAsyncNoRetrySucceeded();
     }
 
     @Test
     public void deleteAsyncRetryFailed() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROs().deleteAsyncRetryFailed();
+            client.lROs().deleteAsyncRetryFailed();
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Failed", e.getMessage());
@@ -335,7 +309,7 @@ public class LROsTests {
     @Test
     public void deleteAsyncRetrycanceled() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROs().deleteAsyncRetrycanceled();
+            client.lROs().deleteAsyncRetrycanceled();
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Canceled", e.getMessage());
@@ -344,41 +318,36 @@ public class LROsTests {
 
     @Test
     public void post200WithPayload() throws Exception {
-        ServiceResponse<SkuInner> response = client.lROs().post200WithPayload();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("1", response.getBody().id());
+        SkuInner response = client.lROs().post200WithPayload();
+        Assert.assertEquals("1", response.id());
     }
 
     @Test
     public void post202Retry200() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lROs().post202Retry200(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROs().post202Retry200(product);
     }
 
     @Test
     public void post202NoRetry204() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().post202NoRetry204(product);
-        Assert.assertEquals(204, response.getResponse().code());
+        ProductInner response = client.lROs().post202NoRetry204(product);
     }
 
     @Test
     public void postAsyncRetrySucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().postAsyncRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        ProductInner response = client.lROs().postAsyncRetrySucceeded(product);
     }
 
     @Test
     public void postAsyncNoRetrySucceeded() throws Exception {
         ProductInner product = new ProductInner();
         product.withLocation("West US");
-        ServiceResponse<ProductInner> response = client.lROs().postAsyncNoRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        ProductInner response = client.lROs().postAsyncNoRetrySucceeded(product);
     }
 
     @Test
@@ -386,7 +355,7 @@ public class LROsTests {
         try {
             ProductInner product = new ProductInner();
             product.withLocation("West US");
-            ServiceResponse<Void> response = client.lROs().postAsyncRetryFailed(product);
+            client.lROs().postAsyncRetryFailed(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Failed", e.getMessage());
@@ -398,7 +367,7 @@ public class LROsTests {
         try {
             ProductInner product = new ProductInner();
             product.withLocation("West US");
-            ServiceResponse<Void> response = client.lROs().postAsyncRetrycanceled(product);
+            client.lROs().postAsyncRetrycanceled(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Canceled", e.getMessage());

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/paging/PagingTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/paging/PagingTests.java
@@ -27,13 +27,13 @@ public class PagingTests {
 
     @Test
     public void getSinglePages() throws Exception {
-        List<ProductInner> response = client.pagings().getSinglePages().getBody();
+        List<ProductInner> response = client.pagings().getSinglePages();
         Assert.assertEquals(1, response.size());
     }
 
     @Test
     public void getMultiplePages() throws Exception {
-        List<ProductInner> response = client.pagings().getMultiplePages().getBody();
+        List<ProductInner> response = client.pagings().getMultiplePages();
         ProductInner p1 = new ProductInner();
         p1.withProperties(new ProductProperties());
         response.add(p1);
@@ -57,7 +57,7 @@ public class PagingTests {
     public void getMultiplePagesWithOffset() throws Exception {
         PagingGetMultiplePagesWithOffsetOptionsInner options = new PagingGetMultiplePagesWithOffsetOptionsInner();
         options.withOffset(100);
-        List<ProductInner> response = client.pagings().getMultiplePagesWithOffset(options, "client-id").getBody();
+        List<ProductInner> response = client.pagings().getMultiplePagesWithOffset(options, "client-id");
         Assert.assertEquals(10, response.size());
         Assert.assertEquals(110, (int) response.get(response.size() - 1).properties().id());
     }
@@ -90,20 +90,20 @@ public class PagingTests {
 
     @Test
     public void getMultiplePagesRetryFirst() throws Exception {
-        List<ProductInner> response = client.pagings().getMultiplePagesRetryFirst().getBody();
+        List<ProductInner> response = client.pagings().getMultiplePagesRetryFirst();
         Assert.assertEquals(10, response.size());
     }
 
     @Test
     public void getMultiplePagesRetrySecond() throws Exception {
-        List<ProductInner> response = client.pagings().getMultiplePagesRetrySecond().getBody();
+        List<ProductInner> response = client.pagings().getMultiplePagesRetrySecond();
         Assert.assertEquals(10, response.size());
     }
 
     @Test
     public void getSinglePagesFailure() throws Exception {
         try {
-            List<ProductInner> response = client.pagings().getSinglePagesFailure().getBody();
+            List<ProductInner> response = client.pagings().getSinglePagesFailure();
             fail();
         } catch (CloudException ex) {
             Assert.assertNotNull(ex.getResponse());
@@ -113,7 +113,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesFailure() throws Exception {
         try {
-            List<ProductInner> response = client.pagings().getMultiplePagesFailure().getBody();
+            List<ProductInner> response = client.pagings().getMultiplePagesFailure();
             response.size();
             fail();
         } catch (CloudException ex) {
@@ -124,7 +124,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesFailureUri() throws Exception {
         try {
-            List<ProductInner> response = client.pagings().getMultiplePagesFailureUri().getBody();
+            List<ProductInner> response = client.pagings().getMultiplePagesFailureUri();
             response.size();
             fail();
         } catch (CloudException ex) {

--- a/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/subscriptionidapiversion/GroupTests.java
+++ b/src/generator/AutoRest.Java.Azure.Fluent.Tests/src/test/java/fixtures/subscriptionidapiversion/GroupTests.java
@@ -20,7 +20,7 @@ public class GroupTests {
     @Test
     public void getSampleResourceGroup() throws Exception {
         client.withSubscriptionId(UUID.randomUUID().toString());
-        SampleResourceGroupInner group = client.groups().getSampleResourceGroup("testgroup101").getBody();
+        SampleResourceGroupInner group = client.groups().getSampleResourceGroup("testgroup101");
         Assert.assertEquals("testgroup101", group.name());
         Assert.assertEquals("West US", group.location());
     }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
@@ -35,7 +35,7 @@ public interface ParameterGroupings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postRequired(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) throws ErrorException, IOException, IllegalArgumentException;
+    void postRequired(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Post a bunch of required parameters grouped.
@@ -52,7 +52,15 @@ public interface ParameterGroupings {
      * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters);
+    Observable<Void> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters);
+
+    /**
+     * Post a bunch of required parameters grouped.
+     *
+     * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postRequiredAsyncWithServiceResponse(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters);
 
     /**
      * Post a bunch of optional parameters grouped.
@@ -61,7 +69,7 @@ public interface ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptional() throws ErrorException, IOException;
+    void postOptional() throws ErrorException, IOException;
 
     /**
      * Post a bunch of optional parameters grouped.
@@ -70,6 +78,22 @@ public interface ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalAsync();
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalAsyncWithServiceResponse();
     /**
      * Post a bunch of optional parameters grouped.
      *
@@ -78,7 +102,7 @@ public interface ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptional(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) throws ErrorException, IOException;
+    void postOptional(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) throws ErrorException, IOException;
 
     /**
      * Post a bunch of optional parameters grouped.
@@ -95,7 +119,15 @@ public interface ParameterGroupings {
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters);
+    Observable<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters);
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalAsyncWithServiceResponse(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters);
 
     /**
      * Post parameters from multiple different parameter groups.
@@ -104,7 +136,7 @@ public interface ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postMultiParamGroups() throws ErrorException, IOException;
+    void postMultiParamGroups() throws ErrorException, IOException;
 
     /**
      * Post parameters from multiple different parameter groups.
@@ -113,6 +145,24 @@ public interface ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postMultiParamGroupsAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postMultiParamGroupsAsync();
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postMultiParamGroupsAsyncWithServiceResponse();
     /**
      * Post parameters from multiple different parameter groups.
      *
@@ -122,7 +172,7 @@ public interface ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postMultiParamGroups(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException;
+    void postMultiParamGroups(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException;
 
     /**
      * Post parameters from multiple different parameter groups.
@@ -141,7 +191,16 @@ public interface ParameterGroupings {
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup);
+    Observable<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup);
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postMultiParamGroupsAsyncWithServiceResponse(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup);
 
     /**
      * Post parameters with a shared parameter group object.
@@ -150,7 +209,7 @@ public interface ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postSharedParameterGroupObject() throws ErrorException, IOException;
+    void postSharedParameterGroupObject() throws ErrorException, IOException;
 
     /**
      * Post parameters with a shared parameter group object.
@@ -159,6 +218,22 @@ public interface ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postSharedParameterGroupObjectAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postSharedParameterGroupObjectAsync();
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsyncWithServiceResponse();
     /**
      * Post parameters with a shared parameter group object.
      *
@@ -167,7 +242,7 @@ public interface ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postSharedParameterGroupObject(FirstParameterGroup firstParameterGroup) throws ErrorException, IOException;
+    void postSharedParameterGroupObject(FirstParameterGroup firstParameterGroup) throws ErrorException, IOException;
 
     /**
      * Post parameters with a shared parameter group object.
@@ -184,6 +259,14 @@ public interface ParameterGroupings {
      * @param firstParameterGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup);
+    Observable<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup);
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsyncWithServiceResponse(FirstParameterGroup firstParameterGroup);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
@@ -33,7 +33,6 @@ public interface ParameterGroupings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postRequired(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -60,14 +59,13 @@ public interface ParameterGroupings {
      * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postRequiredAsyncWithServiceResponse(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters);
+    Observable<ServiceResponse<Void>> postRequiredWithServiceResponseAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters);
 
     /**
      * Post a bunch of optional parameters grouped.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptional() throws ErrorException, IOException;
 
@@ -82,7 +80,6 @@ public interface ParameterGroupings {
     /**
      * Post a bunch of optional parameters grouped.
      *
-     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalAsync();
@@ -90,17 +87,15 @@ public interface ParameterGroupings {
     /**
      * Post a bunch of optional parameters grouped.
      *
-     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalWithServiceResponseAsync();
     /**
      * Post a bunch of optional parameters grouped.
      *
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptional(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) throws ErrorException, IOException;
 
@@ -127,14 +122,13 @@ public interface ParameterGroupings {
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalAsyncWithServiceResponse(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters);
+    Observable<ServiceResponse<Void>> postOptionalWithServiceResponseAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters);
 
     /**
      * Post parameters from multiple different parameter groups.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postMultiParamGroups() throws ErrorException, IOException;
 
@@ -149,8 +143,6 @@ public interface ParameterGroupings {
     /**
      * Post parameters from multiple different parameter groups.
      *
-     * @param firstParameterGroup Additional parameters for the operation
-     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postMultiParamGroupsAsync();
@@ -158,11 +150,9 @@ public interface ParameterGroupings {
     /**
      * Post parameters from multiple different parameter groups.
      *
-     * @param firstParameterGroup Additional parameters for the operation
-     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMultiParamGroupsAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postMultiParamGroupsWithServiceResponseAsync();
     /**
      * Post parameters from multiple different parameter groups.
      *
@@ -170,7 +160,6 @@ public interface ParameterGroupings {
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postMultiParamGroups(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException;
 
@@ -200,14 +189,13 @@ public interface ParameterGroupings {
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMultiParamGroupsAsyncWithServiceResponse(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup);
+    Observable<ServiceResponse<Void>> postMultiParamGroupsWithServiceResponseAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup);
 
     /**
      * Post parameters with a shared parameter group object.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postSharedParameterGroupObject() throws ErrorException, IOException;
 
@@ -222,7 +210,6 @@ public interface ParameterGroupings {
     /**
      * Post parameters with a shared parameter group object.
      *
-     * @param firstParameterGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postSharedParameterGroupObjectAsync();
@@ -230,17 +217,15 @@ public interface ParameterGroupings {
     /**
      * Post parameters with a shared parameter group object.
      *
-     * @param firstParameterGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postSharedParameterGroupObjectWithServiceResponseAsync();
     /**
      * Post parameters with a shared parameter group object.
      *
      * @param firstParameterGroup Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postSharedParameterGroupObject(FirstParameterGroup firstParameterGroup) throws ErrorException, IOException;
 
@@ -267,6 +252,6 @@ public interface ParameterGroupings {
      * @param firstParameterGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsyncWithServiceResponse(FirstParameterGroup firstParameterGroup);
+    Observable<ServiceResponse<Void>> postSharedParameterGroupObjectWithServiceResponseAsync(FirstParameterGroup firstParameterGroup);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsImpl.java
@@ -114,7 +114,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -184,7 +184,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -218,7 +218,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void postOptional(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) throws ErrorException, IOException {
-        postOptionalWithServiceResponseAsync().toBlocking().single().getBody();
+        postOptionalWithServiceResponseAsync(parameterGroupingPostOptionalParameters).toBlocking().single().getBody();
     }
 
     /**
@@ -235,6 +235,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
     /**
      * Post a bunch of optional parameters grouped.
      *
+     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
@@ -243,7 +244,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -314,7 +315,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -352,7 +353,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void postMultiParamGroups(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException {
-        postMultiParamGroupsWithServiceResponseAsync().toBlocking().single().getBody();
+        postMultiParamGroupsWithServiceResponseAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup).toBlocking().single().getBody();
     }
 
     /**
@@ -370,6 +371,8 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
     /**
      * Post parameters from multiple different parameter groups.
      *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) {
@@ -378,7 +381,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -459,7 +462,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -493,7 +496,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void postSharedParameterGroupObject(FirstParameterGroup firstParameterGroup) throws ErrorException, IOException {
-        postSharedParameterGroupObjectWithServiceResponseAsync().toBlocking().single().getBody();
+        postSharedParameterGroupObjectWithServiceResponseAsync(firstParameterGroup).toBlocking().single().getBody();
     }
 
     /**
@@ -510,6 +513,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
     /**
      * Post parameters with a shared parameter group object.
      *
+     * @param firstParameterGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup) {
@@ -518,7 +522,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsImpl.java
@@ -86,10 +86,9 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postRequired(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredAsync(parameterGroupingPostRequiredParameters).toBlocking().single();
+    public void postRequired(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) throws ErrorException, IOException, IllegalArgumentException {
+        postRequiredWithServiceResponseAsync(parameterGroupingPostRequiredParameters).toBlocking().single().getBody();
     }
 
     /**
@@ -100,7 +99,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postRequiredAsync(parameterGroupingPostRequiredParameters), serviceCallback);
+        return ServiceCall.create(postRequiredWithServiceResponseAsync(parameterGroupingPostRequiredParameters), serviceCallback);
     }
 
     /**
@@ -109,7 +108,22 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
+    public Observable<Void> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
+        return postRequiredWithServiceResponseAsync(parameterGroupingPostRequiredParameters).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post a bunch of required parameters grouped.
+     *
+     * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postRequiredWithServiceResponseAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
         if (parameterGroupingPostRequiredParameters == null) {
             throw new IllegalArgumentException("Parameter parameterGroupingPostRequiredParameters is required and cannot be null.");
         }
@@ -144,10 +158,9 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptional() throws ErrorException, IOException {
-        return postOptionalAsync().toBlocking().single();
+    public void postOptional() throws ErrorException, IOException {
+        postOptionalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -157,7 +170,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -165,7 +178,21 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalAsync() {
+    public Observable<Void> postOptionalAsync() {
+        return postOptionalWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalWithServiceResponseAsync() {
         final ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters = null;
         String customHeader = null;
         Integer query = null;
@@ -189,10 +216,9 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptional(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) throws ErrorException, IOException {
-        return postOptionalAsync(parameterGroupingPostOptionalParameters).toBlocking().single();
+    public void postOptional(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) throws ErrorException, IOException {
+        postOptionalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -203,7 +229,21 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalAsync(parameterGroupingPostOptionalParameters), serviceCallback);
+        return ServiceCall.create(postOptionalWithServiceResponseAsync(parameterGroupingPostOptionalParameters), serviceCallback);
+    }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
+        return postOptionalWithServiceResponseAsync(parameterGroupingPostOptionalParameters).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -212,7 +252,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
+    public Observable<ServiceResponse<Void>> postOptionalWithServiceResponseAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
         Validator.validate(parameterGroupingPostOptionalParameters);
         String customHeader = null;
         if (parameterGroupingPostOptionalParameters != null) {
@@ -248,10 +288,9 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMultiParamGroups() throws ErrorException, IOException {
-        return postMultiParamGroupsAsync().toBlocking().single();
+    public void postMultiParamGroups() throws ErrorException, IOException {
+        postMultiParamGroupsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -261,7 +300,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMultiParamGroupsAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMultiParamGroupsAsync(), serviceCallback);
+        return ServiceCall.create(postMultiParamGroupsWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -269,7 +308,21 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMultiParamGroupsAsync() {
+    public Observable<Void> postMultiParamGroupsAsync() {
+        return postMultiParamGroupsWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMultiParamGroupsWithServiceResponseAsync() {
         final FirstParameterGroup firstParameterGroup = null;
         final ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup = null;
         String headerOne = null;
@@ -297,10 +350,9 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMultiParamGroups(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException {
-        return postMultiParamGroupsAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup).toBlocking().single();
+    public void postMultiParamGroups(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) throws ErrorException, IOException {
+        postMultiParamGroupsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -312,7 +364,21 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMultiParamGroupsAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup), serviceCallback);
+        return ServiceCall.create(postMultiParamGroupsWithServiceResponseAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup), serviceCallback);
+    }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+        return postMultiParamGroupsWithServiceResponseAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -322,7 +388,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+    public Observable<ServiceResponse<Void>> postMultiParamGroupsWithServiceResponseAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) {
         Validator.validate(firstParameterGroup);
         Validator.validate(parameterGroupingPostMultiParamGroupsSecondParamGroup);
         String headerOne = null;
@@ -367,10 +433,9 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postSharedParameterGroupObject() throws ErrorException, IOException {
-        return postSharedParameterGroupObjectAsync().toBlocking().single();
+    public void postSharedParameterGroupObject() throws ErrorException, IOException {
+        postSharedParameterGroupObjectWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -380,7 +445,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postSharedParameterGroupObjectAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postSharedParameterGroupObjectAsync(), serviceCallback);
+        return ServiceCall.create(postSharedParameterGroupObjectWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -388,7 +453,21 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsync() {
+    public Observable<Void> postSharedParameterGroupObjectAsync() {
+        return postSharedParameterGroupObjectWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postSharedParameterGroupObjectWithServiceResponseAsync() {
         final FirstParameterGroup firstParameterGroup = null;
         String headerOne = null;
         Integer queryOne = null;
@@ -412,10 +491,9 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @param firstParameterGroup Additional parameters for the operation
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postSharedParameterGroupObject(FirstParameterGroup firstParameterGroup) throws ErrorException, IOException {
-        return postSharedParameterGroupObjectAsync(firstParameterGroup).toBlocking().single();
+    public void postSharedParameterGroupObject(FirstParameterGroup firstParameterGroup) throws ErrorException, IOException {
+        postSharedParameterGroupObjectWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -426,7 +504,21 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postSharedParameterGroupObjectAsync(firstParameterGroup), serviceCallback);
+        return ServiceCall.create(postSharedParameterGroupObjectWithServiceResponseAsync(firstParameterGroup), serviceCallback);
+    }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup) {
+        return postSharedParameterGroupObjectWithServiceResponseAsync(firstParameterGroup).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -435,7 +527,7 @@ public final class ParameterGroupingsImpl implements ParameterGroupings {
      * @param firstParameterGroup Additional parameters for the operation
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup) {
+    public Observable<ServiceResponse<Void>> postSharedParameterGroupObjectWithServiceResponseAsync(FirstParameterGroup firstParameterGroup) {
         Validator.validate(firstParameterGroup);
         String headerOne = null;
         if (firstParameterGroup != null) {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
@@ -96,7 +96,7 @@ public interface AutoRestReportServiceForAzure {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Integer>> getReport() throws ErrorException, IOException;
+    Map<String, Integer> getReport() throws ErrorException, IOException;
 
     /**
      * Get test coverage report.
@@ -111,6 +111,13 @@ public interface AutoRestReportServiceForAzure {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getReportAsync();
+    Observable<Map<String, Integer>> getReportAsync();
+
+    /**
+     * Get test coverage report.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Integer>>> getReportAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
@@ -94,7 +94,7 @@ public interface AutoRestReportServiceForAzure {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     Map<String, Integer> getReport() throws ErrorException, IOException;
 
@@ -118,6 +118,6 @@ public interface AutoRestReportServiceForAzure {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getReportAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Integer>>> getReportWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
@@ -189,10 +189,10 @@ public final class AutoRestReportServiceForAzureImpl extends AzureServiceClient 
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
-    public ServiceResponse<Map<String, Integer>> getReport() throws ErrorException, IOException {
-        return getReportAsync().toBlocking().single();
+    public Map<String, Integer> getReport() throws ErrorException, IOException {
+        return getReportWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -202,7 +202,7 @@ public final class AutoRestReportServiceForAzureImpl extends AzureServiceClient 
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getReportAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getReportAsync(), serviceCallback);
+        return ServiceCall.create(getReportWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -210,7 +210,21 @@ public final class AutoRestReportServiceForAzureImpl extends AzureServiceClient 
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getReportAsync() {
+    public Observable<Map<String, Integer>> getReportAsync() {
+        return getReportWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get test coverage report.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Integer>>> getReportWithServiceResponseAsync() {
         return service.getReport(this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
@@ -216,7 +216,7 @@ public final class AutoRestReportServiceForAzureImpl extends AzureServiceClient 
             public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureresource/AutoRestResourceFlatteningTestService.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureresource/AutoRestResourceFlatteningTestService.java
@@ -98,7 +98,6 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putArray() throws ErrorException, IOException;
 
@@ -113,7 +112,6 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as an Array.
      *
-     * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putArrayAsync();
@@ -121,17 +119,15 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as an Array.
      *
-     * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync();
     /**
      * Put External Resource as an Array.
      *
      * @param resourceArray External Resource as an Array to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putArray(List<Resource> resourceArray) throws ErrorException, IOException;
 
@@ -158,14 +154,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse(List<Resource> resourceArray);
+    Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync(List<Resource> resourceArray);
 
     /**
      * Get External Resource as an Array.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;FlattenedProduct&gt; object if successful.
      */
     List<FlattenedProduct> getArray() throws ErrorException, IOException;
 
@@ -189,14 +185,13 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
-    Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<FlattenedProduct>>> getArrayWithServiceResponseAsync();
 
     /**
      * Put External Resource as a Dictionary.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDictionary() throws ErrorException, IOException;
 
@@ -211,7 +206,6 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as a Dictionary.
      *
-     * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putDictionaryAsync();
@@ -219,17 +213,15 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as a Dictionary.
      *
-     * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync();
     /**
      * Put External Resource as a Dictionary.
      *
      * @param resourceDictionary External Resource as a Dictionary to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException;
 
@@ -256,14 +248,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse(Map<String, FlattenedProduct> resourceDictionary);
+    Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync(Map<String, FlattenedProduct> resourceDictionary);
 
     /**
      * Get External Resource as a Dictionary.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, FlattenedProduct&gt; object if successful.
      */
     Map<String, FlattenedProduct> getDictionary() throws ErrorException, IOException;
 
@@ -287,14 +279,13 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
-    Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryWithServiceResponseAsync();
 
     /**
      * Put External Resource as a ResourceCollection.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putResourceCollection() throws ErrorException, IOException;
 
@@ -309,7 +300,6 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as a ResourceCollection.
      *
-     * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putResourceCollectionAsync();
@@ -317,17 +307,15 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as a ResourceCollection.
      *
-     * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync();
     /**
      * Put External Resource as a ResourceCollection.
      *
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException;
 
@@ -354,14 +342,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse(ResourceCollection resourceComplexObject);
+    Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync(ResourceCollection resourceComplexObject);
 
     /**
      * Get External Resource as a ResourceCollection.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ResourceCollection object wrapped in {@link ServiceResponse} if successful.
+     * @return the ResourceCollection object if successful.
      */
     ResourceCollection getResourceCollection() throws ErrorException, IOException;
 
@@ -385,6 +373,6 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the ResourceCollection object
      */
-    Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsyncWithServiceResponse();
+    Observable<ServiceResponse<ResourceCollection>> getResourceCollectionWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureresource/AutoRestResourceFlatteningTestService.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureresource/AutoRestResourceFlatteningTestService.java
@@ -100,7 +100,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putArray() throws ErrorException, IOException;
+    void putArray() throws ErrorException, IOException;
 
     /**
      * Put External Resource as an Array.
@@ -109,6 +109,22 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putArrayAsync();
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse();
     /**
      * Put External Resource as an Array.
      *
@@ -117,7 +133,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putArray(List<Resource> resourceArray) throws ErrorException, IOException;
+    void putArray(List<Resource> resourceArray) throws ErrorException, IOException;
 
     /**
      * Put External Resource as an Array.
@@ -134,7 +150,15 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayAsync(List<Resource> resourceArray);
+    Observable<Void> putArrayAsync(List<Resource> resourceArray);
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse(List<Resource> resourceArray);
 
     /**
      * Get External Resource as an Array.
@@ -143,7 +167,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<FlattenedProduct>> getArray() throws ErrorException, IOException;
+    List<FlattenedProduct> getArray() throws ErrorException, IOException;
 
     /**
      * Get External Resource as an Array.
@@ -158,7 +182,14 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
-    Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsync();
+    Observable<List<FlattenedProduct>> getArrayAsync();
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @return the observable to the List&lt;FlattenedProduct&gt; object
+     */
+    Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsyncWithServiceResponse();
 
     /**
      * Put External Resource as a Dictionary.
@@ -167,7 +198,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDictionary() throws ErrorException, IOException;
+    void putDictionary() throws ErrorException, IOException;
 
     /**
      * Put External Resource as a Dictionary.
@@ -176,6 +207,22 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putDictionaryAsync();
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse();
     /**
      * Put External Resource as a Dictionary.
      *
@@ -184,7 +231,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException;
+    void putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException;
 
     /**
      * Put External Resource as a Dictionary.
@@ -201,7 +248,15 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary);
+    Observable<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary);
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse(Map<String, FlattenedProduct> resourceDictionary);
 
     /**
      * Get External Resource as a Dictionary.
@@ -210,7 +265,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, FlattenedProduct>> getDictionary() throws ErrorException, IOException;
+    Map<String, FlattenedProduct> getDictionary() throws ErrorException, IOException;
 
     /**
      * Get External Resource as a Dictionary.
@@ -225,7 +280,14 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
-    Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsync();
+    Observable<Map<String, FlattenedProduct>> getDictionaryAsync();
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
+     */
+    Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsyncWithServiceResponse();
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -234,7 +296,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putResourceCollection() throws ErrorException, IOException;
+    void putResourceCollection() throws ErrorException, IOException;
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -243,6 +305,22 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putResourceCollectionAsync();
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse();
     /**
      * Put External Resource as a ResourceCollection.
      *
@@ -251,7 +329,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException;
+    void putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException;
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -268,7 +346,15 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putResourceCollectionAsync(ResourceCollection resourceComplexObject);
+    Observable<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject);
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse(ResourceCollection resourceComplexObject);
 
     /**
      * Get External Resource as a ResourceCollection.
@@ -277,7 +363,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ResourceCollection object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<ResourceCollection> getResourceCollection() throws ErrorException, IOException;
+    ResourceCollection getResourceCollection() throws ErrorException, IOException;
 
     /**
      * Get External Resource as a ResourceCollection.
@@ -292,6 +378,13 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the ResourceCollection object
      */
-    Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsync();
+    Observable<ResourceCollection> getResourceCollectionAsync();
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @return the observable to the ResourceCollection object
+     */
+    Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -242,7 +242,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -274,7 +274,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void putArray(List<Resource> resourceArray) throws ErrorException, IOException {
-        putArrayWithServiceResponseAsync().toBlocking().single().getBody();
+        putArrayWithServiceResponseAsync(resourceArray).toBlocking().single().getBody();
     }
 
     /**
@@ -291,6 +291,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
     /**
      * Put External Resource as an Array.
      *
+     * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putArrayAsync(List<Resource> resourceArray) {
@@ -299,7 +300,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -363,7 +364,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public List<FlattenedProduct> call(ServiceResponse<List<FlattenedProduct>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -424,7 +425,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -456,7 +457,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException {
-        putDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
+        putDictionaryWithServiceResponseAsync(resourceDictionary).toBlocking().single().getBody();
     }
 
     /**
@@ -473,6 +474,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
     /**
      * Put External Resource as a Dictionary.
      *
+     * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
@@ -481,7 +483,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -545,7 +547,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Map<String, FlattenedProduct> call(ServiceResponse<Map<String, FlattenedProduct>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -606,7 +608,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -638,7 +640,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException {
-        putResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
+        putResourceCollectionWithServiceResponseAsync(resourceComplexObject).toBlocking().single().getBody();
     }
 
     /**
@@ -655,6 +657,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
     /**
      * Put External Resource as a ResourceCollection.
      *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
@@ -663,7 +666,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -727,7 +730,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
             public ResourceCollection call(ServiceResponse<ResourceCollection> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -216,10 +216,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putArray() throws ErrorException, IOException {
-        return putArrayAsync().toBlocking().single();
+    public void putArray() throws ErrorException, IOException {
+        putArrayWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -229,7 +228,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayAsync(), serviceCallback);
+        return ServiceCall.create(putArrayWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -237,7 +236,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayAsync() {
+    public Observable<Void> putArrayAsync() {
+        return putArrayWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync() {
         final List<Resource> resourceArray = null;
         return service.putArray(resourceArray, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -259,10 +272,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceArray External Resource as an Array to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putArray(List<Resource> resourceArray) throws ErrorException, IOException {
-        return putArrayAsync(resourceArray).toBlocking().single();
+    public void putArray(List<Resource> resourceArray) throws ErrorException, IOException {
+        putArrayWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -273,7 +285,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayAsync(List<Resource> resourceArray, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayAsync(resourceArray), serviceCallback);
+        return ServiceCall.create(putArrayWithServiceResponseAsync(resourceArray), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putArrayAsync(List<Resource> resourceArray) {
+        return putArrayWithServiceResponseAsync(resourceArray).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -282,7 +308,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayAsync(List<Resource> resourceArray) {
+    public Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync(List<Resource> resourceArray) {
         Validator.validate(resourceArray);
         return service.putArray(resourceArray, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -310,10 +336,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;FlattenedProduct&gt; object if successful.
      */
-    public ServiceResponse<List<FlattenedProduct>> getArray() throws ErrorException, IOException {
-        return getArrayAsync().toBlocking().single();
+    public List<FlattenedProduct> getArray() throws ErrorException, IOException {
+        return getArrayWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -323,7 +349,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<FlattenedProduct>> getArrayAsync(final ServiceCallback<List<FlattenedProduct>> serviceCallback) {
-        return ServiceCall.create(getArrayAsync(), serviceCallback);
+        return ServiceCall.create(getArrayWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -331,7 +357,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
-    public Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsync() {
+    public Observable<List<FlattenedProduct>> getArrayAsync() {
+        return getArrayWithServiceResponseAsync().map(new Func1<ServiceResponse<List<FlattenedProduct>>, List<FlattenedProduct>>() {
+            @Override
+            public List<FlattenedProduct> call(ServiceResponse<List<FlattenedProduct>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @return the observable to the List&lt;FlattenedProduct&gt; object
+     */
+    public Observable<ServiceResponse<List<FlattenedProduct>>> getArrayWithServiceResponseAsync() {
         return service.getArray(this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<FlattenedProduct>>>>() {
                 @Override
@@ -358,10 +398,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDictionary() throws ErrorException, IOException {
-        return putDictionaryAsync().toBlocking().single();
+    public void putDictionary() throws ErrorException, IOException {
+        putDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -371,7 +410,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryAsync(), serviceCallback);
+        return ServiceCall.create(putDictionaryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -379,7 +418,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryAsync() {
+    public Observable<Void> putDictionaryAsync() {
+        return putDictionaryWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync() {
         final Map<String, FlattenedProduct> resourceDictionary = null;
         return service.putDictionary(resourceDictionary, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -401,10 +454,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceDictionary External Resource as a Dictionary to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException {
-        return putDictionaryAsync(resourceDictionary).toBlocking().single();
+    public void putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException {
+        putDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -415,7 +467,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryAsync(resourceDictionary), serviceCallback);
+        return ServiceCall.create(putDictionaryWithServiceResponseAsync(resourceDictionary), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+        return putDictionaryWithServiceResponseAsync(resourceDictionary).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -424,7 +490,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+    public Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync(Map<String, FlattenedProduct> resourceDictionary) {
         Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -452,10 +518,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, FlattenedProduct&gt; object if successful.
      */
-    public ServiceResponse<Map<String, FlattenedProduct>> getDictionary() throws ErrorException, IOException {
-        return getDictionaryAsync().toBlocking().single();
+    public Map<String, FlattenedProduct> getDictionary() throws ErrorException, IOException {
+        return getDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -465,7 +531,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, FlattenedProduct>> getDictionaryAsync(final ServiceCallback<Map<String, FlattenedProduct>> serviceCallback) {
-        return ServiceCall.create(getDictionaryAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -473,7 +539,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
-    public Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsync() {
+    public Observable<Map<String, FlattenedProduct>> getDictionaryAsync() {
+        return getDictionaryWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, FlattenedProduct>>, Map<String, FlattenedProduct>>() {
+            @Override
+            public Map<String, FlattenedProduct> call(ServiceResponse<Map<String, FlattenedProduct>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryWithServiceResponseAsync() {
         return service.getDictionary(this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, FlattenedProduct>>>>() {
                 @Override
@@ -500,10 +580,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putResourceCollection() throws ErrorException, IOException {
-        return putResourceCollectionAsync().toBlocking().single();
+    public void putResourceCollection() throws ErrorException, IOException {
+        putResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -513,7 +592,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putResourceCollectionAsync(), serviceCallback);
+        return ServiceCall.create(putResourceCollectionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -521,7 +600,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putResourceCollectionAsync() {
+    public Observable<Void> putResourceCollectionAsync() {
+        return putResourceCollectionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync() {
         final ResourceCollection resourceComplexObject = null;
         return service.putResourceCollection(resourceComplexObject, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -543,10 +636,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException {
-        return putResourceCollectionAsync(resourceComplexObject).toBlocking().single();
+    public void putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException {
+        putResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -557,7 +649,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putResourceCollectionAsync(resourceComplexObject), serviceCallback);
+        return ServiceCall.create(putResourceCollectionWithServiceResponseAsync(resourceComplexObject), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+        return putResourceCollectionWithServiceResponseAsync(resourceComplexObject).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -566,7 +672,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+    public Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync(ResourceCollection resourceComplexObject) {
         Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject, this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -594,10 +700,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ResourceCollection object wrapped in {@link ServiceResponse} if successful.
+     * @return the ResourceCollection object if successful.
      */
-    public ServiceResponse<ResourceCollection> getResourceCollection() throws ErrorException, IOException {
-        return getResourceCollectionAsync().toBlocking().single();
+    public ResourceCollection getResourceCollection() throws ErrorException, IOException {
+        return getResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -607,7 +713,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ResourceCollection> getResourceCollectionAsync(final ServiceCallback<ResourceCollection> serviceCallback) {
-        return ServiceCall.create(getResourceCollectionAsync(), serviceCallback);
+        return ServiceCall.create(getResourceCollectionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -615,7 +721,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends AzureServic
      *
      * @return the observable to the ResourceCollection object
      */
-    public Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsync() {
+    public Observable<ResourceCollection> getResourceCollectionAsync() {
+        return getResourceCollectionWithServiceResponseAsync().map(new Func1<ServiceResponse<ResourceCollection>, ResourceCollection>() {
+            @Override
+            public ResourceCollection call(ServiceResponse<ResourceCollection> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @return the observable to the ResourceCollection object
+     */
+    public Observable<ServiceResponse<ResourceCollection>> getResourceCollectionWithServiceResponseAsync() {
         return service.getResourceCollection(this.acceptLanguage(), this.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ResourceCollection>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/ApiVersionDefaults.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/ApiVersionDefaults.java
@@ -30,7 +30,7 @@ public interface ApiVersionDefaults {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
+    void getMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * GET method with api-version modeled in global settings.
@@ -45,7 +45,14 @@ public interface ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodGlobalValidAsync();
+    Observable<Void> getMethodGlobalValidAsync();
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodGlobalValidAsyncWithServiceResponse();
 
     /**
      * GET method with api-version modeled in global settings.
@@ -55,7 +62,7 @@ public interface ApiVersionDefaults {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException;
+    void getMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * GET method with api-version modeled in global settings.
@@ -70,7 +77,14 @@ public interface ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodGlobalNotProvidedValidAsync();
+    Observable<Void> getMethodGlobalNotProvidedValidAsync();
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodGlobalNotProvidedValidAsyncWithServiceResponse();
 
     /**
      * GET method with api-version modeled in global settings.
@@ -80,7 +94,7 @@ public interface ApiVersionDefaults {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
+    void getPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * GET method with api-version modeled in global settings.
@@ -95,7 +109,14 @@ public interface ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getPathGlobalValidAsync();
+    Observable<Void> getPathGlobalValidAsync();
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getPathGlobalValidAsyncWithServiceResponse();
 
     /**
      * GET method with api-version modeled in global settings.
@@ -105,7 +126,7 @@ public interface ApiVersionDefaults {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
+    void getSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * GET method with api-version modeled in global settings.
@@ -120,6 +141,13 @@ public interface ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getSwaggerGlobalValidAsync();
+    Observable<Void> getSwaggerGlobalValidAsync();
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getSwaggerGlobalValidAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/ApiVersionDefaults.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/ApiVersionDefaults.java
@@ -28,7 +28,6 @@ public interface ApiVersionDefaults {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -52,7 +51,7 @@ public interface ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodGlobalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getMethodGlobalValidWithServiceResponseAsync();
 
     /**
      * GET method with api-version modeled in global settings.
@@ -60,7 +59,6 @@ public interface ApiVersionDefaults {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -84,7 +82,7 @@ public interface ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodGlobalNotProvidedValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getMethodGlobalNotProvidedValidWithServiceResponseAsync();
 
     /**
      * GET method with api-version modeled in global settings.
@@ -92,7 +90,6 @@ public interface ApiVersionDefaults {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -116,7 +113,7 @@ public interface ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getPathGlobalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getPathGlobalValidWithServiceResponseAsync();
 
     /**
      * GET method with api-version modeled in global settings.
@@ -124,7 +121,6 @@ public interface ApiVersionDefaults {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -148,6 +144,6 @@ public interface ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getSwaggerGlobalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getSwaggerGlobalValidWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/ApiVersionLocals.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/ApiVersionLocals.java
@@ -27,7 +27,6 @@ public interface ApiVersionLocals {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodLocalValid() throws ErrorException, IOException;
 
@@ -51,14 +50,13 @@ public interface ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodLocalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getMethodLocalValidWithServiceResponseAsync();
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodLocalNull() throws ErrorException, IOException;
 
@@ -73,7 +71,6 @@ public interface ApiVersionLocals {
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
-     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getMethodLocalNullAsync();
@@ -81,17 +78,15 @@ public interface ApiVersionLocals {
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
-     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodLocalNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getMethodLocalNullWithServiceResponseAsync();
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodLocalNull(String apiVersion) throws ErrorException, IOException;
 
@@ -118,14 +113,13 @@ public interface ApiVersionLocals {
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodLocalNullAsyncWithServiceResponse(String apiVersion);
+    Observable<ServiceResponse<Void>> getMethodLocalNullWithServiceResponseAsync(String apiVersion);
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getPathLocalValid() throws ErrorException, IOException;
 
@@ -149,14 +143,13 @@ public interface ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getPathLocalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getPathLocalValidWithServiceResponseAsync();
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getSwaggerLocalValid() throws ErrorException, IOException;
 
@@ -180,6 +173,6 @@ public interface ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getSwaggerLocalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getSwaggerLocalValidWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/ApiVersionLocals.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/ApiVersionLocals.java
@@ -29,7 +29,7 @@ public interface ApiVersionLocals {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodLocalValid() throws ErrorException, IOException;
+    void getMethodLocalValid() throws ErrorException, IOException;
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
@@ -44,7 +44,14 @@ public interface ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodLocalValidAsync();
+    Observable<Void> getMethodLocalValidAsync();
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodLocalValidAsyncWithServiceResponse();
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
@@ -53,7 +60,7 @@ public interface ApiVersionLocals {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodLocalNull() throws ErrorException, IOException;
+    void getMethodLocalNull() throws ErrorException, IOException;
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
@@ -62,6 +69,22 @@ public interface ApiVersionLocals {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getMethodLocalNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getMethodLocalNullAsync();
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodLocalNullAsyncWithServiceResponse();
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
@@ -70,7 +93,7 @@ public interface ApiVersionLocals {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodLocalNull(String apiVersion) throws ErrorException, IOException;
+    void getMethodLocalNull(String apiVersion) throws ErrorException, IOException;
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
@@ -87,7 +110,15 @@ public interface ApiVersionLocals {
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodLocalNullAsync(String apiVersion);
+    Observable<Void> getMethodLocalNullAsync(String apiVersion);
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodLocalNullAsyncWithServiceResponse(String apiVersion);
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
@@ -96,7 +127,7 @@ public interface ApiVersionLocals {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getPathLocalValid() throws ErrorException, IOException;
+    void getPathLocalValid() throws ErrorException, IOException;
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
@@ -111,7 +142,14 @@ public interface ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getPathLocalValidAsync();
+    Observable<Void> getPathLocalValidAsync();
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getPathLocalValidAsyncWithServiceResponse();
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
@@ -120,7 +158,7 @@ public interface ApiVersionLocals {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getSwaggerLocalValid() throws ErrorException, IOException;
+    void getSwaggerLocalValid() throws ErrorException, IOException;
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
@@ -135,6 +173,13 @@ public interface ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getSwaggerLocalValidAsync();
+    Observable<Void> getSwaggerLocalValidAsync();
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getSwaggerLocalValidAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/Headers.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/Headers.java
@@ -34,7 +34,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders> customNamedRequestId(String fooClientRequestId) throws ErrorException, IOException, IllegalArgumentException;
+    void customNamedRequestId(String fooClientRequestId) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
@@ -51,7 +51,15 @@ public interface Headers {
      * @param fooClientRequestId The fooRequestId
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders>> customNamedRequestIdAsync(String fooClientRequestId);
+    Observable<Void> customNamedRequestIdAsync(String fooClientRequestId);
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders>> customNamedRequestIdAsyncWithServiceResponse(String fooClientRequestId);
 
     /**
      * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
@@ -62,7 +70,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders> customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) throws ErrorException, IOException, IllegalArgumentException;
+    void customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
@@ -79,6 +87,14 @@ public interface Headers {
      * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders>> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters);
+    Observable<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters);
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
+     *
+     * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders>> customNamedRequestIdParamGroupingAsyncWithServiceResponse(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/Headers.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/Headers.java
@@ -32,7 +32,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void customNamedRequestId(String fooClientRequestId) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -59,7 +58,7 @@ public interface Headers {
      * @param fooClientRequestId The fooRequestId
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders>> customNamedRequestIdAsyncWithServiceResponse(String fooClientRequestId);
+    Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders>> customNamedRequestIdWithServiceResponseAsync(String fooClientRequestId);
 
     /**
      * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
@@ -68,7 +67,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -95,6 +93,6 @@ public interface Headers {
      * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders>> customNamedRequestIdParamGroupingAsyncWithServiceResponse(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters);
+    Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders>> customNamedRequestIdParamGroupingWithServiceResponseAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/Odatas.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/Odatas.java
@@ -27,7 +27,6 @@ public interface Odatas {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getWithFilter() throws ErrorException, IOException;
 
@@ -42,9 +41,6 @@ public interface Odatas {
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
-     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
-     * @param top The top parameter with value 10.
-     * @param orderby The orderby parameter with value id.
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getWithFilterAsync();
@@ -52,12 +48,9 @@ public interface Odatas {
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
-     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
-     * @param top The top parameter with value 10.
-     * @param orderby The orderby parameter with value id.
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getWithFilterAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getWithFilterWithServiceResponseAsync();
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
@@ -66,7 +59,6 @@ public interface Odatas {
      * @param orderby The orderby parameter with value id.
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException;
 
@@ -99,6 +91,6 @@ public interface Odatas {
      * @param orderby The orderby parameter with value id.
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getWithFilterAsyncWithServiceResponse(String filter, Integer top, String orderby);
+    Observable<ServiceResponse<Void>> getWithFilterWithServiceResponseAsync(String filter, Integer top, String orderby);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/Odatas.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/Odatas.java
@@ -29,7 +29,7 @@ public interface Odatas {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getWithFilter() throws ErrorException, IOException;
+    void getWithFilter() throws ErrorException, IOException;
 
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
@@ -38,6 +38,26 @@ public interface Odatas {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getWithFilterAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
+     * @param top The top parameter with value 10.
+     * @param orderby The orderby parameter with value id.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getWithFilterAsync();
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
+     * @param top The top parameter with value 10.
+     * @param orderby The orderby parameter with value id.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getWithFilterAsyncWithServiceResponse();
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
@@ -48,7 +68,7 @@ public interface Odatas {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException;
+    void getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException;
 
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
@@ -69,6 +89,16 @@ public interface Odatas {
      * @param orderby The orderby parameter with value id.
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getWithFilterAsync(String filter, Integer top, String orderby);
+    Observable<Void> getWithFilterAsync(String filter, Integer top, String orderby);
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
+     * @param top The top parameter with value 10.
+     * @param orderby The orderby parameter with value id.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getWithFilterAsyncWithServiceResponse(String filter, Integer top, String orderby);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SkipUrlEncodings.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SkipUrlEncodings.java
@@ -31,7 +31,7 @@ public interface SkipUrlEncodings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException;
+    void getMethodPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
@@ -48,7 +48,15 @@ public interface SkipUrlEncodings {
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodPathValidAsync(String unencodedPathParam);
+    Observable<Void> getMethodPathValidAsync(String unencodedPathParam);
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodPathValidAsyncWithServiceResponse(String unencodedPathParam);
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
@@ -59,7 +67,7 @@ public interface SkipUrlEncodings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getPathPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException;
+    void getPathPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
@@ -76,7 +84,15 @@ public interface SkipUrlEncodings {
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getPathPathValidAsync(String unencodedPathParam);
+    Observable<Void> getPathPathValidAsync(String unencodedPathParam);
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getPathPathValidAsyncWithServiceResponse(String unencodedPathParam);
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
@@ -85,7 +101,7 @@ public interface SkipUrlEncodings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getSwaggerPathValid() throws ErrorException, IOException;
+    void getSwaggerPathValid() throws ErrorException, IOException;
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
@@ -100,7 +116,14 @@ public interface SkipUrlEncodings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getSwaggerPathValidAsync();
+    Observable<Void> getSwaggerPathValidAsync();
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getSwaggerPathValidAsyncWithServiceResponse();
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -111,7 +134,7 @@ public interface SkipUrlEncodings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException;
+    void getMethodQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -128,7 +151,15 @@ public interface SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodQueryValidAsync(String q1);
+    Observable<Void> getMethodQueryValidAsync(String q1);
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodQueryValidAsyncWithServiceResponse(String q1);
 
     /**
      * Get method with unencoded query parameter with value null.
@@ -137,7 +168,7 @@ public interface SkipUrlEncodings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodQueryNull() throws ErrorException, IOException;
+    void getMethodQueryNull() throws ErrorException, IOException;
 
     /**
      * Get method with unencoded query parameter with value null.
@@ -146,6 +177,22 @@ public interface SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getMethodQueryNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @param q1 Unencoded query parameter with value null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getMethodQueryNullAsync();
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @param q1 Unencoded query parameter with value null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodQueryNullAsyncWithServiceResponse();
     /**
      * Get method with unencoded query parameter with value null.
      *
@@ -154,7 +201,7 @@ public interface SkipUrlEncodings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getMethodQueryNull(String q1) throws ErrorException, IOException;
+    void getMethodQueryNull(String q1) throws ErrorException, IOException;
 
     /**
      * Get method with unencoded query parameter with value null.
@@ -171,7 +218,15 @@ public interface SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodQueryNullAsync(String q1);
+    Observable<Void> getMethodQueryNullAsync(String q1);
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @param q1 Unencoded query parameter with value null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getMethodQueryNullAsyncWithServiceResponse(String q1);
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -182,7 +237,7 @@ public interface SkipUrlEncodings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getPathQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException;
+    void getPathQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -199,7 +254,15 @@ public interface SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getPathQueryValidAsync(String q1);
+    Observable<Void> getPathQueryValidAsync(String q1);
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getPathQueryValidAsyncWithServiceResponse(String q1);
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -208,7 +271,7 @@ public interface SkipUrlEncodings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getSwaggerQueryValid() throws ErrorException, IOException;
+    void getSwaggerQueryValid() throws ErrorException, IOException;
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -223,6 +286,13 @@ public interface SkipUrlEncodings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getSwaggerQueryValidAsync();
+    Observable<Void> getSwaggerQueryValidAsync();
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getSwaggerQueryValidAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SkipUrlEncodings.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SkipUrlEncodings.java
@@ -29,7 +29,6 @@ public interface SkipUrlEncodings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -56,7 +55,7 @@ public interface SkipUrlEncodings {
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodPathValidAsyncWithServiceResponse(String unencodedPathParam);
+    Observable<ServiceResponse<Void>> getMethodPathValidWithServiceResponseAsync(String unencodedPathParam);
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
@@ -65,7 +64,6 @@ public interface SkipUrlEncodings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getPathPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -92,14 +90,13 @@ public interface SkipUrlEncodings {
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getPathPathValidAsyncWithServiceResponse(String unencodedPathParam);
+    Observable<ServiceResponse<Void>> getPathPathValidWithServiceResponseAsync(String unencodedPathParam);
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getSwaggerPathValid() throws ErrorException, IOException;
 
@@ -123,7 +120,7 @@ public interface SkipUrlEncodings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getSwaggerPathValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getSwaggerPathValidWithServiceResponseAsync();
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -132,7 +129,6 @@ public interface SkipUrlEncodings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -159,14 +155,13 @@ public interface SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodQueryValidAsyncWithServiceResponse(String q1);
+    Observable<ServiceResponse<Void>> getMethodQueryValidWithServiceResponseAsync(String q1);
 
     /**
      * Get method with unencoded query parameter with value null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodQueryNull() throws ErrorException, IOException;
 
@@ -181,7 +176,6 @@ public interface SkipUrlEncodings {
     /**
      * Get method with unencoded query parameter with value null.
      *
-     * @param q1 Unencoded query parameter with value null
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getMethodQueryNullAsync();
@@ -189,17 +183,15 @@ public interface SkipUrlEncodings {
     /**
      * Get method with unencoded query parameter with value null.
      *
-     * @param q1 Unencoded query parameter with value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodQueryNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getMethodQueryNullWithServiceResponseAsync();
     /**
      * Get method with unencoded query parameter with value null.
      *
      * @param q1 Unencoded query parameter with value null
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getMethodQueryNull(String q1) throws ErrorException, IOException;
 
@@ -226,7 +218,7 @@ public interface SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getMethodQueryNullAsyncWithServiceResponse(String q1);
+    Observable<ServiceResponse<Void>> getMethodQueryNullWithServiceResponseAsync(String q1);
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -235,7 +227,6 @@ public interface SkipUrlEncodings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getPathQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -262,14 +253,13 @@ public interface SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getPathQueryValidAsyncWithServiceResponse(String q1);
+    Observable<ServiceResponse<Void>> getPathQueryValidWithServiceResponseAsync(String q1);
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getSwaggerQueryValid() throws ErrorException, IOException;
 
@@ -293,6 +283,6 @@ public interface SkipUrlEncodings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getSwaggerQueryValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getSwaggerQueryValidWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SubscriptionInCredentials.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SubscriptionInCredentials.java
@@ -28,7 +28,6 @@ public interface SubscriptionInCredentials {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -52,7 +51,7 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodGlobalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postMethodGlobalValidWithServiceResponseAsync();
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
@@ -60,7 +59,6 @@ public interface SubscriptionInCredentials {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postMethodGlobalNull() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -84,7 +82,7 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodGlobalNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postMethodGlobalNullWithServiceResponseAsync();
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -92,7 +90,6 @@ public interface SubscriptionInCredentials {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -116,7 +113,7 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodGlobalNotProvidedValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postMethodGlobalNotProvidedValidWithServiceResponseAsync();
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -124,7 +121,6 @@ public interface SubscriptionInCredentials {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -148,7 +144,7 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postPathGlobalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postPathGlobalValidWithServiceResponseAsync();
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -156,7 +152,6 @@ public interface SubscriptionInCredentials {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -180,6 +175,6 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postSwaggerGlobalValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postSwaggerGlobalValidWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SubscriptionInCredentials.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SubscriptionInCredentials.java
@@ -30,7 +30,7 @@ public interface SubscriptionInCredentials {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
+    void postMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -45,7 +45,14 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodGlobalValidAsync();
+    Observable<Void> postMethodGlobalValidAsync();
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postMethodGlobalValidAsyncWithServiceResponse();
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
@@ -55,7 +62,7 @@ public interface SubscriptionInCredentials {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postMethodGlobalNull() throws ErrorException, IOException, IllegalArgumentException;
+    void postMethodGlobalNull() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
@@ -70,7 +77,14 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodGlobalNullAsync();
+    Observable<Void> postMethodGlobalNullAsync();
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postMethodGlobalNullAsyncWithServiceResponse();
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -80,7 +94,7 @@ public interface SubscriptionInCredentials {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException;
+    void postMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -95,7 +109,14 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodGlobalNotProvidedValidAsync();
+    Observable<Void> postMethodGlobalNotProvidedValidAsync();
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postMethodGlobalNotProvidedValidAsyncWithServiceResponse();
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -105,7 +126,7 @@ public interface SubscriptionInCredentials {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
+    void postPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -120,7 +141,14 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postPathGlobalValidAsync();
+    Observable<Void> postPathGlobalValidAsync();
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postPathGlobalValidAsyncWithServiceResponse();
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -130,7 +158,7 @@ public interface SubscriptionInCredentials {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
+    void postSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -145,6 +173,13 @@ public interface SubscriptionInCredentials {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postSwaggerGlobalValidAsync();
+    Observable<Void> postSwaggerGlobalValidAsync();
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postSwaggerGlobalValidAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SubscriptionInMethods.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SubscriptionInMethods.java
@@ -29,7 +29,6 @@ public interface SubscriptionInMethods {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postMethodLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -56,7 +55,7 @@ public interface SubscriptionInMethods {
      * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodLocalValidAsyncWithServiceResponse(String subscriptionId);
+    Observable<ServiceResponse<Void>> postMethodLocalValidWithServiceResponseAsync(String subscriptionId);
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
@@ -65,7 +64,6 @@ public interface SubscriptionInMethods {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postMethodLocalNull(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -92,7 +90,7 @@ public interface SubscriptionInMethods {
      * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodLocalNullAsyncWithServiceResponse(String subscriptionId);
+    Observable<ServiceResponse<Void>> postMethodLocalNullWithServiceResponseAsync(String subscriptionId);
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
@@ -101,7 +99,6 @@ public interface SubscriptionInMethods {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postPathLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -128,7 +125,7 @@ public interface SubscriptionInMethods {
      * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postPathLocalValidAsyncWithServiceResponse(String subscriptionId);
+    Observable<ServiceResponse<Void>> postPathLocalValidWithServiceResponseAsync(String subscriptionId);
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
@@ -137,7 +134,6 @@ public interface SubscriptionInMethods {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postSwaggerLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -164,6 +160,6 @@ public interface SubscriptionInMethods {
      * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postSwaggerLocalValidAsyncWithServiceResponse(String subscriptionId);
+    Observable<ServiceResponse<Void>> postSwaggerLocalValidWithServiceResponseAsync(String subscriptionId);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SubscriptionInMethods.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/SubscriptionInMethods.java
@@ -31,7 +31,7 @@ public interface SubscriptionInMethods {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postMethodLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
+    void postMethodLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
@@ -48,7 +48,15 @@ public interface SubscriptionInMethods {
      * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodLocalValidAsync(String subscriptionId);
+    Observable<Void> postMethodLocalValidAsync(String subscriptionId);
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postMethodLocalValidAsyncWithServiceResponse(String subscriptionId);
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
@@ -59,7 +67,7 @@ public interface SubscriptionInMethods {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postMethodLocalNull(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
+    void postMethodLocalNull(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
@@ -76,7 +84,15 @@ public interface SubscriptionInMethods {
      * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postMethodLocalNullAsync(String subscriptionId);
+    Observable<Void> postMethodLocalNullAsync(String subscriptionId);
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postMethodLocalNullAsyncWithServiceResponse(String subscriptionId);
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
@@ -87,7 +103,7 @@ public interface SubscriptionInMethods {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postPathLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
+    void postPathLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
@@ -104,7 +120,15 @@ public interface SubscriptionInMethods {
      * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postPathLocalValidAsync(String subscriptionId);
+    Observable<Void> postPathLocalValidAsync(String subscriptionId);
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postPathLocalValidAsyncWithServiceResponse(String subscriptionId);
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
@@ -115,7 +139,7 @@ public interface SubscriptionInMethods {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postSwaggerLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
+    void postSwaggerLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
@@ -132,6 +156,14 @@ public interface SubscriptionInMethods {
      * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postSwaggerLocalValidAsync(String subscriptionId);
+    Observable<Void> postSwaggerLocalValidAsync(String subscriptionId);
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postSwaggerLocalValidAsyncWithServiceResponse(String subscriptionId);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/XMsClientRequestIds.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/XMsClientRequestIds.java
@@ -30,7 +30,7 @@ public interface XMsClientRequestIds {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get() throws CloudException, IOException;
+    void get() throws CloudException, IOException;
 
     /**
      * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -45,7 +45,14 @@ public interface XMsClientRequestIds {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getAsync();
+    Observable<Void> getAsync();
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getAsyncWithServiceResponse();
 
     /**
      * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -56,7 +63,7 @@ public interface XMsClientRequestIds {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramGet(String xMsClientRequestId) throws ErrorException, IOException, IllegalArgumentException;
+    void paramGet(String xMsClientRequestId) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -73,6 +80,14 @@ public interface XMsClientRequestIds {
      * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramGetAsync(String xMsClientRequestId);
+    Observable<Void> paramGetAsync(String xMsClientRequestId);
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramGetAsyncWithServiceResponse(String xMsClientRequestId);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/XMsClientRequestIds.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/XMsClientRequestIds.java
@@ -28,7 +28,6 @@ public interface XMsClientRequestIds {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get() throws CloudException, IOException;
 
@@ -52,7 +51,7 @@ public interface XMsClientRequestIds {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getWithServiceResponseAsync();
 
     /**
      * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -61,7 +60,6 @@ public interface XMsClientRequestIds {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramGet(String xMsClientRequestId) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -88,6 +86,6 @@ public interface XMsClientRequestIds {
      * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramGetAsyncWithServiceResponse(String xMsClientRequestId);
+    Observable<ServiceResponse<Void>> paramGetWithServiceResponseAsync(String xMsClientRequestId);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsImpl.java
@@ -78,10 +78,9 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return getMethodGlobalValidAsync().toBlocking().single();
+    public void getMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        getMethodGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -91,7 +90,7 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(getMethodGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -99,7 +98,21 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodGlobalValidAsync() {
+    public Observable<Void> getMethodGlobalValidAsync() {
+        return getMethodGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodGlobalValidWithServiceResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
@@ -130,10 +143,9 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException {
-        return getMethodGlobalNotProvidedValidAsync().toBlocking().single();
+    public void getMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException {
+        getMethodGlobalNotProvidedValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -143,7 +155,7 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodGlobalNotProvidedValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodGlobalNotProvidedValidAsync(), serviceCallback);
+        return ServiceCall.create(getMethodGlobalNotProvidedValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -151,7 +163,21 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodGlobalNotProvidedValidAsync() {
+    public Observable<Void> getMethodGlobalNotProvidedValidAsync() {
+        return getMethodGlobalNotProvidedValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodGlobalNotProvidedValidWithServiceResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
@@ -182,10 +208,9 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return getPathGlobalValidAsync().toBlocking().single();
+    public void getPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        getPathGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -195,7 +220,7 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getPathGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getPathGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(getPathGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -203,7 +228,21 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getPathGlobalValidAsync() {
+    public Observable<Void> getPathGlobalValidAsync() {
+        return getPathGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getPathGlobalValidWithServiceResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
@@ -234,10 +273,9 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return getSwaggerGlobalValidAsync().toBlocking().single();
+    public void getSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        getSwaggerGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -247,7 +285,7 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getSwaggerGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getSwaggerGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(getSwaggerGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -255,7 +293,21 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getSwaggerGlobalValidAsync() {
+    public Observable<Void> getSwaggerGlobalValidAsync() {
+        return getSwaggerGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getSwaggerGlobalValidWithServiceResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsImpl.java
@@ -104,7 +104,7 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -169,7 +169,7 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -234,7 +234,7 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -299,7 +299,7 @@ public final class ApiVersionDefaultsImpl implements ApiVersionDefaults {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsImpl.java
@@ -77,10 +77,9 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodLocalValid() throws ErrorException, IOException {
-        return getMethodLocalValidAsync().toBlocking().single();
+    public void getMethodLocalValid() throws ErrorException, IOException {
+        getMethodLocalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -90,7 +89,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodLocalValidAsync(), serviceCallback);
+        return ServiceCall.create(getMethodLocalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -98,7 +97,21 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodLocalValidAsync() {
+    public Observable<Void> getMethodLocalValidAsync() {
+        return getMethodLocalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodLocalValidWithServiceResponseAsync() {
         final String apiVersion = "2.0";
         return service.getMethodLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -126,10 +139,9 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodLocalNull() throws ErrorException, IOException {
-        return getMethodLocalNullAsync().toBlocking().single();
+    public void getMethodLocalNull() throws ErrorException, IOException {
+        getMethodLocalNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -139,7 +151,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodLocalNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodLocalNullAsync(), serviceCallback);
+        return ServiceCall.create(getMethodLocalNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -147,7 +159,21 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodLocalNullAsync() {
+    public Observable<Void> getMethodLocalNullAsync() {
+        return getMethodLocalNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodLocalNullWithServiceResponseAsync() {
         final String apiVersion = null;
         return service.getMethodLocalNull(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -169,10 +195,9 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodLocalNull(String apiVersion) throws ErrorException, IOException {
-        return getMethodLocalNullAsync(apiVersion).toBlocking().single();
+    public void getMethodLocalNull(String apiVersion) throws ErrorException, IOException {
+        getMethodLocalNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -183,7 +208,21 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodLocalNullAsync(String apiVersion, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodLocalNullAsync(apiVersion), serviceCallback);
+        return ServiceCall.create(getMethodLocalNullWithServiceResponseAsync(apiVersion), serviceCallback);
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getMethodLocalNullAsync(String apiVersion) {
+        return getMethodLocalNullWithServiceResponseAsync(apiVersion).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -192,7 +231,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodLocalNullAsync(String apiVersion) {
+    public Observable<ServiceResponse<Void>> getMethodLocalNullWithServiceResponseAsync(String apiVersion) {
         return service.getMethodLocalNull(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -219,10 +258,9 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getPathLocalValid() throws ErrorException, IOException {
-        return getPathLocalValidAsync().toBlocking().single();
+    public void getPathLocalValid() throws ErrorException, IOException {
+        getPathLocalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -232,7 +270,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getPathLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getPathLocalValidAsync(), serviceCallback);
+        return ServiceCall.create(getPathLocalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -240,7 +278,21 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getPathLocalValidAsync() {
+    public Observable<Void> getPathLocalValidAsync() {
+        return getPathLocalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getPathLocalValidWithServiceResponseAsync() {
         final String apiVersion = "2.0";
         return service.getPathLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -268,10 +320,9 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getSwaggerLocalValid() throws ErrorException, IOException {
-        return getSwaggerLocalValidAsync().toBlocking().single();
+    public void getSwaggerLocalValid() throws ErrorException, IOException {
+        getSwaggerLocalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -281,7 +332,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getSwaggerLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getSwaggerLocalValidAsync(), serviceCallback);
+        return ServiceCall.create(getSwaggerLocalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -289,7 +340,21 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getSwaggerLocalValidAsync() {
+    public Observable<Void> getSwaggerLocalValidAsync() {
+        return getSwaggerLocalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getSwaggerLocalValidWithServiceResponseAsync() {
         final String apiVersion = "2.0";
         return service.getSwaggerLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsImpl.java
@@ -103,7 +103,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -165,7 +165,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -197,7 +197,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void getMethodLocalNull(String apiVersion) throws ErrorException, IOException {
-        getMethodLocalNullWithServiceResponseAsync().toBlocking().single().getBody();
+        getMethodLocalNullWithServiceResponseAsync(apiVersion).toBlocking().single().getBody();
     }
 
     /**
@@ -214,6 +214,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
+     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getMethodLocalNullAsync(String apiVersion) {
@@ -222,7 +223,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -284,7 +285,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -346,7 +347,7 @@ public final class ApiVersionLocalsImpl implements ApiVersionLocals {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/HeadersImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/HeadersImpl.java
@@ -101,7 +101,7 @@ public final class HeadersImpl implements fixtures.azurespecials.Headers {
             public Void call(ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -170,7 +170,7 @@ public final class HeadersImpl implements fixtures.azurespecials.Headers {
             public Void call(ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/HeadersImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/HeadersImpl.java
@@ -73,10 +73,9 @@ public final class HeadersImpl implements fixtures.azurespecials.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders> customNamedRequestId(String fooClientRequestId) throws ErrorException, IOException, IllegalArgumentException {
-        return customNamedRequestIdAsync(fooClientRequestId).toBlocking().single();
+    public void customNamedRequestId(String fooClientRequestId) throws ErrorException, IOException, IllegalArgumentException {
+        customNamedRequestIdWithServiceResponseAsync(fooClientRequestId).toBlocking().single().getBody();
     }
 
     /**
@@ -87,7 +86,7 @@ public final class HeadersImpl implements fixtures.azurespecials.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> customNamedRequestIdAsync(String fooClientRequestId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(customNamedRequestIdAsync(fooClientRequestId), serviceCallback);
+        return ServiceCall.createWithHeaders(customNamedRequestIdWithServiceResponseAsync(fooClientRequestId), serviceCallback);
     }
 
     /**
@@ -96,7 +95,22 @@ public final class HeadersImpl implements fixtures.azurespecials.Headers {
      * @param fooClientRequestId The fooRequestId
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders>> customNamedRequestIdAsync(String fooClientRequestId) {
+    public Observable<Void> customNamedRequestIdAsync(String fooClientRequestId) {
+        return customNamedRequestIdWithServiceResponseAsync(fooClientRequestId).map(new Func1<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders>> customNamedRequestIdWithServiceResponseAsync(String fooClientRequestId) {
         if (fooClientRequestId == null) {
             throw new IllegalArgumentException("Parameter fooClientRequestId is required and cannot be null.");
         }
@@ -128,10 +142,9 @@ public final class HeadersImpl implements fixtures.azurespecials.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders> customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) throws ErrorException, IOException, IllegalArgumentException {
-        return customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters).toBlocking().single();
+    public void customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) throws ErrorException, IOException, IllegalArgumentException {
+        customNamedRequestIdParamGroupingWithServiceResponseAsync(headerCustomNamedRequestIdParamGroupingParameters).toBlocking().single().getBody();
     }
 
     /**
@@ -142,7 +155,7 @@ public final class HeadersImpl implements fixtures.azurespecials.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters), serviceCallback);
+        return ServiceCall.createWithHeaders(customNamedRequestIdParamGroupingWithServiceResponseAsync(headerCustomNamedRequestIdParamGroupingParameters), serviceCallback);
     }
 
     /**
@@ -151,7 +164,22 @@ public final class HeadersImpl implements fixtures.azurespecials.Headers {
      * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders>> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) {
+    public Observable<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) {
+        return customNamedRequestIdParamGroupingWithServiceResponseAsync(headerCustomNamedRequestIdParamGroupingParameters).map(new Func1<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
+     *
+     * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders>> customNamedRequestIdParamGroupingWithServiceResponseAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) {
         if (headerCustomNamedRequestIdParamGroupingParameters == null) {
             throw new IllegalArgumentException("Parameter headerCustomNamedRequestIdParamGroupingParameters is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/OdatasImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/OdatasImpl.java
@@ -91,7 +91,7 @@ public final class OdatasImpl implements Odatas {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -127,7 +127,7 @@ public final class OdatasImpl implements Odatas {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException {
-        getWithFilterWithServiceResponseAsync().toBlocking().single().getBody();
+        getWithFilterWithServiceResponseAsync(filter, top, orderby).toBlocking().single().getBody();
     }
 
     /**
@@ -146,6 +146,9 @@ public final class OdatasImpl implements Odatas {
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
+     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
+     * @param top The top parameter with value 10.
+     * @param orderby The orderby parameter with value id.
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getWithFilterAsync(String filter, Integer top, String orderby) {
@@ -154,7 +157,7 @@ public final class OdatasImpl implements Odatas {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/OdatasImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/OdatasImpl.java
@@ -65,10 +65,9 @@ public final class OdatasImpl implements Odatas {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getWithFilter() throws ErrorException, IOException {
-        return getWithFilterAsync().toBlocking().single();
+    public void getWithFilter() throws ErrorException, IOException {
+        getWithFilterWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -78,7 +77,7 @@ public final class OdatasImpl implements Odatas {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getWithFilterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getWithFilterAsync(), serviceCallback);
+        return ServiceCall.create(getWithFilterWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -86,7 +85,21 @@ public final class OdatasImpl implements Odatas {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getWithFilterAsync() {
+    public Observable<Void> getWithFilterAsync() {
+        return getWithFilterWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getWithFilterWithServiceResponseAsync() {
         final String filter = null;
         final Integer top = null;
         final String orderby = null;
@@ -112,10 +125,9 @@ public final class OdatasImpl implements Odatas {
      * @param orderby The orderby parameter with value id.
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException {
-        return getWithFilterAsync(filter, top, orderby).toBlocking().single();
+    public void getWithFilter(String filter, Integer top, String orderby) throws ErrorException, IOException {
+        getWithFilterWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -128,7 +140,21 @@ public final class OdatasImpl implements Odatas {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getWithFilterAsync(String filter, Integer top, String orderby, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getWithFilterAsync(filter, top, orderby), serviceCallback);
+        return ServiceCall.create(getWithFilterWithServiceResponseAsync(filter, top, orderby), serviceCallback);
+    }
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getWithFilterAsync(String filter, Integer top, String orderby) {
+        return getWithFilterWithServiceResponseAsync(filter, top, orderby).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -139,7 +165,7 @@ public final class OdatasImpl implements Odatas {
      * @param orderby The orderby parameter with value id.
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getWithFilterAsync(String filter, Integer top, String orderby) {
+    public Observable<ServiceResponse<Void>> getWithFilterWithServiceResponseAsync(String filter, Integer top, String orderby) {
         return service.getWithFilter(filter, top, orderby, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsImpl.java
@@ -92,10 +92,9 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException {
-        return getMethodPathValidAsync(unencodedPathParam).toBlocking().single();
+    public void getMethodPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException {
+        getMethodPathValidWithServiceResponseAsync(unencodedPathParam).toBlocking().single().getBody();
     }
 
     /**
@@ -106,7 +105,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodPathValidAsync(String unencodedPathParam, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodPathValidAsync(unencodedPathParam), serviceCallback);
+        return ServiceCall.create(getMethodPathValidWithServiceResponseAsync(unencodedPathParam), serviceCallback);
     }
 
     /**
@@ -115,7 +114,22 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodPathValidAsync(String unencodedPathParam) {
+    public Observable<Void> getMethodPathValidAsync(String unencodedPathParam) {
+        return getMethodPathValidWithServiceResponseAsync(unencodedPathParam).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodPathValidWithServiceResponseAsync(String unencodedPathParam) {
         if (unencodedPathParam == null) {
             throw new IllegalArgumentException("Parameter unencodedPathParam is required and cannot be null.");
         }
@@ -147,10 +161,9 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getPathPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException {
-        return getPathPathValidAsync(unencodedPathParam).toBlocking().single();
+    public void getPathPathValid(String unencodedPathParam) throws ErrorException, IOException, IllegalArgumentException {
+        getPathPathValidWithServiceResponseAsync(unencodedPathParam).toBlocking().single().getBody();
     }
 
     /**
@@ -161,7 +174,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getPathPathValidAsync(String unencodedPathParam, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getPathPathValidAsync(unencodedPathParam), serviceCallback);
+        return ServiceCall.create(getPathPathValidWithServiceResponseAsync(unencodedPathParam), serviceCallback);
     }
 
     /**
@@ -170,7 +183,22 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getPathPathValidAsync(String unencodedPathParam) {
+    public Observable<Void> getPathPathValidAsync(String unencodedPathParam) {
+        return getPathPathValidWithServiceResponseAsync(unencodedPathParam).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getPathPathValidWithServiceResponseAsync(String unencodedPathParam) {
         if (unencodedPathParam == null) {
             throw new IllegalArgumentException("Parameter unencodedPathParam is required and cannot be null.");
         }
@@ -200,10 +228,9 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getSwaggerPathValid() throws ErrorException, IOException {
-        return getSwaggerPathValidAsync().toBlocking().single();
+    public void getSwaggerPathValid() throws ErrorException, IOException {
+        getSwaggerPathValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -213,7 +240,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getSwaggerPathValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getSwaggerPathValidAsync(), serviceCallback);
+        return ServiceCall.create(getSwaggerPathValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -221,7 +248,21 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getSwaggerPathValidAsync() {
+    public Observable<Void> getSwaggerPathValidAsync() {
+        return getSwaggerPathValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getSwaggerPathValidWithServiceResponseAsync() {
         final String unencodedPathParam = "path1/path2/path3";
         return service.getSwaggerPathValid(unencodedPathParam, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -251,10 +292,9 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException {
-        return getMethodQueryValidAsync(q1).toBlocking().single();
+    public void getMethodQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException {
+        getMethodQueryValidWithServiceResponseAsync(q1).toBlocking().single().getBody();
     }
 
     /**
@@ -265,7 +305,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodQueryValidAsync(String q1, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodQueryValidAsync(q1), serviceCallback);
+        return ServiceCall.create(getMethodQueryValidWithServiceResponseAsync(q1), serviceCallback);
     }
 
     /**
@@ -274,7 +314,22 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodQueryValidAsync(String q1) {
+    public Observable<Void> getMethodQueryValidAsync(String q1) {
+        return getMethodQueryValidWithServiceResponseAsync(q1).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodQueryValidWithServiceResponseAsync(String q1) {
         if (q1 == null) {
             throw new IllegalArgumentException("Parameter q1 is required and cannot be null.");
         }
@@ -304,10 +359,9 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodQueryNull() throws ErrorException, IOException {
-        return getMethodQueryNullAsync().toBlocking().single();
+    public void getMethodQueryNull() throws ErrorException, IOException {
+        getMethodQueryNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -317,7 +371,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodQueryNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodQueryNullAsync(), serviceCallback);
+        return ServiceCall.create(getMethodQueryNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -325,7 +379,21 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodQueryNullAsync() {
+    public Observable<Void> getMethodQueryNullAsync() {
+        return getMethodQueryNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getMethodQueryNullWithServiceResponseAsync() {
         final String q1 = null;
         return service.getMethodQueryNull(q1, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -347,10 +415,9 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value null
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getMethodQueryNull(String q1) throws ErrorException, IOException {
-        return getMethodQueryNullAsync(q1).toBlocking().single();
+    public void getMethodQueryNull(String q1) throws ErrorException, IOException {
+        getMethodQueryNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -361,7 +428,21 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getMethodQueryNullAsync(String q1, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getMethodQueryNullAsync(q1), serviceCallback);
+        return ServiceCall.create(getMethodQueryNullWithServiceResponseAsync(q1), serviceCallback);
+    }
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getMethodQueryNullAsync(String q1) {
+        return getMethodQueryNullWithServiceResponseAsync(q1).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -370,7 +451,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getMethodQueryNullAsync(String q1) {
+    public Observable<ServiceResponse<Void>> getMethodQueryNullWithServiceResponseAsync(String q1) {
         return service.getMethodQueryNull(q1, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -399,10 +480,9 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getPathQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException {
-        return getPathQueryValidAsync(q1).toBlocking().single();
+    public void getPathQueryValid(String q1) throws ErrorException, IOException, IllegalArgumentException {
+        getPathQueryValidWithServiceResponseAsync(q1).toBlocking().single().getBody();
     }
 
     /**
@@ -413,7 +493,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getPathQueryValidAsync(String q1, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getPathQueryValidAsync(q1), serviceCallback);
+        return ServiceCall.create(getPathQueryValidWithServiceResponseAsync(q1), serviceCallback);
     }
 
     /**
@@ -422,7 +502,22 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getPathQueryValidAsync(String q1) {
+    public Observable<Void> getPathQueryValidAsync(String q1) {
+        return getPathQueryValidWithServiceResponseAsync(q1).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getPathQueryValidWithServiceResponseAsync(String q1) {
         if (q1 == null) {
             throw new IllegalArgumentException("Parameter q1 is required and cannot be null.");
         }
@@ -452,10 +547,9 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getSwaggerQueryValid() throws ErrorException, IOException {
-        return getSwaggerQueryValidAsync().toBlocking().single();
+    public void getSwaggerQueryValid() throws ErrorException, IOException {
+        getSwaggerQueryValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -465,7 +559,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getSwaggerQueryValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getSwaggerQueryValidAsync(), serviceCallback);
+        return ServiceCall.create(getSwaggerQueryValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -473,7 +567,21 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getSwaggerQueryValidAsync() {
+    public Observable<Void> getSwaggerQueryValidAsync() {
+        return getSwaggerQueryValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getSwaggerQueryValidWithServiceResponseAsync() {
         final String q1 = "value1&q2=value2&q3=value3";
         return service.getSwaggerQueryValid(q1, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsImpl.java
@@ -120,7 +120,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -189,7 +189,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -254,7 +254,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -320,7 +320,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -385,7 +385,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -417,7 +417,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void getMethodQueryNull(String q1) throws ErrorException, IOException {
-        getMethodQueryNullWithServiceResponseAsync().toBlocking().single().getBody();
+        getMethodQueryNullWithServiceResponseAsync(q1).toBlocking().single().getBody();
     }
 
     /**
@@ -434,6 +434,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
     /**
      * Get method with unencoded query parameter with value null.
      *
+     * @param q1 Unencoded query parameter with value null
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getMethodQueryNullAsync(String q1) {
@@ -442,7 +443,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -508,7 +509,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -573,7 +574,7 @@ public final class SkipUrlEncodingsImpl implements SkipUrlEncodings {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsImpl.java
@@ -109,7 +109,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -174,7 +174,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -239,7 +239,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -307,7 +307,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -372,7 +372,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsImpl.java
@@ -83,10 +83,9 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodGlobalValidAsync().toBlocking().single();
+    public void postMethodGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        postMethodGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -96,7 +95,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(postMethodGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -104,7 +103,21 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodGlobalValidAsync() {
+    public Observable<Void> postMethodGlobalValidAsync() {
+        return postMethodGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodGlobalValidWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -135,10 +148,9 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodGlobalNull() throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodGlobalNullAsync().toBlocking().single();
+    public void postMethodGlobalNull() throws ErrorException, IOException, IllegalArgumentException {
+        postMethodGlobalNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -148,7 +160,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodGlobalNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodGlobalNullAsync(), serviceCallback);
+        return ServiceCall.create(postMethodGlobalNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -156,7 +168,21 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodGlobalNullAsync() {
+    public Observable<Void> postMethodGlobalNullAsync() {
+        return postMethodGlobalNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodGlobalNullWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -187,10 +213,9 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodGlobalNotProvidedValidAsync().toBlocking().single();
+    public void postMethodGlobalNotProvidedValid() throws ErrorException, IOException, IllegalArgumentException {
+        postMethodGlobalNotProvidedValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -200,7 +225,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodGlobalNotProvidedValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodGlobalNotProvidedValidAsync(), serviceCallback);
+        return ServiceCall.create(postMethodGlobalNotProvidedValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -208,7 +233,21 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodGlobalNotProvidedValidAsync() {
+    public Observable<Void> postMethodGlobalNotProvidedValidAsync() {
+        return postMethodGlobalNotProvidedValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodGlobalNotProvidedValidWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -242,10 +281,9 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return postPathGlobalValidAsync().toBlocking().single();
+    public void postPathGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        postPathGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -255,7 +293,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postPathGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postPathGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(postPathGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -263,7 +301,21 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postPathGlobalValidAsync() {
+    public Observable<Void> postPathGlobalValidAsync() {
+        return postPathGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postPathGlobalValidWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -294,10 +346,9 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
-        return postSwaggerGlobalValidAsync().toBlocking().single();
+    public void postSwaggerGlobalValid() throws ErrorException, IOException, IllegalArgumentException {
+        postSwaggerGlobalValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -307,7 +358,7 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postSwaggerGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postSwaggerGlobalValidAsync(), serviceCallback);
+        return ServiceCall.create(postSwaggerGlobalValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -315,7 +366,21 @@ public final class SubscriptionInCredentialsImpl implements SubscriptionInCreden
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postSwaggerGlobalValidAsync() {
+    public Observable<Void> postSwaggerGlobalValidAsync() {
+        return postSwaggerGlobalValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postSwaggerGlobalValidWithServiceResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsImpl.java
@@ -107,7 +107,7 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -176,7 +176,7 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -245,7 +245,7 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -314,7 +314,7 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsImpl.java
@@ -79,10 +79,9 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodLocalValidAsync(subscriptionId).toBlocking().single();
+    public void postMethodLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
+        postMethodLocalValidWithServiceResponseAsync(subscriptionId).toBlocking().single().getBody();
     }
 
     /**
@@ -93,7 +92,7 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodLocalValidAsync(subscriptionId), serviceCallback);
+        return ServiceCall.create(postMethodLocalValidWithServiceResponseAsync(subscriptionId), serviceCallback);
     }
 
     /**
@@ -102,7 +101,22 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodLocalValidAsync(String subscriptionId) {
+    public Observable<Void> postMethodLocalValidAsync(String subscriptionId) {
+        return postMethodLocalValidWithServiceResponseAsync(subscriptionId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodLocalValidWithServiceResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
@@ -134,10 +148,9 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postMethodLocalNull(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
-        return postMethodLocalNullAsync(subscriptionId).toBlocking().single();
+    public void postMethodLocalNull(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
+        postMethodLocalNullWithServiceResponseAsync(subscriptionId).toBlocking().single().getBody();
     }
 
     /**
@@ -148,7 +161,7 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postMethodLocalNullAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postMethodLocalNullAsync(subscriptionId), serviceCallback);
+        return ServiceCall.create(postMethodLocalNullWithServiceResponseAsync(subscriptionId), serviceCallback);
     }
 
     /**
@@ -157,7 +170,22 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postMethodLocalNullAsync(String subscriptionId) {
+    public Observable<Void> postMethodLocalNullAsync(String subscriptionId) {
+        return postMethodLocalNullWithServiceResponseAsync(subscriptionId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postMethodLocalNullWithServiceResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
@@ -189,10 +217,9 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postPathLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
-        return postPathLocalValidAsync(subscriptionId).toBlocking().single();
+    public void postPathLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
+        postPathLocalValidWithServiceResponseAsync(subscriptionId).toBlocking().single().getBody();
     }
 
     /**
@@ -203,7 +230,7 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postPathLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postPathLocalValidAsync(subscriptionId), serviceCallback);
+        return ServiceCall.create(postPathLocalValidWithServiceResponseAsync(subscriptionId), serviceCallback);
     }
 
     /**
@@ -212,7 +239,22 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postPathLocalValidAsync(String subscriptionId) {
+    public Observable<Void> postPathLocalValidAsync(String subscriptionId) {
+        return postPathLocalValidWithServiceResponseAsync(subscriptionId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postPathLocalValidWithServiceResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
@@ -244,10 +286,9 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postSwaggerLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
-        return postSwaggerLocalValidAsync(subscriptionId).toBlocking().single();
+    public void postSwaggerLocalValid(String subscriptionId) throws ErrorException, IOException, IllegalArgumentException {
+        postSwaggerLocalValidWithServiceResponseAsync(subscriptionId).toBlocking().single().getBody();
     }
 
     /**
@@ -258,7 +299,7 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postSwaggerLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postSwaggerLocalValidAsync(subscriptionId), serviceCallback);
+        return ServiceCall.create(postSwaggerLocalValidWithServiceResponseAsync(subscriptionId), serviceCallback);
     }
 
     /**
@@ -267,7 +308,22 @@ public final class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postSwaggerLocalValidAsync(String subscriptionId) {
+    public Observable<Void> postSwaggerLocalValidAsync(String subscriptionId) {
+        return postSwaggerLocalValidWithServiceResponseAsync(subscriptionId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postSwaggerLocalValidWithServiceResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsImpl.java
@@ -95,7 +95,7 @@ public final class XMsClientRequestIdsImpl implements XMsClientRequestIds {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -159,7 +159,7 @@ public final class XMsClientRequestIdsImpl implements XMsClientRequestIds {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsImpl.java
@@ -69,10 +69,9 @@ public final class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get() throws CloudException, IOException {
-        return getAsync().toBlocking().single();
+    public void get() throws CloudException, IOException {
+        getWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -82,7 +81,7 @@ public final class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getAsync(), serviceCallback);
+        return ServiceCall.create(getWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -90,7 +89,21 @@ public final class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getAsync() {
+    public Observable<Void> getAsync() {
+        return getWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getWithServiceResponseAsync() {
         return service.get(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -118,10 +131,9 @@ public final class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramGet(String xMsClientRequestId) throws ErrorException, IOException, IllegalArgumentException {
-        return paramGetAsync(xMsClientRequestId).toBlocking().single();
+    public void paramGet(String xMsClientRequestId) throws ErrorException, IOException, IllegalArgumentException {
+        paramGetWithServiceResponseAsync(xMsClientRequestId).toBlocking().single().getBody();
     }
 
     /**
@@ -132,7 +144,7 @@ public final class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramGetAsync(String xMsClientRequestId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramGetAsync(xMsClientRequestId), serviceCallback);
+        return ServiceCall.create(paramGetWithServiceResponseAsync(xMsClientRequestId), serviceCallback);
     }
 
     /**
@@ -141,7 +153,22 @@ public final class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramGetAsync(String xMsClientRequestId) {
+    public Observable<Void> paramGetAsync(String xMsClientRequestId) {
+        return paramGetWithServiceResponseAsync(xMsClientRequestId).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramGetWithServiceResponseAsync(String xMsClientRequestId) {
         if (xMsClientRequestId == null) {
             throw new IllegalArgumentException("Parameter xMsClientRequestId is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/custombaseuri/Paths.java
@@ -29,7 +29,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -56,6 +55,6 @@ public interface Paths {
      * @param accountName Account Name
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String accountName);
+    Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String accountName);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/custombaseuri/Paths.java
@@ -31,7 +31,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException;
+    void getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a 200 to test a valid base uri.
@@ -48,6 +48,14 @@ public interface Paths {
      * @param accountName Account Name
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getEmptyAsync(String accountName);
+    Observable<Void> getEmptyAsync(String accountName);
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String accountName);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
@@ -67,10 +67,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException {
-        return getEmptyAsync(accountName).toBlocking().single();
+    public void getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException {
+        getEmptyWithServiceResponseAsync(accountName).toBlocking().single().getBody();
     }
 
     /**
@@ -81,7 +80,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getEmptyAsync(String accountName, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(accountName), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(accountName), serviceCallback);
     }
 
     /**
@@ -90,7 +89,22 @@ public final class PathsImpl implements Paths {
      * @param accountName Account Name
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getEmptyAsync(String accountName) {
+    public Observable<Void> getEmptyAsync(String accountName) {
+        return getEmptyWithServiceResponseAsync(accountName).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String accountName) {
         if (accountName == null) {
             throw new IllegalArgumentException("Parameter accountName is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
@@ -95,7 +95,7 @@ public final class PathsImpl implements Paths {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/head/HttpSuccess.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/head/HttpSuccess.java
@@ -29,7 +29,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> head200() throws CloudException, IOException;
+    boolean head200() throws CloudException, IOException;
 
     /**
      * Return 200 status code if successful.
@@ -44,7 +44,14 @@ public interface HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> head200Async();
+    Observable<Boolean> head200Async();
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> head200AsyncWithServiceResponse();
 
     /**
      * Return 204 status code if successful.
@@ -53,7 +60,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> head204() throws CloudException, IOException;
+    boolean head204() throws CloudException, IOException;
 
     /**
      * Return 204 status code if successful.
@@ -68,7 +75,14 @@ public interface HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> head204Async();
+    Observable<Boolean> head204Async();
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> head204AsyncWithServiceResponse();
 
     /**
      * Return 404 status code if successful.
@@ -77,7 +91,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> head404() throws CloudException, IOException;
+    boolean head404() throws CloudException, IOException;
 
     /**
      * Return 404 status code if successful.
@@ -92,6 +106,13 @@ public interface HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> head404Async();
+    Observable<Boolean> head404Async();
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> head404AsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/head/HttpSuccess.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/head/HttpSuccess.java
@@ -27,7 +27,7 @@ public interface HttpSuccess {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean head200() throws CloudException, IOException;
 
@@ -51,14 +51,14 @@ public interface HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> head200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> head200WithServiceResponseAsync();
 
     /**
      * Return 204 status code if successful.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean head204() throws CloudException, IOException;
 
@@ -82,14 +82,14 @@ public interface HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> head204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> head204WithServiceResponseAsync();
 
     /**
      * Return 404 status code if successful.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean head404() throws CloudException, IOException;
 
@@ -113,6 +113,6 @@ public interface HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> head404AsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> head404WithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/head/implementation/HttpSuccessImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/head/implementation/HttpSuccessImpl.java
@@ -71,10 +71,10 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
-    public ServiceResponse<Boolean> head200() throws CloudException, IOException {
-        return head200Async().toBlocking().single();
+    public boolean head200() throws CloudException, IOException {
+        return head200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +84,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> head200Async(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(head200Async(), serviceCallback);
+        return ServiceCall.create(head200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -92,7 +92,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> head200Async() {
+    public Observable<Boolean> head200Async() {
+        return head200WithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> head200WithServiceResponseAsync() {
         return service.head200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -120,10 +134,10 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
-    public ServiceResponse<Boolean> head204() throws CloudException, IOException {
-        return head204Async().toBlocking().single();
+    public boolean head204() throws CloudException, IOException {
+        return head204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -133,7 +147,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> head204Async(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(head204Async(), serviceCallback);
+        return ServiceCall.create(head204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -141,7 +155,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> head204Async() {
+    public Observable<Boolean> head204Async() {
+        return head204WithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> head204WithServiceResponseAsync() {
         return service.head204(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -169,10 +197,10 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
-    public ServiceResponse<Boolean> head404() throws CloudException, IOException {
-        return head404Async().toBlocking().single();
+    public boolean head404() throws CloudException, IOException {
+        return head404WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -182,7 +210,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> head404Async(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(head404Async(), serviceCallback);
+        return ServiceCall.create(head404WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -190,7 +218,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> head404Async() {
+    public Observable<Boolean> head404Async() {
+        return head404WithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> head404WithServiceResponseAsync() {
         return service.head404(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Boolean>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/head/implementation/HttpSuccessImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/head/implementation/HttpSuccessImpl.java
@@ -98,7 +98,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -161,7 +161,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -224,7 +224,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
@@ -29,7 +29,7 @@ public interface HeadExceptions {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> head200() throws CloudException, IOException;
+    void head200() throws CloudException, IOException;
 
     /**
      * Return 200 status code if successful.
@@ -44,7 +44,14 @@ public interface HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head200Async();
+    Observable<Void> head200Async();
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> head200AsyncWithServiceResponse();
 
     /**
      * Return 204 status code if successful.
@@ -53,7 +60,7 @@ public interface HeadExceptions {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> head204() throws CloudException, IOException;
+    void head204() throws CloudException, IOException;
 
     /**
      * Return 204 status code if successful.
@@ -68,7 +75,14 @@ public interface HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head204Async();
+    Observable<Void> head204Async();
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> head204AsyncWithServiceResponse();
 
     /**
      * Return 404 status code if successful.
@@ -77,7 +91,7 @@ public interface HeadExceptions {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> head404() throws CloudException, IOException;
+    void head404() throws CloudException, IOException;
 
     /**
      * Return 404 status code if successful.
@@ -92,6 +106,13 @@ public interface HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head404Async();
+    Observable<Void> head404Async();
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> head404AsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
@@ -27,7 +27,6 @@ public interface HeadExceptions {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void head200() throws CloudException, IOException;
 
@@ -51,14 +50,13 @@ public interface HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> head200WithServiceResponseAsync();
 
     /**
      * Return 204 status code if successful.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void head204() throws CloudException, IOException;
 
@@ -82,14 +80,13 @@ public interface HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> head204WithServiceResponseAsync();
 
     /**
      * Return 404 status code if successful.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void head404() throws CloudException, IOException;
 
@@ -113,6 +110,6 @@ public interface HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head404AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> head404WithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsImpl.java
@@ -71,10 +71,9 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head200() throws CloudException, IOException {
-        return head200Async().toBlocking().single();
+    public void head200() throws CloudException, IOException {
+        head200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +83,7 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head200Async(), serviceCallback);
+        return ServiceCall.create(head200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -92,7 +91,21 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head200Async() {
+    public Observable<Void> head200Async() {
+        return head200WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head200WithServiceResponseAsync() {
         return service.head200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -118,10 +131,9 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head204() throws CloudException, IOException {
-        return head204Async().toBlocking().single();
+    public void head204() throws CloudException, IOException {
+        head204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -131,7 +143,7 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head204Async(), serviceCallback);
+        return ServiceCall.create(head204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -139,7 +151,21 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head204Async() {
+    public Observable<Void> head204Async() {
+        return head204WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head204WithServiceResponseAsync() {
         return service.head204(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -165,10 +191,9 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head404() throws CloudException, IOException {
-        return head404Async().toBlocking().single();
+    public void head404() throws CloudException, IOException {
+        head404WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -178,7 +203,7 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head404Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head404Async(), serviceCallback);
+        return ServiceCall.create(head404WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -186,7 +211,21 @@ public final class HeadExceptionsImpl implements HeadExceptions {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head404Async() {
+    public Observable<Void> head404Async() {
+        return head404WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head404WithServiceResponseAsync() {
         return service.head404(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsImpl.java
@@ -97,7 +97,7 @@ public final class HeadExceptionsImpl implements HeadExceptions {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -157,7 +157,7 @@ public final class HeadExceptionsImpl implements HeadExceptions {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -217,7 +217,7 @@ public final class HeadExceptionsImpl implements HeadExceptions {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LRORetrys.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LRORetrys.java
@@ -36,7 +36,7 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
 
@@ -51,7 +51,6 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put201CreatingSucceeded200Async();
@@ -59,10 +58,9 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -70,7 +68,7 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -97,14 +95,14 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut201CreatingSucceeded200() throws CloudException, IOException;
 
@@ -119,7 +117,6 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut201CreatingSucceeded200Async();
@@ -127,17 +124,16 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
 
@@ -164,7 +160,7 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -172,7 +168,7 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -187,7 +183,6 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRelativeRetrySucceededAsync();
@@ -195,10 +190,9 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -206,7 +200,7 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -233,14 +227,14 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetrySucceeded() throws CloudException, IOException;
 
@@ -255,7 +249,6 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRelativeRetrySucceededAsync();
@@ -263,17 +256,16 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException;
 
@@ -300,7 +292,7 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -308,7 +300,7 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException;
 
@@ -332,14 +324,14 @@ public interface LRORetrys {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException;
 
@@ -363,7 +355,7 @@ public interface LRORetrys {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -371,7 +363,6 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void delete202Retry200() throws CloudException, IOException, InterruptedException;
 
@@ -395,14 +386,13 @@ public interface LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> delete202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> delete202Retry200WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDelete202Retry200() throws CloudException, IOException;
 
@@ -426,7 +416,7 @@ public interface LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> beginDelete202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> beginDelete202Retry200WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -434,7 +424,6 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -458,14 +447,13 @@ public interface LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> deleteAsyncRelativeRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> deleteAsyncRelativeRetrySucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncRelativeRetrySucceeded() throws CloudException, IOException;
 
@@ -489,7 +477,7 @@ public interface LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> beginDeleteAsyncRelativeRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync();
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -497,7 +485,6 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202Retry200() throws CloudException, IOException, InterruptedException;
 
@@ -512,7 +499,6 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> post202Retry200Async();
@@ -520,10 +506,9 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -531,7 +516,6 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -558,14 +542,13 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202Retry200() throws CloudException, IOException;
 
@@ -580,7 +563,6 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPost202Retry200Async();
@@ -588,17 +570,15 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202Retry200(Product product) throws CloudException, IOException;
 
@@ -625,7 +605,7 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -633,7 +613,6 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -648,7 +627,6 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postAsyncRelativeRetrySucceededAsync();
@@ -656,10 +634,9 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -667,7 +644,6 @@ public interface LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -694,14 +670,13 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetrySucceeded() throws CloudException, IOException;
 
@@ -716,7 +691,6 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostAsyncRelativeRetrySucceededAsync();
@@ -724,17 +698,15 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException;
 
@@ -761,6 +733,6 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(Product product);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LRORetrys.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LRORetrys.java
@@ -38,7 +38,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
+    Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -47,6 +47,22 @@ public interface LRORetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put201CreatingSucceeded200Async();
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -56,7 +72,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
+    Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -73,7 +89,15 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async(Product product);
+    Observable<Product> put201CreatingSucceeded200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -82,7 +106,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut201CreatingSucceeded200() throws CloudException, IOException;
+    Product beginPut201CreatingSucceeded200() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -91,6 +115,22 @@ public interface LRORetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut201CreatingSucceeded200Async();
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -99,7 +139,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
+    Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -116,7 +156,15 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async(Product product);
+    Observable<Product> beginPut201CreatingSucceeded200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -126,7 +174,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> putAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -135,6 +183,22 @@ public interface LRORetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRelativeRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRelativeRetrySucceededAsync();
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -144,7 +208,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> putAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -161,7 +225,15 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededAsync(Product product);
+    Observable<Product> putAsyncRelativeRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -170,7 +242,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> beginPutAsyncRelativeRetrySucceeded() throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -179,6 +251,22 @@ public interface LRORetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRelativeRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRelativeRetrySucceededAsync();
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -187,7 +275,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> beginPutAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -204,7 +292,15 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededAsync(Product product);
+    Observable<Product> beginPutAsyncRelativeRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -214,7 +310,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders> deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException;
+    Product deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -229,7 +325,14 @@ public interface LRORetrys {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededAsync();
+    Observable<Product> deleteProvisioning202Accepted200SucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -238,7 +341,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders> beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException;
+    Product beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -253,7 +356,14 @@ public interface LRORetrys {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededAsync();
+    Observable<Product> beginDeleteProvisioning202Accepted200SucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -263,7 +373,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers> delete202Retry200() throws CloudException, IOException, InterruptedException;
+    void delete202Retry200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -278,7 +388,14 @@ public interface LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> delete202Retry200Async();
+    Observable<Void> delete202Retry200Async();
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> delete202Retry200AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -287,7 +404,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers> beginDelete202Retry200() throws CloudException, IOException;
+    void beginDelete202Retry200() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -302,7 +419,14 @@ public interface LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> beginDelete202Retry200Async();
+    Observable<Void> beginDelete202Retry200Async();
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> beginDelete202Retry200AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -312,7 +436,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders> deleteAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -327,7 +451,14 @@ public interface LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> deleteAsyncRelativeRetrySucceededAsync();
+    Observable<Void> deleteAsyncRelativeRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> deleteAsyncRelativeRetrySucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -336,7 +467,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders> beginDeleteAsyncRelativeRetrySucceeded() throws CloudException, IOException;
+    void beginDeleteAsyncRelativeRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -351,7 +482,14 @@ public interface LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> beginDeleteAsyncRelativeRetrySucceededAsync();
+    Observable<Void> beginDeleteAsyncRelativeRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> beginDeleteAsyncRelativeRetrySucceededAsyncWithServiceResponse();
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -361,7 +499,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> post202Retry200() throws CloudException, IOException, InterruptedException;
+    void post202Retry200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -370,6 +508,22 @@ public interface LRORetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> post202Retry200Async();
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -379,7 +533,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
+    void post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -396,7 +550,15 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200Async(Product product);
+    Observable<Void> post202Retry200Async(Product product);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -405,7 +567,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> beginPost202Retry200() throws CloudException, IOException;
+    void beginPost202Retry200() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -414,6 +576,22 @@ public interface LRORetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPost202Retry200Async();
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -422,7 +600,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> beginPost202Retry200(Product product) throws CloudException, IOException;
+    void beginPost202Retry200(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -439,7 +617,15 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200Async(Product product);
+    Observable<Void> beginPost202Retry200Async(Product product);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -449,7 +635,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> postAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -458,6 +644,22 @@ public interface LRORetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postAsyncRelativeRetrySucceededAsync();
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -467,7 +669,7 @@ public interface LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> postAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -484,7 +686,15 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededAsync(Product product);
+    Observable<Void> postAsyncRelativeRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -493,7 +703,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> beginPostAsyncRelativeRetrySucceeded() throws CloudException, IOException;
+    void beginPostAsyncRelativeRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -502,6 +712,22 @@ public interface LRORetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostAsyncRelativeRetrySucceededAsync();
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -510,7 +736,7 @@ public interface LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> beginPostAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException;
+    void beginPostAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -527,6 +753,14 @@ public interface LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededAsync(Product product);
+    Observable<Void> beginPostAsyncRelativeRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededAsyncWithServiceResponse(Product product);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROSADs.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROSADs.java
@@ -50,7 +50,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product putNonRetry400() throws CloudException, IOException, InterruptedException;
 
@@ -65,7 +65,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putNonRetry400Async();
@@ -73,10 +72,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> putNonRetry400WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
@@ -84,7 +82,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product putNonRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -111,14 +109,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> putNonRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutNonRetry400() throws CloudException, IOException;
 
@@ -133,7 +131,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutNonRetry400Async();
@@ -141,17 +138,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPutNonRetry400WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutNonRetry400(Product product) throws CloudException, IOException;
 
@@ -178,7 +174,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPutNonRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -186,7 +182,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product putNonRetry201Creating400() throws CloudException, IOException, InterruptedException;
 
@@ -201,7 +197,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putNonRetry201Creating400Async();
@@ -209,10 +204,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry201Creating400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> putNonRetry201Creating400WithServiceResponseAsync();
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
@@ -220,7 +214,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product putNonRetry201Creating400(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -247,14 +241,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry201Creating400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> putNonRetry201Creating400WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutNonRetry201Creating400() throws CloudException, IOException;
 
@@ -269,7 +263,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutNonRetry201Creating400Async();
@@ -277,17 +270,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400WithServiceResponseAsync();
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutNonRetry201Creating400(Product product) throws CloudException, IOException;
 
@@ -314,7 +306,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -322,7 +314,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product putNonRetry201Creating400InvalidJson() throws CloudException, IOException, InterruptedException;
 
@@ -337,7 +329,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putNonRetry201Creating400InvalidJsonAsync();
@@ -345,10 +336,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonWithServiceResponseAsync();
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
@@ -356,7 +346,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product putNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -383,14 +373,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutNonRetry201Creating400InvalidJson() throws CloudException, IOException;
 
@@ -405,7 +395,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutNonRetry201Creating400InvalidJsonAsync();
@@ -413,17 +402,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync();
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException;
 
@@ -450,7 +438,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -458,7 +446,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
 
@@ -473,7 +461,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRelativeRetry400Async();
@@ -481,10 +468,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -492,7 +478,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -519,14 +505,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetry400() throws CloudException, IOException;
 
@@ -541,7 +527,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRelativeRetry400Async();
@@ -549,17 +534,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetry400(Product product) throws CloudException, IOException;
 
@@ -586,7 +570,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running delete request, service returns a 400 with an error body.
@@ -594,7 +578,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteNonRetry400() throws CloudException, IOException, InterruptedException;
 
@@ -618,14 +601,13 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> deleteNonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> deleteNonRetry400WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 400 with an error body.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteNonRetry400() throws CloudException, IOException;
 
@@ -649,7 +631,7 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> beginDeleteNonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> beginDeleteNonRetry400WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 with a location header.
@@ -657,7 +639,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void delete202NonRetry400() throws CloudException, IOException, InterruptedException;
 
@@ -681,14 +662,13 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> delete202NonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> delete202NonRetry400WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 with a location header.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDelete202NonRetry400() throws CloudException, IOException;
 
@@ -712,7 +692,7 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> beginDelete202NonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> beginDelete202NonRetry400WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -720,7 +700,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
 
@@ -744,14 +723,13 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> deleteAsyncRelativeRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> deleteAsyncRelativeRetry400WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncRelativeRetry400() throws CloudException, IOException;
 
@@ -775,7 +753,7 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> beginDeleteAsyncRelativeRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> beginDeleteAsyncRelativeRetry400WithServiceResponseAsync();
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -783,7 +761,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postNonRetry400() throws CloudException, IOException, InterruptedException;
 
@@ -798,7 +775,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 400 with no error body.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postNonRetry400Async();
@@ -806,10 +782,9 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 400 with no error body.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 400 with no error body.
      *
@@ -817,7 +792,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postNonRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -844,14 +818,13 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 400 with no error body.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostNonRetry400() throws CloudException, IOException;
 
@@ -866,7 +839,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 400 with no error body.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostNonRetry400Async();
@@ -874,17 +846,15 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 400 with no error body.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 400 with no error body.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostNonRetry400(Product product) throws CloudException, IOException;
 
@@ -911,7 +881,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -919,7 +889,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202NonRetry400() throws CloudException, IOException, InterruptedException;
 
@@ -934,7 +903,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 with a location header.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> post202NonRetry400Async();
@@ -942,10 +910,9 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 with a location header.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 with a location header.
      *
@@ -953,7 +920,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202NonRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -980,14 +946,13 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 with a location header.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202NonRetry400() throws CloudException, IOException;
 
@@ -1002,7 +967,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 with a location header.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPost202NonRetry400Async();
@@ -1010,17 +974,15 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 with a location header.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 with a location header.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202NonRetry400(Product product) throws CloudException, IOException;
 
@@ -1047,7 +1009,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1055,7 +1017,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
 
@@ -1070,7 +1031,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postAsyncRelativeRetry400Async();
@@ -1078,10 +1038,9 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1089,7 +1048,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1116,14 +1074,13 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetry400() throws CloudException, IOException;
 
@@ -1138,7 +1095,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostAsyncRelativeRetry400Async();
@@ -1146,17 +1102,15 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetry400(Product product) throws CloudException, IOException;
 
@@ -1183,7 +1137,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -1191,7 +1145,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product putError201NoProvisioningStatePayload() throws CloudException, IOException, InterruptedException;
 
@@ -1206,7 +1160,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putError201NoProvisioningStatePayloadAsync();
@@ -1214,10 +1167,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
@@ -1225,7 +1177,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product putError201NoProvisioningStatePayload(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1252,14 +1204,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutError201NoProvisioningStatePayload() throws CloudException, IOException;
 
@@ -1274,7 +1226,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutError201NoProvisioningStatePayloadAsync();
@@ -1282,17 +1233,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutError201NoProvisioningStatePayload(Product product) throws CloudException, IOException;
 
@@ -1319,7 +1269,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1327,7 +1277,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException;
 
@@ -1342,7 +1292,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRelativeRetryNoStatusAsync();
@@ -1350,10 +1299,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1361,7 +1309,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1388,14 +1336,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetryNoStatus() throws CloudException, IOException;
 
@@ -1410,7 +1358,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRelativeRetryNoStatusAsync();
@@ -1418,17 +1365,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException;
 
@@ -1455,7 +1401,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1463,7 +1409,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException, InterruptedException;
 
@@ -1478,7 +1424,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRelativeRetryNoStatusPayloadAsync();
@@ -1486,10 +1431,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1497,7 +1441,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1524,14 +1468,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException;
 
@@ -1546,7 +1490,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync();
@@ -1554,17 +1497,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException;
 
@@ -1591,7 +1533,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(Product product);
 
     /**
      * Long running delete request, service returns a 204 to the initial request, indicating success.
@@ -1599,7 +1541,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete204Succeeded() throws CloudException, IOException, InterruptedException;
 
@@ -1623,14 +1564,13 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete204SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> delete204SucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 204 to the initial request, indicating success.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void beginDelete204Succeeded() throws CloudException, IOException;
 
@@ -1654,7 +1594,7 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> beginDelete204SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> beginDelete204SucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1662,7 +1602,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException;
 
@@ -1686,14 +1625,13 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> deleteAsyncRelativeRetryNoStatusAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncRelativeRetryNoStatus() throws CloudException, IOException;
 
@@ -1717,7 +1655,7 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> beginDeleteAsyncRelativeRetryNoStatusAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync();
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -1725,7 +1663,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202NoLocation() throws CloudException, IOException, InterruptedException;
 
@@ -1740,7 +1677,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> post202NoLocationAsync();
@@ -1748,10 +1684,9 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
@@ -1759,7 +1694,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202NoLocation(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1786,14 +1720,13 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202NoLocation() throws CloudException, IOException;
 
@@ -1808,7 +1741,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPost202NoLocationAsync();
@@ -1816,17 +1748,15 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202NoLocation(Product product) throws CloudException, IOException;
 
@@ -1853,7 +1783,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1861,7 +1791,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetryNoPayload() throws CloudException, IOException, InterruptedException;
 
@@ -1876,7 +1805,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postAsyncRelativeRetryNoPayloadAsync();
@@ -1884,10 +1812,9 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1895,7 +1822,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1922,14 +1848,13 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetryNoPayload() throws CloudException, IOException;
 
@@ -1944,7 +1869,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync();
@@ -1952,17 +1876,15 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException;
 
@@ -1989,7 +1911,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -1997,7 +1919,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200InvalidJson() throws CloudException, IOException, InterruptedException;
 
@@ -2012,7 +1934,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put200InvalidJsonAsync();
@@ -2020,10 +1941,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200InvalidJsonAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put200InvalidJsonWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
@@ -2031,7 +1951,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200InvalidJson(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -2058,14 +1978,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200InvalidJsonAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put200InvalidJsonWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200InvalidJson() throws CloudException, IOException;
 
@@ -2080,7 +2000,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut200InvalidJsonAsync();
@@ -2088,17 +2007,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200InvalidJsonAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut200InvalidJsonWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200InvalidJson(Product product) throws CloudException, IOException;
 
@@ -2125,7 +2043,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200InvalidJsonAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut200InvalidJsonWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -2133,7 +2051,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
@@ -2148,7 +2066,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRelativeRetryInvalidHeaderAsync();
@@ -2156,10 +2073,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
@@ -2167,7 +2083,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -2194,14 +2110,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
 
@@ -2216,7 +2132,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync();
@@ -2224,17 +2139,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException;
 
@@ -2261,7 +2175,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2269,7 +2183,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
 
@@ -2284,7 +2198,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRelativeRetryInvalidJsonPollingAsync();
@@ -2292,10 +2205,9 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2303,7 +2215,7 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -2330,14 +2242,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
 
@@ -2352,7 +2264,6 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync();
@@ -2360,17 +2271,16 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException;
 
@@ -2397,7 +2307,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(Product product);
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
@@ -2405,7 +2315,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void delete202RetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
@@ -2429,14 +2338,13 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> delete202RetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> delete202RetryInvalidHeaderWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDelete202RetryInvalidHeader() throws CloudException, IOException;
 
@@ -2460,7 +2368,7 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> beginDelete202RetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> beginDelete202RetryInvalidHeaderWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -2468,7 +2376,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
@@ -2492,14 +2399,13 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> deleteAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
 
@@ -2523,7 +2429,7 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> beginDeleteAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2531,7 +2437,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
 
@@ -2555,14 +2460,13 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> deleteAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
 
@@ -2586,7 +2490,7 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync();
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -2594,7 +2498,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202RetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
@@ -2609,7 +2512,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> post202RetryInvalidHeaderAsync();
@@ -2617,10 +2519,9 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
@@ -2628,7 +2529,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202RetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -2655,14 +2555,13 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202RetryInvalidHeader() throws CloudException, IOException;
 
@@ -2677,7 +2576,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPost202RetryInvalidHeaderAsync();
@@ -2685,17 +2583,15 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202RetryInvalidHeader(Product product) throws CloudException, IOException;
 
@@ -2722,7 +2618,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -2730,7 +2626,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
@@ -2745,7 +2640,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postAsyncRelativeRetryInvalidHeaderAsync();
@@ -2753,10 +2647,9 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
@@ -2764,7 +2657,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -2791,14 +2683,13 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
 
@@ -2813,7 +2704,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync();
@@ -2821,17 +2711,15 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException;
 
@@ -2858,7 +2746,7 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2866,7 +2754,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
 
@@ -2881,7 +2768,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postAsyncRelativeRetryInvalidJsonPollingAsync();
@@ -2889,10 +2775,9 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2900,7 +2785,6 @@ public interface LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -2927,14 +2811,13 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
 
@@ -2949,7 +2832,6 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync();
@@ -2957,17 +2839,15 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException;
 
@@ -2994,6 +2874,6 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(Product product);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROSADs.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROSADs.java
@@ -52,7 +52,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> putNonRetry400() throws CloudException, IOException, InterruptedException;
+    Product putNonRetry400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 400 to the initial request.
@@ -61,6 +61,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putNonRetry400Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putNonRetry400Async();
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> putNonRetry400AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
@@ -70,7 +86,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> putNonRetry400(Product product) throws CloudException, IOException, InterruptedException;
+    Product putNonRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 400 to the initial request.
@@ -87,7 +103,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry400Async(Product product);
+    Observable<Product> putNonRetry400Async(Product product);
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> putNonRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 400 to the initial request.
@@ -96,7 +120,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPutNonRetry400() throws CloudException, IOException;
+    Product beginPutNonRetry400() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 400 to the initial request.
@@ -105,6 +129,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutNonRetry400Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutNonRetry400Async();
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPutNonRetry400AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
@@ -113,7 +153,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPutNonRetry400(Product product) throws CloudException, IOException;
+    Product beginPutNonRetry400(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 400 to the initial request.
@@ -130,7 +170,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry400Async(Product product);
+    Observable<Product> beginPutNonRetry400Async(Product product);
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPutNonRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -140,7 +188,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> putNonRetry201Creating400() throws CloudException, IOException, InterruptedException;
+    Product putNonRetry201Creating400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -149,6 +197,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putNonRetry201Creating400Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putNonRetry201Creating400Async();
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> putNonRetry201Creating400AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
@@ -158,7 +222,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> putNonRetry201Creating400(Product product) throws CloudException, IOException, InterruptedException;
+    Product putNonRetry201Creating400(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -175,7 +239,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry201Creating400Async(Product product);
+    Observable<Product> putNonRetry201Creating400Async(Product product);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> putNonRetry201Creating400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -184,7 +256,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPutNonRetry201Creating400() throws CloudException, IOException;
+    Product beginPutNonRetry201Creating400() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -193,6 +265,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutNonRetry201Creating400Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutNonRetry201Creating400Async();
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
@@ -201,7 +289,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPutNonRetry201Creating400(Product product) throws CloudException, IOException;
+    Product beginPutNonRetry201Creating400(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -218,7 +306,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400Async(Product product);
+    Observable<Product> beginPutNonRetry201Creating400Async(Product product);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -228,7 +324,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> putNonRetry201Creating400InvalidJson() throws CloudException, IOException, InterruptedException;
+    Product putNonRetry201Creating400InvalidJson() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -237,6 +333,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putNonRetry201Creating400InvalidJsonAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putNonRetry201Creating400InvalidJsonAsync();
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
@@ -246,7 +358,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> putNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException, InterruptedException;
+    Product putNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -263,7 +375,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonAsync(Product product);
+    Observable<Product> putNonRetry201Creating400InvalidJsonAsync(Product product);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -272,7 +392,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPutNonRetry201Creating400InvalidJson() throws CloudException, IOException;
+    Product beginPutNonRetry201Creating400InvalidJson() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -281,6 +401,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutNonRetry201Creating400InvalidJsonAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutNonRetry201Creating400InvalidJsonAsync();
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
@@ -289,7 +425,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPutNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException;
+    Product beginPutNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -306,7 +442,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonAsync(Product product);
+    Observable<Product> beginPutNonRetry201Creating400InvalidJsonAsync(Product product);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -316,7 +460,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> putAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -325,6 +469,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRelativeRetry400Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRelativeRetry400Async();
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -334,7 +494,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> putAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -351,7 +511,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400Async(Product product);
+    Observable<Product> putAsyncRelativeRetry400Async(Product product);
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -360,7 +528,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> beginPutAsyncRelativeRetry400() throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetry400() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -369,6 +537,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRelativeRetry400Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRelativeRetry400Async();
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -377,7 +561,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> beginPutAsyncRelativeRetry400(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetry400(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -394,7 +578,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400Async(Product product);
+    Observable<Product> beginPutAsyncRelativeRetry400Async(Product product);
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running delete request, service returns a 400 with an error body.
@@ -404,7 +596,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers> deleteNonRetry400() throws CloudException, IOException, InterruptedException;
+    void deleteNonRetry400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 400 with an error body.
@@ -419,7 +611,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> deleteNonRetry400Async();
+    Observable<Void> deleteNonRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> deleteNonRetry400AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 400 with an error body.
@@ -428,7 +627,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers> beginDeleteNonRetry400() throws CloudException, IOException;
+    void beginDeleteNonRetry400() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 400 with an error body.
@@ -443,7 +642,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> beginDeleteNonRetry400Async();
+    Observable<Void> beginDeleteNonRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> beginDeleteNonRetry400AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 with a location header.
@@ -453,7 +659,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers> delete202NonRetry400() throws CloudException, IOException, InterruptedException;
+    void delete202NonRetry400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 with a location header.
@@ -468,7 +674,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> delete202NonRetry400Async();
+    Observable<Void> delete202NonRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> delete202NonRetry400AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 with a location header.
@@ -477,7 +690,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers> beginDelete202NonRetry400() throws CloudException, IOException;
+    void beginDelete202NonRetry400() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 with a location header.
@@ -492,7 +705,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> beginDelete202NonRetry400Async();
+    Observable<Void> beginDelete202NonRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> beginDelete202NonRetry400AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -502,7 +722,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers> deleteAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -517,7 +737,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> deleteAsyncRelativeRetry400Async();
+    Observable<Void> deleteAsyncRelativeRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> deleteAsyncRelativeRetry400AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -526,7 +753,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers> beginDeleteAsyncRelativeRetry400() throws CloudException, IOException;
+    void beginDeleteAsyncRelativeRetry400() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -541,7 +768,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> beginDeleteAsyncRelativeRetry400Async();
+    Observable<Void> beginDeleteAsyncRelativeRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> beginDeleteAsyncRelativeRetry400AsyncWithServiceResponse();
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -551,7 +785,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> postNonRetry400() throws CloudException, IOException, InterruptedException;
+    void postNonRetry400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -560,6 +794,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postNonRetry400Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postNonRetry400Async();
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 400 with no error body.
      *
@@ -569,7 +819,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> postNonRetry400(Product product) throws CloudException, IOException, InterruptedException;
+    void postNonRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -586,7 +836,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400Async(Product product);
+    Observable<Void> postNonRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -595,7 +853,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> beginPostNonRetry400() throws CloudException, IOException;
+    void beginPostNonRetry400() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -604,6 +862,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostNonRetry400Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostNonRetry400Async();
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 400 with no error body.
      *
@@ -612,7 +886,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> beginPostNonRetry400(Product product) throws CloudException, IOException;
+    void beginPostNonRetry400(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -629,7 +903,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400Async(Product product);
+    Observable<Void> beginPostNonRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -639,7 +921,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> post202NonRetry400() throws CloudException, IOException, InterruptedException;
+    void post202NonRetry400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -648,6 +930,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post202NonRetry400Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> post202NonRetry400Async();
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 with a location header.
      *
@@ -657,7 +955,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> post202NonRetry400(Product product) throws CloudException, IOException, InterruptedException;
+    void post202NonRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -674,7 +972,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400Async(Product product);
+    Observable<Void> post202NonRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -683,7 +989,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> beginPost202NonRetry400() throws CloudException, IOException;
+    void beginPost202NonRetry400() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -692,6 +998,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPost202NonRetry400Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPost202NonRetry400Async();
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 with a location header.
      *
@@ -700,7 +1022,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> beginPost202NonRetry400(Product product) throws CloudException, IOException;
+    void beginPost202NonRetry400(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -717,7 +1039,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400Async(Product product);
+    Observable<Void> beginPost202NonRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -727,7 +1057,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> postAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -736,6 +1066,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postAsyncRelativeRetry400Async();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -745,7 +1091,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> postAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -762,7 +1108,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400Async(Product product);
+    Observable<Void> postAsyncRelativeRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -771,7 +1125,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> beginPostAsyncRelativeRetry400() throws CloudException, IOException;
+    void beginPostAsyncRelativeRetry400() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -780,6 +1134,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostAsyncRelativeRetry400Async();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -788,7 +1158,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> beginPostAsyncRelativeRetry400(Product product) throws CloudException, IOException;
+    void beginPostAsyncRelativeRetry400(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -805,7 +1175,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400Async(Product product);
+    Observable<Void> beginPostAsyncRelativeRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -815,7 +1193,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> putError201NoProvisioningStatePayload() throws CloudException, IOException, InterruptedException;
+    Product putError201NoProvisioningStatePayload() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -824,6 +1202,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putError201NoProvisioningStatePayloadAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putError201NoProvisioningStatePayloadAsync();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
@@ -833,7 +1227,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> putError201NoProvisioningStatePayload(Product product) throws CloudException, IOException, InterruptedException;
+    Product putError201NoProvisioningStatePayload(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -850,7 +1244,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadAsync(Product product);
+    Observable<Product> putError201NoProvisioningStatePayloadAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -859,7 +1261,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPutError201NoProvisioningStatePayload() throws CloudException, IOException;
+    Product beginPutError201NoProvisioningStatePayload() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -868,6 +1270,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutError201NoProvisioningStatePayloadAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutError201NoProvisioningStatePayloadAsync();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
@@ -876,7 +1294,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPutError201NoProvisioningStatePayload(Product product) throws CloudException, IOException;
+    Product beginPutError201NoProvisioningStatePayload(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -893,7 +1311,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadAsync(Product product);
+    Observable<Product> beginPutError201NoProvisioningStatePayloadAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -903,7 +1329,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> putAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -912,6 +1338,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRelativeRetryNoStatusAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -921,7 +1363,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> putAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -938,7 +1380,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusAsync(Product product);
+    Observable<Product> putAsyncRelativeRetryNoStatusAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -947,7 +1397,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> beginPutAsyncRelativeRetryNoStatus() throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetryNoStatus() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -956,6 +1406,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRelativeRetryNoStatusAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -964,7 +1430,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> beginPutAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -981,7 +1447,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusAsync(Product product);
+    Observable<Product> beginPutAsyncRelativeRetryNoStatusAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -991,7 +1465,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> putAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1000,6 +1474,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRelativeRetryNoStatusPayloadAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRelativeRetryNoStatusPayloadAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1009,7 +1499,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> putAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1026,7 +1516,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadAsync(Product product);
+    Observable<Product> putAsyncRelativeRetryNoStatusPayloadAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1035,7 +1533,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> beginPutAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1044,6 +1542,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1052,7 +1566,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> beginPutAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1069,7 +1583,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadAsync(Product product);
+    Observable<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadAsyncWithServiceResponse(Product product);
 
     /**
      * Long running delete request, service returns a 204 to the initial request, indicating success.
@@ -1079,7 +1601,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete204Succeeded() throws CloudException, IOException, InterruptedException;
+    void delete204Succeeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 204 to the initial request, indicating success.
@@ -1094,7 +1616,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete204SucceededAsync();
+    Observable<Void> delete204SucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete204SucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 204 to the initial request, indicating success.
@@ -1103,7 +1632,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> beginDelete204Succeeded() throws CloudException, IOException;
+    void beginDelete204Succeeded() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 204 to the initial request, indicating success.
@@ -1118,7 +1647,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> beginDelete204SucceededAsync();
+    Observable<Void> beginDelete204SucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> beginDelete204SucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1128,7 +1664,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders> deleteAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1143,7 +1679,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> deleteAsyncRelativeRetryNoStatusAsync();
+    Observable<Void> deleteAsyncRelativeRetryNoStatusAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> deleteAsyncRelativeRetryNoStatusAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1152,7 +1695,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders> beginDeleteAsyncRelativeRetryNoStatus() throws CloudException, IOException;
+    void beginDeleteAsyncRelativeRetryNoStatus() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1167,7 +1710,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> beginDeleteAsyncRelativeRetryNoStatusAsync();
+    Observable<Void> beginDeleteAsyncRelativeRetryNoStatusAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> beginDeleteAsyncRelativeRetryNoStatusAsyncWithServiceResponse();
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -1177,7 +1727,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> post202NoLocation() throws CloudException, IOException, InterruptedException;
+    void post202NoLocation() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -1186,6 +1736,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post202NoLocationAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> post202NoLocationAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
@@ -1195,7 +1761,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> post202NoLocation(Product product) throws CloudException, IOException, InterruptedException;
+    void post202NoLocation(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -1212,7 +1778,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationAsync(Product product);
+    Observable<Void> post202NoLocationAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -1221,7 +1795,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> beginPost202NoLocation() throws CloudException, IOException;
+    void beginPost202NoLocation() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -1230,6 +1804,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPost202NoLocationAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPost202NoLocationAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
@@ -1238,7 +1828,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> beginPost202NoLocation(Product product) throws CloudException, IOException;
+    void beginPost202NoLocation(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -1255,7 +1845,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationAsync(Product product);
+    Observable<Void> beginPost202NoLocationAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1265,7 +1863,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> postAsyncRelativeRetryNoPayload() throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetryNoPayload() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1274,6 +1872,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postAsyncRelativeRetryNoPayloadAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postAsyncRelativeRetryNoPayloadAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1283,7 +1897,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> postAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1300,7 +1914,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadAsync(Product product);
+    Observable<Void> postAsyncRelativeRetryNoPayloadAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1309,7 +1931,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> beginPostAsyncRelativeRetryNoPayload() throws CloudException, IOException;
+    void beginPostAsyncRelativeRetryNoPayload() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1318,6 +1940,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostAsyncRelativeRetryNoPayloadAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1326,7 +1964,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> beginPostAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException;
+    void beginPostAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1343,7 +1981,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadAsync(Product product);
+    Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -1353,7 +1999,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200InvalidJson() throws CloudException, IOException, InterruptedException;
+    Product put200InvalidJson() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -1362,6 +2008,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put200InvalidJsonAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put200InvalidJsonAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200InvalidJsonAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
@@ -1371,7 +2033,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200InvalidJson(Product product) throws CloudException, IOException, InterruptedException;
+    Product put200InvalidJson(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -1388,7 +2050,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200InvalidJsonAsync(Product product);
+    Observable<Product> put200InvalidJsonAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200InvalidJsonAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -1397,7 +2067,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200InvalidJson() throws CloudException, IOException;
+    Product beginPut200InvalidJson() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -1406,6 +2076,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut200InvalidJsonAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut200InvalidJsonAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200InvalidJsonAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
@@ -1414,7 +2100,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200InvalidJson(Product product) throws CloudException, IOException;
+    Product beginPut200InvalidJson(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -1431,7 +2117,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200InvalidJsonAsync(Product product);
+    Observable<Product> beginPut200InvalidJsonAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200InvalidJsonAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1441,7 +2135,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> putAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1450,6 +2144,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRelativeRetryInvalidHeaderAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
@@ -1459,7 +2169,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> putAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1476,7 +2186,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderAsync(Product product);
+    Observable<Product> putAsyncRelativeRetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1485,7 +2203,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> beginPutAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1494,6 +2212,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
@@ -1502,7 +2236,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> beginPutAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1519,7 +2253,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderAsync(Product product);
+    Observable<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1529,7 +2271,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> putAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1538,6 +2280,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRelativeRetryInvalidJsonPollingAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1547,7 +2305,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> putAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1564,7 +2322,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+    Observable<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1573,7 +2339,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> beginPutAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1582,6 +2348,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1590,7 +2372,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> beginPutAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1607,7 +2389,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+    Observable<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse(Product product);
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
@@ -1617,7 +2407,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders> delete202RetryInvalidHeader() throws CloudException, IOException, InterruptedException;
+    void delete202RetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
@@ -1632,7 +2422,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> delete202RetryInvalidHeaderAsync();
+    Observable<Void> delete202RetryInvalidHeaderAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> delete202RetryInvalidHeaderAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
@@ -1641,7 +2438,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders> beginDelete202RetryInvalidHeader() throws CloudException, IOException;
+    void beginDelete202RetryInvalidHeader() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
@@ -1656,7 +2453,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> beginDelete202RetryInvalidHeaderAsync();
+    Observable<Void> beginDelete202RetryInvalidHeaderAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> beginDelete202RetryInvalidHeaderAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1666,7 +2470,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders> deleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1681,7 +2485,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> deleteAsyncRelativeRetryInvalidHeaderAsync();
+    Observable<Void> deleteAsyncRelativeRetryInvalidHeaderAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> deleteAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1690,7 +2501,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders> beginDeleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
+    void beginDeleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1705,7 +2516,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> beginDeleteAsyncRelativeRetryInvalidHeaderAsync();
+    Observable<Void> beginDeleteAsyncRelativeRetryInvalidHeaderAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> beginDeleteAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1715,7 +2533,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders> deleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1730,7 +2548,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> deleteAsyncRelativeRetryInvalidJsonPollingAsync();
+    Observable<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> deleteAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1739,7 +2564,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders> beginDeleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
+    void beginDeleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1754,7 +2579,14 @@ public interface LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync();
+    Observable<Void> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -1764,7 +2596,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> post202RetryInvalidHeader() throws CloudException, IOException, InterruptedException;
+    void post202RetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -1773,6 +2605,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> post202RetryInvalidHeaderAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
@@ -1782,7 +2630,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> post202RetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
+    void post202RetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -1799,7 +2647,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderAsync(Product product);
+    Observable<Void> post202RetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -1808,7 +2664,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> beginPost202RetryInvalidHeader() throws CloudException, IOException;
+    void beginPost202RetryInvalidHeader() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -1817,6 +2673,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPost202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPost202RetryInvalidHeaderAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
@@ -1825,7 +2697,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> beginPost202RetryInvalidHeader(Product product) throws CloudException, IOException;
+    void beginPost202RetryInvalidHeader(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -1842,7 +2714,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderAsync(Product product);
+    Observable<Void> beginPost202RetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1852,7 +2732,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> postAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1861,6 +2741,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postAsyncRelativeRetryInvalidHeaderAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
@@ -1870,7 +2766,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> postAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1887,7 +2783,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderAsync(Product product);
+    Observable<Void> postAsyncRelativeRetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1896,7 +2800,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> beginPostAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
+    void beginPostAsyncRelativeRetryInvalidHeader() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1905,6 +2809,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
@@ -1913,7 +2833,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> beginPostAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException;
+    void beginPostAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -1930,7 +2850,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderAsync(Product product);
+    Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1940,7 +2868,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> postAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1949,6 +2877,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postAsyncRelativeRetryInvalidJsonPollingAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1958,7 +2902,7 @@ public interface LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> postAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException;
+    void postAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1975,7 +2919,15 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+    Observable<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1984,7 +2936,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> beginPostAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
+    void beginPostAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1993,6 +2945,22 @@ public interface LROSADs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2001,7 +2969,7 @@ public interface LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> beginPostAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException;
+    void beginPostAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2018,6 +2986,14 @@ public interface LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+    Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingAsyncWithServiceResponse(Product product);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROs.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROs.java
@@ -55,7 +55,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200Succeeded() throws CloudException, IOException, InterruptedException;
 
@@ -70,7 +70,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put200SucceededAsync();
@@ -78,10 +77,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put200SucceededWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
@@ -89,7 +87,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200Succeeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -116,14 +114,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200SucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put200SucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200Succeeded() throws CloudException, IOException;
 
@@ -138,7 +136,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut200SucceededAsync();
@@ -146,17 +143,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut200SucceededWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200Succeeded(Product product) throws CloudException, IOException;
 
@@ -183,7 +179,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200SucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut200SucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -191,7 +187,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200SucceededNoState() throws CloudException, IOException, InterruptedException;
 
@@ -206,7 +202,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put200SucceededNoStateAsync();
@@ -214,10 +209,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200SucceededNoStateAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put200SucceededNoStateWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
@@ -225,7 +219,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200SucceededNoState(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -252,14 +246,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200SucceededNoStateAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put200SucceededNoStateWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200SucceededNoState() throws CloudException, IOException;
 
@@ -274,7 +268,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut200SucceededNoStateAsync();
@@ -282,17 +275,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200SucceededNoStateAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut200SucceededNoStateWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200SucceededNoState(Product product) throws CloudException, IOException;
 
@@ -319,7 +311,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200SucceededNoStateAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut200SucceededNoStateWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -327,7 +319,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put202Retry200() throws CloudException, IOException, InterruptedException;
 
@@ -342,7 +334,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put202Retry200Async();
@@ -350,10 +341,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put202Retry200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
@@ -361,7 +351,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put202Retry200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -388,14 +378,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put202Retry200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put202Retry200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut202Retry200() throws CloudException, IOException;
 
@@ -410,7 +400,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut202Retry200Async();
@@ -418,17 +407,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut202Retry200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut202Retry200(Product product) throws CloudException, IOException;
 
@@ -455,7 +443,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut202Retry200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut202Retry200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -463,7 +451,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
 
@@ -478,7 +466,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put201CreatingSucceeded200Async();
@@ -486,10 +473,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -497,7 +483,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -524,14 +510,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut201CreatingSucceeded200() throws CloudException, IOException;
 
@@ -546,7 +532,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut201CreatingSucceeded200Async();
@@ -554,17 +539,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
 
@@ -591,7 +575,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -599,7 +583,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200UpdatingSucceeded204() throws CloudException, IOException, InterruptedException;
 
@@ -614,7 +598,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put200UpdatingSucceeded204Async();
@@ -622,10 +605,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200UpdatingSucceeded204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put200UpdatingSucceeded204WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -633,7 +615,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200UpdatingSucceeded204(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -660,14 +642,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200UpdatingSucceeded204AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put200UpdatingSucceeded204WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200UpdatingSucceeded204() throws CloudException, IOException;
 
@@ -682,7 +664,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut200UpdatingSucceeded204Async();
@@ -690,17 +671,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200UpdatingSucceeded204(Product product) throws CloudException, IOException;
 
@@ -727,7 +707,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -735,7 +715,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put201CreatingFailed200() throws CloudException, IOException, InterruptedException;
 
@@ -750,7 +730,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put201CreatingFailed200Async();
@@ -758,10 +737,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingFailed200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put201CreatingFailed200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
@@ -769,7 +747,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put201CreatingFailed200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -796,14 +774,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingFailed200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put201CreatingFailed200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut201CreatingFailed200() throws CloudException, IOException;
 
@@ -818,7 +796,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut201CreatingFailed200Async();
@@ -826,17 +803,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingFailed200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut201CreatingFailed200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut201CreatingFailed200(Product product) throws CloudException, IOException;
 
@@ -863,7 +839,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingFailed200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut201CreatingFailed200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -871,7 +847,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200Acceptedcanceled200() throws CloudException, IOException, InterruptedException;
 
@@ -886,7 +862,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put200Acceptedcanceled200Async();
@@ -894,10 +869,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200Acceptedcanceled200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put200Acceptedcanceled200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
@@ -905,7 +879,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put200Acceptedcanceled200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -932,14 +906,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200Acceptedcanceled200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put200Acceptedcanceled200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200Acceptedcanceled200() throws CloudException, IOException;
 
@@ -954,7 +928,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut200Acceptedcanceled200Async();
@@ -962,17 +935,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200WithServiceResponseAsync();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut200Acceptedcanceled200(Product product) throws CloudException, IOException;
 
@@ -999,7 +971,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200WithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -1007,7 +979,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
 
@@ -1022,7 +994,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putNoHeaderInRetryAsync();
@@ -1030,10 +1001,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
@@ -1041,7 +1011,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1068,14 +1038,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutNoHeaderInRetry() throws CloudException, IOException;
 
@@ -1090,7 +1060,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutNoHeaderInRetryAsync();
@@ -1098,17 +1067,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutNoHeaderInRetry(Product product) throws CloudException, IOException;
 
@@ -1135,7 +1103,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1143,7 +1111,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -1158,7 +1126,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRetrySucceededAsync();
@@ -1166,10 +1133,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1177,7 +1143,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1204,14 +1170,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRetrySucceeded() throws CloudException, IOException;
 
@@ -1226,7 +1192,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRetrySucceededAsync();
@@ -1234,17 +1199,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException;
 
@@ -1271,7 +1235,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1279,7 +1243,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -1294,7 +1258,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncNoRetrySucceededAsync();
@@ -1302,10 +1265,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1313,7 +1275,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1340,14 +1302,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncNoRetrySucceeded() throws CloudException, IOException;
 
@@ -1362,7 +1324,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncNoRetrySucceededAsync();
@@ -1370,17 +1331,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncNoRetrySucceeded(Product product) throws CloudException, IOException;
 
@@ -1407,7 +1367,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1415,7 +1375,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
 
@@ -1430,7 +1390,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRetryFailedAsync();
@@ -1438,10 +1397,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1449,7 +1407,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1476,14 +1434,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRetryFailed() throws CloudException, IOException;
 
@@ -1498,7 +1456,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRetryFailedAsync();
@@ -1506,17 +1463,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRetryFailed(Product product) throws CloudException, IOException;
 
@@ -1543,7 +1499,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1551,7 +1507,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncNoRetrycanceled() throws CloudException, IOException, InterruptedException;
 
@@ -1566,7 +1522,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncNoRetrycanceledAsync();
@@ -1574,10 +1529,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1585,7 +1539,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncNoRetrycanceled(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1612,14 +1566,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncNoRetrycanceled() throws CloudException, IOException;
 
@@ -1634,7 +1588,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncNoRetrycanceledAsync();
@@ -1642,17 +1595,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncNoRetrycanceled(Product product) throws CloudException, IOException;
 
@@ -1679,7 +1631,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1687,7 +1639,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
 
@@ -1702,7 +1654,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncNoHeaderInRetryAsync();
@@ -1710,10 +1661,9 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
@@ -1721,7 +1671,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -1748,14 +1698,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncNoHeaderInRetry() throws CloudException, IOException;
 
@@ -1770,7 +1720,6 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncNoHeaderInRetryAsync();
@@ -1778,17 +1727,16 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryWithServiceResponseAsync();
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncNoHeaderInRetry(Product product) throws CloudException, IOException;
 
@@ -1815,7 +1763,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(Product product);
 
     /**
      * Long running put request with non resource.
@@ -1823,7 +1771,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku putNonResource() throws CloudException, IOException, InterruptedException;
 
@@ -1838,7 +1786,6 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
-     * @param sku sku to put
      * @return the observable to the Sku object
      */
     Observable<Sku> putNonResourceAsync();
@@ -1846,10 +1793,9 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
-     * @param sku sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> putNonResourceAsyncWithServiceResponse();
+    Observable<ServiceResponse<Sku>> putNonResourceWithServiceResponseAsync();
     /**
      * Long running put request with non resource.
      *
@@ -1857,7 +1803,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku putNonResource(Sku sku) throws CloudException, IOException, InterruptedException;
 
@@ -1884,14 +1830,14 @@ public interface LROs {
      * @param sku sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> putNonResourceAsyncWithServiceResponse(Sku sku);
+    Observable<ServiceResponse<Sku>> putNonResourceWithServiceResponseAsync(Sku sku);
 
     /**
      * Long running put request with non resource.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku beginPutNonResource() throws CloudException, IOException;
 
@@ -1906,7 +1852,6 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
-     * @param sku sku to put
      * @return the observable to the Sku object
      */
     Observable<Sku> beginPutNonResourceAsync();
@@ -1914,17 +1859,16 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
-     * @param sku sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> beginPutNonResourceAsyncWithServiceResponse();
+    Observable<ServiceResponse<Sku>> beginPutNonResourceWithServiceResponseAsync();
     /**
      * Long running put request with non resource.
      *
      * @param sku sku to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku beginPutNonResource(Sku sku) throws CloudException, IOException;
 
@@ -1951,7 +1895,7 @@ public interface LROs {
      * @param sku sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> beginPutNonResourceAsyncWithServiceResponse(Sku sku);
+    Observable<ServiceResponse<Sku>> beginPutNonResourceWithServiceResponseAsync(Sku sku);
 
     /**
      * Long running put request with non resource.
@@ -1959,7 +1903,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku putAsyncNonResource() throws CloudException, IOException, InterruptedException;
 
@@ -1974,7 +1918,6 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
-     * @param sku Sku to put
      * @return the observable to the Sku object
      */
     Observable<Sku> putAsyncNonResourceAsync();
@@ -1982,10 +1925,9 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
-     * @param sku Sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> putAsyncNonResourceAsyncWithServiceResponse();
+    Observable<ServiceResponse<Sku>> putAsyncNonResourceWithServiceResponseAsync();
     /**
      * Long running put request with non resource.
      *
@@ -1993,7 +1935,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku putAsyncNonResource(Sku sku) throws CloudException, IOException, InterruptedException;
 
@@ -2020,14 +1962,14 @@ public interface LROs {
      * @param sku Sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> putAsyncNonResourceAsyncWithServiceResponse(Sku sku);
+    Observable<ServiceResponse<Sku>> putAsyncNonResourceWithServiceResponseAsync(Sku sku);
 
     /**
      * Long running put request with non resource.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku beginPutAsyncNonResource() throws CloudException, IOException;
 
@@ -2042,7 +1984,6 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
-     * @param sku Sku to put
      * @return the observable to the Sku object
      */
     Observable<Sku> beginPutAsyncNonResourceAsync();
@@ -2050,17 +1991,16 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
-     * @param sku Sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceAsyncWithServiceResponse();
+    Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceWithServiceResponseAsync();
     /**
      * Long running put request with non resource.
      *
      * @param sku Sku to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku beginPutAsyncNonResource(Sku sku) throws CloudException, IOException;
 
@@ -2087,7 +2027,7 @@ public interface LROs {
      * @param sku Sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceAsyncWithServiceResponse(Sku sku);
+    Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceWithServiceResponseAsync(Sku sku);
 
     /**
      * Long running put request with sub resource.
@@ -2095,7 +2035,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
     SubProduct putSubResource() throws CloudException, IOException, InterruptedException;
 
@@ -2110,7 +2050,6 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
-     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
     Observable<SubProduct> putSubResourceAsync();
@@ -2118,10 +2057,9 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
-     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> putSubResourceAsyncWithServiceResponse();
+    Observable<ServiceResponse<SubProduct>> putSubResourceWithServiceResponseAsync();
     /**
      * Long running put request with sub resource.
      *
@@ -2129,7 +2067,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
     SubProduct putSubResource(SubProduct product) throws CloudException, IOException, InterruptedException;
 
@@ -2156,14 +2094,14 @@ public interface LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> putSubResourceAsyncWithServiceResponse(SubProduct product);
+    Observable<ServiceResponse<SubProduct>> putSubResourceWithServiceResponseAsync(SubProduct product);
 
     /**
      * Long running put request with sub resource.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
     SubProduct beginPutSubResource() throws CloudException, IOException;
 
@@ -2178,7 +2116,6 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
-     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
     Observable<SubProduct> beginPutSubResourceAsync();
@@ -2186,17 +2123,16 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
-     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> beginPutSubResourceAsyncWithServiceResponse();
+    Observable<ServiceResponse<SubProduct>> beginPutSubResourceWithServiceResponseAsync();
     /**
      * Long running put request with sub resource.
      *
      * @param product Sub Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
     SubProduct beginPutSubResource(SubProduct product) throws CloudException, IOException;
 
@@ -2223,7 +2159,7 @@ public interface LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> beginPutSubResourceAsyncWithServiceResponse(SubProduct product);
+    Observable<ServiceResponse<SubProduct>> beginPutSubResourceWithServiceResponseAsync(SubProduct product);
 
     /**
      * Long running put request with sub resource.
@@ -2231,7 +2167,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
     SubProduct putAsyncSubResource() throws CloudException, IOException, InterruptedException;
 
@@ -2246,7 +2182,6 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
-     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
     Observable<SubProduct> putAsyncSubResourceAsync();
@@ -2254,10 +2189,9 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
-     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> putAsyncSubResourceAsyncWithServiceResponse();
+    Observable<ServiceResponse<SubProduct>> putAsyncSubResourceWithServiceResponseAsync();
     /**
      * Long running put request with sub resource.
      *
@@ -2265,7 +2199,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
     SubProduct putAsyncSubResource(SubProduct product) throws CloudException, IOException, InterruptedException;
 
@@ -2292,14 +2226,14 @@ public interface LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> putAsyncSubResourceAsyncWithServiceResponse(SubProduct product);
+    Observable<ServiceResponse<SubProduct>> putAsyncSubResourceWithServiceResponseAsync(SubProduct product);
 
     /**
      * Long running put request with sub resource.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
     SubProduct beginPutAsyncSubResource() throws CloudException, IOException;
 
@@ -2314,7 +2248,6 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
-     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
     Observable<SubProduct> beginPutAsyncSubResourceAsync();
@@ -2322,17 +2255,16 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
-     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceAsyncWithServiceResponse();
+    Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceWithServiceResponseAsync();
     /**
      * Long running put request with sub resource.
      *
      * @param product Sub Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
     SubProduct beginPutAsyncSubResource(SubProduct product) throws CloudException, IOException;
 
@@ -2359,7 +2291,7 @@ public interface LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceAsyncWithServiceResponse(SubProduct product);
+    Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceWithServiceResponseAsync(SubProduct product);
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -2367,7 +2299,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException;
 
@@ -2391,14 +2323,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException;
 
@@ -2422,7 +2354,7 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -2430,7 +2362,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product deleteProvisioning202DeletingFailed200() throws CloudException, IOException, InterruptedException;
 
@@ -2454,14 +2386,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> deleteProvisioning202DeletingFailed200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> deleteProvisioning202DeletingFailed200WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginDeleteProvisioning202DeletingFailed200() throws CloudException, IOException;
 
@@ -2485,7 +2417,7 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> beginDeleteProvisioning202DeletingFailed200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -2493,7 +2425,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product deleteProvisioning202Deletingcanceled200() throws CloudException, IOException, InterruptedException;
 
@@ -2517,14 +2449,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> deleteProvisioning202Deletingcanceled200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> deleteProvisioning202Deletingcanceled200WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginDeleteProvisioning202Deletingcanceled200() throws CloudException, IOException;
 
@@ -2548,7 +2480,7 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> beginDeleteProvisioning202Deletingcanceled200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync();
 
     /**
      * Long running delete succeeds and returns right away.
@@ -2556,7 +2488,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete204Succeeded() throws CloudException, IOException, InterruptedException;
 
@@ -2580,14 +2511,13 @@ public interface LROs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete204SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> delete204SucceededWithServiceResponseAsync();
 
     /**
      * Long running delete succeeds and returns right away.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void beginDelete204Succeeded() throws CloudException, IOException;
 
@@ -2611,7 +2541,7 @@ public interface LROs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> beginDelete204SucceededAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> beginDelete204SucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -2619,7 +2549,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product delete202Retry200() throws CloudException, IOException, InterruptedException;
 
@@ -2643,14 +2573,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> delete202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> delete202Retry200WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginDelete202Retry200() throws CloudException, IOException;
 
@@ -2674,7 +2604,7 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> beginDelete202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> beginDelete202Retry200WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -2682,7 +2612,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product delete202NoRetry204() throws CloudException, IOException, InterruptedException;
 
@@ -2706,14 +2636,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> delete202NoRetry204AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> delete202NoRetry204WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginDelete202NoRetry204() throws CloudException, IOException;
 
@@ -2737,7 +2667,7 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> beginDelete202NoRetry204AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> beginDelete202NoRetry204WithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
@@ -2745,7 +2675,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
 
@@ -2769,14 +2698,13 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> deleteNoHeaderInRetryAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> deleteNoHeaderInRetryWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteNoHeaderInRetry() throws CloudException, IOException;
 
@@ -2800,7 +2728,7 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> beginDeleteNoHeaderInRetryAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> beginDeleteNoHeaderInRetryWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -2808,7 +2736,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
 
@@ -2832,14 +2759,13 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> deleteAsyncNoHeaderInRetryAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> deleteAsyncNoHeaderInRetryWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncNoHeaderInRetry() throws CloudException, IOException;
 
@@ -2863,7 +2789,7 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> beginDeleteAsyncNoHeaderInRetryAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2871,7 +2797,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -2895,14 +2820,13 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> deleteAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> deleteAsyncRetrySucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncRetrySucceeded() throws CloudException, IOException;
 
@@ -2926,7 +2850,7 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> beginDeleteAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> beginDeleteAsyncRetrySucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2934,7 +2858,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -2958,14 +2881,13 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> deleteAsyncNoRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> deleteAsyncNoRetrySucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncNoRetrySucceeded() throws CloudException, IOException;
 
@@ -2989,7 +2911,7 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> beginDeleteAsyncNoRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2997,7 +2919,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
 
@@ -3021,14 +2942,13 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> deleteAsyncRetryFailedAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> deleteAsyncRetryFailedWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncRetryFailed() throws CloudException, IOException;
 
@@ -3052,7 +2972,7 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> beginDeleteAsyncRetryFailedAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> beginDeleteAsyncRetryFailedWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -3060,7 +2980,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void deleteAsyncRetrycanceled() throws CloudException, IOException, InterruptedException;
 
@@ -3084,14 +3003,13 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> deleteAsyncRetrycanceledAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> deleteAsyncRetrycanceledWithServiceResponseAsync();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginDeleteAsyncRetrycanceled() throws CloudException, IOException;
 
@@ -3115,7 +3033,7 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> beginDeleteAsyncRetrycanceledAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> beginDeleteAsyncRetrycanceledWithServiceResponseAsync();
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
@@ -3123,7 +3041,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku post200WithPayload() throws CloudException, IOException, InterruptedException;
 
@@ -3147,14 +3065,14 @@ public interface LROs {
      *
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> post200WithPayloadAsyncWithServiceResponse();
+    Observable<ServiceResponse<Sku>> post200WithPayloadWithServiceResponseAsync();
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
     Sku beginPost200WithPayload() throws CloudException, IOException;
 
@@ -3178,7 +3096,7 @@ public interface LROs {
      *
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> beginPost200WithPayloadAsyncWithServiceResponse();
+    Observable<ServiceResponse<Sku>> beginPost200WithPayloadWithServiceResponseAsync();
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -3186,7 +3104,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202Retry200() throws CloudException, IOException, InterruptedException;
 
@@ -3201,7 +3118,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> post202Retry200Async();
@@ -3209,10 +3125,9 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -3220,7 +3135,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -3247,14 +3161,13 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202Retry200() throws CloudException, IOException;
 
@@ -3269,7 +3182,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPost202Retry200Async();
@@ -3277,17 +3189,15 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202Retry200(Product product) throws CloudException, IOException;
 
@@ -3314,7 +3224,7 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -3322,7 +3232,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product post202NoRetry204() throws CloudException, IOException, InterruptedException;
 
@@ -3337,7 +3247,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> post202NoRetry204Async();
@@ -3345,10 +3254,9 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
@@ -3356,7 +3264,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product post202NoRetry204(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -3383,14 +3291,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPost202NoRetry204() throws CloudException, IOException;
 
@@ -3405,7 +3313,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPost202NoRetry204Async();
@@ -3413,17 +3320,16 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204WithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPost202NoRetry204(Product product) throws CloudException, IOException;
 
@@ -3450,7 +3356,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204WithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -3458,7 +3364,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -3473,7 +3379,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> postAsyncRetrySucceededAsync();
@@ -3481,10 +3386,9 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -3492,7 +3396,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -3519,14 +3423,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPostAsyncRetrySucceeded() throws CloudException, IOException;
 
@@ -3541,7 +3445,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPostAsyncRetrySucceededAsync();
@@ -3549,17 +3452,16 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException;
 
@@ -3586,7 +3488,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -3594,7 +3496,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product postAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -3609,7 +3511,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> postAsyncNoRetrySucceededAsync();
@@ -3617,10 +3518,9 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -3628,7 +3528,7 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product postAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -3655,14 +3555,14 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPostAsyncNoRetrySucceeded() throws CloudException, IOException;
 
@@ -3677,7 +3577,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPostAsyncNoRetrySucceededAsync();
@@ -3685,17 +3584,16 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPostAsyncNoRetrySucceeded(Product product) throws CloudException, IOException;
 
@@ -3722,7 +3620,7 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -3730,7 +3628,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
 
@@ -3745,7 +3642,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postAsyncRetryFailedAsync();
@@ -3753,10 +3649,9 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -3764,7 +3659,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -3791,14 +3685,13 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRetryFailed() throws CloudException, IOException;
 
@@ -3813,7 +3706,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostAsyncRetryFailedAsync();
@@ -3821,17 +3713,15 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRetryFailed(Product product) throws CloudException, IOException;
 
@@ -3858,7 +3748,7 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -3866,7 +3756,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRetrycanceled() throws CloudException, IOException, InterruptedException;
 
@@ -3881,7 +3770,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postAsyncRetrycanceledAsync();
@@ -3889,10 +3777,9 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -3900,7 +3787,6 @@ public interface LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRetrycanceled(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -3927,14 +3813,13 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledWithServiceResponseAsync(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRetrycanceled() throws CloudException, IOException;
 
@@ -3949,7 +3834,6 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostAsyncRetrycanceledAsync();
@@ -3957,17 +3841,15 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledWithServiceResponseAsync();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRetrycanceled(Product product) throws CloudException, IOException;
 
@@ -3994,6 +3876,6 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledWithServiceResponseAsync(Product product);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROs.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROs.java
@@ -57,7 +57,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200Succeeded() throws CloudException, IOException, InterruptedException;
+    Product put200Succeeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -66,6 +66,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put200SucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put200SucceededAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200SucceededAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
@@ -75,7 +91,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200Succeeded(Product product) throws CloudException, IOException, InterruptedException;
+    Product put200Succeeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -92,7 +108,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200SucceededAsync(Product product);
+    Observable<Product> put200SucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200SucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -101,7 +125,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200Succeeded() throws CloudException, IOException;
+    Product beginPut200Succeeded() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -110,6 +134,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut200SucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut200SucceededAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200SucceededAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
@@ -118,7 +158,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200Succeeded(Product product) throws CloudException, IOException;
+    Product beginPut200Succeeded(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -135,7 +175,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200SucceededAsync(Product product);
+    Observable<Product> beginPut200SucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200SucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -145,7 +193,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200SucceededNoState() throws CloudException, IOException, InterruptedException;
+    Product put200SucceededNoState() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -154,6 +202,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put200SucceededNoStateAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put200SucceededNoStateAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200SucceededNoStateAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
@@ -163,7 +227,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200SucceededNoState(Product product) throws CloudException, IOException, InterruptedException;
+    Product put200SucceededNoState(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -180,7 +244,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200SucceededNoStateAsync(Product product);
+    Observable<Product> put200SucceededNoStateAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200SucceededNoStateAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -189,7 +261,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200SucceededNoState() throws CloudException, IOException;
+    Product beginPut200SucceededNoState() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -198,6 +270,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut200SucceededNoStateAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut200SucceededNoStateAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200SucceededNoStateAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
@@ -206,7 +294,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200SucceededNoState(Product product) throws CloudException, IOException;
+    Product beginPut200SucceededNoState(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -223,7 +311,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200SucceededNoStateAsync(Product product);
+    Observable<Product> beginPut200SucceededNoStateAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200SucceededNoStateAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -233,7 +329,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put202Retry200() throws CloudException, IOException, InterruptedException;
+    Product put202Retry200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -242,6 +338,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put202Retry200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put202Retry200Async();
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put202Retry200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
@@ -251,7 +363,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put202Retry200(Product product) throws CloudException, IOException, InterruptedException;
+    Product put202Retry200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -268,7 +380,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put202Retry200Async(Product product);
+    Observable<Product> put202Retry200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put202Retry200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -277,7 +397,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut202Retry200() throws CloudException, IOException;
+    Product beginPut202Retry200() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -286,6 +406,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut202Retry200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut202Retry200Async();
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut202Retry200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
@@ -294,7 +430,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut202Retry200(Product product) throws CloudException, IOException;
+    Product beginPut202Retry200(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -311,7 +447,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut202Retry200Async(Product product);
+    Observable<Product> beginPut202Retry200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut202Retry200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -321,7 +465,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
+    Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -330,6 +474,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put201CreatingSucceeded200Async();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -339,7 +499,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
+    Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -356,7 +516,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async(Product product);
+    Observable<Product> put201CreatingSucceeded200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -365,7 +533,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut201CreatingSucceeded200() throws CloudException, IOException;
+    Product beginPut201CreatingSucceeded200() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -374,6 +542,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut201CreatingSucceeded200Async();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -382,7 +566,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
+    Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -399,7 +583,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async(Product product);
+    Observable<Product> beginPut201CreatingSucceeded200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -409,7 +601,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200UpdatingSucceeded204() throws CloudException, IOException, InterruptedException;
+    Product put200UpdatingSucceeded204() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -418,6 +610,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put200UpdatingSucceeded204Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put200UpdatingSucceeded204Async();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200UpdatingSucceeded204AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -427,7 +635,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200UpdatingSucceeded204(Product product) throws CloudException, IOException, InterruptedException;
+    Product put200UpdatingSucceeded204(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -444,7 +652,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200UpdatingSucceeded204Async(Product product);
+    Observable<Product> put200UpdatingSucceeded204Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200UpdatingSucceeded204AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -453,7 +669,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200UpdatingSucceeded204() throws CloudException, IOException;
+    Product beginPut200UpdatingSucceeded204() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -462,6 +678,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut200UpdatingSucceeded204Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut200UpdatingSucceeded204Async();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -470,7 +702,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200UpdatingSucceeded204(Product product) throws CloudException, IOException;
+    Product beginPut200UpdatingSucceeded204(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -487,7 +719,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204Async(Product product);
+    Observable<Product> beginPut200UpdatingSucceeded204Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -497,7 +737,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put201CreatingFailed200() throws CloudException, IOException, InterruptedException;
+    Product put201CreatingFailed200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -506,6 +746,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put201CreatingFailed200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put201CreatingFailed200Async();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put201CreatingFailed200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
@@ -515,7 +771,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put201CreatingFailed200(Product product) throws CloudException, IOException, InterruptedException;
+    Product put201CreatingFailed200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -532,7 +788,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingFailed200Async(Product product);
+    Observable<Product> put201CreatingFailed200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put201CreatingFailed200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -541,7 +805,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut201CreatingFailed200() throws CloudException, IOException;
+    Product beginPut201CreatingFailed200() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -550,6 +814,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut201CreatingFailed200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut201CreatingFailed200Async();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut201CreatingFailed200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
@@ -558,7 +838,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut201CreatingFailed200(Product product) throws CloudException, IOException;
+    Product beginPut201CreatingFailed200(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -575,7 +855,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingFailed200Async(Product product);
+    Observable<Product> beginPut201CreatingFailed200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut201CreatingFailed200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -585,7 +873,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200Acceptedcanceled200() throws CloudException, IOException, InterruptedException;
+    Product put200Acceptedcanceled200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -594,6 +882,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put200Acceptedcanceled200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put200Acceptedcanceled200Async();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200Acceptedcanceled200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
@@ -603,7 +907,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put200Acceptedcanceled200(Product product) throws CloudException, IOException, InterruptedException;
+    Product put200Acceptedcanceled200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -620,7 +924,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put200Acceptedcanceled200Async(Product product);
+    Observable<Product> put200Acceptedcanceled200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put200Acceptedcanceled200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -629,7 +941,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200Acceptedcanceled200() throws CloudException, IOException;
+    Product beginPut200Acceptedcanceled200() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -638,6 +950,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut200Acceptedcanceled200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut200Acceptedcanceled200Async();
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200AsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
@@ -646,7 +974,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut200Acceptedcanceled200(Product product) throws CloudException, IOException;
+    Product beginPut200Acceptedcanceled200(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -663,7 +991,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200Async(Product product);
+    Observable<Product> beginPut200Acceptedcanceled200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -673,7 +1009,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> putNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
+    Product putNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -682,6 +1018,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putNoHeaderInRetryAsync();
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
@@ -691,7 +1043,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> putNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException;
+    Product putNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -708,7 +1060,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryAsync(Product product);
+    Observable<Product> putNoHeaderInRetryAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -717,7 +1077,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> beginPutNoHeaderInRetry() throws CloudException, IOException;
+    Product beginPutNoHeaderInRetry() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -726,6 +1086,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutNoHeaderInRetryAsync();
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
@@ -734,7 +1110,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> beginPutNoHeaderInRetry(Product product) throws CloudException, IOException;
+    Product beginPutNoHeaderInRetry(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -751,7 +1127,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryAsync(Product product);
+    Observable<Product> beginPutNoHeaderInRetryAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -761,7 +1145,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -770,6 +1154,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRetrySucceededAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -779,7 +1179,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -796,7 +1196,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsync(Product product);
+    Observable<Product> putAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -805,7 +1213,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> beginPutAsyncRetrySucceeded() throws CloudException, IOException;
+    Product beginPutAsyncRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -814,6 +1222,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRetrySucceededAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -822,7 +1246,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -839,7 +1263,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsync(Product product);
+    Observable<Product> beginPutAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -849,7 +1281,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> putAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    Product putAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -858,6 +1290,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncNoRetrySucceededAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -867,7 +1315,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> putAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -884,7 +1332,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededAsync(Product product);
+    Observable<Product> putAsyncNoRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -893,7 +1349,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> beginPutAsyncNoRetrySucceeded() throws CloudException, IOException;
+    Product beginPutAsyncNoRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -902,6 +1358,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncNoRetrySucceededAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -910,7 +1382,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> beginPutAsyncNoRetrySucceeded(Product product) throws CloudException, IOException;
+    Product beginPutAsyncNoRetrySucceeded(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -927,7 +1399,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededAsync(Product product);
+    Observable<Product> beginPutAsyncNoRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -937,7 +1417,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> putAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -946,6 +1426,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRetryFailedAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRetryFailedAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -955,7 +1451,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> putAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -972,7 +1468,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedAsync(Product product);
+    Observable<Product> putAsyncRetryFailedAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -981,7 +1485,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> beginPutAsyncRetryFailed() throws CloudException, IOException;
+    Product beginPutAsyncRetryFailed() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -990,6 +1494,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRetryFailedAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRetryFailedAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -998,7 +1518,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> beginPutAsyncRetryFailed(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRetryFailed(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1015,7 +1535,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedAsync(Product product);
+    Observable<Product> beginPutAsyncRetryFailedAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1025,7 +1553,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> putAsyncNoRetrycanceled() throws CloudException, IOException, InterruptedException;
+    Product putAsyncNoRetrycanceled() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1034,6 +1562,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncNoRetrycanceledAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncNoRetrycanceledAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1043,7 +1587,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> putAsyncNoRetrycanceled(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncNoRetrycanceled(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1060,7 +1604,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledAsync(Product product);
+    Observable<Product> putAsyncNoRetrycanceledAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1069,7 +1621,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> beginPutAsyncNoRetrycanceled() throws CloudException, IOException;
+    Product beginPutAsyncNoRetrycanceled() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1078,6 +1630,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncNoRetrycanceledAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncNoRetrycanceledAsync();
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -1086,7 +1654,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> beginPutAsyncNoRetrycanceled(Product product) throws CloudException, IOException;
+    Product beginPutAsyncNoRetrycanceled(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1103,7 +1671,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledAsync(Product product);
+    Observable<Product> beginPutAsyncNoRetrycanceledAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1113,7 +1689,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> putAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
+    Product putAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1122,6 +1698,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncNoHeaderInRetryAsync();
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
@@ -1131,7 +1723,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> putAsyncNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1148,7 +1740,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryAsync(Product product);
+    Observable<Product> putAsyncNoHeaderInRetryAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1157,7 +1757,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> beginPutAsyncNoHeaderInRetry() throws CloudException, IOException;
+    Product beginPutAsyncNoHeaderInRetry() throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1166,6 +1766,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncNoHeaderInRetryAsync();
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryAsyncWithServiceResponse();
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
@@ -1174,7 +1790,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> beginPutAsyncNoHeaderInRetry(Product product) throws CloudException, IOException;
+    Product beginPutAsyncNoHeaderInRetry(Product product) throws CloudException, IOException;
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1191,7 +1807,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryAsync(Product product);
+    Observable<Product> beginPutAsyncNoHeaderInRetryAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryAsyncWithServiceResponse(Product product);
 
     /**
      * Long running put request with non resource.
@@ -1201,7 +1825,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> putNonResource() throws CloudException, IOException, InterruptedException;
+    Sku putNonResource() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request with non resource.
@@ -1210,6 +1834,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Sku> putNonResourceAsync(final ServiceCallback<Sku> serviceCallback);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<Sku> putNonResourceAsync();
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> putNonResourceAsyncWithServiceResponse();
     /**
      * Long running put request with non resource.
      *
@@ -1219,7 +1859,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> putNonResource(Sku sku) throws CloudException, IOException, InterruptedException;
+    Sku putNonResource(Sku sku) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request with non resource.
@@ -1236,7 +1876,15 @@ public interface LROs {
      * @param sku sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> putNonResourceAsync(Sku sku);
+    Observable<Sku> putNonResourceAsync(Sku sku);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> putNonResourceAsyncWithServiceResponse(Sku sku);
 
     /**
      * Long running put request with non resource.
@@ -1245,7 +1893,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> beginPutNonResource() throws CloudException, IOException;
+    Sku beginPutNonResource() throws CloudException, IOException;
 
     /**
      * Long running put request with non resource.
@@ -1254,6 +1902,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Sku> beginPutNonResourceAsync(final ServiceCallback<Sku> serviceCallback);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<Sku> beginPutNonResourceAsync();
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> beginPutNonResourceAsyncWithServiceResponse();
     /**
      * Long running put request with non resource.
      *
@@ -1262,7 +1926,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> beginPutNonResource(Sku sku) throws CloudException, IOException;
+    Sku beginPutNonResource(Sku sku) throws CloudException, IOException;
 
     /**
      * Long running put request with non resource.
@@ -1279,7 +1943,15 @@ public interface LROs {
      * @param sku sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> beginPutNonResourceAsync(Sku sku);
+    Observable<Sku> beginPutNonResourceAsync(Sku sku);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> beginPutNonResourceAsyncWithServiceResponse(Sku sku);
 
     /**
      * Long running put request with non resource.
@@ -1289,7 +1961,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> putAsyncNonResource() throws CloudException, IOException, InterruptedException;
+    Sku putAsyncNonResource() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request with non resource.
@@ -1298,6 +1970,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Sku> putAsyncNonResourceAsync(final ServiceCallback<Sku> serviceCallback);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<Sku> putAsyncNonResourceAsync();
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> putAsyncNonResourceAsyncWithServiceResponse();
     /**
      * Long running put request with non resource.
      *
@@ -1307,7 +1995,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> putAsyncNonResource(Sku sku) throws CloudException, IOException, InterruptedException;
+    Sku putAsyncNonResource(Sku sku) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request with non resource.
@@ -1324,7 +2012,15 @@ public interface LROs {
      * @param sku Sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> putAsyncNonResourceAsync(Sku sku);
+    Observable<Sku> putAsyncNonResourceAsync(Sku sku);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> putAsyncNonResourceAsyncWithServiceResponse(Sku sku);
 
     /**
      * Long running put request with non resource.
@@ -1333,7 +2029,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> beginPutAsyncNonResource() throws CloudException, IOException;
+    Sku beginPutAsyncNonResource() throws CloudException, IOException;
 
     /**
      * Long running put request with non resource.
@@ -1342,6 +2038,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Sku> beginPutAsyncNonResourceAsync(final ServiceCallback<Sku> serviceCallback);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<Sku> beginPutAsyncNonResourceAsync();
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceAsyncWithServiceResponse();
     /**
      * Long running put request with non resource.
      *
@@ -1350,7 +2062,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> beginPutAsyncNonResource(Sku sku) throws CloudException, IOException;
+    Sku beginPutAsyncNonResource(Sku sku) throws CloudException, IOException;
 
     /**
      * Long running put request with non resource.
@@ -1367,7 +2079,15 @@ public interface LROs {
      * @param sku Sku to put
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceAsync(Sku sku);
+    Observable<Sku> beginPutAsyncNonResourceAsync(Sku sku);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceAsyncWithServiceResponse(Sku sku);
 
     /**
      * Long running put request with sub resource.
@@ -1377,7 +2097,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SubProduct> putSubResource() throws CloudException, IOException, InterruptedException;
+    SubProduct putSubResource() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request with sub resource.
@@ -1386,6 +2106,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<SubProduct> putSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<SubProduct> putSubResourceAsync();
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<ServiceResponse<SubProduct>> putSubResourceAsyncWithServiceResponse();
     /**
      * Long running put request with sub resource.
      *
@@ -1395,7 +2131,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SubProduct> putSubResource(SubProduct product) throws CloudException, IOException, InterruptedException;
+    SubProduct putSubResource(SubProduct product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request with sub resource.
@@ -1412,7 +2148,15 @@ public interface LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> putSubResourceAsync(SubProduct product);
+    Observable<SubProduct> putSubResourceAsync(SubProduct product);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<ServiceResponse<SubProduct>> putSubResourceAsyncWithServiceResponse(SubProduct product);
 
     /**
      * Long running put request with sub resource.
@@ -1421,7 +2165,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SubProduct> beginPutSubResource() throws CloudException, IOException;
+    SubProduct beginPutSubResource() throws CloudException, IOException;
 
     /**
      * Long running put request with sub resource.
@@ -1430,6 +2174,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<SubProduct> beginPutSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<SubProduct> beginPutSubResourceAsync();
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<ServiceResponse<SubProduct>> beginPutSubResourceAsyncWithServiceResponse();
     /**
      * Long running put request with sub resource.
      *
@@ -1438,7 +2198,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SubProduct> beginPutSubResource(SubProduct product) throws CloudException, IOException;
+    SubProduct beginPutSubResource(SubProduct product) throws CloudException, IOException;
 
     /**
      * Long running put request with sub resource.
@@ -1455,7 +2215,15 @@ public interface LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> beginPutSubResourceAsync(SubProduct product);
+    Observable<SubProduct> beginPutSubResourceAsync(SubProduct product);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<ServiceResponse<SubProduct>> beginPutSubResourceAsyncWithServiceResponse(SubProduct product);
 
     /**
      * Long running put request with sub resource.
@@ -1465,7 +2233,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SubProduct> putAsyncSubResource() throws CloudException, IOException, InterruptedException;
+    SubProduct putAsyncSubResource() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request with sub resource.
@@ -1474,6 +2242,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<SubProduct> putAsyncSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<SubProduct> putAsyncSubResourceAsync();
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<ServiceResponse<SubProduct>> putAsyncSubResourceAsyncWithServiceResponse();
     /**
      * Long running put request with sub resource.
      *
@@ -1483,7 +2267,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SubProduct> putAsyncSubResource(SubProduct product) throws CloudException, IOException, InterruptedException;
+    SubProduct putAsyncSubResource(SubProduct product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running put request with sub resource.
@@ -1500,7 +2284,15 @@ public interface LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> putAsyncSubResourceAsync(SubProduct product);
+    Observable<SubProduct> putAsyncSubResourceAsync(SubProduct product);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<ServiceResponse<SubProduct>> putAsyncSubResourceAsyncWithServiceResponse(SubProduct product);
 
     /**
      * Long running put request with sub resource.
@@ -1509,7 +2301,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SubProduct> beginPutAsyncSubResource() throws CloudException, IOException;
+    SubProduct beginPutAsyncSubResource() throws CloudException, IOException;
 
     /**
      * Long running put request with sub resource.
@@ -1518,6 +2310,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<SubProduct> beginPutAsyncSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<SubProduct> beginPutAsyncSubResourceAsync();
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceAsyncWithServiceResponse();
     /**
      * Long running put request with sub resource.
      *
@@ -1526,7 +2334,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SubProduct> beginPutAsyncSubResource(SubProduct product) throws CloudException, IOException;
+    SubProduct beginPutAsyncSubResource(SubProduct product) throws CloudException, IOException;
 
     /**
      * Long running put request with sub resource.
@@ -1543,7 +2351,15 @@ public interface LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceAsync(SubProduct product);
+    Observable<SubProduct> beginPutAsyncSubResourceAsync(SubProduct product);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable to the SubProduct object
+     */
+    Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceAsyncWithServiceResponse(SubProduct product);
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1553,7 +2369,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders> deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException;
+    Product deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1568,7 +2384,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededAsync();
+    Observable<Product> deleteProvisioning202Accepted200SucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1577,7 +2400,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders> beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException;
+    Product beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1592,7 +2415,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededAsync();
+    Observable<Product> beginDeleteProvisioning202Accepted200SucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -1602,7 +2432,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers> deleteProvisioning202DeletingFailed200() throws CloudException, IOException, InterruptedException;
+    Product deleteProvisioning202DeletingFailed200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -1617,7 +2447,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> deleteProvisioning202DeletingFailed200Async();
+    Observable<Product> deleteProvisioning202DeletingFailed200Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> deleteProvisioning202DeletingFailed200AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -1626,7 +2463,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers> beginDeleteProvisioning202DeletingFailed200() throws CloudException, IOException;
+    Product beginDeleteProvisioning202DeletingFailed200() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -1641,7 +2478,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> beginDeleteProvisioning202DeletingFailed200Async();
+    Observable<Product> beginDeleteProvisioning202DeletingFailed200Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> beginDeleteProvisioning202DeletingFailed200AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -1651,7 +2495,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers> deleteProvisioning202Deletingcanceled200() throws CloudException, IOException, InterruptedException;
+    Product deleteProvisioning202Deletingcanceled200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -1666,7 +2510,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> deleteProvisioning202Deletingcanceled200Async();
+    Observable<Product> deleteProvisioning202Deletingcanceled200Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> deleteProvisioning202Deletingcanceled200AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -1675,7 +2526,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers> beginDeleteProvisioning202Deletingcanceled200() throws CloudException, IOException;
+    Product beginDeleteProvisioning202Deletingcanceled200() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -1690,7 +2541,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> beginDeleteProvisioning202Deletingcanceled200Async();
+    Observable<Product> beginDeleteProvisioning202Deletingcanceled200Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> beginDeleteProvisioning202Deletingcanceled200AsyncWithServiceResponse();
 
     /**
      * Long running delete succeeds and returns right away.
@@ -1700,7 +2558,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete204Succeeded() throws CloudException, IOException, InterruptedException;
+    void delete204Succeeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete succeeds and returns right away.
@@ -1715,7 +2573,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete204SucceededAsync();
+    Observable<Void> delete204SucceededAsync();
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete204SucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete succeeds and returns right away.
@@ -1724,7 +2589,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> beginDelete204Succeeded() throws CloudException, IOException;
+    void beginDelete204Succeeded() throws CloudException, IOException;
 
     /**
      * Long running delete succeeds and returns right away.
@@ -1739,7 +2604,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> beginDelete204SucceededAsync();
+    Observable<Void> beginDelete204SucceededAsync();
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> beginDelete204SucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1749,7 +2621,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers> delete202Retry200() throws CloudException, IOException, InterruptedException;
+    Product delete202Retry200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1764,7 +2636,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> delete202Retry200Async();
+    Observable<Product> delete202Retry200Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> delete202Retry200AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1773,7 +2652,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers> beginDelete202Retry200() throws CloudException, IOException;
+    Product beginDelete202Retry200() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1788,7 +2667,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> beginDelete202Retry200Async();
+    Observable<Product> beginDelete202Retry200Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> beginDelete202Retry200AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1798,7 +2684,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers> delete202NoRetry204() throws CloudException, IOException, InterruptedException;
+    Product delete202NoRetry204() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1813,7 +2699,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> delete202NoRetry204Async();
+    Observable<Product> delete202NoRetry204Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> delete202NoRetry204AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1822,7 +2715,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers> beginDelete202NoRetry204() throws CloudException, IOException;
+    Product beginDelete202NoRetry204() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1837,7 +2730,14 @@ public interface LROs {
      *
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> beginDelete202NoRetry204Async();
+    Observable<Product> beginDelete202NoRetry204Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> beginDelete202NoRetry204AsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
@@ -1847,7 +2747,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders> deleteNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
+    void deleteNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
@@ -1862,7 +2762,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> deleteNoHeaderInRetryAsync();
+    Observable<Void> deleteNoHeaderInRetryAsync();
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> deleteNoHeaderInRetryAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
@@ -1871,7 +2778,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders> beginDeleteNoHeaderInRetry() throws CloudException, IOException;
+    void beginDeleteNoHeaderInRetry() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
@@ -1886,7 +2793,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> beginDeleteNoHeaderInRetryAsync();
+    Observable<Void> beginDeleteNoHeaderInRetryAsync();
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> beginDeleteNoHeaderInRetryAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1896,7 +2810,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders> deleteAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1911,7 +2825,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> deleteAsyncNoHeaderInRetryAsync();
+    Observable<Void> deleteAsyncNoHeaderInRetryAsync();
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> deleteAsyncNoHeaderInRetryAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1920,7 +2841,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders> beginDeleteAsyncNoHeaderInRetry() throws CloudException, IOException;
+    void beginDeleteAsyncNoHeaderInRetry() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -1935,7 +2856,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> beginDeleteAsyncNoHeaderInRetryAsync();
+    Observable<Void> beginDeleteAsyncNoHeaderInRetryAsync();
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> beginDeleteAsyncNoHeaderInRetryAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1945,7 +2873,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders> deleteAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1960,7 +2888,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> deleteAsyncRetrySucceededAsync();
+    Observable<Void> deleteAsyncRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> deleteAsyncRetrySucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1969,7 +2904,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders> beginDeleteAsyncRetrySucceeded() throws CloudException, IOException;
+    void beginDeleteAsyncRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1984,7 +2919,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> beginDeleteAsyncRetrySucceededAsync();
+    Observable<Void> beginDeleteAsyncRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> beginDeleteAsyncRetrySucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1994,7 +2936,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders> deleteAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2009,7 +2951,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> deleteAsyncNoRetrySucceededAsync();
+    Observable<Void> deleteAsyncNoRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> deleteAsyncNoRetrySucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2018,7 +2967,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders> beginDeleteAsyncNoRetrySucceeded() throws CloudException, IOException;
+    void beginDeleteAsyncNoRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2033,7 +2982,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> beginDeleteAsyncNoRetrySucceededAsync();
+    Observable<Void> beginDeleteAsyncNoRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> beginDeleteAsyncNoRetrySucceededAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2043,7 +2999,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders> deleteAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2058,7 +3014,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> deleteAsyncRetryFailedAsync();
+    Observable<Void> deleteAsyncRetryFailedAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> deleteAsyncRetryFailedAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2067,7 +3030,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders> beginDeleteAsyncRetryFailed() throws CloudException, IOException;
+    void beginDeleteAsyncRetryFailed() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2082,7 +3045,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> beginDeleteAsyncRetryFailedAsync();
+    Observable<Void> beginDeleteAsyncRetryFailedAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> beginDeleteAsyncRetryFailedAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2092,7 +3062,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders> deleteAsyncRetrycanceled() throws CloudException, IOException, InterruptedException;
+    void deleteAsyncRetrycanceled() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2107,7 +3077,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> deleteAsyncRetrycanceledAsync();
+    Observable<Void> deleteAsyncRetrycanceledAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> deleteAsyncRetrycanceledAsyncWithServiceResponse();
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2116,7 +3093,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders> beginDeleteAsyncRetrycanceled() throws CloudException, IOException;
+    void beginDeleteAsyncRetrycanceled() throws CloudException, IOException;
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2131,7 +3108,14 @@ public interface LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> beginDeleteAsyncRetrycanceledAsync();
+    Observable<Void> beginDeleteAsyncRetrycanceledAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> beginDeleteAsyncRetrycanceledAsyncWithServiceResponse();
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
@@ -2141,7 +3125,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> post200WithPayload() throws CloudException, IOException, InterruptedException;
+    Sku post200WithPayload() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
@@ -2156,7 +3140,14 @@ public interface LROs {
      *
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> post200WithPayloadAsync();
+    Observable<Sku> post200WithPayloadAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> post200WithPayloadAsyncWithServiceResponse();
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
@@ -2165,7 +3156,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Sku object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Sku> beginPost200WithPayload() throws CloudException, IOException;
+    Sku beginPost200WithPayload() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
@@ -2180,7 +3171,14 @@ public interface LROs {
      *
      * @return the observable to the Sku object
      */
-    Observable<ServiceResponse<Sku>> beginPost200WithPayloadAsync();
+    Observable<Sku> beginPost200WithPayloadAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @return the observable to the Sku object
+     */
+    Observable<ServiceResponse<Sku>> beginPost200WithPayloadAsyncWithServiceResponse();
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -2190,7 +3188,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> post202Retry200() throws CloudException, IOException, InterruptedException;
+    void post202Retry200() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -2199,6 +3197,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> post202Retry200Async();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -2208,7 +3222,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
+    void post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -2225,7 +3239,15 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200Async(Product product);
+    Observable<Void> post202Retry200Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -2234,7 +3256,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> beginPost202Retry200() throws CloudException, IOException;
+    void beginPost202Retry200() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -2243,6 +3265,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPost202Retry200Async();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -2251,7 +3289,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> beginPost202Retry200(Product product) throws CloudException, IOException;
+    void beginPost202Retry200(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -2268,7 +3306,15 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200Async(Product product);
+    Observable<Void> beginPost202Retry200Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -2278,7 +3324,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> post202NoRetry204() throws CloudException, IOException, InterruptedException;
+    Product post202NoRetry204() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -2287,6 +3333,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> post202NoRetry204Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> post202NoRetry204Async();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
@@ -2296,7 +3358,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> post202NoRetry204(Product product) throws CloudException, IOException, InterruptedException;
+    Product post202NoRetry204(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -2313,7 +3375,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204Async(Product product);
+    Observable<Product> post202NoRetry204Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -2322,7 +3392,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> beginPost202NoRetry204() throws CloudException, IOException;
+    Product beginPost202NoRetry204() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -2331,6 +3401,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPost202NoRetry204Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPost202NoRetry204Async();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204AsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
@@ -2339,7 +3425,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> beginPost202NoRetry204(Product product) throws CloudException, IOException;
+    Product beginPost202NoRetry204(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -2356,7 +3442,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204Async(Product product);
+    Observable<Product> beginPost202NoRetry204Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204AsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2366,7 +3460,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    Product postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2375,6 +3469,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> postAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> postAsyncRetrySucceededAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2384,7 +3494,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
+    Product postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2401,7 +3511,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsync(Product product);
+    Observable<Product> postAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2410,7 +3528,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> beginPostAsyncRetrySucceeded() throws CloudException, IOException;
+    Product beginPostAsyncRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2419,6 +3537,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPostAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPostAsyncRetrySucceededAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2427,7 +3561,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException;
+    Product beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2444,7 +3578,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsync(Product product);
+    Observable<Product> beginPostAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2454,7 +3596,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> postAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    Product postAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2463,6 +3605,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> postAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> postAsyncNoRetrySucceededAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2472,7 +3630,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> postAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
+    Product postAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2489,7 +3647,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededAsync(Product product);
+    Observable<Product> postAsyncNoRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2498,7 +3664,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> beginPostAsyncNoRetrySucceeded() throws CloudException, IOException;
+    Product beginPostAsyncNoRetrySucceeded() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2507,6 +3673,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPostAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPostAsyncNoRetrySucceededAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2515,7 +3697,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> beginPostAsyncNoRetrySucceeded(Product product) throws CloudException, IOException;
+    Product beginPostAsyncNoRetrySucceeded(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2532,7 +3714,15 @@ public interface LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededAsync(Product product);
+    Observable<Product> beginPostAsyncNoRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2542,7 +3732,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> postAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
+    void postAsyncRetryFailed() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2551,6 +3741,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postAsyncRetryFailedAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2560,7 +3766,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> postAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException;
+    void postAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2577,7 +3783,15 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedAsync(Product product);
+    Observable<Void> postAsyncRetryFailedAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2586,7 +3800,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> beginPostAsyncRetryFailed() throws CloudException, IOException;
+    void beginPostAsyncRetryFailed() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2595,6 +3809,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostAsyncRetryFailedAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2603,7 +3833,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> beginPostAsyncRetryFailed(Product product) throws CloudException, IOException;
+    void beginPostAsyncRetryFailed(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2620,7 +3850,15 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedAsync(Product product);
+    Observable<Void> beginPostAsyncRetryFailedAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2630,7 +3868,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> postAsyncRetrycanceled() throws CloudException, IOException, InterruptedException;
+    void postAsyncRetrycanceled() throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2639,6 +3877,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postAsyncRetrycanceledAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2648,7 +3902,7 @@ public interface LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> postAsyncRetrycanceled(Product product) throws CloudException, IOException, InterruptedException;
+    void postAsyncRetrycanceled(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2665,7 +3919,15 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledAsync(Product product);
+    Observable<Void> postAsyncRetrycanceledAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledAsyncWithServiceResponse(Product product);
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2674,7 +3936,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> beginPostAsyncRetrycanceled() throws CloudException, IOException;
+    void beginPostAsyncRetrycanceled() throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2683,6 +3945,22 @@ public interface LROs {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostAsyncRetrycanceledAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledAsyncWithServiceResponse();
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -2691,7 +3969,7 @@ public interface LROs {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> beginPostAsyncRetrycanceled(Product product) throws CloudException, IOException;
+    void beginPostAsyncRetrycanceled(Product product) throws CloudException, IOException;
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2708,6 +3986,14 @@ public interface LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledAsync(Product product);
+    Observable<Void> beginPostAsyncRetrycanceledAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledAsyncWithServiceResponse(Product product);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROsCustomHeaders.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROsCustomHeaders.java
@@ -35,7 +35,7 @@ public interface LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    Product putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -44,6 +44,22 @@ public interface LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> putAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> putAsyncRetrySucceededAsync();
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsyncWithServiceResponse();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -53,7 +69,7 @@ public interface LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
+    Product putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -70,7 +86,15 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsync(Product product);
+    Observable<Product> putAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -79,7 +103,7 @@ public interface LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> beginPutAsyncRetrySucceeded() throws CloudException, IOException;
+    Product beginPutAsyncRetrySucceeded() throws CloudException, IOException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -88,6 +112,22 @@ public interface LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPutAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPutAsyncRetrySucceededAsync();
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsyncWithServiceResponse();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -96,7 +136,7 @@ public interface LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException;
+    Product beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -113,7 +153,15 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsync(Product product);
+    Observable<Product> beginPutAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -123,7 +171,7 @@ public interface LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
+    Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -132,6 +180,22 @@ public interface LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> put201CreatingSucceeded200Async();
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -141,7 +205,7 @@ public interface LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
+    Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -158,7 +222,15 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async(Product product);
+    Observable<Product> put201CreatingSucceeded200Async(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -167,7 +239,7 @@ public interface LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut201CreatingSucceeded200() throws CloudException, IOException;
+    Product beginPut201CreatingSucceeded200() throws CloudException, IOException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -176,6 +248,22 @@ public interface LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> beginPut201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<Product> beginPut201CreatingSucceeded200Async();
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -184,7 +272,7 @@ public interface LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
+    Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -201,7 +289,15 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async(Product product);
+    Observable<Product> beginPut201CreatingSucceeded200Async(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -211,7 +307,7 @@ public interface LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> post202Retry200() throws CloudException, IOException, InterruptedException;
+    void post202Retry200() throws CloudException, IOException, InterruptedException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -220,6 +316,22 @@ public interface LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> post202Retry200Async();
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -229,7 +341,7 @@ public interface LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
+    void post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -246,7 +358,15 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200Async(Product product);
+    Observable<Void> post202Retry200Async(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -255,7 +375,7 @@ public interface LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> beginPost202Retry200() throws CloudException, IOException;
+    void beginPost202Retry200() throws CloudException, IOException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -264,6 +384,22 @@ public interface LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPost202Retry200Async();
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -272,7 +408,7 @@ public interface LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> beginPost202Retry200(Product product) throws CloudException, IOException;
+    void beginPost202Retry200(Product product) throws CloudException, IOException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -289,7 +425,15 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200Async(Product product);
+    Observable<Void> beginPost202Retry200Async(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -299,7 +443,7 @@ public interface LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
+    void postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -308,6 +452,22 @@ public interface LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> postAsyncRetrySucceededAsync();
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsyncWithServiceResponse();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -317,7 +477,7 @@ public interface LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
+    void postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -334,7 +494,15 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsync(Product product);
+    Observable<Void> postAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsyncWithServiceResponse(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -343,7 +511,7 @@ public interface LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> beginPostAsyncRetrySucceeded() throws CloudException, IOException;
+    void beginPostAsyncRetrySucceeded() throws CloudException, IOException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -352,6 +520,22 @@ public interface LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> beginPostAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> beginPostAsyncRetrySucceededAsync();
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsyncWithServiceResponse();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -360,7 +544,7 @@ public interface LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException;
+    void beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException;
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -377,6 +561,14 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsync(Product product);
+    Observable<Void> beginPostAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsyncWithServiceResponse(Product product);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROsCustomHeaders.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/LROsCustomHeaders.java
@@ -33,7 +33,7 @@ public interface LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -48,7 +48,6 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> putAsyncRetrySucceededAsync();
@@ -56,10 +55,9 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededWithServiceResponseAsync();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -67,7 +65,7 @@ public interface LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -94,14 +92,14 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRetrySucceeded() throws CloudException, IOException;
 
@@ -116,7 +114,6 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPutAsyncRetrySucceededAsync();
@@ -124,17 +121,16 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededWithServiceResponseAsync();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
     Product beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException;
 
@@ -161,7 +157,7 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -169,7 +165,7 @@ public interface LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException;
 
@@ -184,7 +180,6 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> put201CreatingSucceeded200Async();
@@ -192,10 +187,9 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
@@ -203,7 +197,7 @@ public interface LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -230,14 +224,14 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> put201CreatingSucceeded200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut201CreatingSucceeded200() throws CloudException, IOException;
 
@@ -252,7 +246,6 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
     Observable<Product> beginPut201CreatingSucceeded200Async();
@@ -260,17 +253,16 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
-     * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException;
 
@@ -297,7 +289,7 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -305,7 +297,6 @@ public interface LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202Retry200() throws CloudException, IOException, InterruptedException;
 
@@ -320,7 +311,6 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> post202Retry200Async();
@@ -328,10 +318,9 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200WithServiceResponseAsync();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
@@ -339,7 +328,6 @@ public interface LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post202Retry200(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -366,14 +354,13 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200WithServiceResponseAsync(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202Retry200() throws CloudException, IOException;
 
@@ -388,7 +375,6 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPost202Retry200Async();
@@ -396,17 +382,15 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPost202Retry200(Product product) throws CloudException, IOException;
 
@@ -433,7 +417,7 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200AsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -441,7 +425,6 @@ public interface LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException;
 
@@ -456,7 +439,6 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> postAsyncRetrySucceededAsync();
@@ -464,10 +446,9 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededWithServiceResponseAsync();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
@@ -475,7 +456,6 @@ public interface LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException;
 
@@ -502,14 +482,13 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededWithServiceResponseAsync(Product product);
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRetrySucceeded() throws CloudException, IOException;
 
@@ -524,7 +503,6 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> beginPostAsyncRetrySucceededAsync();
@@ -532,17 +510,15 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
-     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededWithServiceResponseAsync();
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException;
 
@@ -569,6 +545,6 @@ public interface LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsyncWithServiceResponse(Product product);
+    Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededWithServiceResponseAsync(Product product);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
@@ -129,10 +129,10 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async().toBlocking().last();
+    public Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -142,7 +142,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -150,7 +150,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async() {
+    public Observable<Product> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -162,10 +176,10 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async(product).toBlocking().last();
+    public Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -176,7 +190,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -185,7 +199,22 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async(Product product) {
+    public Observable<Product> put201CreatingSucceeded200Async(Product product) {
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -196,10 +225,10 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut201CreatingSucceeded200() throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async().toBlocking().single();
+    public Product beginPut201CreatingSucceeded200() throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -209,7 +238,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -217,7 +246,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async() {
+    public Observable<Product> beginPut201CreatingSucceeded200Async() {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -239,10 +282,10 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async(product).toBlocking().single();
+    public Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -253,7 +296,21 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut201CreatingSucceeded200Async(Product product) {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -262,7 +319,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -292,10 +349,10 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> putAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetrySucceededAsync().toBlocking().last();
+    public Product putAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -305,7 +362,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -313,7 +370,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededAsync() {
+    public Observable<Product> putAsyncRelativeRetrySucceededAsync() {
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LRORetrysPutAsyncRelativeRetrySucceededHeaders.class);
@@ -325,10 +396,10 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> putAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetrySucceededAsync(product).toBlocking().last();
+    public Product putAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -339,7 +410,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -348,7 +419,22 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededAsync(Product product) {
+    public Observable<Product> putAsyncRelativeRetrySucceededAsync(Product product) {
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> putAsyncRelativeRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LRORetrysPutAsyncRelativeRetrySucceededHeaders.class);
@@ -359,10 +445,10 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> beginPutAsyncRelativeRetrySucceeded() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetrySucceededAsync().toBlocking().single();
+    public Product beginPutAsyncRelativeRetrySucceeded() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -372,7 +458,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -380,7 +466,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededAsync() {
+    public Observable<Product> beginPutAsyncRelativeRetrySucceededAsync() {
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>>>() {
@@ -402,10 +502,10 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> beginPutAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetrySucceededAsync(product).toBlocking().single();
+    public Product beginPutAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -416,7 +516,21 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRelativeRetrySucceededAsync(Product product) {
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -425,7 +539,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>> beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders>>>() {
@@ -454,10 +568,10 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders> deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException {
-        return deleteProvisioning202Accepted200SucceededAsync().toBlocking().last();
+    public Product deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException {
+        return deleteProvisioning202Accepted200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -467,7 +581,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> deleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteProvisioning202Accepted200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -475,7 +589,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededAsync() {
+    public Observable<Product> deleteProvisioning202Accepted200SucceededAsync() {
+        return deleteProvisioning202Accepted200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.class);
     }
@@ -485,10 +613,10 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders> beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException {
-        return beginDeleteProvisioning202Accepted200SucceededAsync().toBlocking().single();
+    public Product beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException {
+        return beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -498,7 +626,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginDeleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -506,7 +634,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededAsync() {
+    public Observable<Product> beginDeleteProvisioning202Accepted200SucceededAsync() {
+        return beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync() {
         return service.beginDeleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders>>>() {
                 @Override
@@ -535,10 +677,9 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers> delete202Retry200() throws CloudException, IOException, InterruptedException {
-        return delete202Retry200Async().toBlocking().last();
+    public void delete202Retry200() throws CloudException, IOException, InterruptedException {
+        delete202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -548,7 +689,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -556,7 +697,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> delete202Retry200Async() {
+    public Observable<Void> delete202Retry200Async() {
+        return delete202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> delete202Retry200WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202Retry200(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysDelete202Retry200Headers.class);
     }
@@ -566,10 +721,9 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers> beginDelete202Retry200() throws CloudException, IOException {
-        return beginDelete202Retry200Async().toBlocking().single();
+    public void beginDelete202Retry200() throws CloudException, IOException {
+        beginDelete202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -579,7 +733,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -587,7 +741,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> beginDelete202Retry200Async() {
+    public Observable<Void> beginDelete202Retry200Async() {
+        return beginDelete202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>> beginDelete202Retry200WithServiceResponseAsync() {
         return service.beginDelete202Retry200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers>>>() {
                 @Override
@@ -615,10 +783,9 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders> deleteAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetrySucceededAsync().toBlocking().last();
+    public void deleteAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -628,7 +795,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -636,7 +803,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> deleteAsyncRelativeRetrySucceededAsync() {
+    public Observable<Void> deleteAsyncRelativeRetrySucceededAsync() {
+        return deleteAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> deleteAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.class);
     }
@@ -646,10 +827,9 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders> beginDeleteAsyncRelativeRetrySucceeded() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetrySucceededAsync().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetrySucceeded() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -659,7 +839,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -667,7 +847,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> beginDeleteAsyncRelativeRetrySucceededAsync() {
+    public Observable<Void> beginDeleteAsyncRelativeRetrySucceededAsync() {
+        return beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> beginDeleteAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>>>() {
                 @Override
@@ -695,10 +889,9 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> post202Retry200() throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async().toBlocking().last();
+    public void post202Retry200() throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -708,7 +901,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -716,7 +909,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200Async() {
+    public Observable<Void> post202Retry200Async() {
+        return post202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysPost202Retry200Headers.class);
@@ -728,10 +935,9 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async(product).toBlocking().last();
+    public void post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -742,7 +948,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -751,7 +957,22 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200Async(Product product) {
+    public Observable<Void> post202Retry200Async(Product product) {
+        return post202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> post202Retry200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysPost202Retry200Headers.class);
@@ -762,10 +983,9 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> beginPost202Retry200() throws CloudException, IOException {
-        return beginPost202Retry200Async().toBlocking().single();
+    public void beginPost202Retry200() throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -775,7 +995,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -783,7 +1003,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200Async() {
+    public Observable<Void> beginPost202Retry200Async() {
+        return beginPost202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>>>() {
@@ -805,10 +1039,9 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> beginPost202Retry200(Product product) throws CloudException, IOException {
-        return beginPost202Retry200Async(product).toBlocking().single();
+    public void beginPost202Retry200(Product product) throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -819,7 +1052,21 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202Retry200Async(Product product) {
+        return beginPost202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -828,7 +1075,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200Async(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers>>>() {
@@ -857,10 +1104,9 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> postAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetrySucceededAsync().toBlocking().last();
+    public void postAsyncRelativeRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -870,7 +1116,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -878,7 +1124,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededAsync() {
+    public Observable<Void> postAsyncRelativeRetrySucceededAsync() {
+        return postAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysPostAsyncRelativeRetrySucceededHeaders.class);
@@ -890,10 +1150,9 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> postAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetrySucceededAsync(product).toBlocking().last();
+    public void postAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -904,7 +1163,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetrySucceededAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -913,7 +1172,22 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededAsync(Product product) {
+    public Observable<Void> postAsyncRelativeRetrySucceededAsync(Product product) {
+        return postAsyncRelativeRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> postAsyncRelativeRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LRORetrysPostAsyncRelativeRetrySucceededHeaders.class);
@@ -924,10 +1198,9 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> beginPostAsyncRelativeRetrySucceeded() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetrySucceededAsync().toBlocking().single();
+    public void beginPostAsyncRelativeRetrySucceeded() throws CloudException, IOException {
+        beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -937,7 +1210,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -945,7 +1218,21 @@ public final class LRORetrysImpl implements LRORetrys {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededAsync() {
+    public Observable<Void> beginPostAsyncRelativeRetrySucceededAsync() {
+        return beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>>>() {
@@ -967,10 +1254,9 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> beginPostAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetrySucceededAsync(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -981,7 +1267,21 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetrySucceededAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetrySucceededAsync(Product product) {
+        return beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -990,7 +1290,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>> beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders>>>() {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
@@ -179,7 +179,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the Product object if successful.
      */
     public Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -252,7 +252,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -285,7 +285,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the Product object if successful.
      */
     public Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -302,6 +302,7 @@ public final class LRORetrysImpl implements LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut201CreatingSucceeded200Async(Product product) {
@@ -310,7 +311,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -399,7 +400,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the Product object if successful.
      */
     public Product putAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -472,7 +473,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Product call(ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -505,7 +506,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -522,6 +523,7 @@ public final class LRORetrysImpl implements LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRelativeRetrySucceededAsync(Product product) {
@@ -530,7 +532,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Product call(ServiceResponseWithHeaders<Product, LRORetrysPutAsyncRelativeRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -640,7 +642,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Product call(ServiceResponseWithHeaders<Product, LRORetrysDeleteProvisioning202Accepted200SucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -747,7 +749,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysDelete202Retry200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -853,7 +855,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysDeleteAsyncRelativeRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -937,7 +939,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
-        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
+        post202Retry200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1009,7 +1011,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1041,7 +1043,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202Retry200(Product product) throws CloudException, IOException {
-        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202Retry200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1058,6 +1060,7 @@ public final class LRORetrysImpl implements LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202Retry200Async(Product product) {
@@ -1066,7 +1069,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysPost202Retry200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1152,7 +1155,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1224,7 +1227,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1256,7 +1259,7 @@ public final class LRORetrysImpl implements LRORetrys {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetrySucceeded(Product product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1273,6 +1276,7 @@ public final class LRORetrysImpl implements LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetrySucceededAsync(Product product) {
@@ -1281,7 +1285,7 @@ public final class LRORetrysImpl implements LRORetrys {
             public Void call(ServiceResponseWithHeaders<Void, LRORetrysPostAsyncRelativeRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROSADsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROSADsImpl.java
@@ -295,10 +295,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> putNonRetry400() throws CloudException, IOException, InterruptedException {
-        return putNonRetry400Async().toBlocking().last();
+    public Product putNonRetry400() throws CloudException, IOException, InterruptedException {
+        return putNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -308,7 +308,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putNonRetry400Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(putNonRetry400Async(), serviceCallback);
+        return ServiceCall.create(putNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -316,7 +316,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> putNonRetry400Async() {
+    public Observable<Product> putNonRetry400Async() {
+        return putNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> putNonRetry400WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -328,10 +342,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> putNonRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry400Async(product).toBlocking().last();
+    public Product putNonRetry400(Product product) throws CloudException, IOException, InterruptedException {
+        return putNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -342,7 +356,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putNonRetry400Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(putNonRetry400Async(product), serviceCallback);
+        return ServiceCall.create(putNonRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -351,7 +365,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> putNonRetry400Async(Product product) {
+    public Observable<Product> putNonRetry400Async(Product product) {
+        return putNonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> putNonRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -362,10 +391,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPutNonRetry400() throws CloudException, IOException {
-        return beginPutNonRetry400Async().toBlocking().single();
+    public Product beginPutNonRetry400() throws CloudException, IOException {
+        return beginPutNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -375,7 +404,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutNonRetry400Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry400Async(), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -383,7 +412,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPutNonRetry400Async() {
+    public Observable<Product> beginPutNonRetry400Async() {
+        return beginPutNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPutNonRetry400WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -405,10 +448,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPutNonRetry400(Product product) throws CloudException, IOException {
-        return beginPutNonRetry400Async(product).toBlocking().single();
+    public Product beginPutNonRetry400(Product product) throws CloudException, IOException {
+        return beginPutNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -419,7 +462,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutNonRetry400Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry400Async(product), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutNonRetry400Async(Product product) {
+        return beginPutNonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -428,7 +485,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPutNonRetry400Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPutNonRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -458,10 +515,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> putNonRetry201Creating400() throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400Async().toBlocking().last();
+    public Product putNonRetry201Creating400() throws CloudException, IOException, InterruptedException {
+        return putNonRetry201Creating400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -471,7 +528,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putNonRetry201Creating400Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(putNonRetry201Creating400Async(), serviceCallback);
+        return ServiceCall.create(putNonRetry201Creating400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -479,7 +536,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> putNonRetry201Creating400Async() {
+    public Observable<Product> putNonRetry201Creating400Async() {
+        return putNonRetry201Creating400WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> putNonRetry201Creating400WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -491,10 +562,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> putNonRetry201Creating400(Product product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400Async(product).toBlocking().last();
+    public Product putNonRetry201Creating400(Product product) throws CloudException, IOException, InterruptedException {
+        return putNonRetry201Creating400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -505,7 +576,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putNonRetry201Creating400Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(putNonRetry201Creating400Async(product), serviceCallback);
+        return ServiceCall.create(putNonRetry201Creating400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -514,7 +585,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> putNonRetry201Creating400Async(Product product) {
+    public Observable<Product> putNonRetry201Creating400Async(Product product) {
+        return putNonRetry201Creating400WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> putNonRetry201Creating400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -525,10 +611,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPutNonRetry201Creating400() throws CloudException, IOException {
-        return beginPutNonRetry201Creating400Async().toBlocking().single();
+    public Product beginPutNonRetry201Creating400() throws CloudException, IOException {
+        return beginPutNonRetry201Creating400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -538,7 +624,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutNonRetry201Creating400Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry201Creating400Async(), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry201Creating400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -546,7 +632,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400Async() {
+    public Observable<Product> beginPutNonRetry201Creating400Async() {
+        return beginPutNonRetry201Creating400WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -568,10 +668,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPutNonRetry201Creating400(Product product) throws CloudException, IOException {
-        return beginPutNonRetry201Creating400Async(product).toBlocking().single();
+    public Product beginPutNonRetry201Creating400(Product product) throws CloudException, IOException {
+        return beginPutNonRetry201Creating400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -582,7 +682,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutNonRetry201Creating400Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry201Creating400Async(product), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry201Creating400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutNonRetry201Creating400Async(Product product) {
+        return beginPutNonRetry201Creating400WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -591,7 +705,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -621,10 +735,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> putNonRetry201Creating400InvalidJson() throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400InvalidJsonAsync().toBlocking().last();
+    public Product putNonRetry201Creating400InvalidJson() throws CloudException, IOException, InterruptedException {
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -634,7 +748,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putNonRetry201Creating400InvalidJsonAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(putNonRetry201Creating400InvalidJsonAsync(), serviceCallback);
+        return ServiceCall.create(putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -642,7 +756,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonAsync() {
+    public Observable<Product> putNonRetry201Creating400InvalidJsonAsync() {
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -654,10 +782,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> putNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400InvalidJsonAsync(product).toBlocking().last();
+    public Product putNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException, InterruptedException {
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -668,7 +796,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putNonRetry201Creating400InvalidJsonAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(putNonRetry201Creating400InvalidJsonAsync(product), serviceCallback);
+        return ServiceCall.create(putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -677,7 +805,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonAsync(Product product) {
+    public Observable<Product> putNonRetry201Creating400InvalidJsonAsync(Product product) {
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -688,10 +831,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPutNonRetry201Creating400InvalidJson() throws CloudException, IOException {
-        return beginPutNonRetry201Creating400InvalidJsonAsync().toBlocking().single();
+    public Product beginPutNonRetry201Creating400InvalidJson() throws CloudException, IOException {
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -701,7 +844,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutNonRetry201Creating400InvalidJsonAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry201Creating400InvalidJsonAsync(), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -709,7 +852,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonAsync() {
+    public Observable<Product> beginPutNonRetry201Creating400InvalidJsonAsync() {
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -731,10 +888,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPutNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException {
-        return beginPutNonRetry201Creating400InvalidJsonAsync(product).toBlocking().single();
+    public Product beginPutNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException {
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -745,7 +902,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutNonRetry201Creating400InvalidJsonAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPutNonRetry201Creating400InvalidJsonAsync(product), serviceCallback);
+        return ServiceCall.create(beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutNonRetry201Creating400InvalidJsonAsync(Product product) {
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -754,7 +925,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonAsync(Product product) {
+    public Observable<ServiceResponse<Product>> beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -784,10 +955,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> putAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetry400Async().toBlocking().last();
+    public Product putAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -797,7 +968,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetry400Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -805,7 +976,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400Async() {
+    public Observable<Product> putAsyncRelativeRetry400Async() {
+        return putAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetry400Headers.class);
@@ -817,10 +1002,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> putAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetry400Async(product).toBlocking().last();
+    public Product putAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -831,7 +1016,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetry400Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -840,7 +1025,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400Async(Product product) {
+    public Observable<Product> putAsyncRelativeRetry400Async(Product product) {
+        return putAsyncRelativeRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> putAsyncRelativeRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetry400Headers.class);
@@ -851,10 +1051,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> beginPutAsyncRelativeRetry400() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetry400Async().toBlocking().single();
+    public Product beginPutAsyncRelativeRetry400() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -864,7 +1064,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetry400Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -872,7 +1072,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400Async() {
+    public Observable<Product> beginPutAsyncRelativeRetry400Async() {
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>>>() {
@@ -894,10 +1108,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> beginPutAsyncRelativeRetry400(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetry400Async(product).toBlocking().single();
+    public Product beginPutAsyncRelativeRetry400(Product product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -908,7 +1122,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetry400Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRelativeRetry400Async(Product product) {
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -917,7 +1145,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400Async(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>> beginPutAsyncRelativeRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers>>>() {
@@ -946,10 +1174,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers> deleteNonRetry400() throws CloudException, IOException, InterruptedException {
-        return deleteNonRetry400Async().toBlocking().last();
+    public void deleteNonRetry400() throws CloudException, IOException, InterruptedException {
+        deleteNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -959,7 +1186,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteNonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -967,7 +1194,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> deleteNonRetry400Async() {
+    public Observable<Void> deleteNonRetry400Async() {
+        return deleteNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> deleteNonRetry400WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteNonRetry400(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteNonRetry400Headers.class);
     }
@@ -977,10 +1218,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers> beginDeleteNonRetry400() throws CloudException, IOException {
-        return beginDeleteNonRetry400Async().toBlocking().single();
+    public void beginDeleteNonRetry400() throws CloudException, IOException {
+        beginDeleteNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -990,7 +1230,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteNonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -998,7 +1238,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> beginDeleteNonRetry400Async() {
+    public Observable<Void> beginDeleteNonRetry400Async() {
+        return beginDeleteNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>> beginDeleteNonRetry400WithServiceResponseAsync() {
         return service.beginDeleteNonRetry400(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers>>>() {
                 @Override
@@ -1026,10 +1280,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers> delete202NonRetry400() throws CloudException, IOException, InterruptedException {
-        return delete202NonRetry400Async().toBlocking().last();
+    public void delete202NonRetry400() throws CloudException, IOException, InterruptedException {
+        delete202NonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1039,7 +1292,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202NonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202NonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1047,7 +1300,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> delete202NonRetry400Async() {
+    public Observable<Void> delete202NonRetry400Async() {
+        return delete202NonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> delete202NonRetry400WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202NonRetry400(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDelete202NonRetry400Headers.class);
     }
@@ -1057,10 +1324,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers> beginDelete202NonRetry400() throws CloudException, IOException {
-        return beginDelete202NonRetry400Async().toBlocking().single();
+    public void beginDelete202NonRetry400() throws CloudException, IOException {
+        beginDelete202NonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1070,7 +1336,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202NonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202NonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1078,7 +1344,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> beginDelete202NonRetry400Async() {
+    public Observable<Void> beginDelete202NonRetry400Async() {
+        return beginDelete202NonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>> beginDelete202NonRetry400WithServiceResponseAsync() {
         return service.beginDelete202NonRetry400(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers>>>() {
                 @Override
@@ -1106,10 +1386,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers> deleteAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetry400Async().toBlocking().last();
+    public void deleteAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1119,7 +1398,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1127,7 +1406,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> deleteAsyncRelativeRetry400Async() {
+    public Observable<Void> deleteAsyncRelativeRetry400Async() {
+        return deleteAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> deleteAsyncRelativeRetry400WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetry400(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteAsyncRelativeRetry400Headers.class);
     }
@@ -1137,10 +1430,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers> beginDeleteAsyncRelativeRetry400() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetry400Async().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetry400() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1150,7 +1442,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1158,7 +1450,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> beginDeleteAsyncRelativeRetry400Async() {
+    public Observable<Void> beginDeleteAsyncRelativeRetry400Async() {
+        return beginDeleteAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>> beginDeleteAsyncRelativeRetry400WithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetry400(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers>>>() {
                 @Override
@@ -1186,10 +1492,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> postNonRetry400() throws CloudException, IOException, InterruptedException {
-        return postNonRetry400Async().toBlocking().last();
+    public void postNonRetry400() throws CloudException, IOException, InterruptedException {
+        postNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1199,7 +1504,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postNonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(postNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1207,7 +1512,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400Async() {
+    public Observable<Void> postNonRetry400Async() {
+        return postNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostNonRetry400Headers.class);
@@ -1219,10 +1538,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> postNonRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        return postNonRetry400Async(product).toBlocking().last();
+    public void postNonRetry400(Product product) throws CloudException, IOException, InterruptedException {
+        postNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1233,7 +1551,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postNonRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postNonRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postNonRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1242,7 +1560,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400Async(Product product) {
+    public Observable<Void> postNonRetry400Async(Product product) {
+        return postNonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> postNonRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostNonRetry400Headers.class);
@@ -1253,10 +1586,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> beginPostNonRetry400() throws CloudException, IOException {
-        return beginPostNonRetry400Async().toBlocking().single();
+    public void beginPostNonRetry400() throws CloudException, IOException {
+        beginPostNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1266,7 +1598,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostNonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostNonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1274,7 +1606,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400Async() {
+    public Observable<Void> beginPostNonRetry400Async() {
+        return beginPostNonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>>>() {
@@ -1296,10 +1642,9 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> beginPostNonRetry400(Product product) throws CloudException, IOException {
-        return beginPostNonRetry400Async(product).toBlocking().single();
+    public void beginPostNonRetry400(Product product) throws CloudException, IOException {
+        beginPostNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1310,7 +1655,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostNonRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostNonRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostNonRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostNonRetry400Async(Product product) {
+        return beginPostNonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1319,7 +1678,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400Async(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>> beginPostNonRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers>>>() {
@@ -1348,10 +1707,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> post202NonRetry400() throws CloudException, IOException, InterruptedException {
-        return post202NonRetry400Async().toBlocking().last();
+    public void post202NonRetry400() throws CloudException, IOException, InterruptedException {
+        post202NonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1361,7 +1719,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1369,7 +1727,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400Async() {
+    public Observable<Void> post202NonRetry400Async() {
+        return post202NonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.post202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202NonRetry400Headers.class);
@@ -1381,10 +1753,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> post202NonRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        return post202NonRetry400Async(product).toBlocking().last();
+    public void post202NonRetry400(Product product) throws CloudException, IOException, InterruptedException {
+        post202NonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1395,7 +1766,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202NonRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NonRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NonRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1404,7 +1775,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400Async(Product product) {
+    public Observable<Void> post202NonRetry400Async(Product product) {
+        return post202NonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> post202NonRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202NonRetry400Headers.class);
@@ -1415,10 +1801,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> beginPost202NonRetry400() throws CloudException, IOException {
-        return beginPost202NonRetry400Async().toBlocking().single();
+    public void beginPost202NonRetry400() throws CloudException, IOException {
+        beginPost202NonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1428,7 +1813,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NonRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NonRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1436,7 +1821,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400Async() {
+    public Observable<Void> beginPost202NonRetry400Async() {
+        return beginPost202NonRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPost202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>>>() {
@@ -1458,10 +1857,9 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> beginPost202NonRetry400(Product product) throws CloudException, IOException {
-        return beginPost202NonRetry400Async(product).toBlocking().single();
+    public void beginPost202NonRetry400(Product product) throws CloudException, IOException {
+        beginPost202NonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1472,7 +1870,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202NonRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NonRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NonRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202NonRetry400Async(Product product) {
+        return beginPost202NonRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1481,7 +1893,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400Async(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>> beginPost202NonRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPost202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers>>>() {
@@ -1510,10 +1922,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> postAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetry400Async().toBlocking().last();
+    public void postAsyncRelativeRetry400() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1523,7 +1934,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1531,7 +1942,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400Async() {
+    public Observable<Void> postAsyncRelativeRetry400Async() {
+        return postAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetry400Headers.class);
@@ -1543,10 +1968,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> postAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetry400Async(product).toBlocking().last();
+    public void postAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1557,7 +1981,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetry400WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1566,7 +1990,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400Async(Product product) {
+    public Observable<Void> postAsyncRelativeRetry400Async(Product product) {
+        return postAsyncRelativeRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> postAsyncRelativeRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetry400Headers.class);
@@ -1577,10 +2016,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> beginPostAsyncRelativeRetry400() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetry400Async().toBlocking().single();
+    public void beginPostAsyncRelativeRetry400() throws CloudException, IOException {
+        beginPostAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1590,7 +2028,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetry400Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetry400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1598,7 +2036,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400Async() {
+    public Observable<Void> beginPostAsyncRelativeRetry400Async() {
+        return beginPostAsyncRelativeRetry400WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>>>() {
@@ -1620,10 +2072,9 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> beginPostAsyncRelativeRetry400(Product product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetry400Async(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetry400(Product product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1634,7 +2085,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetry400Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetry400WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetry400Async(Product product) {
+        return beginPostAsyncRelativeRetry400WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1643,7 +2108,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400Async(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>> beginPostAsyncRelativeRetry400WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers>>>() {
@@ -1672,10 +2137,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> putError201NoProvisioningStatePayload() throws CloudException, IOException, InterruptedException {
-        return putError201NoProvisioningStatePayloadAsync().toBlocking().last();
+    public Product putError201NoProvisioningStatePayload() throws CloudException, IOException, InterruptedException {
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1685,7 +2150,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putError201NoProvisioningStatePayloadAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(putError201NoProvisioningStatePayloadAsync(), serviceCallback);
+        return ServiceCall.create(putError201NoProvisioningStatePayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1693,7 +2158,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadAsync() {
+    public Observable<Product> putError201NoProvisioningStatePayloadAsync() {
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -1705,10 +2184,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> putError201NoProvisioningStatePayload(Product product) throws CloudException, IOException, InterruptedException {
-        return putError201NoProvisioningStatePayloadAsync(product).toBlocking().last();
+    public Product putError201NoProvisioningStatePayload(Product product) throws CloudException, IOException, InterruptedException {
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1719,7 +2198,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putError201NoProvisioningStatePayloadAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(putError201NoProvisioningStatePayloadAsync(product), serviceCallback);
+        return ServiceCall.create(putError201NoProvisioningStatePayloadWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1728,7 +2207,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadAsync(Product product) {
+    public Observable<Product> putError201NoProvisioningStatePayloadAsync(Product product) {
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> putError201NoProvisioningStatePayloadWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -1739,10 +2233,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPutError201NoProvisioningStatePayload() throws CloudException, IOException {
-        return beginPutError201NoProvisioningStatePayloadAsync().toBlocking().single();
+    public Product beginPutError201NoProvisioningStatePayload() throws CloudException, IOException {
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1752,7 +2246,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutError201NoProvisioningStatePayloadAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPutError201NoProvisioningStatePayloadAsync(), serviceCallback);
+        return ServiceCall.create(beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1760,7 +2254,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadAsync() {
+    public Observable<Product> beginPutError201NoProvisioningStatePayloadAsync() {
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1782,10 +2290,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPutError201NoProvisioningStatePayload(Product product) throws CloudException, IOException {
-        return beginPutError201NoProvisioningStatePayloadAsync(product).toBlocking().single();
+    public Product beginPutError201NoProvisioningStatePayload(Product product) throws CloudException, IOException {
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1796,7 +2304,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutError201NoProvisioningStatePayloadAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPutError201NoProvisioningStatePayloadAsync(product), serviceCallback);
+        return ServiceCall.create(beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutError201NoProvisioningStatePayloadAsync(Product product) {
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1805,7 +2327,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadAsync(Product product) {
+    public Observable<ServiceResponse<Product>> beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1835,10 +2357,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> putAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusAsync().toBlocking().last();
+    public Product putAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1848,7 +2370,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1856,7 +2378,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusAsync() {
+    public Observable<Product> putAsyncRelativeRetryNoStatusAsync() {
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetryNoStatusHeaders.class);
@@ -1868,10 +2404,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> putAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusAsync(product).toBlocking().last();
+    public Product putAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1882,7 +2418,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetryNoStatusAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1891,7 +2427,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusAsync(Product product) {
+    public Observable<Product> putAsyncRelativeRetryNoStatusAsync(Product product) {
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> putAsyncRelativeRetryNoStatusWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetryNoStatusHeaders.class);
@@ -1902,10 +2453,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> beginPutAsyncRelativeRetryNoStatus() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusAsync().toBlocking().single();
+    public Product beginPutAsyncRelativeRetryNoStatus() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1915,7 +2466,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1923,7 +2474,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusAsync() {
+    public Observable<Product> beginPutAsyncRelativeRetryNoStatusAsync() {
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>>>() {
@@ -1945,10 +2510,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> beginPutAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusAsync(product).toBlocking().single();
+    public Product beginPutAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1959,7 +2524,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetryNoStatusAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRelativeRetryNoStatusAsync(Product product) {
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1968,7 +2547,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>> beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders>>>() {
@@ -1997,10 +2576,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> putAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusPayloadAsync().toBlocking().last();
+    public Product putAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2010,7 +2589,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetryNoStatusPayloadAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusPayloadAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2018,7 +2597,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadAsync() {
+    public Observable<Product> putAsyncRelativeRetryNoStatusPayloadAsync() {
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders.class);
@@ -2030,10 +2623,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> putAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusPayloadAsync(product).toBlocking().last();
+    public Product putAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2044,7 +2637,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetryNoStatusPayloadAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusPayloadAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2053,7 +2646,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadAsync(Product product) {
+    public Observable<Product> putAsyncRelativeRetryNoStatusPayloadAsync(Product product) {
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders.class);
@@ -2064,10 +2672,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> beginPutAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusPayloadAsync().toBlocking().single();
+    public Product beginPutAsyncRelativeRetryNoStatusPayload() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2077,7 +2685,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusPayloadAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2085,7 +2693,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadAsync() {
+    public Observable<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync() {
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>>>() {
@@ -2107,10 +2729,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> beginPutAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusPayloadAsync(product).toBlocking().single();
+    public Product beginPutAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2121,7 +2743,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusPayloadAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync(Product product) {
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2130,7 +2766,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>> beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders>>>() {
@@ -2159,10 +2795,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponse object if successful.
      */
-    public ServiceResponse<Void> delete204Succeeded() throws CloudException, IOException, InterruptedException {
-        return delete204SucceededAsync().toBlocking().last();
+    public void delete204Succeeded() throws CloudException, IOException, InterruptedException {
+        delete204SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2172,7 +2807,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete204SucceededAsync(), serviceCallback);
+        return ServiceCall.create(delete204SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2180,7 +2815,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Void>> delete204SucceededAsync() {
+    public Observable<Void> delete204SucceededAsync() {
+        return delete204SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Void>> delete204SucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete204Succeeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<Void>() { }.getType());
     }
@@ -2190,10 +2839,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> beginDelete204Succeeded() throws CloudException, IOException {
-        return beginDelete204SucceededAsync().toBlocking().single();
+    public void beginDelete204Succeeded() throws CloudException, IOException {
+        beginDelete204SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2203,7 +2851,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(beginDelete204SucceededAsync(), serviceCallback);
+        return ServiceCall.create(beginDelete204SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2211,7 +2859,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> beginDelete204SucceededAsync() {
+    public Observable<Void> beginDelete204SucceededAsync() {
+        return beginDelete204SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> beginDelete204SucceededWithServiceResponseAsync() {
         return service.beginDelete204Succeeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -2239,10 +2901,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders> deleteAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetryNoStatusAsync().toBlocking().last();
+    public void deleteAsyncRelativeRetryNoStatus() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2252,7 +2913,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2260,7 +2921,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> deleteAsyncRelativeRetryNoStatusAsync() {
+    public Observable<Void> deleteAsyncRelativeRetryNoStatusAsync() {
+        return deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> deleteAsyncRelativeRetryNoStatusWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetryNoStatus(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteAsyncRelativeRetryNoStatusHeaders.class);
     }
@@ -2270,10 +2945,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders> beginDeleteAsyncRelativeRetryNoStatus() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetryNoStatusAsync().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetryNoStatus() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2283,7 +2957,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2291,7 +2965,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> beginDeleteAsyncRelativeRetryNoStatusAsync() {
+    public Observable<Void> beginDeleteAsyncRelativeRetryNoStatusAsync() {
+        return beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>> beginDeleteAsyncRelativeRetryNoStatusWithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetryNoStatus(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders>>>() {
                 @Override
@@ -2319,10 +3007,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> post202NoLocation() throws CloudException, IOException, InterruptedException {
-        return post202NoLocationAsync().toBlocking().last();
+    public void post202NoLocation() throws CloudException, IOException, InterruptedException {
+        post202NoLocationWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2332,7 +3019,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202NoLocationAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NoLocationAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NoLocationWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2340,7 +3027,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationAsync() {
+    public Observable<Void> post202NoLocationAsync() {
+        return post202NoLocationWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.post202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202NoLocationHeaders.class);
@@ -2352,10 +3053,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> post202NoLocation(Product product) throws CloudException, IOException, InterruptedException {
-        return post202NoLocationAsync(product).toBlocking().last();
+    public void post202NoLocation(Product product) throws CloudException, IOException, InterruptedException {
+        post202NoLocationWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2366,7 +3066,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202NoLocationAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NoLocationAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NoLocationWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2375,7 +3075,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationAsync(Product product) {
+    public Observable<Void> post202NoLocationAsync(Product product) {
+        return post202NoLocationWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> post202NoLocationWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202NoLocationHeaders.class);
@@ -2386,10 +3101,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> beginPost202NoLocation() throws CloudException, IOException {
-        return beginPost202NoLocationAsync().toBlocking().single();
+    public void beginPost202NoLocation() throws CloudException, IOException {
+        beginPost202NoLocationWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2399,7 +3113,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202NoLocationAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NoLocationAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NoLocationWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2407,7 +3121,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationAsync() {
+    public Observable<Void> beginPost202NoLocationAsync() {
+        return beginPost202NoLocationWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPost202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>>>() {
@@ -2429,10 +3157,9 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> beginPost202NoLocation(Product product) throws CloudException, IOException {
-        return beginPost202NoLocationAsync(product).toBlocking().single();
+    public void beginPost202NoLocation(Product product) throws CloudException, IOException {
+        beginPost202NoLocationWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2443,7 +3170,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202NoLocationAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NoLocationAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NoLocationWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202NoLocationAsync(Product product) {
+        return beginPost202NoLocationWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2452,7 +3193,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>> beginPost202NoLocationWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPost202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders>>>() {
@@ -2481,10 +3222,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> postAsyncRelativeRetryNoPayload() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryNoPayloadAsync().toBlocking().last();
+    public void postAsyncRelativeRetryNoPayload() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2494,7 +3234,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryNoPayloadAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryNoPayloadAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2502,7 +3242,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadAsync() {
+    public Observable<Void> postAsyncRelativeRetryNoPayloadAsync() {
+        return postAsyncRelativeRetryNoPayloadWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryNoPayloadHeaders.class);
@@ -2514,10 +3268,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> postAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryNoPayloadAsync(product).toBlocking().last();
+    public void postAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2528,7 +3281,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryNoPayloadAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryNoPayloadAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2537,7 +3290,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadAsync(Product product) {
+    public Observable<Void> postAsyncRelativeRetryNoPayloadAsync(Product product) {
+        return postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryNoPayloadHeaders.class);
@@ -2548,10 +3316,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> beginPostAsyncRelativeRetryNoPayload() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryNoPayloadAsync().toBlocking().single();
+    public void beginPostAsyncRelativeRetryNoPayload() throws CloudException, IOException {
+        beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2561,7 +3328,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryNoPayloadAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryNoPayloadAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2569,7 +3336,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadAsync() {
+    public Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync() {
+        return beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>>>() {
@@ -2591,10 +3372,9 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> beginPostAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryNoPayloadAsync(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2605,7 +3385,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryNoPayloadAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryNoPayloadAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync(Product product) {
+        return beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2614,7 +3408,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>> beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders>>>() {
@@ -2643,10 +3437,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put200InvalidJson() throws CloudException, IOException, InterruptedException {
-        return put200InvalidJsonAsync().toBlocking().last();
+    public Product put200InvalidJson() throws CloudException, IOException, InterruptedException {
+        return put200InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2656,7 +3450,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200InvalidJsonAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200InvalidJsonAsync(), serviceCallback);
+        return ServiceCall.create(put200InvalidJsonWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2664,7 +3458,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200InvalidJsonAsync() {
+    public Observable<Product> put200InvalidJsonAsync() {
+        return put200InvalidJsonWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200InvalidJsonWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -2676,10 +3484,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put200InvalidJson(Product product) throws CloudException, IOException, InterruptedException {
-        return put200InvalidJsonAsync(product).toBlocking().last();
+    public Product put200InvalidJson(Product product) throws CloudException, IOException, InterruptedException {
+        return put200InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2690,7 +3498,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200InvalidJsonAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200InvalidJsonAsync(product), serviceCallback);
+        return ServiceCall.create(put200InvalidJsonWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2699,7 +3507,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200InvalidJsonAsync(Product product) {
+    public Observable<Product> put200InvalidJsonAsync(Product product) {
+        return put200InvalidJsonWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200InvalidJsonWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -2710,10 +3533,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200InvalidJson() throws CloudException, IOException {
-        return beginPut200InvalidJsonAsync().toBlocking().single();
+    public Product beginPut200InvalidJson() throws CloudException, IOException {
+        return beginPut200InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2723,7 +3546,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200InvalidJsonAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200InvalidJsonAsync(), serviceCallback);
+        return ServiceCall.create(beginPut200InvalidJsonWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2731,7 +3554,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200InvalidJsonAsync() {
+    public Observable<Product> beginPut200InvalidJsonAsync() {
+        return beginPut200InvalidJsonWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut200InvalidJsonWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -2753,10 +3590,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200InvalidJson(Product product) throws CloudException, IOException {
-        return beginPut200InvalidJsonAsync(product).toBlocking().single();
+    public Product beginPut200InvalidJson(Product product) throws CloudException, IOException {
+        return beginPut200InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2767,7 +3604,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200InvalidJsonAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200InvalidJsonAsync(product), serviceCallback);
+        return ServiceCall.create(beginPut200InvalidJsonWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut200InvalidJsonAsync(Product product) {
+        return beginPut200InvalidJsonWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2776,7 +3627,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200InvalidJsonAsync(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut200InvalidJsonWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -2806,10 +3657,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> putAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidHeaderAsync().toBlocking().last();
+    public Product putAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2819,7 +3670,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2827,7 +3678,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Product> putAsyncRelativeRetryInvalidHeaderAsync() {
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders.class);
@@ -2839,10 +3704,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> putAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().last();
+    public Product putAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2853,7 +3718,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetryInvalidHeaderAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2862,7 +3727,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+    public Observable<Product> putAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders.class);
@@ -2873,10 +3753,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> beginPutAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidHeaderAsync().toBlocking().single();
+    public Product beginPutAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2886,7 +3766,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2894,7 +3774,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync() {
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>>>() {
@@ -2916,10 +3810,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> beginPutAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().single();
+    public Product beginPutAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2930,7 +3824,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2939,7 +3847,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>>>() {
@@ -2968,10 +3876,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> putAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().last();
+    public Product putAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2981,7 +3889,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2989,7 +3897,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Product> putAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders.class);
@@ -3001,10 +3923,10 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> putAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().last();
+    public Product putAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3015,7 +3937,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3024,7 +3946,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+    public Observable<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders.class);
@@ -3035,10 +3972,10 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> beginPutAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().single();
+    public Product beginPutAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3048,7 +3985,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3056,7 +3993,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>>>() {
@@ -3078,10 +4029,10 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> beginPutAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().single();
+    public Product beginPutAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException {
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3092,7 +4043,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3101,7 +4066,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders>>>() {
@@ -3130,10 +4095,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders> delete202RetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return delete202RetryInvalidHeaderAsync().toBlocking().last();
+    public void delete202RetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        delete202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3143,7 +4107,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202RetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202RetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3151,7 +4115,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> delete202RetryInvalidHeaderAsync() {
+    public Observable<Void> delete202RetryInvalidHeaderAsync() {
+        return delete202RetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> delete202RetryInvalidHeaderWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202RetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDelete202RetryInvalidHeaderHeaders.class);
     }
@@ -3161,10 +4139,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders> beginDelete202RetryInvalidHeader() throws CloudException, IOException {
-        return beginDelete202RetryInvalidHeaderAsync().toBlocking().single();
+    public void beginDelete202RetryInvalidHeader() throws CloudException, IOException {
+        beginDelete202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3174,7 +4151,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202RetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202RetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3182,7 +4159,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> beginDelete202RetryInvalidHeaderAsync() {
+    public Observable<Void> beginDelete202RetryInvalidHeaderAsync() {
+        return beginDelete202RetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>> beginDelete202RetryInvalidHeaderWithServiceResponseAsync() {
         return service.beginDelete202RetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders>>>() {
                 @Override
@@ -3210,10 +4201,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders> deleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetryInvalidHeaderAsync().toBlocking().last();
+    public void deleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3223,7 +4213,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3231,7 +4221,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> deleteAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Void> deleteAsyncRelativeRetryInvalidHeaderAsync() {
+        return deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> deleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders.class);
     }
@@ -3241,10 +4245,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders> beginDeleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetryInvalidHeaderAsync().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3254,7 +4257,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3262,7 +4265,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> beginDeleteAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Void> beginDeleteAsyncRelativeRetryInvalidHeaderAsync() {
+        return beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>> beginDeleteAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders>>>() {
                 @Override
@@ -3290,10 +4307,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders> deleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().last();
+    public void deleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3303,7 +4319,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3311,7 +4327,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> deleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> deleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRelativeRetryInvalidJsonPolling(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.class);
     }
@@ -3321,10 +4351,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders> beginDeleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
-        return beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().single();
+    public void beginDeleteAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
+        beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3334,7 +4363,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3342,7 +4371,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Void> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>> beginDeleteAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         return service.beginDeleteAsyncRelativeRetryInvalidJsonPolling(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders>>>() {
                 @Override
@@ -3370,10 +4413,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> post202RetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return post202RetryInvalidHeaderAsync().toBlocking().last();
+    public void post202RetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        post202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3383,7 +4425,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202RetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202RetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3391,7 +4433,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderAsync() {
+    public Observable<Void> post202RetryInvalidHeaderAsync() {
+        return post202RetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.post202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202RetryInvalidHeaderHeaders.class);
@@ -3403,10 +4459,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> post202RetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
-        return post202RetryInvalidHeaderAsync(product).toBlocking().last();
+    public void post202RetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
+        post202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3417,7 +4472,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202RetryInvalidHeaderAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202RetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202RetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3426,7 +4481,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderAsync(Product product) {
+    public Observable<Void> post202RetryInvalidHeaderAsync(Product product) {
+        return post202RetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> post202RetryInvalidHeaderWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPost202RetryInvalidHeaderHeaders.class);
@@ -3437,10 +4507,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> beginPost202RetryInvalidHeader() throws CloudException, IOException {
-        return beginPost202RetryInvalidHeaderAsync().toBlocking().single();
+    public void beginPost202RetryInvalidHeader() throws CloudException, IOException {
+        beginPost202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3450,7 +4519,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202RetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202RetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3458,7 +4527,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderAsync() {
+    public Observable<Void> beginPost202RetryInvalidHeaderAsync() {
+        return beginPost202RetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPost202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>>>() {
@@ -3480,10 +4563,9 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> beginPost202RetryInvalidHeader(Product product) throws CloudException, IOException {
-        return beginPost202RetryInvalidHeaderAsync(product).toBlocking().single();
+    public void beginPost202RetryInvalidHeader(Product product) throws CloudException, IOException {
+        beginPost202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3494,7 +4576,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202RetryInvalidHeaderAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202RetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202RetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202RetryInvalidHeaderAsync(Product product) {
+        return beginPost202RetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3503,7 +4599,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>> beginPost202RetryInvalidHeaderWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPost202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders>>>() {
@@ -3532,10 +4628,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> postAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryInvalidHeaderAsync().toBlocking().last();
+    public void postAsyncRelativeRetryInvalidHeader() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3545,7 +4640,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3553,7 +4648,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Void> postAsyncRelativeRetryInvalidHeaderAsync() {
+        return postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders.class);
@@ -3565,10 +4674,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> postAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().last();
+    public void postAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3579,7 +4687,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryInvalidHeaderAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3588,7 +4696,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+    public Observable<Void> postAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+        return postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders.class);
@@ -3599,10 +4722,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> beginPostAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryInvalidHeaderAsync().toBlocking().single();
+    public void beginPostAsyncRelativeRetryInvalidHeader() throws CloudException, IOException {
+        beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3612,7 +4734,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3620,7 +4742,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderAsync() {
+    public Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync() {
+        return beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>>>() {
@@ -3642,10 +4778,9 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> beginPostAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3656,7 +4791,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+        return beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3665,7 +4814,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>>>() {
@@ -3694,10 +4843,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> postAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().last();
+    public void postAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3707,7 +4855,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3715,7 +4863,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Void> postAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders.class);
@@ -3727,10 +4889,9 @@ public final class LROSADsImpl implements LROSADs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> postAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().last();
+    public void postAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException {
+        postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3741,7 +4902,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3750,7 +4911,22 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+    public Observable<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+        return postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders.class);
@@ -3761,10 +4937,9 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> beginPostAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().single();
+    public void beginPostAsyncRelativeRetryInvalidJsonPolling() throws CloudException, IOException {
+        beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3774,7 +4949,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3782,7 +4957,21 @@ public final class LROSADsImpl implements LROSADs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>>>() {
@@ -3804,10 +4993,9 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> beginPostAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException {
-        return beginPostAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().single();
+    public void beginPostAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException {
+        beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3818,7 +5006,21 @@ public final class LROSADsImpl implements LROSADs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+        return beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3827,7 +5029,7 @@ public final class LROSADsImpl implements LROSADs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>> beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders>>>() {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROSADsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROSADsImpl.java
@@ -345,7 +345,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putNonRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        return putNonRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -418,7 +418,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -451,7 +451,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutNonRetry400(Product product) throws CloudException, IOException {
-        return beginPutNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNonRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -468,6 +468,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutNonRetry400Async(Product product) {
@@ -476,7 +477,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -565,7 +566,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putNonRetry201Creating400(Product product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400WithServiceResponseAsync().toBlocking().last().getBody();
+        return putNonRetry201Creating400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -638,7 +639,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -671,7 +672,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutNonRetry201Creating400(Product product) throws CloudException, IOException {
-        return beginPutNonRetry201Creating400WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNonRetry201Creating400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -688,6 +689,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutNonRetry201Creating400Async(Product product) {
@@ -696,7 +698,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -785,7 +787,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException, InterruptedException {
-        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
+        return putNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -858,7 +860,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -891,7 +893,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutNonRetry201Creating400InvalidJson(Product product) throws CloudException, IOException {
-        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNonRetry201Creating400InvalidJsonWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -908,6 +910,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutNonRetry201Creating400InvalidJsonAsync(Product product) {
@@ -916,7 +919,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1005,7 +1008,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1078,7 +1081,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1111,7 +1114,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRelativeRetry400(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1128,6 +1131,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRelativeRetry400Async(Product product) {
@@ -1136,7 +1140,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1244,7 +1248,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteNonRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1350,7 +1354,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202NonRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1456,7 +1460,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1540,7 +1544,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postNonRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        postNonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        postNonRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1612,7 +1616,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1644,7 +1648,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostNonRetry400(Product product) throws CloudException, IOException {
-        beginPostNonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostNonRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1661,6 +1665,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running post request, service returns a 400 with no error body.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostNonRetry400Async(Product product) {
@@ -1669,7 +1674,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostNonRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1755,7 +1760,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202NonRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        post202NonRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        post202NonRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1827,7 +1832,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1859,7 +1864,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202NonRetry400(Product product) throws CloudException, IOException {
-        beginPost202NonRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202NonRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1876,6 +1881,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running post request, service returns a 202 with a location header.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202NonRetry400Async(Product product) {
@@ -1884,7 +1890,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NonRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1970,7 +1976,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetry400(Product product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetry400WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2042,7 +2048,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2074,7 +2080,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetry400(Product product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetry400WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetry400WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2091,6 +2097,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetry400Async(Product product) {
@@ -2099,7 +2106,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetry400Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2187,7 +2194,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putError201NoProvisioningStatePayload(Product product) throws CloudException, IOException, InterruptedException {
-        return putError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().last().getBody();
+        return putError201NoProvisioningStatePayloadWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2260,7 +2267,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2293,7 +2300,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutError201NoProvisioningStatePayload(Product product) throws CloudException, IOException {
-        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutError201NoProvisioningStatePayloadWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2310,6 +2317,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutError201NoProvisioningStatePayloadAsync(Product product) {
@@ -2318,7 +2326,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2407,7 +2415,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetryNoStatusWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2480,7 +2488,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2513,7 +2521,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRelativeRetryNoStatus(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetryNoStatusWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2530,6 +2538,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRelativeRetryNoStatusAsync(Product product) {
@@ -2538,7 +2547,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2626,7 +2635,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2699,7 +2708,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2732,7 +2741,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRelativeRetryNoStatusPayload(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetryNoStatusPayloadWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2749,6 +2758,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRelativeRetryNoStatusPayloadAsync(Product product) {
@@ -2757,7 +2767,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2865,7 +2875,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2971,7 +2981,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryNoStatusHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3055,7 +3065,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202NoLocation(Product product) throws CloudException, IOException, InterruptedException {
-        post202NoLocationWithServiceResponseAsync().toBlocking().last().getBody();
+        post202NoLocationWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3127,7 +3137,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3159,7 +3169,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202NoLocation(Product product) throws CloudException, IOException {
-        beginPost202NoLocationWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202NoLocationWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3176,6 +3186,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202NoLocationAsync(Product product) {
@@ -3184,7 +3195,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202NoLocationHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3270,7 +3281,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3342,7 +3353,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3374,7 +3385,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetryNoPayload(Product product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetryNoPayloadWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3391,6 +3402,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetryNoPayloadAsync(Product product) {
@@ -3399,7 +3411,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryNoPayloadHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3487,7 +3499,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product put200InvalidJson(Product product) throws CloudException, IOException, InterruptedException {
-        return put200InvalidJsonWithServiceResponseAsync().toBlocking().last().getBody();
+        return put200InvalidJsonWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3560,7 +3572,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3593,7 +3605,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPut200InvalidJson(Product product) throws CloudException, IOException {
-        return beginPut200InvalidJsonWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200InvalidJsonWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3610,6 +3622,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut200InvalidJsonAsync(Product product) {
@@ -3618,7 +3631,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3707,7 +3720,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3780,7 +3793,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3813,7 +3826,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3830,6 +3843,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRelativeRetryInvalidHeaderAsync(Product product) {
@@ -3838,7 +3852,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3926,7 +3940,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product putAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3999,7 +4013,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4032,7 +4046,7 @@ public final class LROSADsImpl implements LROSADs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException {
-        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4049,6 +4063,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
@@ -4057,7 +4072,7 @@ public final class LROSADsImpl implements LROSADs {
             public Product call(ServiceResponseWithHeaders<Product, LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4165,7 +4180,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDelete202RetryInvalidHeaderHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4271,7 +4286,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4377,7 +4392,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4461,7 +4476,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202RetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
-        post202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
+        post202RetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -4533,7 +4548,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4565,7 +4580,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202RetryInvalidHeader(Product product) throws CloudException, IOException {
-        beginPost202RetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202RetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4582,6 +4597,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202RetryInvalidHeaderAsync(Product product) {
@@ -4590,7 +4606,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPost202RetryInvalidHeaderHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4676,7 +4692,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -4748,7 +4764,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4780,7 +4796,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetryInvalidHeader(Product product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetryInvalidHeaderWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4797,6 +4813,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetryInvalidHeaderAsync(Product product) {
@@ -4805,7 +4822,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4891,7 +4908,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException, InterruptedException {
-        postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -4963,7 +4980,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4995,7 +5012,7 @@ public final class LROSADsImpl implements LROSADs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRelativeRetryInvalidJsonPolling(Product product) throws CloudException, IOException {
-        beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRelativeRetryInvalidJsonPollingWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -5012,6 +5029,7 @@ public final class LROSADsImpl implements LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
@@ -5020,7 +5038,7 @@ public final class LROSADsImpl implements LROSADs {
             public Void call(ServiceResponseWithHeaders<Void, LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
@@ -101,10 +101,10 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededAsync().toBlocking().last();
+    public Product putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -114,7 +114,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -122,7 +122,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsync() {
+    public Observable<Product> putAsyncRetrySucceededAsync() {
+        return putAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsCustomHeaderPutAsyncRetrySucceededHeaders.class);
@@ -134,10 +148,10 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededAsync(product).toBlocking().last();
+    public Product putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -148,7 +162,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -157,7 +171,22 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsync(Product product) {
+    public Observable<Product> putAsyncRetrySucceededAsync(Product product) {
+        return putAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsCustomHeaderPutAsyncRetrySucceededHeaders.class);
@@ -168,10 +197,10 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> beginPutAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededAsync().toBlocking().single();
+    public Product beginPutAsyncRetrySucceeded() throws CloudException, IOException {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -181,7 +210,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -189,7 +218,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsync() {
+    public Observable<Product> beginPutAsyncRetrySucceededAsync() {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>>>() {
@@ -211,10 +254,10 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededAsync(product).toBlocking().single();
+    public Product beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -225,7 +268,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRetrySucceededAsync(Product product) {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -234,7 +291,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders>>>() {
@@ -263,10 +320,10 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async().toBlocking().last();
+    public Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -276,7 +333,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -284,7 +341,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async() {
+    public Observable<Product> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -296,10 +367,10 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async(product).toBlocking().last();
+    public Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -310,7 +381,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -319,7 +390,22 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async(Product product) {
+    public Observable<Product> put201CreatingSucceeded200Async(Product product) {
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -330,10 +416,10 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut201CreatingSucceeded200() throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async().toBlocking().single();
+    public Product beginPut201CreatingSucceeded200() throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -343,7 +429,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -351,7 +437,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async() {
+    public Observable<Product> beginPut201CreatingSucceeded200Async() {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -373,10 +473,10 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async(product).toBlocking().single();
+    public Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -387,7 +487,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut201CreatingSucceeded200Async(Product product) {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -396,7 +510,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -426,10 +540,9 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> post202Retry200() throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async().toBlocking().last();
+    public void post202Retry200() throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -439,7 +552,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -447,7 +560,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200Async() {
+    public Observable<Void> post202Retry200Async() {
+        return post202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsCustomHeaderPost202Retry200Headers.class);
@@ -459,10 +586,9 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async(product).toBlocking().last();
+    public void post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -473,7 +599,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -482,7 +608,22 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200Async(Product product) {
+    public Observable<Void> post202Retry200Async(Product product) {
+        return post202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> post202Retry200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsCustomHeaderPost202Retry200Headers.class);
@@ -493,10 +634,9 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> beginPost202Retry200() throws CloudException, IOException {
-        return beginPost202Retry200Async().toBlocking().single();
+    public void beginPost202Retry200() throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -506,7 +646,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -514,7 +654,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200Async() {
+    public Observable<Void> beginPost202Retry200Async() {
+        return beginPost202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>>>() {
@@ -536,10 +690,9 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> beginPost202Retry200(Product product) throws CloudException, IOException {
-        return beginPost202Retry200Async(product).toBlocking().single();
+    public void beginPost202Retry200(Product product) throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -550,7 +703,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202Retry200Async(Product product) {
+        return beginPost202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -559,7 +726,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200Async(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers>>>() {
@@ -588,10 +755,9 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededAsync().toBlocking().last();
+    public void postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -601,7 +767,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -609,7 +775,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsync() {
+    public Observable<Void> postAsyncRetrySucceededAsync() {
+        return postAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsCustomHeaderPostAsyncRetrySucceededHeaders.class);
@@ -621,10 +801,9 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededAsync(product).toBlocking().last();
+    public void postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
+        postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -635,7 +814,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetrySucceededAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -644,7 +823,22 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsync(Product product) {
+    public Observable<Void> postAsyncRetrySucceededAsync(Product product) {
+        return postAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsCustomHeaderPostAsyncRetrySucceededHeaders.class);
@@ -655,10 +849,9 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> beginPostAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededAsync().toBlocking().single();
+    public void beginPostAsyncRetrySucceeded() throws CloudException, IOException {
+        beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -668,7 +861,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -676,7 +869,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsync() {
+    public Observable<Void> beginPostAsyncRetrySucceededAsync() {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>>>() {
@@ -698,10 +905,9 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededAsync(product).toBlocking().single();
+    public void beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException {
+        beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -712,7 +918,21 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetrySucceededAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRetrySucceededAsync(Product product) {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -721,7 +941,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders>>>() {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
@@ -151,7 +151,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the Product object if successful.
      */
     public Product putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -224,7 +224,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
             public Product call(ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -257,7 +257,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -274,6 +274,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRetrySucceededAsync(Product product) {
@@ -282,7 +283,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
             public Product call(ServiceResponseWithHeaders<Product, LROsCustomHeaderPutAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -370,7 +371,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the Product object if successful.
      */
     public Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -443,7 +444,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -476,7 +477,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @return the Product object if successful.
      */
     public Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -493,6 +494,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut201CreatingSucceeded200Async(Product product) {
@@ -501,7 +503,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -588,7 +590,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
-        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
+        post202Retry200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -660,7 +662,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
             public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -692,7 +694,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202Retry200(Product product) throws CloudException, IOException {
-        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202Retry200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -709,6 +711,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202Retry200Async(Product product) {
@@ -717,7 +720,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
             public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPost202Retry200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -803,7 +806,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -875,7 +878,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
             public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -907,7 +910,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException {
-        beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -924,6 +927,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRetrySucceededAsync(Product product) {
@@ -932,7 +936,7 @@ public final class LROsCustomHeadersImpl implements LROsCustomHeaders {
             public Void call(ServiceResponseWithHeaders<Void, LROsCustomHeaderPostAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -380,10 +380,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put200Succeeded() throws CloudException, IOException, InterruptedException {
-        return put200SucceededAsync().toBlocking().last();
+    public Product put200Succeeded() throws CloudException, IOException, InterruptedException {
+        return put200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -393,7 +393,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200SucceededAsync(), serviceCallback);
+        return ServiceCall.create(put200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -401,7 +401,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200SucceededAsync() {
+    public Observable<Product> put200SucceededAsync() {
+        return put200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200SucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -413,10 +427,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put200Succeeded(Product product) throws CloudException, IOException, InterruptedException {
-        return put200SucceededAsync(product).toBlocking().last();
+    public Product put200Succeeded(Product product) throws CloudException, IOException, InterruptedException {
+        return put200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -427,7 +441,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200SucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200SucceededAsync(product), serviceCallback);
+        return ServiceCall.create(put200SucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -436,7 +450,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200SucceededAsync(Product product) {
+    public Observable<Product> put200SucceededAsync(Product product) {
+        return put200SucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200SucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -447,10 +476,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200Succeeded() throws CloudException, IOException {
-        return beginPut200SucceededAsync().toBlocking().single();
+    public Product beginPut200Succeeded() throws CloudException, IOException {
+        return beginPut200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -460,7 +489,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200SucceededAsync(), serviceCallback);
+        return ServiceCall.create(beginPut200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -468,7 +497,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200SucceededAsync() {
+    public Observable<Product> beginPut200SucceededAsync() {
+        return beginPut200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut200SucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -490,10 +533,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200Succeeded(Product product) throws CloudException, IOException {
-        return beginPut200SucceededAsync(product).toBlocking().single();
+    public Product beginPut200Succeeded(Product product) throws CloudException, IOException {
+        return beginPut200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -504,7 +547,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200SucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200SucceededAsync(product), serviceCallback);
+        return ServiceCall.create(beginPut200SucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut200SucceededAsync(Product product) {
+        return beginPut200SucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -513,7 +570,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200SucceededAsync(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut200SucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -543,10 +600,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put200SucceededNoState() throws CloudException, IOException, InterruptedException {
-        return put200SucceededNoStateAsync().toBlocking().last();
+    public Product put200SucceededNoState() throws CloudException, IOException, InterruptedException {
+        return put200SucceededNoStateWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -556,7 +613,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200SucceededNoStateAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200SucceededNoStateAsync(), serviceCallback);
+        return ServiceCall.create(put200SucceededNoStateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -564,7 +621,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200SucceededNoStateAsync() {
+    public Observable<Product> put200SucceededNoStateAsync() {
+        return put200SucceededNoStateWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200SucceededNoStateWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -576,10 +647,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put200SucceededNoState(Product product) throws CloudException, IOException, InterruptedException {
-        return put200SucceededNoStateAsync(product).toBlocking().last();
+    public Product put200SucceededNoState(Product product) throws CloudException, IOException, InterruptedException {
+        return put200SucceededNoStateWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -590,7 +661,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200SucceededNoStateAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200SucceededNoStateAsync(product), serviceCallback);
+        return ServiceCall.create(put200SucceededNoStateWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -599,7 +670,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200SucceededNoStateAsync(Product product) {
+    public Observable<Product> put200SucceededNoStateAsync(Product product) {
+        return put200SucceededNoStateWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200SucceededNoStateWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -610,10 +696,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200SucceededNoState() throws CloudException, IOException {
-        return beginPut200SucceededNoStateAsync().toBlocking().single();
+    public Product beginPut200SucceededNoState() throws CloudException, IOException {
+        return beginPut200SucceededNoStateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -623,7 +709,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200SucceededNoStateAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200SucceededNoStateAsync(), serviceCallback);
+        return ServiceCall.create(beginPut200SucceededNoStateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -631,7 +717,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200SucceededNoStateAsync() {
+    public Observable<Product> beginPut200SucceededNoStateAsync() {
+        return beginPut200SucceededNoStateWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut200SucceededNoStateWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -653,10 +753,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200SucceededNoState(Product product) throws CloudException, IOException {
-        return beginPut200SucceededNoStateAsync(product).toBlocking().single();
+    public Product beginPut200SucceededNoState(Product product) throws CloudException, IOException {
+        return beginPut200SucceededNoStateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -667,7 +767,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200SucceededNoStateAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200SucceededNoStateAsync(product), serviceCallback);
+        return ServiceCall.create(beginPut200SucceededNoStateWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut200SucceededNoStateAsync(Product product) {
+        return beginPut200SucceededNoStateWithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -676,7 +790,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200SucceededNoStateAsync(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut200SucceededNoStateWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -705,10 +819,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put202Retry200() throws CloudException, IOException, InterruptedException {
-        return put202Retry200Async().toBlocking().last();
+    public Product put202Retry200() throws CloudException, IOException, InterruptedException {
+        return put202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -718,7 +832,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put202Retry200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put202Retry200Async(), serviceCallback);
+        return ServiceCall.create(put202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -726,7 +840,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put202Retry200Async() {
+    public Observable<Product> put202Retry200Async() {
+        return put202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put202Retry200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -738,10 +866,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put202Retry200(Product product) throws CloudException, IOException, InterruptedException {
-        return put202Retry200Async(product).toBlocking().last();
+    public Product put202Retry200(Product product) throws CloudException, IOException, InterruptedException {
+        return put202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -752,7 +880,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put202Retry200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put202Retry200Async(product), serviceCallback);
+        return ServiceCall.create(put202Retry200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -761,7 +889,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put202Retry200Async(Product product) {
+    public Observable<Product> put202Retry200Async(Product product) {
+        return put202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put202Retry200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -772,10 +915,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut202Retry200() throws CloudException, IOException {
-        return beginPut202Retry200Async().toBlocking().single();
+    public Product beginPut202Retry200() throws CloudException, IOException {
+        return beginPut202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -785,7 +928,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut202Retry200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut202Retry200Async(), serviceCallback);
+        return ServiceCall.create(beginPut202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -793,7 +936,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut202Retry200Async() {
+    public Observable<Product> beginPut202Retry200Async() {
+        return beginPut202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut202Retry200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -815,10 +972,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut202Retry200(Product product) throws CloudException, IOException {
-        return beginPut202Retry200Async(product).toBlocking().single();
+    public Product beginPut202Retry200(Product product) throws CloudException, IOException {
+        return beginPut202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -829,7 +986,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut202Retry200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut202Retry200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut202Retry200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut202Retry200Async(Product product) {
+        return beginPut202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -838,7 +1009,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut202Retry200Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut202Retry200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -867,10 +1038,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async().toBlocking().last();
+    public Product put201CreatingSucceeded200() throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -880,7 +1051,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -888,7 +1059,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async() {
+    public Observable<Product> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -900,10 +1085,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200Async(product).toBlocking().last();
+    public Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
+        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -914,7 +1099,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(put201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -923,7 +1108,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200Async(Product product) {
+    public Observable<Product> put201CreatingSucceeded200Async(Product product) {
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put201CreatingSucceeded200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -934,10 +1134,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut201CreatingSucceeded200() throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async().toBlocking().single();
+    public Product beginPut201CreatingSucceeded200() throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -947,7 +1147,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -955,7 +1155,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async() {
+    public Observable<Product> beginPut201CreatingSucceeded200Async() {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -977,10 +1191,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200Async(product).toBlocking().single();
+    public Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -991,7 +1205,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingSucceeded200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingSucceeded200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut201CreatingSucceeded200Async(Product product) {
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1000,7 +1228,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut201CreatingSucceeded200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1030,10 +1258,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put200UpdatingSucceeded204() throws CloudException, IOException, InterruptedException {
-        return put200UpdatingSucceeded204Async().toBlocking().last();
+    public Product put200UpdatingSucceeded204() throws CloudException, IOException, InterruptedException {
+        return put200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1043,7 +1271,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200UpdatingSucceeded204Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200UpdatingSucceeded204Async(), serviceCallback);
+        return ServiceCall.create(put200UpdatingSucceeded204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1051,7 +1279,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200UpdatingSucceeded204Async() {
+    public Observable<Product> put200UpdatingSucceeded204Async() {
+        return put200UpdatingSucceeded204WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200UpdatingSucceeded204WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -1063,10 +1305,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put200UpdatingSucceeded204(Product product) throws CloudException, IOException, InterruptedException {
-        return put200UpdatingSucceeded204Async(product).toBlocking().last();
+    public Product put200UpdatingSucceeded204(Product product) throws CloudException, IOException, InterruptedException {
+        return put200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1077,7 +1319,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200UpdatingSucceeded204Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200UpdatingSucceeded204Async(product), serviceCallback);
+        return ServiceCall.create(put200UpdatingSucceeded204WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1086,7 +1328,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200UpdatingSucceeded204Async(Product product) {
+    public Observable<Product> put200UpdatingSucceeded204Async(Product product) {
+        return put200UpdatingSucceeded204WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200UpdatingSucceeded204WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -1097,10 +1354,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200UpdatingSucceeded204() throws CloudException, IOException {
-        return beginPut200UpdatingSucceeded204Async().toBlocking().single();
+    public Product beginPut200UpdatingSucceeded204() throws CloudException, IOException {
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1110,7 +1367,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200UpdatingSucceeded204Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200UpdatingSucceeded204Async(), serviceCallback);
+        return ServiceCall.create(beginPut200UpdatingSucceeded204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1118,7 +1375,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204Async() {
+    public Observable<Product> beginPut200UpdatingSucceeded204Async() {
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1140,10 +1411,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200UpdatingSucceeded204(Product product) throws CloudException, IOException {
-        return beginPut200UpdatingSucceeded204Async(product).toBlocking().single();
+    public Product beginPut200UpdatingSucceeded204(Product product) throws CloudException, IOException {
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1154,7 +1425,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200UpdatingSucceeded204Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200UpdatingSucceeded204Async(product), serviceCallback);
+        return ServiceCall.create(beginPut200UpdatingSucceeded204WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut200UpdatingSucceeded204Async(Product product) {
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1163,7 +1448,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut200UpdatingSucceeded204WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1192,10 +1477,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put201CreatingFailed200() throws CloudException, IOException, InterruptedException {
-        return put201CreatingFailed200Async().toBlocking().last();
+    public Product put201CreatingFailed200() throws CloudException, IOException, InterruptedException {
+        return put201CreatingFailed200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1205,7 +1490,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put201CreatingFailed200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put201CreatingFailed200Async(), serviceCallback);
+        return ServiceCall.create(put201CreatingFailed200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1213,7 +1498,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put201CreatingFailed200Async() {
+    public Observable<Product> put201CreatingFailed200Async() {
+        return put201CreatingFailed200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put201CreatingFailed200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -1225,10 +1524,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put201CreatingFailed200(Product product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingFailed200Async(product).toBlocking().last();
+    public Product put201CreatingFailed200(Product product) throws CloudException, IOException, InterruptedException {
+        return put201CreatingFailed200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1239,7 +1538,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put201CreatingFailed200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put201CreatingFailed200Async(product), serviceCallback);
+        return ServiceCall.create(put201CreatingFailed200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1248,7 +1547,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put201CreatingFailed200Async(Product product) {
+    public Observable<Product> put201CreatingFailed200Async(Product product) {
+        return put201CreatingFailed200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put201CreatingFailed200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -1259,10 +1573,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut201CreatingFailed200() throws CloudException, IOException {
-        return beginPut201CreatingFailed200Async().toBlocking().single();
+    public Product beginPut201CreatingFailed200() throws CloudException, IOException {
+        return beginPut201CreatingFailed200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1272,7 +1586,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut201CreatingFailed200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingFailed200Async(), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingFailed200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1280,7 +1594,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut201CreatingFailed200Async() {
+    public Observable<Product> beginPut201CreatingFailed200Async() {
+        return beginPut201CreatingFailed200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut201CreatingFailed200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1302,10 +1630,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut201CreatingFailed200(Product product) throws CloudException, IOException {
-        return beginPut201CreatingFailed200Async(product).toBlocking().single();
+    public Product beginPut201CreatingFailed200(Product product) throws CloudException, IOException {
+        return beginPut201CreatingFailed200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1316,7 +1644,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut201CreatingFailed200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut201CreatingFailed200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut201CreatingFailed200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut201CreatingFailed200Async(Product product) {
+        return beginPut201CreatingFailed200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1325,7 +1667,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut201CreatingFailed200Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut201CreatingFailed200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1355,10 +1697,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponse<Product> put200Acceptedcanceled200() throws CloudException, IOException, InterruptedException {
-        return put200Acceptedcanceled200Async().toBlocking().last();
+    public Product put200Acceptedcanceled200() throws CloudException, IOException, InterruptedException {
+        return put200Acceptedcanceled200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1368,7 +1710,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200Acceptedcanceled200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200Acceptedcanceled200Async(), serviceCallback);
+        return ServiceCall.create(put200Acceptedcanceled200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1376,7 +1718,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200Acceptedcanceled200Async() {
+    public Observable<Product> put200Acceptedcanceled200Async() {
+        return put200Acceptedcanceled200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200Acceptedcanceled200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.put200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -1388,10 +1744,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponse if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> put200Acceptedcanceled200(Product product) throws CloudException, IOException, InterruptedException {
-        return put200Acceptedcanceled200Async(product).toBlocking().last();
+    public Product put200Acceptedcanceled200(Product product) throws CloudException, IOException, InterruptedException {
+        return put200Acceptedcanceled200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1402,7 +1758,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> put200Acceptedcanceled200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(put200Acceptedcanceled200Async(product), serviceCallback);
+        return ServiceCall.create(put200Acceptedcanceled200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1411,7 +1767,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Product>> put200Acceptedcanceled200Async(Product product) {
+    public Observable<Product> put200Acceptedcanceled200Async(Product product) {
+        return put200Acceptedcanceled200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Product>> put200Acceptedcanceled200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.put200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Product>() { }.getType());
@@ -1422,10 +1793,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200Acceptedcanceled200() throws CloudException, IOException {
-        return beginPut200Acceptedcanceled200Async().toBlocking().single();
+    public Product beginPut200Acceptedcanceled200() throws CloudException, IOException {
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1435,7 +1806,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200Acceptedcanceled200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200Acceptedcanceled200Async(), serviceCallback);
+        return ServiceCall.create(beginPut200Acceptedcanceled200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1443,7 +1814,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200Async() {
+    public Observable<Product> beginPut200Acceptedcanceled200Async() {
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPut200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1465,10 +1850,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponse<Product> beginPut200Acceptedcanceled200(Product product) throws CloudException, IOException {
-        return beginPut200Acceptedcanceled200Async(product).toBlocking().single();
+    public Product beginPut200Acceptedcanceled200(Product product) throws CloudException, IOException {
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1479,7 +1864,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPut200Acceptedcanceled200Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(beginPut200Acceptedcanceled200Async(product), serviceCallback);
+        return ServiceCall.create(beginPut200Acceptedcanceled200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPut200Acceptedcanceled200Async(Product product) {
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync(product).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1488,7 +1887,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200Async(Product product) {
+    public Observable<ServiceResponse<Product>> beginPut200Acceptedcanceled200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPut200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Product>>>() {
@@ -1517,10 +1916,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> putNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
-        return putNoHeaderInRetryAsync().toBlocking().last();
+    public Product putNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
+        return putNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1530,7 +1929,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1538,7 +1937,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryAsync() {
+    public Observable<Product> putNoHeaderInRetryAsync() {
+        return putNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutNoHeaderInRetryHeaders.class);
@@ -1550,10 +1963,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> putNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException {
-        return putNoHeaderInRetryAsync(product).toBlocking().last();
+    public Product putNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException {
+        return putNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1564,7 +1977,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putNoHeaderInRetryAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putNoHeaderInRetryAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putNoHeaderInRetryWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1573,7 +1986,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryAsync(Product product) {
+    public Observable<Product> putNoHeaderInRetryAsync(Product product) {
+        return putNoHeaderInRetryWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> putNoHeaderInRetryWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutNoHeaderInRetryHeaders.class);
@@ -1584,10 +2012,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> beginPutNoHeaderInRetry() throws CloudException, IOException {
-        return beginPutNoHeaderInRetryAsync().toBlocking().single();
+    public Product beginPutNoHeaderInRetry() throws CloudException, IOException {
+        return beginPutNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1597,7 +2025,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1605,7 +2033,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryAsync() {
+    public Observable<Product> beginPutNoHeaderInRetryAsync() {
+        return beginPutNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>>>() {
@@ -1627,10 +2069,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> beginPutNoHeaderInRetry(Product product) throws CloudException, IOException {
-        return beginPutNoHeaderInRetryAsync(product).toBlocking().single();
+    public Product beginPutNoHeaderInRetry(Product product) throws CloudException, IOException {
+        return beginPutNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1641,7 +2083,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutNoHeaderInRetryAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutNoHeaderInRetryAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutNoHeaderInRetryWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutNoHeaderInRetryAsync(Product product) {
+        return beginPutNoHeaderInRetryWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1650,7 +2106,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>> beginPutNoHeaderInRetryWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders>>>() {
@@ -1679,10 +2135,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededAsync().toBlocking().last();
+    public Product putAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1692,7 +2148,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1700,7 +2156,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsync() {
+    public Observable<Product> putAsyncRetrySucceededAsync() {
+        return putAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncRetrySucceededHeaders.class);
@@ -1712,10 +2182,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededAsync(product).toBlocking().last();
+    public Product putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1726,7 +2196,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1735,7 +2205,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededAsync(Product product) {
+    public Observable<Product> putAsyncRetrySucceededAsync(Product product) {
+        return putAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> putAsyncRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncRetrySucceededHeaders.class);
@@ -1746,10 +2231,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> beginPutAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededAsync().toBlocking().single();
+    public Product beginPutAsyncRetrySucceeded() throws CloudException, IOException {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1759,7 +2244,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1767,7 +2252,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsync() {
+    public Observable<Product> beginPutAsyncRetrySucceededAsync() {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>>>() {
@@ -1789,10 +2288,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededAsync(product).toBlocking().single();
+    public Product beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1803,7 +2302,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRetrySucceededAsync(Product product) {
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1812,7 +2325,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>> beginPutAsyncRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders>>>() {
@@ -1841,10 +2354,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> putAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrySucceededAsync().toBlocking().last();
+    public Product putAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return putAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1854,7 +2367,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1862,7 +2375,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededAsync() {
+    public Observable<Product> putAsyncNoRetrySucceededAsync() {
+        return putAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncNoRetrySucceededHeaders.class);
@@ -1874,10 +2401,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> putAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrySucceededAsync(product).toBlocking().last();
+    public Product putAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -1888,7 +2415,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncNoRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -1897,7 +2424,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededAsync(Product product) {
+    public Observable<Product> putAsyncNoRetrySucceededAsync(Product product) {
+        return putAsyncNoRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> putAsyncNoRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncNoRetrySucceededHeaders.class);
@@ -1908,10 +2450,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> beginPutAsyncNoRetrySucceeded() throws CloudException, IOException {
-        return beginPutAsyncNoRetrySucceededAsync().toBlocking().single();
+    public Product beginPutAsyncNoRetrySucceeded() throws CloudException, IOException {
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1921,7 +2463,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1929,7 +2471,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededAsync() {
+    public Observable<Product> beginPutAsyncNoRetrySucceededAsync() {
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>>>() {
@@ -1951,10 +2507,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> beginPutAsyncNoRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPutAsyncNoRetrySucceededAsync(product).toBlocking().single();
+    public Product beginPutAsyncNoRetrySucceeded(Product product) throws CloudException, IOException {
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1965,7 +2521,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncNoRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncNoRetrySucceededAsync(Product product) {
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1974,7 +2544,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>> beginPutAsyncNoRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders>>>() {
@@ -2003,10 +2573,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> putAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
-        return putAsyncRetryFailedAsync().toBlocking().last();
+    public Product putAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
+        return putAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2016,7 +2586,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRetryFailedAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2024,7 +2594,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedAsync() {
+    public Observable<Product> putAsyncRetryFailedAsync() {
+        return putAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncRetryFailedHeaders.class);
@@ -2036,10 +2620,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> putAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetryFailedAsync(product).toBlocking().last();
+    public Product putAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2050,7 +2634,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncRetryFailedAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncRetryFailedAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncRetryFailedWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2059,7 +2643,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedAsync(Product product) {
+    public Observable<Product> putAsyncRetryFailedAsync(Product product) {
+        return putAsyncRetryFailedWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> putAsyncRetryFailedWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncRetryFailedHeaders.class);
@@ -2070,10 +2669,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> beginPutAsyncRetryFailed() throws CloudException, IOException {
-        return beginPutAsyncRetryFailedAsync().toBlocking().single();
+    public Product beginPutAsyncRetryFailed() throws CloudException, IOException {
+        return beginPutAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2083,7 +2682,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRetryFailedAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2091,7 +2690,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedAsync() {
+    public Observable<Product> beginPutAsyncRetryFailedAsync() {
+        return beginPutAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>>>() {
@@ -2113,10 +2726,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> beginPutAsyncRetryFailed(Product product) throws CloudException, IOException {
-        return beginPutAsyncRetryFailedAsync(product).toBlocking().single();
+    public Product beginPutAsyncRetryFailed(Product product) throws CloudException, IOException {
+        return beginPutAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2127,7 +2740,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncRetryFailedAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncRetryFailedAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncRetryFailedWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncRetryFailedAsync(Product product) {
+        return beginPutAsyncRetryFailedWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2136,7 +2763,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>> beginPutAsyncRetryFailedWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders>>>() {
@@ -2165,10 +2792,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> putAsyncNoRetrycanceled() throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrycanceledAsync().toBlocking().last();
+    public Product putAsyncNoRetrycanceled() throws CloudException, IOException, InterruptedException {
+        return putAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2178,7 +2805,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncNoRetrycanceledAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2186,7 +2813,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledAsync() {
+    public Observable<Product> putAsyncNoRetrycanceledAsync() {
+        return putAsyncNoRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncNoRetrycanceledHeaders.class);
@@ -2198,10 +2839,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> putAsyncNoRetrycanceled(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrycanceledAsync(product).toBlocking().last();
+    public Product putAsyncNoRetrycanceled(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2212,7 +2853,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncNoRetrycanceledAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoRetrycanceledAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoRetrycanceledWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2221,7 +2862,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledAsync(Product product) {
+    public Observable<Product> putAsyncNoRetrycanceledAsync(Product product) {
+        return putAsyncNoRetrycanceledWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> putAsyncNoRetrycanceledWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncNoRetrycanceledHeaders.class);
@@ -2232,10 +2888,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> beginPutAsyncNoRetrycanceled() throws CloudException, IOException {
-        return beginPutAsyncNoRetrycanceledAsync().toBlocking().single();
+    public Product beginPutAsyncNoRetrycanceled() throws CloudException, IOException {
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2245,7 +2901,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncNoRetrycanceledAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2253,7 +2909,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledAsync() {
+    public Observable<Product> beginPutAsyncNoRetrycanceledAsync() {
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>>>() {
@@ -2275,10 +2945,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> beginPutAsyncNoRetrycanceled(Product product) throws CloudException, IOException {
-        return beginPutAsyncNoRetrycanceledAsync(product).toBlocking().single();
+    public Product beginPutAsyncNoRetrycanceled(Product product) throws CloudException, IOException {
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2289,7 +2959,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncNoRetrycanceledAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrycanceledAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoRetrycanceledWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncNoRetrycanceledAsync(Product product) {
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2298,7 +2982,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>> beginPutAsyncNoRetrycanceledWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders>>>() {
@@ -2327,10 +3011,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> putAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
-        return putAsyncNoHeaderInRetryAsync().toBlocking().last();
+    public Product putAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2340,7 +3024,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2348,7 +3032,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryAsync() {
+    public Observable<Product> putAsyncNoHeaderInRetryAsync() {
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncNoHeaderInRetryHeaders.class);
@@ -2360,10 +3058,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> putAsyncNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoHeaderInRetryAsync(product).toBlocking().last();
+    public Product putAsyncNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException {
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2374,7 +3072,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> putAsyncNoHeaderInRetryAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(putAsyncNoHeaderInRetryAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(putAsyncNoHeaderInRetryWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2383,7 +3081,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryAsync(Product product) {
+    public Observable<Product> putAsyncNoHeaderInRetryAsync(Product product) {
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> putAsyncNoHeaderInRetryWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPutAsyncNoHeaderInRetryHeaders.class);
@@ -2394,10 +3107,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> beginPutAsyncNoHeaderInRetry() throws CloudException, IOException {
-        return beginPutAsyncNoHeaderInRetryAsync().toBlocking().single();
+    public Product beginPutAsyncNoHeaderInRetry() throws CloudException, IOException {
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2407,7 +3120,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2415,7 +3128,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryAsync() {
+    public Observable<Product> beginPutAsyncNoHeaderInRetryAsync() {
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPutAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>>>() {
@@ -2437,10 +3164,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> beginPutAsyncNoHeaderInRetry(Product product) throws CloudException, IOException {
-        return beginPutAsyncNoHeaderInRetryAsync(product).toBlocking().single();
+    public Product beginPutAsyncNoHeaderInRetry(Product product) throws CloudException, IOException {
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2451,7 +3178,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPutAsyncNoHeaderInRetryAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPutAsyncNoHeaderInRetryAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPutAsyncNoHeaderInRetryAsync(Product product) {
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2460,7 +3201,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>> beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPutAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders>>>() {
@@ -2489,10 +3230,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in ServiceResponse if successful.
+     * @return the Sku object  if successful.
      */
-    public ServiceResponse<Sku> putNonResource() throws CloudException, IOException, InterruptedException {
-        return putNonResourceAsync().toBlocking().last();
+    public Sku putNonResource() throws CloudException, IOException, InterruptedException {
+        return putNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2502,7 +3243,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> putNonResourceAsync(final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(putNonResourceAsync(), serviceCallback);
+        return ServiceCall.create(putNonResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2510,7 +3251,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Sku>> putNonResourceAsync() {
+    public Observable<Sku> putNonResourceAsync() {
+        return putNonResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Sku>> putNonResourceWithServiceResponseAsync() {
         final Sku sku = null;
         Observable<Response<ResponseBody>> observable = service.putNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Sku>() { }.getType());
@@ -2522,10 +3277,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in ServiceResponse if successful.
+     * @return the Sku object if successful.
      */
-    public ServiceResponse<Sku> putNonResource(Sku sku) throws CloudException, IOException, InterruptedException {
-        return putNonResourceAsync(sku).toBlocking().last();
+    public Sku putNonResource(Sku sku) throws CloudException, IOException, InterruptedException {
+        return putNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2536,7 +3291,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> putNonResourceAsync(Sku sku, final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(putNonResourceAsync(sku), serviceCallback);
+        return ServiceCall.create(putNonResourceWithServiceResponseAsync(sku), serviceCallback);
     }
 
     /**
@@ -2545,7 +3300,22 @@ public final class LROsImpl implements LROs {
      * @param sku sku to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Sku>> putNonResourceAsync(Sku sku) {
+    public Observable<Sku> putNonResourceAsync(Sku sku) {
+        return putNonResourceWithServiceResponseAsync(sku).map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Sku>> putNonResourceWithServiceResponseAsync(Sku sku) {
         Validator.validate(sku);
         Observable<Response<ResponseBody>> observable = service.putNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Sku>() { }.getType());
@@ -2556,10 +3326,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
-    public ServiceResponse<Sku> beginPutNonResource() throws CloudException, IOException {
-        return beginPutNonResourceAsync().toBlocking().single();
+    public Sku beginPutNonResource() throws CloudException, IOException {
+        return beginPutNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2569,7 +3339,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> beginPutNonResourceAsync(final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(beginPutNonResourceAsync(), serviceCallback);
+        return ServiceCall.create(beginPutNonResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2577,7 +3347,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Sku object
      */
-    public Observable<ServiceResponse<Sku>> beginPutNonResourceAsync() {
+    public Observable<Sku> beginPutNonResourceAsync() {
+        return beginPutNonResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable to the Sku object
+     */
+    public Observable<ServiceResponse<Sku>> beginPutNonResourceWithServiceResponseAsync() {
         final Sku sku = null;
         return service.beginPutNonResource(sku, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Sku>>>() {
@@ -2599,10 +3383,10 @@ public final class LROsImpl implements LROs {
      * @param sku sku to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
-    public ServiceResponse<Sku> beginPutNonResource(Sku sku) throws CloudException, IOException {
-        return beginPutNonResourceAsync(sku).toBlocking().single();
+    public Sku beginPutNonResource(Sku sku) throws CloudException, IOException {
+        return beginPutNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2613,7 +3397,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> beginPutNonResourceAsync(Sku sku, final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(beginPutNonResourceAsync(sku), serviceCallback);
+        return ServiceCall.create(beginPutNonResourceWithServiceResponseAsync(sku), serviceCallback);
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable to the Sku object
+     */
+    public Observable<Sku> beginPutNonResourceAsync(Sku sku) {
+        return beginPutNonResourceWithServiceResponseAsync(sku).map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2622,7 +3420,7 @@ public final class LROsImpl implements LROs {
      * @param sku sku to put
      * @return the observable to the Sku object
      */
-    public Observable<ServiceResponse<Sku>> beginPutNonResourceAsync(Sku sku) {
+    public Observable<ServiceResponse<Sku>> beginPutNonResourceWithServiceResponseAsync(Sku sku) {
         Validator.validate(sku);
         return service.beginPutNonResource(sku, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Sku>>>() {
@@ -2651,10 +3449,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in ServiceResponse if successful.
+     * @return the Sku object  if successful.
      */
-    public ServiceResponse<Sku> putAsyncNonResource() throws CloudException, IOException, InterruptedException {
-        return putAsyncNonResourceAsync().toBlocking().last();
+    public Sku putAsyncNonResource() throws CloudException, IOException, InterruptedException {
+        return putAsyncNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2664,7 +3462,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> putAsyncNonResourceAsync(final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(putAsyncNonResourceAsync(), serviceCallback);
+        return ServiceCall.create(putAsyncNonResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2672,7 +3470,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Sku>> putAsyncNonResourceAsync() {
+    public Observable<Sku> putAsyncNonResourceAsync() {
+        return putAsyncNonResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Sku>> putAsyncNonResourceWithServiceResponseAsync() {
         final Sku sku = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Sku>() { }.getType());
@@ -2684,10 +3496,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in ServiceResponse if successful.
+     * @return the Sku object if successful.
      */
-    public ServiceResponse<Sku> putAsyncNonResource(Sku sku) throws CloudException, IOException, InterruptedException {
-        return putAsyncNonResourceAsync(sku).toBlocking().last();
+    public Sku putAsyncNonResource(Sku sku) throws CloudException, IOException, InterruptedException {
+        return putAsyncNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2698,7 +3510,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> putAsyncNonResourceAsync(Sku sku, final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(putAsyncNonResourceAsync(sku), serviceCallback);
+        return ServiceCall.create(putAsyncNonResourceWithServiceResponseAsync(sku), serviceCallback);
     }
 
     /**
@@ -2707,7 +3519,22 @@ public final class LROsImpl implements LROs {
      * @param sku Sku to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Sku>> putAsyncNonResourceAsync(Sku sku) {
+    public Observable<Sku> putAsyncNonResourceAsync(Sku sku) {
+        return putAsyncNonResourceWithServiceResponseAsync(sku).map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Sku>> putAsyncNonResourceWithServiceResponseAsync(Sku sku) {
         Validator.validate(sku);
         Observable<Response<ResponseBody>> observable = service.putAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<Sku>() { }.getType());
@@ -2718,10 +3545,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
-    public ServiceResponse<Sku> beginPutAsyncNonResource() throws CloudException, IOException {
-        return beginPutAsyncNonResourceAsync().toBlocking().single();
+    public Sku beginPutAsyncNonResource() throws CloudException, IOException {
+        return beginPutAsyncNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2731,7 +3558,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> beginPutAsyncNonResourceAsync(final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(beginPutAsyncNonResourceAsync(), serviceCallback);
+        return ServiceCall.create(beginPutAsyncNonResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2739,7 +3566,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Sku object
      */
-    public Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceAsync() {
+    public Observable<Sku> beginPutAsyncNonResourceAsync() {
+        return beginPutAsyncNonResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable to the Sku object
+     */
+    public Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceWithServiceResponseAsync() {
         final Sku sku = null;
         return service.beginPutAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Sku>>>() {
@@ -2761,10 +3602,10 @@ public final class LROsImpl implements LROs {
      * @param sku Sku to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
-    public ServiceResponse<Sku> beginPutAsyncNonResource(Sku sku) throws CloudException, IOException {
-        return beginPutAsyncNonResourceAsync(sku).toBlocking().single();
+    public Sku beginPutAsyncNonResource(Sku sku) throws CloudException, IOException {
+        return beginPutAsyncNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2775,7 +3616,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> beginPutAsyncNonResourceAsync(Sku sku, final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(beginPutAsyncNonResourceAsync(sku), serviceCallback);
+        return ServiceCall.create(beginPutAsyncNonResourceWithServiceResponseAsync(sku), serviceCallback);
+    }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @return the observable to the Sku object
+     */
+    public Observable<Sku> beginPutAsyncNonResourceAsync(Sku sku) {
+        return beginPutAsyncNonResourceWithServiceResponseAsync(sku).map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2784,7 +3639,7 @@ public final class LROsImpl implements LROs {
      * @param sku Sku to put
      * @return the observable to the Sku object
      */
-    public Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceAsync(Sku sku) {
+    public Observable<ServiceResponse<Sku>> beginPutAsyncNonResourceWithServiceResponseAsync(Sku sku) {
         Validator.validate(sku);
         return service.beginPutAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Sku>>>() {
@@ -2813,10 +3668,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProduct object wrapped in ServiceResponse if successful.
+     * @return the SubProduct object  if successful.
      */
-    public ServiceResponse<SubProduct> putSubResource() throws CloudException, IOException, InterruptedException {
-        return putSubResourceAsync().toBlocking().last();
+    public SubProduct putSubResource() throws CloudException, IOException, InterruptedException {
+        return putSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2826,7 +3681,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProduct> putSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback) {
-        return ServiceCall.create(putSubResourceAsync(), serviceCallback);
+        return ServiceCall.create(putSubResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2834,7 +3689,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SubProduct>> putSubResourceAsync() {
+    public Observable<SubProduct> putSubResourceAsync() {
+        return putSubResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SubProduct>, SubProduct>() {
+            @Override
+            public SubProduct call(ServiceResponse<SubProduct> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SubProduct>> putSubResourceWithServiceResponseAsync() {
         final SubProduct product = null;
         Observable<Response<ResponseBody>> observable = service.putSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SubProduct>() { }.getType());
@@ -2846,10 +3715,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProduct object wrapped in ServiceResponse if successful.
+     * @return the SubProduct object if successful.
      */
-    public ServiceResponse<SubProduct> putSubResource(SubProduct product) throws CloudException, IOException, InterruptedException {
-        return putSubResourceAsync(product).toBlocking().last();
+    public SubProduct putSubResource(SubProduct product) throws CloudException, IOException, InterruptedException {
+        return putSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2860,7 +3729,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProduct> putSubResourceAsync(SubProduct product, final ServiceCallback<SubProduct> serviceCallback) {
-        return ServiceCall.create(putSubResourceAsync(product), serviceCallback);
+        return ServiceCall.create(putSubResourceWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -2869,7 +3738,22 @@ public final class LROsImpl implements LROs {
      * @param product Sub Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SubProduct>> putSubResourceAsync(SubProduct product) {
+    public Observable<SubProduct> putSubResourceAsync(SubProduct product) {
+        return putSubResourceWithServiceResponseAsync(product).map(new Func1<ServiceResponse<SubProduct>, SubProduct>() {
+            @Override
+            public SubProduct call(ServiceResponse<SubProduct> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SubProduct>> putSubResourceWithServiceResponseAsync(SubProduct product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SubProduct>() { }.getType());
@@ -2880,10 +3764,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
-    public ServiceResponse<SubProduct> beginPutSubResource() throws CloudException, IOException {
-        return beginPutSubResourceAsync().toBlocking().single();
+    public SubProduct beginPutSubResource() throws CloudException, IOException {
+        return beginPutSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2893,7 +3777,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProduct> beginPutSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback) {
-        return ServiceCall.create(beginPutSubResourceAsync(), serviceCallback);
+        return ServiceCall.create(beginPutSubResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2901,7 +3785,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the SubProduct object
      */
-    public Observable<ServiceResponse<SubProduct>> beginPutSubResourceAsync() {
+    public Observable<SubProduct> beginPutSubResourceAsync() {
+        return beginPutSubResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SubProduct>, SubProduct>() {
+            @Override
+            public SubProduct call(ServiceResponse<SubProduct> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable to the SubProduct object
+     */
+    public Observable<ServiceResponse<SubProduct>> beginPutSubResourceWithServiceResponseAsync() {
         final SubProduct product = null;
         return service.beginPutSubResource(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SubProduct>>>() {
@@ -2923,10 +3821,10 @@ public final class LROsImpl implements LROs {
      * @param product Sub Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
-    public ServiceResponse<SubProduct> beginPutSubResource(SubProduct product) throws CloudException, IOException {
-        return beginPutSubResourceAsync(product).toBlocking().single();
+    public SubProduct beginPutSubResource(SubProduct product) throws CloudException, IOException {
+        return beginPutSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2937,7 +3835,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProduct> beginPutSubResourceAsync(SubProduct product, final ServiceCallback<SubProduct> serviceCallback) {
-        return ServiceCall.create(beginPutSubResourceAsync(product), serviceCallback);
+        return ServiceCall.create(beginPutSubResourceWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable to the SubProduct object
+     */
+    public Observable<SubProduct> beginPutSubResourceAsync(SubProduct product) {
+        return beginPutSubResourceWithServiceResponseAsync(product).map(new Func1<ServiceResponse<SubProduct>, SubProduct>() {
+            @Override
+            public SubProduct call(ServiceResponse<SubProduct> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2946,7 +3858,7 @@ public final class LROsImpl implements LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    public Observable<ServiceResponse<SubProduct>> beginPutSubResourceAsync(SubProduct product) {
+    public Observable<ServiceResponse<SubProduct>> beginPutSubResourceWithServiceResponseAsync(SubProduct product) {
         Validator.validate(product);
         return service.beginPutSubResource(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SubProduct>>>() {
@@ -2975,10 +3887,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProduct object wrapped in ServiceResponse if successful.
+     * @return the SubProduct object  if successful.
      */
-    public ServiceResponse<SubProduct> putAsyncSubResource() throws CloudException, IOException, InterruptedException {
-        return putAsyncSubResourceAsync().toBlocking().last();
+    public SubProduct putAsyncSubResource() throws CloudException, IOException, InterruptedException {
+        return putAsyncSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -2988,7 +3900,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProduct> putAsyncSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback) {
-        return ServiceCall.create(putAsyncSubResourceAsync(), serviceCallback);
+        return ServiceCall.create(putAsyncSubResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2996,7 +3908,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SubProduct>> putAsyncSubResourceAsync() {
+    public Observable<SubProduct> putAsyncSubResourceAsync() {
+        return putAsyncSubResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SubProduct>, SubProduct>() {
+            @Override
+            public SubProduct call(ServiceResponse<SubProduct> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SubProduct>> putAsyncSubResourceWithServiceResponseAsync() {
         final SubProduct product = null;
         Observable<Response<ResponseBody>> observable = service.putAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SubProduct>() { }.getType());
@@ -3008,10 +3934,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the SubProduct object wrapped in ServiceResponse if successful.
+     * @return the SubProduct object if successful.
      */
-    public ServiceResponse<SubProduct> putAsyncSubResource(SubProduct product) throws CloudException, IOException, InterruptedException {
-        return putAsyncSubResourceAsync(product).toBlocking().last();
+    public SubProduct putAsyncSubResource(SubProduct product) throws CloudException, IOException, InterruptedException {
+        return putAsyncSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3022,7 +3948,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProduct> putAsyncSubResourceAsync(SubProduct product, final ServiceCallback<SubProduct> serviceCallback) {
-        return ServiceCall.create(putAsyncSubResourceAsync(product), serviceCallback);
+        return ServiceCall.create(putAsyncSubResourceWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -3031,7 +3957,22 @@ public final class LROsImpl implements LROs {
      * @param product Sub Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<SubProduct>> putAsyncSubResourceAsync(SubProduct product) {
+    public Observable<SubProduct> putAsyncSubResourceAsync(SubProduct product) {
+        return putAsyncSubResourceWithServiceResponseAsync(product).map(new Func1<ServiceResponse<SubProduct>, SubProduct>() {
+            @Override
+            public SubProduct call(ServiceResponse<SubProduct> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<SubProduct>> putAsyncSubResourceWithServiceResponseAsync(SubProduct product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.putAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPutOrPatchResultAsync(observable, new TypeToken<SubProduct>() { }.getType());
@@ -3042,10 +3983,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
-    public ServiceResponse<SubProduct> beginPutAsyncSubResource() throws CloudException, IOException {
-        return beginPutAsyncSubResourceAsync().toBlocking().single();
+    public SubProduct beginPutAsyncSubResource() throws CloudException, IOException {
+        return beginPutAsyncSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3055,7 +3996,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProduct> beginPutAsyncSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback) {
-        return ServiceCall.create(beginPutAsyncSubResourceAsync(), serviceCallback);
+        return ServiceCall.create(beginPutAsyncSubResourceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3063,7 +4004,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the SubProduct object
      */
-    public Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceAsync() {
+    public Observable<SubProduct> beginPutAsyncSubResourceAsync() {
+        return beginPutAsyncSubResourceWithServiceResponseAsync().map(new Func1<ServiceResponse<SubProduct>, SubProduct>() {
+            @Override
+            public SubProduct call(ServiceResponse<SubProduct> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable to the SubProduct object
+     */
+    public Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceWithServiceResponseAsync() {
         final SubProduct product = null;
         return service.beginPutAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SubProduct>>>() {
@@ -3085,10 +4040,10 @@ public final class LROsImpl implements LROs {
      * @param product Sub Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SubProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SubProduct object if successful.
      */
-    public ServiceResponse<SubProduct> beginPutAsyncSubResource(SubProduct product) throws CloudException, IOException {
-        return beginPutAsyncSubResourceAsync(product).toBlocking().single();
+    public SubProduct beginPutAsyncSubResource(SubProduct product) throws CloudException, IOException {
+        return beginPutAsyncSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3099,7 +4054,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SubProduct> beginPutAsyncSubResourceAsync(SubProduct product, final ServiceCallback<SubProduct> serviceCallback) {
-        return ServiceCall.create(beginPutAsyncSubResourceAsync(product), serviceCallback);
+        return ServiceCall.create(beginPutAsyncSubResourceWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @return the observable to the SubProduct object
+     */
+    public Observable<SubProduct> beginPutAsyncSubResourceAsync(SubProduct product) {
+        return beginPutAsyncSubResourceWithServiceResponseAsync(product).map(new Func1<ServiceResponse<SubProduct>, SubProduct>() {
+            @Override
+            public SubProduct call(ServiceResponse<SubProduct> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -3108,7 +4077,7 @@ public final class LROsImpl implements LROs {
      * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
-    public Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceAsync(SubProduct product) {
+    public Observable<ServiceResponse<SubProduct>> beginPutAsyncSubResourceWithServiceResponseAsync(SubProduct product) {
         Validator.validate(product);
         return service.beginPutAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SubProduct>>>() {
@@ -3137,10 +4106,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders> deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException {
-        return deleteProvisioning202Accepted200SucceededAsync().toBlocking().last();
+    public Product deleteProvisioning202Accepted200Succeeded() throws CloudException, IOException, InterruptedException {
+        return deleteProvisioning202Accepted200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3150,7 +4119,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> deleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteProvisioning202Accepted200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3158,7 +4127,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededAsync() {
+    public Observable<Product> deleteProvisioning202Accepted200SucceededAsync() {
+        return deleteProvisioning202Accepted200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> deleteProvisioning202Accepted200SucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsDeleteProvisioning202Accepted200SucceededHeaders.class);
     }
@@ -3168,10 +4151,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders> beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException {
-        return beginDeleteProvisioning202Accepted200SucceededAsync().toBlocking().single();
+    public Product beginDeleteProvisioning202Accepted200Succeeded() throws CloudException, IOException {
+        return beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3181,7 +4164,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginDeleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3189,7 +4172,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededAsync() {
+    public Observable<Product> beginDeleteProvisioning202Accepted200SucceededAsync() {
+        return beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>> beginDeleteProvisioning202Accepted200SucceededWithServiceResponseAsync() {
         return service.beginDeleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders>>>() {
                 @Override
@@ -3218,10 +4215,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers> deleteProvisioning202DeletingFailed200() throws CloudException, IOException, InterruptedException {
-        return deleteProvisioning202DeletingFailed200Async().toBlocking().last();
+    public Product deleteProvisioning202DeletingFailed200() throws CloudException, IOException, InterruptedException {
+        return deleteProvisioning202DeletingFailed200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3231,7 +4228,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> deleteProvisioning202DeletingFailed200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteProvisioning202DeletingFailed200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteProvisioning202DeletingFailed200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3239,7 +4236,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> deleteProvisioning202DeletingFailed200Async() {
+    public Observable<Product> deleteProvisioning202DeletingFailed200Async() {
+        return deleteProvisioning202DeletingFailed200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> deleteProvisioning202DeletingFailed200WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteProvisioning202DeletingFailed200(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsDeleteProvisioning202DeletingFailed200Headers.class);
     }
@@ -3249,10 +4260,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers> beginDeleteProvisioning202DeletingFailed200() throws CloudException, IOException {
-        return beginDeleteProvisioning202DeletingFailed200Async().toBlocking().single();
+    public Product beginDeleteProvisioning202DeletingFailed200() throws CloudException, IOException {
+        return beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3262,7 +4273,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginDeleteProvisioning202DeletingFailed200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteProvisioning202DeletingFailed200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3270,7 +4281,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> beginDeleteProvisioning202DeletingFailed200Async() {
+    public Observable<Product> beginDeleteProvisioning202DeletingFailed200Async() {
+        return beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>> beginDeleteProvisioning202DeletingFailed200WithServiceResponseAsync() {
         return service.beginDeleteProvisioning202DeletingFailed200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers>>>() {
                 @Override
@@ -3299,10 +4324,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers> deleteProvisioning202Deletingcanceled200() throws CloudException, IOException, InterruptedException {
-        return deleteProvisioning202Deletingcanceled200Async().toBlocking().last();
+    public Product deleteProvisioning202Deletingcanceled200() throws CloudException, IOException, InterruptedException {
+        return deleteProvisioning202Deletingcanceled200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3312,7 +4337,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> deleteProvisioning202Deletingcanceled200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteProvisioning202Deletingcanceled200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteProvisioning202Deletingcanceled200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3320,7 +4345,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> deleteProvisioning202Deletingcanceled200Async() {
+    public Observable<Product> deleteProvisioning202Deletingcanceled200Async() {
+        return deleteProvisioning202Deletingcanceled200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> deleteProvisioning202Deletingcanceled200WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteProvisioning202Deletingcanceled200(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsDeleteProvisioning202Deletingcanceled200Headers.class);
     }
@@ -3330,10 +4369,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers> beginDeleteProvisioning202Deletingcanceled200() throws CloudException, IOException {
-        return beginDeleteProvisioning202Deletingcanceled200Async().toBlocking().single();
+    public Product beginDeleteProvisioning202Deletingcanceled200() throws CloudException, IOException {
+        return beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3343,7 +4382,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginDeleteProvisioning202Deletingcanceled200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Deletingcanceled200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3351,7 +4390,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> beginDeleteProvisioning202Deletingcanceled200Async() {
+    public Observable<Product> beginDeleteProvisioning202Deletingcanceled200Async() {
+        return beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>> beginDeleteProvisioning202Deletingcanceled200WithServiceResponseAsync() {
         return service.beginDeleteProvisioning202Deletingcanceled200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers>>>() {
                 @Override
@@ -3380,10 +4433,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponse object if successful.
      */
-    public ServiceResponse<Void> delete204Succeeded() throws CloudException, IOException, InterruptedException {
-        return delete204SucceededAsync().toBlocking().last();
+    public void delete204Succeeded() throws CloudException, IOException, InterruptedException {
+        delete204SucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3393,7 +4445,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete204SucceededAsync(), serviceCallback);
+        return ServiceCall.create(delete204SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3401,7 +4453,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Void>> delete204SucceededAsync() {
+    public Observable<Void> delete204SucceededAsync() {
+        return delete204SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Void>> delete204SucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete204Succeeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<Void>() { }.getType());
     }
@@ -3411,10 +4477,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> beginDelete204Succeeded() throws CloudException, IOException {
-        return beginDelete204SucceededAsync().toBlocking().single();
+    public void beginDelete204Succeeded() throws CloudException, IOException {
+        beginDelete204SucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3424,7 +4489,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDelete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(beginDelete204SucceededAsync(), serviceCallback);
+        return ServiceCall.create(beginDelete204SucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3432,7 +4497,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> beginDelete204SucceededAsync() {
+    public Observable<Void> beginDelete204SucceededAsync() {
+        return beginDelete204SucceededWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> beginDelete204SucceededWithServiceResponseAsync() {
         return service.beginDelete204Succeeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -3460,10 +4539,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers> delete202Retry200() throws CloudException, IOException, InterruptedException {
-        return delete202Retry200Async().toBlocking().last();
+    public Product delete202Retry200() throws CloudException, IOException, InterruptedException {
+        return delete202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3473,7 +4552,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> delete202Retry200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3481,7 +4560,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> delete202Retry200Async() {
+    public Observable<Product> delete202Retry200Async() {
+        return delete202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> delete202Retry200WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202Retry200(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsDelete202Retry200Headers.class);
     }
@@ -3491,10 +4584,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers> beginDelete202Retry200() throws CloudException, IOException {
-        return beginDelete202Retry200Async().toBlocking().single();
+    public Product beginDelete202Retry200() throws CloudException, IOException {
+        return beginDelete202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3504,7 +4597,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginDelete202Retry200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3512,7 +4605,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> beginDelete202Retry200Async() {
+    public Observable<Product> beginDelete202Retry200Async() {
+        return beginDelete202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>> beginDelete202Retry200WithServiceResponseAsync() {
         return service.beginDelete202Retry200(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers>>>() {
                 @Override
@@ -3541,10 +4648,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers> delete202NoRetry204() throws CloudException, IOException, InterruptedException {
-        return delete202NoRetry204Async().toBlocking().last();
+    public Product delete202NoRetry204() throws CloudException, IOException, InterruptedException {
+        return delete202NoRetry204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3554,7 +4661,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> delete202NoRetry204Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete202NoRetry204Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete202NoRetry204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3562,7 +4669,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> delete202NoRetry204Async() {
+    public Observable<Product> delete202NoRetry204Async() {
+        return delete202NoRetry204WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> delete202NoRetry204WithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.delete202NoRetry204(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsDelete202NoRetry204Headers.class);
     }
@@ -3572,10 +4693,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers> beginDelete202NoRetry204() throws CloudException, IOException {
-        return beginDelete202NoRetry204Async().toBlocking().single();
+    public Product beginDelete202NoRetry204() throws CloudException, IOException {
+        return beginDelete202NoRetry204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3585,7 +4706,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginDelete202NoRetry204Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDelete202NoRetry204Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDelete202NoRetry204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3593,7 +4714,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> beginDelete202NoRetry204Async() {
+    public Observable<Product> beginDelete202NoRetry204Async() {
+        return beginDelete202NoRetry204WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>> beginDelete202NoRetry204WithServiceResponseAsync() {
         return service.beginDelete202NoRetry204(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers>>>() {
                 @Override
@@ -3622,10 +4757,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders> deleteNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
-        return deleteNoHeaderInRetryAsync().toBlocking().last();
+    public void deleteNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
+        deleteNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3635,7 +4769,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3643,7 +4777,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> deleteNoHeaderInRetryAsync() {
+    public Observable<Void> deleteNoHeaderInRetryAsync() {
+        return deleteNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> deleteNoHeaderInRetryWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteNoHeaderInRetryHeaders.class);
     }
@@ -3653,10 +4801,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders> beginDeleteNoHeaderInRetry() throws CloudException, IOException {
-        return beginDeleteNoHeaderInRetryAsync().toBlocking().single();
+    public void beginDeleteNoHeaderInRetry() throws CloudException, IOException {
+        beginDeleteNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3666,7 +4813,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3674,7 +4821,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> beginDeleteNoHeaderInRetryAsync() {
+    public Observable<Void> beginDeleteNoHeaderInRetryAsync() {
+        return beginDeleteNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>> beginDeleteNoHeaderInRetryWithServiceResponseAsync() {
         return service.beginDeleteNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders>>>() {
                 @Override
@@ -3703,10 +4864,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders> deleteAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncNoHeaderInRetryAsync().toBlocking().last();
+    public void deleteAsyncNoHeaderInRetry() throws CloudException, IOException, InterruptedException {
+        deleteAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3716,7 +4876,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3724,7 +4884,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> deleteAsyncNoHeaderInRetryAsync() {
+    public Observable<Void> deleteAsyncNoHeaderInRetryAsync() {
+        return deleteAsyncNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> deleteAsyncNoHeaderInRetryWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncNoHeaderInRetryHeaders.class);
     }
@@ -3734,10 +4908,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders> beginDeleteAsyncNoHeaderInRetry() throws CloudException, IOException {
-        return beginDeleteAsyncNoHeaderInRetryAsync().toBlocking().single();
+    public void beginDeleteAsyncNoHeaderInRetry() throws CloudException, IOException {
+        beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3747,7 +4920,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncNoHeaderInRetryAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3755,7 +4928,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> beginDeleteAsyncNoHeaderInRetryAsync() {
+    public Observable<Void> beginDeleteAsyncNoHeaderInRetryAsync() {
+        return beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>> beginDeleteAsyncNoHeaderInRetryWithServiceResponseAsync() {
         return service.beginDeleteAsyncNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders>>>() {
                 @Override
@@ -3784,10 +4971,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders> deleteAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRetrySucceededAsync().toBlocking().last();
+    public void deleteAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3797,7 +4983,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3805,7 +4991,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> deleteAsyncRetrySucceededAsync() {
+    public Observable<Void> deleteAsyncRetrySucceededAsync() {
+        return deleteAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> deleteAsyncRetrySucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncRetrySucceededHeaders.class);
     }
@@ -3815,10 +5015,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders> beginDeleteAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginDeleteAsyncRetrySucceededAsync().toBlocking().single();
+    public void beginDeleteAsyncRetrySucceeded() throws CloudException, IOException {
+        beginDeleteAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3828,7 +5027,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3836,7 +5035,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> beginDeleteAsyncRetrySucceededAsync() {
+    public Observable<Void> beginDeleteAsyncRetrySucceededAsync() {
+        return beginDeleteAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>> beginDeleteAsyncRetrySucceededWithServiceResponseAsync() {
         return service.beginDeleteAsyncRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders>>>() {
                 @Override
@@ -3864,10 +5077,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders> deleteAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncNoRetrySucceededAsync().toBlocking().last();
+    public void deleteAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        deleteAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3877,7 +5089,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncNoRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3885,7 +5097,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> deleteAsyncNoRetrySucceededAsync() {
+    public Observable<Void> deleteAsyncNoRetrySucceededAsync() {
+        return deleteAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> deleteAsyncNoRetrySucceededWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncNoRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncNoRetrySucceededHeaders.class);
     }
@@ -3895,10 +5121,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders> beginDeleteAsyncNoRetrySucceeded() throws CloudException, IOException {
-        return beginDeleteAsyncNoRetrySucceededAsync().toBlocking().single();
+    public void beginDeleteAsyncNoRetrySucceeded() throws CloudException, IOException {
+        beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3908,7 +5133,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncNoRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3916,7 +5141,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> beginDeleteAsyncNoRetrySucceededAsync() {
+    public Observable<Void> beginDeleteAsyncNoRetrySucceededAsync() {
+        return beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>> beginDeleteAsyncNoRetrySucceededWithServiceResponseAsync() {
         return service.beginDeleteAsyncNoRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders>>>() {
                 @Override
@@ -3944,10 +5183,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders> deleteAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRetryFailedAsync().toBlocking().last();
+    public void deleteAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -3957,7 +5195,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3965,7 +5203,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> deleteAsyncRetryFailedAsync() {
+    public Observable<Void> deleteAsyncRetryFailedAsync() {
+        return deleteAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> deleteAsyncRetryFailedWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRetryFailed(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncRetryFailedHeaders.class);
     }
@@ -3975,10 +5227,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders> beginDeleteAsyncRetryFailed() throws CloudException, IOException {
-        return beginDeleteAsyncRetryFailedAsync().toBlocking().single();
+    public void beginDeleteAsyncRetryFailed() throws CloudException, IOException {
+        beginDeleteAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3988,7 +5239,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3996,7 +5247,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> beginDeleteAsyncRetryFailedAsync() {
+    public Observable<Void> beginDeleteAsyncRetryFailedAsync() {
+        return beginDeleteAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>> beginDeleteAsyncRetryFailedWithServiceResponseAsync() {
         return service.beginDeleteAsyncRetryFailed(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders>>>() {
                 @Override
@@ -4024,10 +5289,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders> deleteAsyncRetrycanceled() throws CloudException, IOException, InterruptedException {
-        return deleteAsyncRetrycanceledAsync().toBlocking().last();
+    public void deleteAsyncRetrycanceled() throws CloudException, IOException, InterruptedException {
+        deleteAsyncRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4037,7 +5301,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> deleteAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(deleteAsyncRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(deleteAsyncRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4045,7 +5309,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> deleteAsyncRetrycanceledAsync() {
+    public Observable<Void> deleteAsyncRetrycanceledAsync() {
+        return deleteAsyncRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> deleteAsyncRetrycanceledWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.deleteAsyncRetrycanceled(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsDeleteAsyncRetrycanceledHeaders.class);
     }
@@ -4055,10 +5333,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders> beginDeleteAsyncRetrycanceled() throws CloudException, IOException {
-        return beginDeleteAsyncRetrycanceledAsync().toBlocking().single();
+    public void beginDeleteAsyncRetrycanceled() throws CloudException, IOException {
+        beginDeleteAsyncRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4068,7 +5345,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginDeleteAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginDeleteAsyncRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginDeleteAsyncRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4076,7 +5353,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> beginDeleteAsyncRetrycanceledAsync() {
+    public Observable<Void> beginDeleteAsyncRetrycanceledAsync() {
+        return beginDeleteAsyncRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>> beginDeleteAsyncRetrycanceledWithServiceResponseAsync() {
         return service.beginDeleteAsyncRetrycanceled(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders>>>() {
                 @Override
@@ -4104,10 +5395,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Sku object wrapped in ServiceResponse if successful.
+     * @return the Sku object if successful.
      */
-    public ServiceResponse<Sku> post200WithPayload() throws CloudException, IOException, InterruptedException {
-        return post200WithPayloadAsync().toBlocking().last();
+    public Sku post200WithPayload() throws CloudException, IOException, InterruptedException {
+        return post200WithPayloadWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4117,7 +5408,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> post200WithPayloadAsync(final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(post200WithPayloadAsync(), serviceCallback);
+        return ServiceCall.create(post200WithPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4125,7 +5416,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponse<Sku>> post200WithPayloadAsync() {
+    public Observable<Sku> post200WithPayloadAsync() {
+        return post200WithPayloadWithServiceResponseAsync().map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponse<Sku>> post200WithPayloadWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.post200WithPayload(this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<Sku>() { }.getType());
     }
@@ -4135,10 +5440,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Sku object wrapped in {@link ServiceResponse} if successful.
+     * @return the Sku object if successful.
      */
-    public ServiceResponse<Sku> beginPost200WithPayload() throws CloudException, IOException {
-        return beginPost200WithPayloadAsync().toBlocking().single();
+    public Sku beginPost200WithPayload() throws CloudException, IOException {
+        return beginPost200WithPayloadWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4148,7 +5453,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Sku> beginPost200WithPayloadAsync(final ServiceCallback<Sku> serviceCallback) {
-        return ServiceCall.create(beginPost200WithPayloadAsync(), serviceCallback);
+        return ServiceCall.create(beginPost200WithPayloadWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4156,7 +5461,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Sku object
      */
-    public Observable<ServiceResponse<Sku>> beginPost200WithPayloadAsync() {
+    public Observable<Sku> beginPost200WithPayloadAsync() {
+        return beginPost200WithPayloadWithServiceResponseAsync().map(new Func1<ServiceResponse<Sku>, Sku>() {
+            @Override
+            public Sku call(ServiceResponse<Sku> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @return the observable to the Sku object
+     */
+    public Observable<ServiceResponse<Sku>> beginPost200WithPayloadWithServiceResponseAsync() {
         return service.beginPost200WithPayload(this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Sku>>>() {
                 @Override
@@ -4185,10 +5504,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> post202Retry200() throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async().toBlocking().last();
+    public void post202Retry200() throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4198,7 +5516,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4206,7 +5524,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200Async() {
+    public Observable<Void> post202Retry200Async() {
+        return post202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPost202Retry200Headers.class);
@@ -4218,10 +5550,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
-        return post202Retry200Async(product).toBlocking().last();
+    public void post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
+        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4232,7 +5563,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202Retry200WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4241,7 +5572,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200Async(Product product) {
+    public Observable<Void> post202Retry200Async(Product product) {
+        return post202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> post202Retry200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPost202Retry200Headers.class);
@@ -4252,10 +5598,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> beginPost202Retry200() throws CloudException, IOException {
-        return beginPost202Retry200Async().toBlocking().single();
+    public void beginPost202Retry200() throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4265,7 +5610,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4273,7 +5618,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200Async() {
+    public Observable<Void> beginPost202Retry200Async() {
+        return beginPost202Retry200WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>>>() {
@@ -4295,10 +5654,9 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> beginPost202Retry200(Product product) throws CloudException, IOException {
-        return beginPost202Retry200Async(product).toBlocking().single();
+    public void beginPost202Retry200(Product product) throws CloudException, IOException {
+        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4309,7 +5667,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPost202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202Retry200Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202Retry200WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPost202Retry200Async(Product product) {
+        return beginPost202Retry200WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4318,7 +5690,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200Async(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>> beginPost202Retry200WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPost202Retry200(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers>>>() {
@@ -4347,10 +5719,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> post202NoRetry204() throws CloudException, IOException, InterruptedException {
-        return post202NoRetry204Async().toBlocking().last();
+    public Product post202NoRetry204() throws CloudException, IOException, InterruptedException {
+        return post202NoRetry204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4360,7 +5732,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> post202NoRetry204Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NoRetry204Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NoRetry204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4368,7 +5740,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204Async() {
+    public Observable<Product> post202NoRetry204Async() {
+        return post202NoRetry204WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204WithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.post202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPost202NoRetry204Headers.class);
@@ -4380,10 +5766,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> post202NoRetry204(Product product) throws CloudException, IOException, InterruptedException {
-        return post202NoRetry204Async(product).toBlocking().last();
+    public Product post202NoRetry204(Product product) throws CloudException, IOException, InterruptedException {
+        return post202NoRetry204WithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4394,7 +5780,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> post202NoRetry204Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(post202NoRetry204Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(post202NoRetry204WithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4403,7 +5789,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204Async(Product product) {
+    public Observable<Product> post202NoRetry204Async(Product product) {
+        return post202NoRetry204WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> post202NoRetry204WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.post202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPost202NoRetry204Headers.class);
@@ -4414,10 +5815,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> beginPost202NoRetry204() throws CloudException, IOException {
-        return beginPost202NoRetry204Async().toBlocking().single();
+    public Product beginPost202NoRetry204() throws CloudException, IOException {
+        return beginPost202NoRetry204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4427,7 +5828,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPost202NoRetry204Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NoRetry204Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NoRetry204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4435,7 +5836,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204Async() {
+    public Observable<Product> beginPost202NoRetry204Async() {
+        return beginPost202NoRetry204WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204WithServiceResponseAsync() {
         final Product product = null;
         return service.beginPost202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>>>() {
@@ -4457,10 +5872,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> beginPost202NoRetry204(Product product) throws CloudException, IOException {
-        return beginPost202NoRetry204Async(product).toBlocking().single();
+    public Product beginPost202NoRetry204(Product product) throws CloudException, IOException {
+        return beginPost202NoRetry204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4471,7 +5886,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPost202NoRetry204Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPost202NoRetry204Async(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPost202NoRetry204WithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPost202NoRetry204Async(Product product) {
+        return beginPost202NoRetry204WithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4480,7 +5909,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204Async(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>> beginPost202NoRetry204WithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPost202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers>>>() {
@@ -4509,10 +5938,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededAsync().toBlocking().last();
+    public Product postAsyncRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4522,7 +5951,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> postAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4530,7 +5959,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsync() {
+    public Observable<Product> postAsyncRetrySucceededAsync() {
+        return postAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPostAsyncRetrySucceededHeaders.class);
@@ -4542,10 +5985,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededAsync(product).toBlocking().last();
+    public Product postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
+        return postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4556,7 +5999,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> postAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4565,7 +6008,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededAsync(Product product) {
+    public Observable<Product> postAsyncRetrySucceededAsync(Product product) {
+        return postAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> postAsyncRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPostAsyncRetrySucceededHeaders.class);
@@ -4576,10 +6034,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> beginPostAsyncRetrySucceeded() throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededAsync().toBlocking().single();
+    public Product beginPostAsyncRetrySucceeded() throws CloudException, IOException {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4589,7 +6047,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPostAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4597,7 +6055,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsync() {
+    public Observable<Product> beginPostAsyncRetrySucceededAsync() {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>>>() {
@@ -4619,10 +6091,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededAsync(product).toBlocking().single();
+    public Product beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4633,7 +6105,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPostAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPostAsyncRetrySucceededAsync(Product product) {
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4642,7 +6128,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>> beginPostAsyncRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders>>>() {
@@ -4672,10 +6158,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object  if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> postAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
-        return postAsyncNoRetrySucceededAsync().toBlocking().last();
+    public Product postAsyncNoRetrySucceeded() throws CloudException, IOException, InterruptedException {
+        return postAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4685,7 +6171,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> postAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4693,7 +6179,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededAsync() {
+    public Observable<Product> postAsyncNoRetrySucceededAsync() {
+        return postAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPostAsyncNoRetrySucceededHeaders.class);
@@ -4705,10 +6205,10 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the Product object wrapped in ServiceResponseWithHeaders if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> postAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncNoRetrySucceededAsync(product).toBlocking().last();
+    public Product postAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
+        return postAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4719,7 +6219,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> postAsyncNoRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncNoRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncNoRetrySucceededWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4728,7 +6228,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededAsync(Product product) {
+    public Observable<Product> postAsyncNoRetrySucceededAsync(Product product) {
+        return postAsyncNoRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> postAsyncNoRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Product>() { }.getType(), LROsPostAsyncNoRetrySucceededHeaders.class);
@@ -4739,10 +6254,10 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> beginPostAsyncNoRetrySucceeded() throws CloudException, IOException {
-        return beginPostAsyncNoRetrySucceededAsync().toBlocking().single();
+    public Product beginPostAsyncNoRetrySucceeded() throws CloudException, IOException {
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4752,7 +6267,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPostAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncNoRetrySucceededAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncNoRetrySucceededWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4760,7 +6275,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededAsync() {
+    public Observable<Product> beginPostAsyncNoRetrySucceededAsync() {
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>>>() {
@@ -4782,10 +6311,10 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the Product object if successful.
      */
-    public ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> beginPostAsyncNoRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPostAsyncNoRetrySucceededAsync(product).toBlocking().single();
+    public Product beginPostAsyncNoRetrySucceeded(Product product) throws CloudException, IOException {
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4796,7 +6325,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> beginPostAsyncNoRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncNoRetrySucceededAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncNoRetrySucceededWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> beginPostAsyncNoRetrySucceededAsync(Product product) {
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>, Product>() {
+            @Override
+            public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4805,7 +6348,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>> beginPostAsyncNoRetrySucceededWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders>>>() {
@@ -4835,10 +6378,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> postAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
-        return postAsyncRetryFailedAsync().toBlocking().last();
+    public void postAsyncRetryFailed() throws CloudException, IOException, InterruptedException {
+        postAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4848,7 +6390,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4856,7 +6398,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedAsync() {
+    public Observable<Void> postAsyncRetryFailedAsync() {
+        return postAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPostAsyncRetryFailedHeaders.class);
@@ -4868,10 +6424,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> postAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetryFailedAsync(product).toBlocking().last();
+    public void postAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException {
+        postAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -4882,7 +6437,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetryFailedAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetryFailedAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetryFailedWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -4891,7 +6446,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedAsync(Product product) {
+    public Observable<Void> postAsyncRetryFailedAsync(Product product) {
+        return postAsyncRetryFailedWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> postAsyncRetryFailedWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPostAsyncRetryFailedHeaders.class);
@@ -4902,10 +6472,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> beginPostAsyncRetryFailed() throws CloudException, IOException {
-        return beginPostAsyncRetryFailedAsync().toBlocking().single();
+    public void beginPostAsyncRetryFailed() throws CloudException, IOException {
+        beginPostAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4915,7 +6484,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetryFailedAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetryFailedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4923,7 +6492,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedAsync() {
+    public Observable<Void> beginPostAsyncRetryFailedAsync() {
+        return beginPostAsyncRetryFailedWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>>>() {
@@ -4945,10 +6528,9 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> beginPostAsyncRetryFailed(Product product) throws CloudException, IOException {
-        return beginPostAsyncRetryFailedAsync(product).toBlocking().single();
+    public void beginPostAsyncRetryFailed(Product product) throws CloudException, IOException {
+        beginPostAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4959,7 +6541,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetryFailedAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetryFailedAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetryFailedWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRetryFailedAsync(Product product) {
+        return beginPostAsyncRetryFailedWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -4968,7 +6564,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>> beginPostAsyncRetryFailedWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders>>>() {
@@ -4997,10 +6593,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> postAsyncRetrycanceled() throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrycanceledAsync().toBlocking().last();
+    public void postAsyncRetrycanceled() throws CloudException, IOException, InterruptedException {
+        postAsyncRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -5010,7 +6605,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -5018,7 +6613,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledAsync() {
+    public Observable<Void> postAsyncRetrycanceledAsync() {
+        return postAsyncRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledWithServiceResponseAsync() {
         final Product product = null;
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPostAsyncRetrycanceledHeaders.class);
@@ -5030,10 +6639,9 @@ public final class LROsImpl implements LROs {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws InterruptedException exception thrown when long running operation is interrupted
-     * @return the ServiceResponseWithHeaders object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> postAsyncRetrycanceled(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrycanceledAsync(product).toBlocking().last();
+    public void postAsyncRetrycanceled(Product product) throws CloudException, IOException, InterruptedException {
+        postAsyncRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
     }
 
     /**
@@ -5044,7 +6652,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postAsyncRetrycanceledAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(postAsyncRetrycanceledAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(postAsyncRetrycanceledWithServiceResponseAsync(product), serviceCallback);
     }
 
     /**
@@ -5053,7 +6661,22 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the observable for the request
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledAsync(Product product) {
+    public Observable<Void> postAsyncRetrycanceledAsync(Product product) {
+        return postAsyncRetrycanceledWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @return the observable for the request
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> postAsyncRetrycanceledWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         Observable<Response<ResponseBody>> observable = service.postAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
         return client.getAzureClient().getPostOrDeleteResultWithHeadersAsync(observable, new TypeToken<Void>() { }.getType(), LROsPostAsyncRetrycanceledHeaders.class);
@@ -5064,10 +6687,9 @@ public final class LROsImpl implements LROs {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> beginPostAsyncRetrycanceled() throws CloudException, IOException {
-        return beginPostAsyncRetrycanceledAsync().toBlocking().single();
+    public void beginPostAsyncRetrycanceled() throws CloudException, IOException {
+        beginPostAsyncRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -5077,7 +6699,7 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrycanceledAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrycanceledWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -5085,7 +6707,21 @@ public final class LROsImpl implements LROs {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledAsync() {
+    public Observable<Void> beginPostAsyncRetrycanceledAsync() {
+        return beginPostAsyncRetrycanceledWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledWithServiceResponseAsync() {
         final Product product = null;
         return service.beginPostAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>>>() {
@@ -5107,10 +6743,9 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> beginPostAsyncRetrycanceled(Product product) throws CloudException, IOException {
-        return beginPostAsyncRetrycanceledAsync(product).toBlocking().single();
+    public void beginPostAsyncRetrycanceled(Product product) throws CloudException, IOException {
+        beginPostAsyncRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -5121,7 +6756,21 @@ public final class LROsImpl implements LROs {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> beginPostAsyncRetrycanceledAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(beginPostAsyncRetrycanceledAsync(product), serviceCallback);
+        return ServiceCall.createWithHeaders(beginPostAsyncRetrycanceledWithServiceResponseAsync(product), serviceCallback);
+    }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> beginPostAsyncRetrycanceledAsync(Product product) {
+        return beginPostAsyncRetrycanceledWithServiceResponseAsync(product).map(new Func1<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -5130,7 +6779,7 @@ public final class LROsImpl implements LROs {
      * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledAsync(Product product) {
+    public Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>> beginPostAsyncRetrycanceledWithServiceResponseAsync(Product product) {
         Validator.validate(product);
         return service.beginPostAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders>>>() {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -430,7 +430,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product put200Succeeded(Product product) throws CloudException, IOException, InterruptedException {
-        return put200SucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return put200SucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -503,7 +503,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -536,7 +536,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPut200Succeeded(Product product) throws CloudException, IOException {
-        return beginPut200SucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200SucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -553,6 +553,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut200SucceededAsync(Product product) {
@@ -561,7 +562,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -650,7 +651,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product put200SucceededNoState(Product product) throws CloudException, IOException, InterruptedException {
-        return put200SucceededNoStateWithServiceResponseAsync().toBlocking().last().getBody();
+        return put200SucceededNoStateWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -723,7 +724,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -756,7 +757,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPut200SucceededNoState(Product product) throws CloudException, IOException {
-        return beginPut200SucceededNoStateWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200SucceededNoStateWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -773,6 +774,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut200SucceededNoStateAsync(Product product) {
@@ -781,7 +783,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -869,7 +871,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product put202Retry200(Product product) throws CloudException, IOException, InterruptedException {
-        return put202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put202Retry200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -942,7 +944,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -975,7 +977,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPut202Retry200(Product product) throws CloudException, IOException {
-        return beginPut202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut202Retry200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -992,6 +994,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut202Retry200Async(Product product) {
@@ -1000,7 +1003,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1088,7 +1091,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product put201CreatingSucceeded200(Product product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingSucceeded200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1161,7 +1164,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1194,7 +1197,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPut201CreatingSucceeded200(Product product) throws CloudException, IOException {
-        return beginPut201CreatingSucceeded200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut201CreatingSucceeded200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1211,6 +1214,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut201CreatingSucceeded200Async(Product product) {
@@ -1219,7 +1223,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1308,7 +1312,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product put200UpdatingSucceeded204(Product product) throws CloudException, IOException, InterruptedException {
-        return put200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().last().getBody();
+        return put200UpdatingSucceeded204WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1381,7 +1385,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1414,7 +1418,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPut200UpdatingSucceeded204(Product product) throws CloudException, IOException {
-        return beginPut200UpdatingSucceeded204WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200UpdatingSucceeded204WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1431,6 +1435,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut200UpdatingSucceeded204Async(Product product) {
@@ -1439,7 +1444,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1527,7 +1532,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product put201CreatingFailed200(Product product) throws CloudException, IOException, InterruptedException {
-        return put201CreatingFailed200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put201CreatingFailed200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1600,7 +1605,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1633,7 +1638,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPut201CreatingFailed200(Product product) throws CloudException, IOException {
-        return beginPut201CreatingFailed200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut201CreatingFailed200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1650,6 +1655,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut201CreatingFailed200Async(Product product) {
@@ -1658,7 +1664,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1747,7 +1753,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product put200Acceptedcanceled200(Product product) throws CloudException, IOException, InterruptedException {
-        return put200Acceptedcanceled200WithServiceResponseAsync().toBlocking().last().getBody();
+        return put200Acceptedcanceled200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -1820,7 +1826,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1853,7 +1859,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPut200Acceptedcanceled200(Product product) throws CloudException, IOException {
-        return beginPut200Acceptedcanceled200WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPut200Acceptedcanceled200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -1870,6 +1876,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPut200Acceptedcanceled200Async(Product product) {
@@ -1878,7 +1885,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1966,7 +1973,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product putNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException {
-        return putNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
+        return putNoHeaderInRetryWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2039,7 +2046,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2072,7 +2079,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPutNoHeaderInRetry(Product product) throws CloudException, IOException {
-        return beginPutNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNoHeaderInRetryWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2089,6 +2096,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutNoHeaderInRetryAsync(Product product) {
@@ -2097,7 +2105,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutNoHeaderInRetryHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2185,7 +2193,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product putAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2258,7 +2266,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2291,7 +2299,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPutAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2308,6 +2316,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRetrySucceededAsync(Product product) {
@@ -2316,7 +2325,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2404,7 +2413,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product putAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncNoRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2477,7 +2486,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2510,7 +2519,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncNoRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncNoRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2527,6 +2536,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncNoRetrySucceededAsync(Product product) {
@@ -2535,7 +2545,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2623,7 +2633,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product putAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncRetryFailedWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2696,7 +2706,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2729,7 +2739,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncRetryFailed(Product product) throws CloudException, IOException {
-        return beginPutAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncRetryFailedWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2746,6 +2756,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncRetryFailedAsync(Product product) {
@@ -2754,7 +2765,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncRetryFailedHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2842,7 +2853,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product putAsyncNoRetrycanceled(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncNoRetrycanceledWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -2915,7 +2926,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2948,7 +2959,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncNoRetrycanceled(Product product) throws CloudException, IOException {
-        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncNoRetrycanceledWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -2965,6 +2976,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncNoRetrycanceledAsync(Product product) {
@@ -2973,7 +2985,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoRetrycanceledHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3061,7 +3073,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product putAsyncNoHeaderInRetry(Product product) throws CloudException, IOException, InterruptedException {
-        return putAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncNoHeaderInRetryWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3134,7 +3146,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3167,7 +3179,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPutAsyncNoHeaderInRetry(Product product) throws CloudException, IOException {
-        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncNoHeaderInRetryWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3184,6 +3196,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPutAsyncNoHeaderInRetryAsync(Product product) {
@@ -3192,7 +3205,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPutAsyncNoHeaderInRetryHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3280,7 +3293,7 @@ public final class LROsImpl implements LROs {
      * @return the Sku object if successful.
      */
     public Sku putNonResource(Sku sku) throws CloudException, IOException, InterruptedException {
-        return putNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
+        return putNonResourceWithServiceResponseAsync(sku).toBlocking().last().getBody();
     }
 
     /**
@@ -3353,7 +3366,7 @@ public final class LROsImpl implements LROs {
             public Sku call(ServiceResponse<Sku> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3386,7 +3399,7 @@ public final class LROsImpl implements LROs {
      * @return the Sku object if successful.
      */
     public Sku beginPutNonResource(Sku sku) throws CloudException, IOException {
-        return beginPutNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutNonResourceWithServiceResponseAsync(sku).toBlocking().single().getBody();
     }
 
     /**
@@ -3403,6 +3416,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request with non resource.
      *
+     * @param sku sku to put
      * @return the observable to the Sku object
      */
     public Observable<Sku> beginPutNonResourceAsync(Sku sku) {
@@ -3411,7 +3425,7 @@ public final class LROsImpl implements LROs {
             public Sku call(ServiceResponse<Sku> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3499,7 +3513,7 @@ public final class LROsImpl implements LROs {
      * @return the Sku object if successful.
      */
     public Sku putAsyncNonResource(Sku sku) throws CloudException, IOException, InterruptedException {
-        return putAsyncNonResourceWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncNonResourceWithServiceResponseAsync(sku).toBlocking().last().getBody();
     }
 
     /**
@@ -3572,7 +3586,7 @@ public final class LROsImpl implements LROs {
             public Sku call(ServiceResponse<Sku> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3605,7 +3619,7 @@ public final class LROsImpl implements LROs {
      * @return the Sku object if successful.
      */
     public Sku beginPutAsyncNonResource(Sku sku) throws CloudException, IOException {
-        return beginPutAsyncNonResourceWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncNonResourceWithServiceResponseAsync(sku).toBlocking().single().getBody();
     }
 
     /**
@@ -3622,6 +3636,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request with non resource.
      *
+     * @param sku Sku to put
      * @return the observable to the Sku object
      */
     public Observable<Sku> beginPutAsyncNonResourceAsync(Sku sku) {
@@ -3630,7 +3645,7 @@ public final class LROsImpl implements LROs {
             public Sku call(ServiceResponse<Sku> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3718,7 +3733,7 @@ public final class LROsImpl implements LROs {
      * @return the SubProduct object if successful.
      */
     public SubProduct putSubResource(SubProduct product) throws CloudException, IOException, InterruptedException {
-        return putSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
+        return putSubResourceWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -3791,7 +3806,7 @@ public final class LROsImpl implements LROs {
             public SubProduct call(ServiceResponse<SubProduct> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3824,7 +3839,7 @@ public final class LROsImpl implements LROs {
      * @return the SubProduct object if successful.
      */
     public SubProduct beginPutSubResource(SubProduct product) throws CloudException, IOException {
-        return beginPutSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutSubResourceWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -3841,6 +3856,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request with sub resource.
      *
+     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
     public Observable<SubProduct> beginPutSubResourceAsync(SubProduct product) {
@@ -3849,7 +3865,7 @@ public final class LROsImpl implements LROs {
             public SubProduct call(ServiceResponse<SubProduct> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3937,7 +3953,7 @@ public final class LROsImpl implements LROs {
      * @return the SubProduct object if successful.
      */
     public SubProduct putAsyncSubResource(SubProduct product) throws CloudException, IOException, InterruptedException {
-        return putAsyncSubResourceWithServiceResponseAsync().toBlocking().last().getBody();
+        return putAsyncSubResourceWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -4010,7 +4026,7 @@ public final class LROsImpl implements LROs {
             public SubProduct call(ServiceResponse<SubProduct> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4043,7 +4059,7 @@ public final class LROsImpl implements LROs {
      * @return the SubProduct object if successful.
      */
     public SubProduct beginPutAsyncSubResource(SubProduct product) throws CloudException, IOException {
-        return beginPutAsyncSubResourceWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPutAsyncSubResourceWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -4060,6 +4076,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running put request with sub resource.
      *
+     * @param product Sub Product to put
      * @return the observable to the SubProduct object
      */
     public Observable<SubProduct> beginPutAsyncSubResourceAsync(SubProduct product) {
@@ -4068,7 +4085,7 @@ public final class LROsImpl implements LROs {
             public SubProduct call(ServiceResponse<SubProduct> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4178,7 +4195,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Accepted200SucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4287,7 +4304,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202DeletingFailed200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4396,7 +4413,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsDeleteProvisioning202Deletingcanceled200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4503,7 +4520,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4611,7 +4628,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsDelete202Retry200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4720,7 +4737,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsDelete202NoRetry204Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4827,7 +4844,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteNoHeaderInRetryHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4934,7 +4951,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoHeaderInRetryHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5041,7 +5058,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5147,7 +5164,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncNoRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5253,7 +5270,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetryFailedHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5359,7 +5376,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsDeleteAsyncRetrycanceledHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5467,7 +5484,7 @@ public final class LROsImpl implements LROs {
             public Sku call(ServiceResponse<Sku> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5552,7 +5569,7 @@ public final class LROsImpl implements LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void post202Retry200(Product product) throws CloudException, IOException, InterruptedException {
-        post202Retry200WithServiceResponseAsync().toBlocking().last().getBody();
+        post202Retry200WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -5624,7 +5641,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5656,7 +5673,7 @@ public final class LROsImpl implements LROs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPost202Retry200(Product product) throws CloudException, IOException {
-        beginPost202Retry200WithServiceResponseAsync().toBlocking().single().getBody();
+        beginPost202Retry200WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -5673,6 +5690,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPost202Retry200Async(Product product) {
@@ -5681,7 +5699,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsPost202Retry200Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5769,7 +5787,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product post202NoRetry204(Product product) throws CloudException, IOException, InterruptedException {
-        return post202NoRetry204WithServiceResponseAsync().toBlocking().last().getBody();
+        return post202NoRetry204WithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -5842,7 +5860,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5875,7 +5893,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPost202NoRetry204(Product product) throws CloudException, IOException {
-        return beginPost202NoRetry204WithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPost202NoRetry204WithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -5892,6 +5910,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPost202NoRetry204Async(Product product) {
@@ -5900,7 +5919,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPost202NoRetry204Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -5988,7 +6007,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product postAsyncRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return postAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -6061,7 +6080,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6094,7 +6113,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPostAsyncRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPostAsyncRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPostAsyncRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -6111,6 +6130,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPostAsyncRetrySucceededAsync(Product product) {
@@ -6119,7 +6139,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6208,7 +6228,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product postAsyncNoRetrySucceeded(Product product) throws CloudException, IOException, InterruptedException {
-        return postAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().last().getBody();
+        return postAsyncNoRetrySucceededWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -6281,7 +6301,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6314,7 +6334,7 @@ public final class LROsImpl implements LROs {
      * @return the Product object if successful.
      */
     public Product beginPostAsyncNoRetrySucceeded(Product product) throws CloudException, IOException {
-        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync().toBlocking().single().getBody();
+        return beginPostAsyncNoRetrySucceededWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -6331,6 +6351,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the observable to the Product object
      */
     public Observable<Product> beginPostAsyncNoRetrySucceededAsync(Product product) {
@@ -6339,7 +6360,7 @@ public final class LROsImpl implements LROs {
             public Product call(ServiceResponseWithHeaders<Product, LROsPostAsyncNoRetrySucceededHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6426,7 +6447,7 @@ public final class LROsImpl implements LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRetryFailed(Product product) throws CloudException, IOException, InterruptedException {
-        postAsyncRetryFailedWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRetryFailedWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -6498,7 +6519,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6530,7 +6551,7 @@ public final class LROsImpl implements LROs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRetryFailed(Product product) throws CloudException, IOException {
-        beginPostAsyncRetryFailedWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRetryFailedWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -6547,6 +6568,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRetryFailedAsync(Product product) {
@@ -6555,7 +6577,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetryFailedHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6641,7 +6663,7 @@ public final class LROsImpl implements LROs {
      * @throws InterruptedException exception thrown when long running operation is interrupted
      */
     public void postAsyncRetrycanceled(Product product) throws CloudException, IOException, InterruptedException {
-        postAsyncRetrycanceledWithServiceResponseAsync().toBlocking().last().getBody();
+        postAsyncRetrycanceledWithServiceResponseAsync(product).toBlocking().last().getBody();
     }
 
     /**
@@ -6713,7 +6735,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -6745,7 +6767,7 @@ public final class LROsImpl implements LROs {
      * @throws IOException exception thrown from serialization/deserialization
      */
     public void beginPostAsyncRetrycanceled(Product product) throws CloudException, IOException {
-        beginPostAsyncRetrycanceledWithServiceResponseAsync().toBlocking().single().getBody();
+        beginPostAsyncRetrycanceledWithServiceResponseAsync(product).toBlocking().single().getBody();
     }
 
     /**
@@ -6762,6 +6784,7 @@ public final class LROsImpl implements LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @param product Product to put
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> beginPostAsyncRetrycanceledAsync(Product product) {
@@ -6770,7 +6793,7 @@ public final class LROsImpl implements LROs {
             public Void call(ServiceResponseWithHeaders<Void, LROsPostAsyncRetrycanceledHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/paging/Pagings.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/paging/Pagings.java
@@ -37,7 +37,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getSinglePages() throws CloudException, IOException;
+    List<Product> getSinglePages() throws CloudException, IOException;
 
     /**
      * A paging operation that finishes on the first call without a nextlink.
@@ -52,7 +52,14 @@ public interface Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getSinglePagesAsync();
+    Observable<Page<Product>> getSinglePagesAsync();
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getSinglePagesAsyncWithServiceResponse();
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -61,7 +68,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePages() throws CloudException, IOException;
+    List<Product> getMultiplePages() throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -70,6 +77,24 @@ public interface Pagings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<List<Product>> getMultiplePagesAsync(final ListOperationCallback<Product> serviceCallback);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<Page<Product>> getMultiplePagesAsync();
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsyncWithServiceResponse();
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -79,7 +104,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException;
+    List<Product> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -98,7 +123,16 @@ public interface Pagings {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
+    Observable<Page<Product>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsyncWithServiceResponse(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -107,7 +141,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getOdataMultiplePages() throws CloudException, IOException;
+    List<Product> getOdataMultiplePages() throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -116,6 +150,24 @@ public interface Pagings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<List<Product>> getOdataMultiplePagesAsync(final ListOperationCallback<Product> serviceCallback);
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<Page<Product>> getOdataMultiplePagesAsync();
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsyncWithServiceResponse();
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
@@ -125,7 +177,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException;
+    List<Product> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -144,7 +196,16 @@ public interface Pagings {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
+    Observable<Page<Product>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsyncWithServiceResponse(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -155,7 +216,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -165,6 +226,24 @@ public interface Pagings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<List<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final ListOperationCallback<Product> serviceCallback);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @param clientRequestId the String value
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @param clientRequestId the String value
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsyncWithServiceResponse(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions);
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -175,7 +254,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -194,7 +273,16 @@ public interface Pagings {
      * @param clientRequestId the String value
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId);
+    Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @param clientRequestId the String value
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsyncWithServiceResponse(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId);
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
@@ -203,7 +291,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesRetryFirst() throws CloudException, IOException;
+    List<Product> getMultiplePagesRetryFirst() throws CloudException, IOException;
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
@@ -218,7 +306,14 @@ public interface Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstAsync();
+    Observable<Page<Product>> getMultiplePagesRetryFirstAsync();
+
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstAsyncWithServiceResponse();
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -227,7 +322,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesRetrySecond() throws CloudException, IOException;
+    List<Product> getMultiplePagesRetrySecond() throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -242,7 +337,14 @@ public interface Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondAsync();
+    Observable<Page<Product>> getMultiplePagesRetrySecondAsync();
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondAsyncWithServiceResponse();
 
     /**
      * A paging operation that receives a 400 on the first call.
@@ -251,7 +353,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getSinglePagesFailure() throws CloudException, IOException;
+    List<Product> getSinglePagesFailure() throws CloudException, IOException;
 
     /**
      * A paging operation that receives a 400 on the first call.
@@ -266,7 +368,14 @@ public interface Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureAsync();
+    Observable<Page<Product>> getSinglePagesFailureAsync();
+
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureAsyncWithServiceResponse();
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -275,7 +384,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesFailure() throws CloudException, IOException;
+    List<Product> getMultiplePagesFailure() throws CloudException, IOException;
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -290,7 +399,14 @@ public interface Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureAsync();
+    Observable<Page<Product>> getMultiplePagesFailureAsync();
+
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureAsyncWithServiceResponse();
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -299,7 +415,7 @@ public interface Pagings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesFailureUri() throws CloudException, IOException;
+    List<Product> getMultiplePagesFailureUri() throws CloudException, IOException;
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -314,7 +430,14 @@ public interface Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriAsync();
+    Observable<Page<Product>> getMultiplePagesFailureUriAsync();
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriAsyncWithServiceResponse();
 
     /**
      * A paging operation that finishes on the first call without a nextlink.
@@ -325,7 +448,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that finishes on the first call without a nextlink.
@@ -343,7 +466,15 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getSinglePagesNextAsync(final String nextPageLink);
+    Observable<Page<Product>> getSinglePagesNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getSinglePagesNextAsyncWithServiceResponse(final String nextPageLink);
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -354,7 +485,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -365,6 +496,26 @@ public interface Pagings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<List<Product>> getMultiplePagesNextAsync(final String nextPageLink, final ServiceCall<List<Product>> serviceCall, final ListOperationCallback<Product> serviceCallback);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsyncWithServiceResponse(final String nextPageLink);
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -376,7 +527,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -398,7 +549,17 @@ public interface Pagings {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
+    Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsyncWithServiceResponse(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -409,7 +570,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -420,6 +581,26 @@ public interface Pagings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<List<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink, final ServiceCall<List<Product>> serviceCall, final ListOperationCallback<Product> serviceCallback);
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsyncWithServiceResponse(final String nextPageLink);
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
@@ -431,7 +612,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -453,7 +634,17 @@ public interface Pagings {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
+    Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsyncWithServiceResponse(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -464,7 +655,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -475,6 +666,26 @@ public interface Pagings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<List<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final ServiceCall<List<Product>> serviceCall, final ListOperationCallback<Product> serviceCallback);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsyncWithServiceResponse(final String nextPageLink);
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -486,7 +697,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -508,7 +719,17 @@ public interface Pagings {
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions);
+    Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsyncWithServiceResponse(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions);
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
@@ -519,7 +740,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
@@ -537,7 +758,15 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink);
+    Observable<Page<Product>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextAsyncWithServiceResponse(final String nextPageLink);
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -548,7 +777,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -566,7 +795,15 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink);
+    Observable<Page<Product>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextAsyncWithServiceResponse(final String nextPageLink);
 
     /**
      * A paging operation that receives a 400 on the first call.
@@ -577,7 +814,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that receives a 400 on the first call.
@@ -595,7 +832,15 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextAsync(final String nextPageLink);
+    Observable<Page<Product>> getSinglePagesFailureNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextAsyncWithServiceResponse(final String nextPageLink);
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -606,7 +851,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -624,7 +869,15 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextAsync(final String nextPageLink);
+    Observable<Page<Product>> getMultiplePagesFailureNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextAsyncWithServiceResponse(final String nextPageLink);
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -635,7 +888,7 @@ public interface Pagings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<PagedList<Product>> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    List<Product> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -653,6 +906,14 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextAsync(final String nextPageLink);
+    Observable<Page<Product>> getMultiplePagesFailureUriNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextAsyncWithServiceResponse(final String nextPageLink);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/paging/Pagings.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/paging/Pagings.java
@@ -35,9 +35,9 @@ public interface Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getSinglePages() throws CloudException, IOException;
+    PagedList<Product> getSinglePages() throws CloudException, IOException;
 
     /**
      * A paging operation that finishes on the first call without a nextlink.
@@ -50,25 +50,25 @@ public interface Pagings {
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getSinglePagesAsync();
 
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getSinglePagesAsyncWithServiceResponse();
+    Observable<ServiceResponse<Page<Product>>> getSinglePagesWithServiceResponseAsync();
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePages() throws CloudException, IOException;
+    PagedList<Product> getMultiplePages() throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -81,20 +81,16 @@ public interface Pagings {
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
-     * @param clientRequestId the String value
-     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesAsync();
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
-     * @param clientRequestId the String value
-     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsyncWithServiceResponse();
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithServiceResponseAsync();
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -102,9 +98,9 @@ public interface Pagings {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException;
+    PagedList<Product> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -121,7 +117,7 @@ public interface Pagings {
      *
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
 
@@ -130,18 +126,18 @@ public interface Pagings {
      *
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsyncWithServiceResponse(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getOdataMultiplePages() throws CloudException, IOException;
+    PagedList<Product> getOdataMultiplePages() throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -154,20 +150,16 @@ public interface Pagings {
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
-     * @param clientRequestId the String value
-     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getOdataMultiplePagesAsync();
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
-     * @param clientRequestId the String value
-     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsyncWithServiceResponse();
+    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesWithServiceResponseAsync();
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
@@ -175,9 +167,9 @@ public interface Pagings {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException;
+    PagedList<Product> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -194,7 +186,7 @@ public interface Pagings {
      *
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
 
@@ -203,9 +195,9 @@ public interface Pagings {
      *
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsyncWithServiceResponse(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
+    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -214,9 +206,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -231,8 +223,7 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
-     * @param clientRequestId the String value
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions);
 
@@ -240,10 +231,9 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
-     * @param clientRequestId the String value
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsyncWithServiceResponse(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions);
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -252,9 +242,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -271,7 +261,7 @@ public interface Pagings {
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @param clientRequestId the String value
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId);
 
@@ -280,18 +270,18 @@ public interface Pagings {
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @param clientRequestId the String value
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsyncWithServiceResponse(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId);
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesRetryFirst() throws CloudException, IOException;
+    PagedList<Product> getMultiplePagesRetryFirst() throws CloudException, IOException;
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
@@ -304,25 +294,25 @@ public interface Pagings {
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesRetryFirstAsync();
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstAsyncWithServiceResponse();
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstWithServiceResponseAsync();
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesRetrySecond() throws CloudException, IOException;
+    PagedList<Product> getMultiplePagesRetrySecond() throws CloudException, IOException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -335,25 +325,25 @@ public interface Pagings {
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesRetrySecondAsync();
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondAsyncWithServiceResponse();
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondWithServiceResponseAsync();
 
     /**
      * A paging operation that receives a 400 on the first call.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getSinglePagesFailure() throws CloudException, IOException;
+    PagedList<Product> getSinglePagesFailure() throws CloudException, IOException;
 
     /**
      * A paging operation that receives a 400 on the first call.
@@ -366,25 +356,25 @@ public interface Pagings {
     /**
      * A paging operation that receives a 400 on the first call.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getSinglePagesFailureAsync();
 
     /**
      * A paging operation that receives a 400 on the first call.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureAsyncWithServiceResponse();
+    Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureWithServiceResponseAsync();
 
     /**
      * A paging operation that receives a 400 on the second call.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesFailure() throws CloudException, IOException;
+    PagedList<Product> getMultiplePagesFailure() throws CloudException, IOException;
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -397,25 +387,25 @@ public interface Pagings {
     /**
      * A paging operation that receives a 400 on the second call.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesFailureAsync();
 
     /**
      * A paging operation that receives a 400 on the second call.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureAsyncWithServiceResponse();
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureWithServiceResponseAsync();
 
     /**
      * A paging operation that receives an invalid nextLink.
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesFailureUri() throws CloudException, IOException;
+    PagedList<Product> getMultiplePagesFailureUri() throws CloudException, IOException;
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -428,16 +418,16 @@ public interface Pagings {
     /**
      * A paging operation that receives an invalid nextLink.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesFailureUriAsync();
 
     /**
      * A paging operation that receives an invalid nextLink.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriAsyncWithServiceResponse();
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriWithServiceResponseAsync();
 
     /**
      * A paging operation that finishes on the first call without a nextlink.
@@ -446,9 +436,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that finishes on the first call without a nextlink.
@@ -464,7 +454,7 @@ public interface Pagings {
      * A paging operation that finishes on the first call without a nextlink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getSinglePagesNextAsync(final String nextPageLink);
 
@@ -472,9 +462,9 @@ public interface Pagings {
      * A paging operation that finishes on the first call without a nextlink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getSinglePagesNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getSinglePagesNextWithServiceResponseAsync(final String nextPageLink);
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -483,9 +473,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -501,9 +491,7 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @param clientRequestId the String value
-     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink);
 
@@ -511,11 +499,9 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @param clientRequestId the String value
-     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink);
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -525,9 +511,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -547,7 +533,7 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
 
@@ -557,9 +543,9 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsyncWithServiceResponse(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -568,9 +554,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -586,9 +572,7 @@ public interface Pagings {
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @param clientRequestId the String value
-     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink);
 
@@ -596,11 +580,9 @@ public interface Pagings {
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @param clientRequestId the String value
-     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink);
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
@@ -610,9 +592,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -632,7 +614,7 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
 
@@ -642,9 +624,9 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsyncWithServiceResponse(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
+    Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -653,9 +635,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -671,9 +653,7 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @param clientRequestId the String value
-     * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink);
 
@@ -681,11 +661,9 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @param clientRequestId the String value
-     * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink);
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -695,9 +673,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -717,7 +695,7 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions);
 
@@ -727,9 +705,9 @@ public interface Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsyncWithServiceResponse(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions);
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
@@ -738,9 +716,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
@@ -756,7 +734,7 @@ public interface Pagings {
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink);
 
@@ -764,9 +742,9 @@ public interface Pagings {
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextWithServiceResponseAsync(final String nextPageLink);
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -775,9 +753,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -793,7 +771,7 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink);
 
@@ -801,9 +779,9 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextWithServiceResponseAsync(final String nextPageLink);
 
     /**
      * A paging operation that receives a 400 on the first call.
@@ -812,9 +790,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that receives a 400 on the first call.
@@ -830,7 +808,7 @@ public interface Pagings {
      * A paging operation that receives a 400 on the first call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getSinglePagesFailureNextAsync(final String nextPageLink);
 
@@ -838,9 +816,9 @@ public interface Pagings {
      * A paging operation that receives a 400 on the first call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextWithServiceResponseAsync(final String nextPageLink);
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -849,9 +827,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -867,7 +845,7 @@ public interface Pagings {
      * A paging operation that receives a 400 on the second call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesFailureNextAsync(final String nextPageLink);
 
@@ -875,9 +853,9 @@ public interface Pagings {
      * A paging operation that receives a 400 on the second call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextWithServiceResponseAsync(final String nextPageLink);
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -886,9 +864,9 @@ public interface Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    List<Product> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
+    PagedList<Product> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException;
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -904,7 +882,7 @@ public interface Pagings {
      * A paging operation that receives an invalid nextLink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesFailureUriNextAsync(final String nextPageLink);
 
@@ -912,8 +890,8 @@ public interface Pagings {
      * A paging operation that receives an invalid nextLink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
-    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextAsyncWithServiceResponse(final String nextPageLink);
+    Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextWithServiceResponseAsync(final String nextPageLink);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -146,17 +146,16 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getSinglePages() throws CloudException, IOException {
+    public List<Product> getSinglePages() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getSinglePagesSinglePageAsync().toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getSinglePagesNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -182,13 +181,36 @@ public final class PagingsImpl implements Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getSinglePagesAsync() {
+    public Observable<Page<Product>> getSinglePagesAsync() {
+        return getSinglePagesWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getSinglePagesAsyncWithServiceResponse() {
+        return null;
+    }
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getSinglePagesWithServiceResponseAsync() {
         return getSinglePagesSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getSinglePagesNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getSinglePagesNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -225,17 +247,16 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePages() throws CloudException, IOException {
+    public List<Product> getMultiplePages() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesSinglePageAsync().toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -261,13 +282,36 @@ public final class PagingsImpl implements Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsync() {
+    public Observable<Page<Product>> getMultiplePagesAsync() {
+        return getMultiplePagesWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsyncWithServiceResponse() {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithServiceResponseAsync() {
         return getMultiplePagesSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -303,17 +347,16 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException {
+    public List<Product> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -343,13 +386,38 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
+    public Observable<Page<Product>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
+        return getMultiplePagesWithServiceResponseAsync(clientRequestId, pagingGetMultiplePagesOptions)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsyncWithServiceResponse(String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions));
                 }
             });
     }
@@ -397,17 +465,16 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getOdataMultiplePages() throws CloudException, IOException {
+    public List<Product> getOdataMultiplePages() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getOdataMultiplePagesSinglePageAsync().toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -433,13 +500,36 @@ public final class PagingsImpl implements Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsync() {
+    public Observable<Page<Product>> getOdataMultiplePagesAsync() {
+        return getOdataMultiplePagesWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsyncWithServiceResponse() {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesWithServiceResponseAsync() {
         return getOdataMultiplePagesSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -475,17 +565,16 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException {
+    public List<Product> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -515,13 +604,38 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
+    public Observable<Page<Product>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
+        return getOdataMultiplePagesWithServiceResponseAsync(clientRequestId, pagingGetOdataMultiplePagesOptions)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsyncWithServiceResponse(String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
                 }
             });
     }
@@ -571,11 +685,11 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions = new PagingGetMultiplePagesWithOffsetNextOptions();
@@ -584,7 +698,6 @@ public final class PagingsImpl implements Pagings {
                 return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, null, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -615,16 +728,40 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
+    public Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
+        return getMultiplePagesWithOffsetWithServiceResponseAsync(pagingGetMultiplePagesWithOffsetOptions)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsyncWithServiceResponse(PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
                     PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions = new PagingGetMultiplePagesWithOffsetNextOptions();
                     pagingGetMultiplePagesWithOffsetNextOptions.withMaxresults(pagingGetMultiplePagesWithOffsetOptions.maxresults());
                     pagingGetMultiplePagesWithOffsetNextOptions.withTimeout(pagingGetMultiplePagesWithOffsetOptions.timeout());
-                    return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, null, pagingGetMultiplePagesWithOffsetNextOptions);
+                    return Observable.just(page).concatWith(getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, null, pagingGetMultiplePagesWithOffsetNextOptions));
                 }
             });
     }
@@ -666,11 +803,11 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions = new PagingGetMultiplePagesWithOffsetNextOptions();
@@ -679,7 +816,6 @@ public final class PagingsImpl implements Pagings {
                 return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -712,16 +848,41 @@ public final class PagingsImpl implements Pagings {
      * @param clientRequestId the String value
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
+    public Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
+        return getMultiplePagesWithOffsetWithServiceResponseAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsyncWithServiceResponse(PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @param clientRequestId the String value
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
                     PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions = new PagingGetMultiplePagesWithOffsetNextOptions();
                     pagingGetMultiplePagesWithOffsetNextOptions.withMaxresults(pagingGetMultiplePagesWithOffsetOptions.maxresults());
                     pagingGetMultiplePagesWithOffsetNextOptions.withTimeout(pagingGetMultiplePagesWithOffsetOptions.timeout());
-                    return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions);
+                    return Observable.just(page).concatWith(getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions));
                 }
             });
     }
@@ -767,17 +928,16 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesRetryFirst() throws CloudException, IOException {
+    public List<Product> getMultiplePagesRetryFirst() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesRetryFirstSinglePageAsync().toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -803,13 +963,36 @@ public final class PagingsImpl implements Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstAsync() {
+    public Observable<Page<Product>> getMultiplePagesRetryFirstAsync() {
+        return getMultiplePagesRetryFirstWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstAsyncWithServiceResponse() {
+        return null;
+    }
+
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstWithServiceResponseAsync() {
         return getMultiplePagesRetryFirstSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesRetryFirstNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -846,17 +1029,16 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesRetrySecond() throws CloudException, IOException {
+    public List<Product> getMultiplePagesRetrySecond() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesRetrySecondSinglePageAsync().toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -882,13 +1064,36 @@ public final class PagingsImpl implements Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondAsync() {
+    public Observable<Page<Product>> getMultiplePagesRetrySecondAsync() {
+        return getMultiplePagesRetrySecondWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondAsyncWithServiceResponse() {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondWithServiceResponseAsync() {
         return getMultiplePagesRetrySecondSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesRetrySecondNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -925,17 +1130,16 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getSinglePagesFailure() throws CloudException, IOException {
+    public List<Product> getSinglePagesFailure() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getSinglePagesFailureSinglePageAsync().toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getSinglePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -961,13 +1165,36 @@ public final class PagingsImpl implements Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureAsync() {
+    public Observable<Page<Product>> getSinglePagesFailureAsync() {
+        return getSinglePagesFailureWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureAsyncWithServiceResponse() {
+        return null;
+    }
+
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureWithServiceResponseAsync() {
         return getSinglePagesFailureSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getSinglePagesFailureNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getSinglePagesFailureNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1004,17 +1231,16 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesFailure() throws CloudException, IOException {
+    public List<Product> getMultiplePagesFailure() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesFailureSinglePageAsync().toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1040,13 +1266,36 @@ public final class PagingsImpl implements Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureAsync() {
+    public Observable<Page<Product>> getMultiplePagesFailureAsync() {
+        return getMultiplePagesFailureWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureAsyncWithServiceResponse() {
+        return null;
+    }
+
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureWithServiceResponseAsync() {
         return getMultiplePagesFailureSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesFailureNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesFailureNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1083,17 +1332,16 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesFailureUri() throws CloudException, IOException {
+    public List<Product> getMultiplePagesFailureUri() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesFailureUriSinglePageAsync().toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1119,13 +1367,36 @@ public final class PagingsImpl implements Pagings {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriAsync() {
+    public Observable<Page<Product>> getMultiplePagesFailureUriAsync() {
+        return getMultiplePagesFailureUriWithServiceResponseAsync()
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriAsyncWithServiceResponse() {
+        return null;
+    }
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriWithServiceResponseAsync() {
         return getMultiplePagesFailureUriSinglePageAsync()
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesFailureUriNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1164,17 +1435,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getSinglePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getSinglePagesNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1203,13 +1473,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getSinglePagesNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getSinglePagesNextAsync(final String nextPageLink) {
+        return getSinglePagesNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getSinglePagesNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getSinglePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getSinglePagesNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getSinglePagesNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getSinglePagesNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1252,17 +1546,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1291,13 +1584,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink) {
+        return getMultiplePagesNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -1339,17 +1656,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1382,13 +1698,39 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
+    public Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
+        return getMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsyncWithServiceResponse(String nextPageLink, String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions));
                 }
             });
     }
@@ -1442,17 +1784,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getOdataMultiplePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1481,13 +1822,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink) {
+        return getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getOdataMultiplePagesNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -1529,17 +1894,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1572,13 +1936,39 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
+    public Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
+        return getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsyncWithServiceResponse(String nextPageLink, String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
                 }
             });
     }
@@ -1632,17 +2022,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, null, null).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1671,13 +2060,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink) {
+        return getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, null, null);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, null, null));
                 }
             });
     }
@@ -1719,17 +2132,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1762,13 +2174,39 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) {
+    public Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) {
+        return getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsyncWithServiceResponse(String nextPageLink, String clientRequestId, PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) {
         return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions));
                 }
             });
     }
@@ -1822,17 +2260,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1861,13 +2298,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink) {
+        return getMultiplePagesRetryFirstNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesRetryFirstNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1910,17 +2371,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -1949,13 +2409,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink) {
+        return getMultiplePagesRetrySecondNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesRetrySecondNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -1998,17 +2482,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getSinglePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getSinglePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -2037,13 +2520,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getSinglePagesFailureNextAsync(final String nextPageLink) {
+        return getSinglePagesFailureNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextWithServiceResponseAsync(final String nextPageLink) {
         return getSinglePagesFailureNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getSinglePagesFailureNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getSinglePagesFailureNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -2086,17 +2593,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -2125,13 +2631,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getMultiplePagesFailureNextAsync(final String nextPageLink) {
+        return getMultiplePagesFailureNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesFailureNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesFailureNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesFailureNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }
@@ -2174,17 +2704,16 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
-    public ServiceResponse<PagedList<Product>> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public List<Product> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink).toBlocking().single();
-        PagedList<Product> pagedList = new PagedList<Product>(response.getBody()) {
+        return new PagedList<Product>(response.getBody()) {
             @Override
             public Page<Product> nextPage(String nextPageLink) throws RestException, IOException {
                 return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink).toBlocking().single().getBody();
             }
         };
-        return new ServiceResponse<PagedList<Product>>(pagedList, response.getResponse());
     }
 
     /**
@@ -2213,13 +2742,37 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextAsync(final String nextPageLink) {
+    public Observable<Page<Product>> getMultiplePagesFailureUriNextAsync(final String nextPageLink) {
+        return getMultiplePagesFailureUriNextWithServiceResponseAsync(nextPageLink)
+            .map(new Func1<ServiceResponse<Page<Product>>, Page<Product>>() {
+                @Override
+                public Page<Product> call(ServiceResponse<Page<Product>> response) {
+                    return response.getBody();
+                }
+            });
+    }
+
+    @Override
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextAsyncWithServiceResponse(String nextPageLink) {
+        return null;
+    }
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink)
             .concatMap(new Func1<ServiceResponse<Page<Product>>, Observable<ServiceResponse<Page<Product>>>>() {
                 @Override
                 public Observable<ServiceResponse<Page<Product>>> call(ServiceResponse<Page<Product>> page) {
                     String nextPageLink = page.getBody().getNextPageLink();
-                    return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink);
+                    if (nextPageLink == null) {
+                        return Observable.just(page);
+                    }
+                    return Observable.just(page).concatWith(getMultiplePagesFailureUriNextWithServiceResponseAsync(nextPageLink));
                 }
             });
     }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -146,9 +146,9 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getSinglePages() throws CloudException, IOException {
+    public PagedList<Product> getSinglePages() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getSinglePagesSinglePageAsync().toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -179,7 +179,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getSinglePagesAsync() {
         return getSinglePagesWithServiceResponseAsync()
@@ -191,15 +191,10 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getSinglePagesAsyncWithServiceResponse() {
-        return null;
-    }
-
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getSinglePagesWithServiceResponseAsync() {
         return getSinglePagesSinglePageAsync()
@@ -218,7 +213,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getSinglePagesSinglePageAsync() {
         return service.getSinglePages(this.client.acceptLanguage(), this.client.userAgent())
@@ -247,9 +242,9 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePages() throws CloudException, IOException {
+    public PagedList<Product> getMultiplePages() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesSinglePageAsync().toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -280,7 +275,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesAsync() {
         return getMultiplePagesWithServiceResponseAsync()
@@ -292,15 +287,10 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsyncWithServiceResponse() {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithServiceResponseAsync() {
         return getMultiplePagesSinglePageAsync()
@@ -319,7 +309,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesSinglePageAsync() {
         final String clientRequestId = null;
@@ -347,9 +337,9 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException {
+    public PagedList<Product> getMultiplePages(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -384,7 +374,7 @@ public final class PagingsImpl implements Pagings {
      *
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return getMultiplePagesWithServiceResponseAsync(clientRequestId, pagingGetMultiplePagesOptions)
@@ -396,17 +386,12 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesAsyncWithServiceResponse(String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions)
@@ -427,7 +412,7 @@ public final class PagingsImpl implements Pagings {
      *
     ServiceResponse<PageImpl<Product>> * @param clientRequestId the String value
     ServiceResponse<PageImpl<Product>> * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesSinglePageAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         Validator.validate(pagingGetMultiplePagesOptions);
@@ -465,9 +450,9 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getOdataMultiplePages() throws CloudException, IOException {
+    public PagedList<Product> getOdataMultiplePages() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getOdataMultiplePagesSinglePageAsync().toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -498,7 +483,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getOdataMultiplePagesAsync() {
         return getOdataMultiplePagesWithServiceResponseAsync()
@@ -510,15 +495,10 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsyncWithServiceResponse() {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesWithServiceResponseAsync() {
         return getOdataMultiplePagesSinglePageAsync()
@@ -537,7 +517,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesSinglePageAsync() {
         final String clientRequestId = null;
@@ -565,9 +545,9 @@ public final class PagingsImpl implements Pagings {
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException {
+    public PagedList<Product> getOdataMultiplePages(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -602,7 +582,7 @@ public final class PagingsImpl implements Pagings {
      *
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesWithServiceResponseAsync(clientRequestId, pagingGetOdataMultiplePagesOptions)
@@ -614,17 +594,12 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesAsyncWithServiceResponse(String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesWithServiceResponseAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions)
@@ -645,7 +620,7 @@ public final class PagingsImpl implements Pagings {
      *
     ServiceResponse<PageImpl1<Product>> * @param clientRequestId the String value
     ServiceResponse<PageImpl1<Product>> * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesSinglePageAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         Validator.validate(pagingGetOdataMultiplePagesOptions);
@@ -685,9 +660,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -726,7 +701,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
         return getMultiplePagesWithOffsetWithServiceResponseAsync(pagingGetMultiplePagesWithOffsetOptions)
@@ -738,16 +713,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsyncWithServiceResponse(PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions)
@@ -770,7 +740,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetSinglePageAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
         if (pagingGetMultiplePagesWithOffsetOptions == null) {
@@ -803,9 +773,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesWithOffset(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -846,7 +816,7 @@ public final class PagingsImpl implements Pagings {
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @param clientRequestId the String value
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
         return getMultiplePagesWithOffsetWithServiceResponseAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
@@ -858,17 +828,12 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetAsyncWithServiceResponse(PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @param clientRequestId the String value
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetWithServiceResponseAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
@@ -892,7 +857,7 @@ public final class PagingsImpl implements Pagings {
      *
     ServiceResponse<PageImpl<Product>> * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
     ServiceResponse<PageImpl<Product>> * @param clientRequestId the String value
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetSinglePageAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId) {
         if (pagingGetMultiplePagesWithOffsetOptions == null) {
@@ -928,9 +893,9 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesRetryFirst() throws CloudException, IOException {
+    public PagedList<Product> getMultiplePagesRetryFirst() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesRetryFirstSinglePageAsync().toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -961,7 +926,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesRetryFirstAsync() {
         return getMultiplePagesRetryFirstWithServiceResponseAsync()
@@ -973,15 +938,10 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstAsyncWithServiceResponse() {
-        return null;
-    }
-
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstWithServiceResponseAsync() {
         return getMultiplePagesRetryFirstSinglePageAsync()
@@ -1000,7 +960,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstSinglePageAsync() {
         return service.getMultiplePagesRetryFirst(this.client.acceptLanguage(), this.client.userAgent())
@@ -1029,9 +989,9 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesRetrySecond() throws CloudException, IOException {
+    public PagedList<Product> getMultiplePagesRetrySecond() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesRetrySecondSinglePageAsync().toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1062,7 +1022,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesRetrySecondAsync() {
         return getMultiplePagesRetrySecondWithServiceResponseAsync()
@@ -1074,15 +1034,10 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondAsyncWithServiceResponse() {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondWithServiceResponseAsync() {
         return getMultiplePagesRetrySecondSinglePageAsync()
@@ -1101,7 +1056,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondSinglePageAsync() {
         return service.getMultiplePagesRetrySecond(this.client.acceptLanguage(), this.client.userAgent())
@@ -1130,9 +1085,9 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getSinglePagesFailure() throws CloudException, IOException {
+    public PagedList<Product> getSinglePagesFailure() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getSinglePagesFailureSinglePageAsync().toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1163,7 +1118,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that receives a 400 on the first call.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getSinglePagesFailureAsync() {
         return getSinglePagesFailureWithServiceResponseAsync()
@@ -1175,15 +1130,10 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureAsyncWithServiceResponse() {
-        return null;
-    }
-
     /**
      * A paging operation that receives a 400 on the first call.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureWithServiceResponseAsync() {
         return getSinglePagesFailureSinglePageAsync()
@@ -1202,7 +1152,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that receives a 400 on the first call.
      *
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureSinglePageAsync() {
         return service.getSinglePagesFailure(this.client.acceptLanguage(), this.client.userAgent())
@@ -1231,9 +1181,9 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesFailure() throws CloudException, IOException {
+    public PagedList<Product> getMultiplePagesFailure() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesFailureSinglePageAsync().toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1264,7 +1214,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that receives a 400 on the second call.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesFailureAsync() {
         return getMultiplePagesFailureWithServiceResponseAsync()
@@ -1276,15 +1226,10 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureAsyncWithServiceResponse() {
-        return null;
-    }
-
     /**
      * A paging operation that receives a 400 on the second call.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureWithServiceResponseAsync() {
         return getMultiplePagesFailureSinglePageAsync()
@@ -1303,7 +1248,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that receives a 400 on the second call.
      *
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureSinglePageAsync() {
         return service.getMultiplePagesFailure(this.client.acceptLanguage(), this.client.userAgent())
@@ -1332,9 +1277,9 @@ public final class PagingsImpl implements Pagings {
      *
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesFailureUri() throws CloudException, IOException {
+    public PagedList<Product> getMultiplePagesFailureUri() throws CloudException, IOException {
         ServiceResponse<Page<Product>> response = getMultiplePagesFailureUriSinglePageAsync().toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1365,7 +1310,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that receives an invalid nextLink.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesFailureUriAsync() {
         return getMultiplePagesFailureUriWithServiceResponseAsync()
@@ -1377,15 +1322,10 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriAsyncWithServiceResponse() {
-        return null;
-    }
-
     /**
      * A paging operation that receives an invalid nextLink.
      *
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriWithServiceResponseAsync() {
         return getMultiplePagesFailureUriSinglePageAsync()
@@ -1404,7 +1344,7 @@ public final class PagingsImpl implements Pagings {
     /**
      * A paging operation that receives an invalid nextLink.
      *
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriSinglePageAsync() {
         return service.getMultiplePagesFailureUri(this.client.acceptLanguage(), this.client.userAgent())
@@ -1435,9 +1375,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getSinglePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getSinglePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1471,7 +1411,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that finishes on the first call without a nextlink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getSinglePagesNextAsync(final String nextPageLink) {
         return getSinglePagesNextWithServiceResponseAsync(nextPageLink)
@@ -1483,16 +1423,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getSinglePagesNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that finishes on the first call without a nextlink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getSinglePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getSinglePagesNextSinglePageAsync(nextPageLink)
@@ -1512,7 +1447,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that finishes on the first call without a nextlink.
      *
     ServiceResponse<PageImpl<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getSinglePagesNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -1546,9 +1481,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1582,7 +1517,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink) {
         return getMultiplePagesNextWithServiceResponseAsync(nextPageLink)
@@ -1594,16 +1529,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesNextSinglePageAsync(nextPageLink)
@@ -1623,7 +1553,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -1656,9 +1586,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1696,7 +1626,7 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return getMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions)
@@ -1708,18 +1638,13 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextAsyncWithServiceResponse(String nextPageLink, String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return getMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesOptions)
@@ -1741,7 +1666,7 @@ public final class PagingsImpl implements Pagings {
     ServiceResponse<PageImpl<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
     ServiceResponse<PageImpl<Product>> * @param clientRequestId the String value
     ServiceResponse<PageImpl<Product>> * @param pagingGetMultiplePagesOptions Additional parameters for the operation
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesNextSinglePageAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         if (nextPageLink == null) {
@@ -1784,9 +1709,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getOdataMultiplePagesNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getOdataMultiplePagesNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1820,7 +1745,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink) {
         return getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink)
@@ -1832,16 +1757,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink) {
         return getOdataMultiplePagesNextSinglePageAsync(nextPageLink)
@@ -1861,7 +1781,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -1894,9 +1814,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getOdataMultiplePagesNext(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -1934,7 +1854,7 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions)
@@ -1946,18 +1866,13 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextAsyncWithServiceResponse(String nextPageLink, String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetOdataMultiplePagesOptions)
@@ -1979,7 +1894,7 @@ public final class PagingsImpl implements Pagings {
     ServiceResponse<PageImpl1<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
     ServiceResponse<PageImpl1<Product>> * @param clientRequestId the String value
     ServiceResponse<PageImpl1<Product>> * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getOdataMultiplePagesNextSinglePageAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         if (nextPageLink == null) {
@@ -2022,9 +1937,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesWithOffsetNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -2058,7 +1973,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink) {
         return getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink)
@@ -2070,16 +1985,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink)
@@ -2099,7 +2009,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2132,9 +2042,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesWithOffsetNext(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -2172,7 +2082,7 @@ public final class PagingsImpl implements Pagings {
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) {
         return getMultiplePagesWithOffsetNextWithServiceResponseAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions)
@@ -2184,18 +2094,13 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextAsyncWithServiceResponse(String nextPageLink, String clientRequestId, PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextWithServiceResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) {
         return getMultiplePagesWithOffsetNextSinglePageAsync(nextPageLink, clientRequestId, pagingGetMultiplePagesWithOffsetNextOptions)
@@ -2217,7 +2122,7 @@ public final class PagingsImpl implements Pagings {
     ServiceResponse<PageImpl<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
     ServiceResponse<PageImpl<Product>> * @param clientRequestId the String value
     ServiceResponse<PageImpl<Product>> * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesWithOffsetNextSinglePageAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions) {
         if (nextPageLink == null) {
@@ -2260,9 +2165,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesRetryFirstNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -2296,7 +2201,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink) {
         return getMultiplePagesRetryFirstNextWithServiceResponseAsync(nextPageLink)
@@ -2308,16 +2213,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesRetryFirstNextSinglePageAsync(nextPageLink)
@@ -2337,7 +2237,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
      *
     ServiceResponse<PageImpl<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetryFirstNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2371,9 +2271,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesRetrySecondNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -2407,7 +2307,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink) {
         return getMultiplePagesRetrySecondNextWithServiceResponseAsync(nextPageLink)
@@ -2419,16 +2319,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesRetrySecondNextSinglePageAsync(nextPageLink)
@@ -2448,7 +2343,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
      *
     ServiceResponse<PageImpl<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesRetrySecondNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2482,9 +2377,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getSinglePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getSinglePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -2518,7 +2413,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that receives a 400 on the first call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getSinglePagesFailureNextAsync(final String nextPageLink) {
         return getSinglePagesFailureNextWithServiceResponseAsync(nextPageLink)
@@ -2530,16 +2425,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that receives a 400 on the first call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextWithServiceResponseAsync(final String nextPageLink) {
         return getSinglePagesFailureNextSinglePageAsync(nextPageLink)
@@ -2559,7 +2449,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that receives a 400 on the first call.
      *
     ServiceResponse<PageImpl<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getSinglePagesFailureNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2593,9 +2483,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesFailureNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesFailureNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -2629,7 +2519,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that receives a 400 on the second call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesFailureNextAsync(final String nextPageLink) {
         return getMultiplePagesFailureNextWithServiceResponseAsync(nextPageLink)
@@ -2641,16 +2531,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that receives a 400 on the second call.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesFailureNextSinglePageAsync(nextPageLink)
@@ -2670,7 +2555,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that receives a 400 on the second call.
      *
     ServiceResponse<PageImpl<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {
@@ -2704,9 +2589,9 @@ public final class PagingsImpl implements Pagings {
      * @throws CloudException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the List&lt;Product&gt; object if successful.
+     * @return the PagedList&lt;Product&gt; object if successful.
      */
-    public List<Product> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
+    public PagedList<Product> getMultiplePagesFailureUriNext(final String nextPageLink) throws CloudException, IOException, IllegalArgumentException {
         ServiceResponse<Page<Product>> response = getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink).toBlocking().single();
         return new PagedList<Product>(response.getBody()) {
             @Override
@@ -2740,7 +2625,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that receives an invalid nextLink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<Page<Product>> getMultiplePagesFailureUriNextAsync(final String nextPageLink) {
         return getMultiplePagesFailureUriNextWithServiceResponseAsync(nextPageLink)
@@ -2752,16 +2637,11 @@ public final class PagingsImpl implements Pagings {
             });
     }
 
-    @Override
-    public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextAsyncWithServiceResponse(String nextPageLink) {
-        return null;
-    }
-
     /**
      * A paging operation that receives an invalid nextLink.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the observable to the List&lt;Product&gt; object
+     * @return the observable to the PagedList&lt;Product&gt; object
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextWithServiceResponseAsync(final String nextPageLink) {
         return getMultiplePagesFailureUriNextSinglePageAsync(nextPageLink)
@@ -2781,7 +2661,7 @@ public final class PagingsImpl implements Pagings {
      * A paging operation that receives an invalid nextLink.
      *
     ServiceResponse<PageImpl<Product>> * @param nextPageLink The NextLink from the previous successful call to List operation.
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the PagedList&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
     public Observable<ServiceResponse<Page<Product>>> getMultiplePagesFailureUriNextSinglePageAsync(final String nextPageLink) {
         if (nextPageLink == null) {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/subscriptionidapiversion/Groups.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/subscriptionidapiversion/Groups.java
@@ -32,7 +32,7 @@ public interface Groups {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the SampleResourceGroup object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SampleResourceGroup> getSampleResourceGroup(String resourceGroupName) throws ErrorException, IOException, IllegalArgumentException;
+    SampleResourceGroup getSampleResourceGroup(String resourceGroupName) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Provides a resouce group with name 'testgroup101' and location 'West US'.
@@ -49,6 +49,14 @@ public interface Groups {
      * @param resourceGroupName Resource Group name 'testgroup101'.
      * @return the observable to the SampleResourceGroup object
      */
-    Observable<ServiceResponse<SampleResourceGroup>> getSampleResourceGroupAsync(String resourceGroupName);
+    Observable<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName);
+
+    /**
+     * Provides a resouce group with name 'testgroup101' and location 'West US'.
+     *
+     * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @return the observable to the SampleResourceGroup object
+     */
+    Observable<ServiceResponse<SampleResourceGroup>> getSampleResourceGroupAsyncWithServiceResponse(String resourceGroupName);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/subscriptionidapiversion/Groups.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/subscriptionidapiversion/Groups.java
@@ -30,7 +30,7 @@ public interface Groups {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SampleResourceGroup object wrapped in {@link ServiceResponse} if successful.
+     * @return the SampleResourceGroup object if successful.
      */
     SampleResourceGroup getSampleResourceGroup(String resourceGroupName) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -57,6 +57,6 @@ public interface Groups {
      * @param resourceGroupName Resource Group name 'testgroup101'.
      * @return the observable to the SampleResourceGroup object
      */
-    Observable<ServiceResponse<SampleResourceGroup>> getSampleResourceGroupAsyncWithServiceResponse(String resourceGroupName);
+    Observable<ServiceResponse<SampleResourceGroup>> getSampleResourceGroupWithServiceResponseAsync(String resourceGroupName);
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsImpl.java
@@ -69,10 +69,10 @@ public final class GroupsImpl implements Groups {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SampleResourceGroup object wrapped in {@link ServiceResponse} if successful.
+     * @return the SampleResourceGroup object if successful.
      */
-    public ServiceResponse<SampleResourceGroup> getSampleResourceGroup(String resourceGroupName) throws ErrorException, IOException, IllegalArgumentException {
-        return getSampleResourceGroupAsync(resourceGroupName).toBlocking().single();
+    public SampleResourceGroup getSampleResourceGroup(String resourceGroupName) throws ErrorException, IOException, IllegalArgumentException {
+        return getSampleResourceGroupWithServiceResponseAsync(resourceGroupName).toBlocking().single().getBody();
     }
 
     /**
@@ -83,7 +83,7 @@ public final class GroupsImpl implements Groups {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName, final ServiceCallback<SampleResourceGroup> serviceCallback) {
-        return ServiceCall.create(getSampleResourceGroupAsync(resourceGroupName), serviceCallback);
+        return ServiceCall.create(getSampleResourceGroupWithServiceResponseAsync(resourceGroupName), serviceCallback);
     }
 
     /**
@@ -92,7 +92,22 @@ public final class GroupsImpl implements Groups {
      * @param resourceGroupName Resource Group name 'testgroup101'.
      * @return the observable to the SampleResourceGroup object
      */
-    public Observable<ServiceResponse<SampleResourceGroup>> getSampleResourceGroupAsync(String resourceGroupName) {
+    public Observable<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName) {
+        return getSampleResourceGroupWithServiceResponseAsync(resourceGroupName).map(new Func1<ServiceResponse<SampleResourceGroup>, SampleResourceGroup>() {
+            @Override
+            public SampleResourceGroup call(ServiceResponse<SampleResourceGroup> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Provides a resouce group with name 'testgroup101' and location 'West US'.
+     *
+     * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @return the observable to the SampleResourceGroup object
+     */
+    public Observable<ServiceResponse<SampleResourceGroup>> getSampleResourceGroupWithServiceResponseAsync(String resourceGroupName) {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsImpl.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsImpl.java
@@ -98,7 +98,7 @@ public final class GroupsImpl implements Groups {
             public SampleResourceGroup call(ServiceResponse<SampleResourceGroup> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurecustombaseuri/AzureCustomBaseUriTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurecustombaseuri/AzureCustomBaseUriTests.java
@@ -22,7 +22,7 @@ public class AzureCustomBaseUriTests {
     @Test
     public void getEmptyWithValidCustomUri() throws Exception {
         client.withHost("host:3000");
-        Assert.assertTrue(client.paths().getEmpty("local").getResponse().isSuccessful());
+        client.paths().getEmpty("local");
     }
 
     @Test

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azureparametergrouping/ParameterGroupingTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azureparametergrouping/ParameterGroupingTests.java
@@ -1,7 +1,5 @@
 package fixtures.azureparametergrouping;
 
-import com.microsoft.rest.ServiceResponse;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -26,7 +24,7 @@ public class ParameterGroupingTests {
         params.withPath("path");
         params.withQuery(21);
         params.withCustomHeader("header");
-        ServiceResponse<Void> group = client.parameterGroupings().postRequired(params);
+        client.parameterGroupings().postRequired(params);
     }
 
     @Test
@@ -34,7 +32,7 @@ public class ParameterGroupingTests {
         ParameterGroupingPostOptionalParameters params = new ParameterGroupingPostOptionalParameters();
         params.withQuery(21);
         params.withCustomHeader("header");
-        ServiceResponse<Void> group = client.parameterGroupings().postOptional(params);
+        client.parameterGroupings().postOptional(params);
     }
 
     @Test
@@ -45,7 +43,7 @@ public class ParameterGroupingTests {
         ParameterGroupingPostMultiParamGroupsSecondParamGroup second = new ParameterGroupingPostMultiParamGroupsSecondParamGroup();
         second.withHeaderTwo("header2");
         second.withQueryTwo(42);
-        ServiceResponse<Void> group = client.parameterGroupings().postMultiParamGroups(first, second);
+        client.parameterGroupings().postMultiParamGroups(first, second);
     }
 
     @Test
@@ -53,6 +51,6 @@ public class ParameterGroupingTests {
         FirstParameterGroup first = new FirstParameterGroup();
         first.withQueryOne(21);
         first.withHeaderOne("header");
-        ServiceResponse<Void> group = client.parameterGroupings().postSharedParameterGroupObject(first);
+        client.parameterGroupings().postSharedParameterGroupObject(first);
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurereport/CoverageReporter.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurereport/CoverageReporter.java
@@ -12,7 +12,7 @@ public final class CoverageReporter {
     private CoverageReporter() { }
 
     public static void main(String[] args) throws Exception {
-        Map<String, Integer> report = client.getReport().getBody();
+        Map<String, Integer> report = client.getReport();
 
         // Pending URL encoding
         report.put("AzureMethodQueryUrlEncoding", 1);

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/ApiVersionDefaultTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/ApiVersionDefaultTests.java
@@ -17,25 +17,25 @@ public class ApiVersionDefaultTests {
 
     @Test
     public void getMethodGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionDefaults().getMethodGlobalValid();
+        ServiceResponse<Void> response = client.apiVersionDefaults().getMethodGlobalValidWithServiceResponseAsync().toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 
     @Test
     public void getMethodGlobalNotProvidedValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionDefaults().getMethodGlobalNotProvidedValid();
+        ServiceResponse<Void> response = client.apiVersionDefaults().getMethodGlobalNotProvidedValidWithServiceResponseAsync().toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 
     @Test
     public void getPathGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionDefaults().getPathGlobalValid();
+        ServiceResponse<Void> response = client.apiVersionDefaults().getPathGlobalValidWithServiceResponseAsync().toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 
     @Test
     public void getSwaggerGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionDefaults().getSwaggerGlobalValid();
+        ServiceResponse<Void> response = client.apiVersionDefaults().getSwaggerGlobalValidWithServiceResponseAsync().toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/ApiVersionLocalTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/ApiVersionLocalTests.java
@@ -17,25 +17,25 @@ public class ApiVersionLocalTests {
 
     @Test
     public void getMethodLocalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionLocals().getMethodLocalValid();
+        ServiceResponse<Void> response = client.apiVersionLocals().getMethodLocalValidWithServiceResponseAsync().toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 
     @Test
     public void getMethodGlobalNotProvidedValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionLocals().getMethodLocalNull(null);
+        ServiceResponse<Void> response = client.apiVersionLocals().getMethodLocalNullWithServiceResponseAsync().toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 
     @Test
     public void getPathGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionLocals().getPathLocalValid();
+        ServiceResponse<Void> response = client.apiVersionLocals().getPathLocalValidWithServiceResponseAsync().toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 
     @Test
     public void getSwaggerGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.apiVersionLocals().getSwaggerLocalValid();
+        ServiceResponse<Void> response = client.apiVersionLocals().getSwaggerLocalValidWithServiceResponseAsync().toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/HeaderOperationsTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/HeaderOperationsTests.java
@@ -20,7 +20,7 @@ public class HeaderOperationsTests {
 
     @Test
     public void customNamedRequestId() throws Exception {
-        ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders> response = client.headers().customNamedRequestId("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
+        ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdHeaders> response = client.headers().customNamedRequestIdWithServiceResponseAsync("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0").toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
         Assert.assertEquals("123", response.getHeaders().fooRequestId());
     }
@@ -29,7 +29,7 @@ public class HeaderOperationsTests {
     public void customNamedRequestIdParamGrouping() throws Exception {
         HeaderCustomNamedRequestIdParamGroupingParameters group = new HeaderCustomNamedRequestIdParamGroupingParameters();
         group.withFooClientRequestId("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
-        ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders> response = client.headers().customNamedRequestIdParamGrouping(group);
+        ServiceResponseWithHeaders<Void, HeaderCustomNamedRequestIdParamGroupingHeaders> response = client.headers().customNamedRequestIdParamGroupingWithServiceResponseAsync(group).toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
         Assert.assertEquals("123", response.getHeaders().fooRequestId());
     }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/SkipUrlEncodingTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/SkipUrlEncodingTests.java
@@ -1,8 +1,5 @@
 package fixtures.azurespecials;
 
-import com.microsoft.rest.ServiceResponse;
-
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -10,9 +7,6 @@ import org.junit.Test;
 import fixtures.azurespecials.implementation.AutoRestAzureSpecialParametersTestClientImpl;
 
 public class SkipUrlEncodingTests {
-    private static final int OK_STATUS_CODE = 200;
-    private static final int NOT_FOUND_STATUS_CODE = 404;
-
     private static String baseUrl = "http://localhost:3000";
     private static String unencodedPath = "path1/path2/path3";
     private static String unencodedQuery = "value1&q2=value2&q3=value3";
@@ -26,44 +20,37 @@ public class SkipUrlEncodingTests {
 
     @Test
     public void getMethodPathValid() throws Exception {
-        ServiceResponse<Void> response = client.getMethodPathValid(unencodedPath);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getMethodPathValid(unencodedPath);
     }
 
     @Test
     public void getPathPathValid() throws Exception {
-        ServiceResponse<Void> response = client.getPathPathValid(unencodedPath);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getPathPathValid(unencodedPath);
     }
 
     @Test
     public void getSwaggerPathValid() throws Exception {
-        ServiceResponse<Void> response = client.getSwaggerPathValid();
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getSwaggerPathValid();
     }
 
     @Ignore("Not supported by OkHttp: https://github.com/square/okhttp/issues/2623")
     public void getMethodQueryValid() throws Exception {
-        ServiceResponse<Void> response = client.getMethodQueryValid(unencodedQuery);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getMethodQueryValid(unencodedQuery);
     }
 
     @Ignore("Not supported by OkHttp: https://github.com/square/okhttp/issues/2623")
     public void getPathQueryValid() throws Exception {
-        ServiceResponse<Void> response = client.getPathQueryValid(unencodedQuery);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getPathQueryValid(unencodedQuery);
     }
 
     @Ignore("Not supported by OkHttp: https://github.com/square/okhttp/issues/2623")
     public void getSwaggerQueryValid() throws Exception {
-        ServiceResponse<Void> response = client.getSwaggerQueryValid();
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getSwaggerQueryValid();
     }
 
     @Test
     public void getMethodQueryNull() throws Exception {
-        ServiceResponse<Void> response = client.getMethodQueryNull(null);
-        Assert.assertEquals(OK_STATUS_CODE, response.getResponse().code());
+        client.getMethodQueryNull(null);
     }
 
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/SubscriptionInCredentialsTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/SubscriptionInCredentialsTests.java
@@ -2,10 +2,8 @@ package fixtures.azurespecials;
 
 import com.microsoft.azure.RequestIdHeaderInterceptor;
 import com.microsoft.azure.RestClient;
-import com.microsoft.rest.ServiceResponse;
 import com.microsoft.rest.credentials.TokenCredentials;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -29,25 +27,21 @@ public class SubscriptionInCredentialsTests {
 
     @Test
     public void postMethodGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInCredentials().postMethodGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInCredentials().postMethodGlobalValid();
     }
 
     @Test
     public void postMethodGlobalNotProvidedValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInCredentials().postMethodGlobalNotProvidedValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInCredentials().postMethodGlobalNotProvidedValid();
     }
 
     @Test
     public void postPathGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInCredentials().postPathGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInCredentials().postPathGlobalValid();
     }
 
     @Test
     public void postSwaggerGlobalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInCredentials().postSwaggerGlobalValid();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInCredentials().postSwaggerGlobalValid();
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/SubscriptionInMethodTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/SubscriptionInMethodTests.java
@@ -2,7 +2,6 @@ package fixtures.azurespecials;
 
 import com.microsoft.azure.RequestIdHeaderInterceptor;
 import com.microsoft.azure.RestClient;
-import com.microsoft.rest.ServiceResponse;
 import com.microsoft.rest.credentials.TokenCredentials;
 
 import org.junit.Assert;
@@ -31,14 +30,13 @@ public class SubscriptionInMethodTests {
 
     @Test
     public void postMethodLocalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInMethods().postMethodLocalValid("1234-5678-9012-3456");
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInMethods().postMethodLocalValid("1234-5678-9012-3456");
     }
 
     @Test
     public void postMethodLocalNull() throws Exception {
         try {
-            ServiceResponse<Void> response = client.subscriptionInMethods().postMethodLocalNull(null);
+            client.subscriptionInMethods().postMethodLocalNull(null);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter subscriptionId is required"));
@@ -47,13 +45,11 @@ public class SubscriptionInMethodTests {
 
     @Test
     public void postPathLocalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInMethods().postPathLocalValid("1234-5678-9012-3456");
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInMethods().postPathLocalValid("1234-5678-9012-3456");
     }
 
     @Test
     public void postSwaggerLocalValid() throws Exception {
-        ServiceResponse<Void> response = client.subscriptionInMethods().postSwaggerLocalValid("1234-5678-9012-3456");
-        Assert.assertEquals(200, response.getResponse().code());
+        client.subscriptionInMethods().postSwaggerLocalValid("1234-5678-9012-3456");
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/XMsClientRequestIdTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/azurespecials/XMsClientRequestIdTests.java
@@ -24,7 +24,7 @@ public class XMsClientRequestIdTests {
     public void get() throws Exception {
         client.restClient().headers().removeHeader("x-ms-client-request-id");
         client.restClient().headers().addHeader("x-ms-client-request-id", "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
-        ServiceResponse<Void> response = client.xMsClientRequestIds().get();
+        ServiceResponse<Void> response = client.xMsClientRequestIds().getWithServiceResponseAsync().toBlocking().last();
         client.restClient().headers().removeHeader("x-ms-client-request-id");
         Assert.assertEquals(200, response.getResponse().code());
     }
@@ -32,7 +32,7 @@ public class XMsClientRequestIdTests {
     @Test
     public void paramGet() throws Exception {
         client.restClient().headers().removeHeader("x-ms-client-request-id");
-        ServiceResponse<Void> response = client.xMsClientRequestIds().paramGet("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
+        ServiceResponse<Void> response = client.xMsClientRequestIds().paramGetWithServiceResponseAsync("9C4D50EE-2D56-4CD3-8152-34347DC9F2B0").toBlocking().last();
         Assert.assertEquals(200, response.getResponse().code());
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/head/HttpSuccessTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/head/HttpSuccessTests.java
@@ -16,16 +16,16 @@ public class HttpSuccessTests {
 
     @Test
     public void head200() throws Exception {
-        Assert.assertTrue(client.httpSuccess().head200().getBody());
+        Assert.assertTrue(client.httpSuccess().head200());
     }
 
     @Test
     public void head204() throws Exception {
-        Assert.assertTrue(client.httpSuccess().head204().getBody());
+        Assert.assertTrue(client.httpSuccess().head204());
     }
 
     @Test
     public void head404() throws Exception {
-        Assert.assertFalse(client.httpSuccess().head404().getBody());
+        Assert.assertFalse(client.httpSuccess().head404());
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/lro/LRORetrysTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/lro/LRORetrysTests.java
@@ -1,7 +1,6 @@
 package fixtures.lro;
 
 import com.microsoft.azure.RestClient;
-import com.microsoft.rest.ServiceResponse;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -28,52 +27,45 @@ public class LRORetrysTests {
     public void put201CreatingSucceeded200() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lRORetrys().put201CreatingSucceeded200(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lRORetrys().put201CreatingSucceeded200(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putAsyncRelativeRetrySucceeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lRORetrys().putAsyncRelativeRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lRORetrys().putAsyncRelativeRetrySucceeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void deleteProvisioning202Accepted200Succeeded() throws Exception {
-        ServiceResponse<Product> response = client.lRORetrys().deleteProvisioning202Accepted200Succeeded();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lRORetrys().deleteProvisioning202Accepted200Succeeded();
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void delete202Retry200() throws Exception {
-        ServiceResponse<Void> response = client.lRORetrys().delete202Retry200();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lRORetrys().delete202Retry200();
     }
 
     @Test
     public void deleteAsyncRelativeRetrySucceeded() throws Exception {
-        ServiceResponse<Void> response = client.lRORetrys().deleteAsyncRelativeRetrySucceeded();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lRORetrys().deleteAsyncRelativeRetrySucceeded();
     }
 
     @Test
     public void post202Retry200() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lRORetrys().post202Retry200(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lRORetrys().post202Retry200(product);
     }
 
     @Test
     public void postAsyncRelativeRetrySucceeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lRORetrys().postAsyncRelativeRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lRORetrys().postAsyncRelativeRetrySucceeded(product);
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/lro/LROSADsTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/lro/LROSADsTests.java
@@ -1,7 +1,6 @@
 package fixtures.lro;
 
 import com.microsoft.azure.CloudException;
-import com.microsoft.rest.ServiceResponse;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -26,7 +25,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().putNonRetry400(product);
+            client.lROSADs().putNonRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -38,7 +37,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().putNonRetry201Creating400(product);
+            client.lROSADs().putNonRetry201Creating400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -50,7 +49,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().putAsyncRelativeRetry400(product);
+            client.lROSADs().putAsyncRelativeRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -60,7 +59,7 @@ public class LROSADsTests {
     @Test
     public void deleteNonRetry400() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteNonRetry400();
+            client.lROSADs().deleteNonRetry400();
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -70,7 +69,7 @@ public class LROSADsTests {
     @Test
     public void delete202NonRetry400() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().delete202NonRetry400();
+            client.lROSADs().delete202NonRetry400();
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -80,7 +79,7 @@ public class LROSADsTests {
     @Test
     public void deleteAsyncRelativeRetry400() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteAsyncRelativeRetry400();
+            client.lROSADs().deleteAsyncRelativeRetry400();
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -92,7 +91,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postNonRetry400(product);
+            client.lROSADs().postNonRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -104,7 +103,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().post202NonRetry400(product);
+            client.lROSADs().post202NonRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -116,7 +115,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postAsyncRelativeRetry400(product);
+            client.lROSADs().postAsyncRelativeRetry400(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
@@ -128,7 +127,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().putError201NoProvisioningStatePayload(product);
+            client.lROSADs().putError201NoProvisioningStatePayload(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -141,7 +140,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().putAsyncRelativeRetryNoStatus(product);
+            client.lROSADs().putAsyncRelativeRetryNoStatus(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -154,7 +153,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().putAsyncRelativeRetryNoStatusPayload(product);
+            client.lROSADs().putAsyncRelativeRetryNoStatusPayload(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -164,14 +163,13 @@ public class LROSADsTests {
 
     @Test
     public void delete204Succeeded() throws Exception {
-        ServiceResponse<Void> response = client.lROSADs().delete204Succeeded();
-        Assert.assertEquals(204, response.getResponse().code());
+        client.lROSADs().delete204Succeeded();
     }
 
     @Test
     public void deleteAsyncRelativeRetryNoStatus() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteAsyncRelativeRetryNoStatus();
+            client.lROSADs().deleteAsyncRelativeRetryNoStatus();
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -184,7 +182,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().post202NoLocation(product);
+            client.lROSADs().post202NoLocation(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(202, ex.getResponse().code());
@@ -197,7 +195,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postAsyncRelativeRetryNoPayload(product);
+            client.lROSADs().postAsyncRelativeRetryNoPayload(product);
             fail();
         } catch (CloudException ex) {
             Assert.assertEquals(200, ex.getResponse().code());
@@ -210,7 +208,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().put200InvalidJson(product);
+            client.lROSADs().put200InvalidJson(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("Unexpected end-of-input"));
@@ -222,7 +220,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().putAsyncRelativeRetryInvalidHeader(product);
+            client.lROSADs().putAsyncRelativeRetryInvalidHeader(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -234,7 +232,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROSADs().putAsyncRelativeRetryInvalidJsonPolling(product);
+            client.lROSADs().putAsyncRelativeRetryInvalidJsonPolling(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("does not contain a valid body"));
@@ -244,7 +242,7 @@ public class LROSADsTests {
     @Test
     public void delete202RetryInvalidHeader() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().delete202RetryInvalidHeader();
+            client.lROSADs().delete202RetryInvalidHeader();
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -254,7 +252,7 @@ public class LROSADsTests {
     @Test
     public void deleteAsyncRelativeRetryInvalidHeader() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteAsyncRelativeRetryInvalidHeader();
+            client.lROSADs().deleteAsyncRelativeRetryInvalidHeader();
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -264,7 +262,7 @@ public class LROSADsTests {
     @Test
     public void deleteAsyncRelativeRetryInvalidJsonPolling() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROSADs().deleteAsyncRelativeRetryInvalidJsonPolling();
+            client.lROSADs().deleteAsyncRelativeRetryInvalidJsonPolling();
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("does not contain a valid body"));
@@ -276,7 +274,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().post202RetryInvalidHeader(product);
+            client.lROSADs().post202RetryInvalidHeader(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -288,7 +286,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postAsyncRelativeRetryInvalidHeader(product);
+            client.lROSADs().postAsyncRelativeRetryInvalidHeader(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("no protocol: /foo"));
@@ -300,7 +298,7 @@ public class LROSADsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Void> response = client.lROSADs().postAsyncRelativeRetryInvalidJsonPolling(product);
+            client.lROSADs().postAsyncRelativeRetryInvalidJsonPolling(product);
             fail();
         } catch (RuntimeException ex) {
             Assert.assertTrue(ex.getMessage().contains("polling response does not contain a valid body"));

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/lro/LROsCustomHeaderTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/lro/LROsCustomHeaderTests.java
@@ -1,7 +1,6 @@
 package fixtures.lro;
 
 import com.microsoft.azure.CustomHeaderInterceptor;
-import com.microsoft.rest.ServiceResponse;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -34,33 +33,29 @@ public class LROsCustomHeaderTests {
     public void putAsyncRetrySucceeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROsCustomHeaders().putAsyncRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROsCustomHeaders().putAsyncRetrySucceeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void put201CreatingSucceeded200() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROsCustomHeaders().put201CreatingSucceeded200(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROsCustomHeaders().put201CreatingSucceeded200(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void post202Retry200() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lROsCustomHeaders().post202Retry200(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROsCustomHeaders().post202Retry200(product);
     }
 
     @Test
     public void postAsyncRetrySucceeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lROsCustomHeaders().postAsyncRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROsCustomHeaders().postAsyncRetrySucceeded(product);
     }
 }

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/lro/LROsTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/lro/LROsTests.java
@@ -3,7 +3,6 @@ package fixtures.lro;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.RestClient;
 import com.microsoft.rest.ServiceCallback;
-import com.microsoft.rest.ServiceResponse;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -38,27 +37,24 @@ public class LROsTests {
     public void put200Succeeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().put200Succeeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROs().put200Succeeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void put200SucceededNoState() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().put200SucceededNoState(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("100", response.getBody().id());
+        Product response = client.lROs().put200SucceededNoState(product);
+        Assert.assertEquals("100", response.id());
     }
 
     @Test
     public void put202Retry200() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().put202Retry200(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("100", response.getBody().id());
+        Product response = client.lROs().put202Retry200(product);
+        Assert.assertEquals("100", response.id());
     }
 
     @Ignore("Can cause flakiness - only run manually")
@@ -76,9 +72,8 @@ public class LROsTests {
             }
 
             @Override
-            public void success(ServiceResponse<Product> result) {
-                Assert.assertEquals(200, result.getResponse().code());
-                Assert.assertEquals("100", result.getBody().id());
+            public void success(Product result) {
+                Assert.assertEquals("100", result.id());
                 callbackTime[0] = System.currentTimeMillis();
                 lock.countDown();
             }
@@ -94,18 +89,16 @@ public class LROsTests {
     public void put201CreatingSucceeded200() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().put201CreatingSucceeded200(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROs().put201CreatingSucceeded200(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void put200UpdatingSucceeded204() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().put200UpdatingSucceeded204(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROs().put200UpdatingSucceeded204(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
@@ -113,7 +106,7 @@ public class LROsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROs().put201CreatingFailed200(product);
+            Product response = client.lROs().put201CreatingFailed200(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Failed", e.getMessage());
@@ -125,7 +118,7 @@ public class LROsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROs().put200Acceptedcanceled200(product);
+            Product response = client.lROs().put200Acceptedcanceled200(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Canceled", e.getMessage());
@@ -136,27 +129,24 @@ public class LROsTests {
     public void putNoHeaderInRetry() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().putNoHeaderInRetry(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROs().putNoHeaderInRetry(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putAsyncRetrySucceeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().putAsyncRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROs().putAsyncRetrySucceeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putAsyncNoRetrySucceeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().putAsyncNoRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROs().putAsyncNoRetrySucceeded(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
@@ -164,7 +154,7 @@ public class LROsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROs().putAsyncRetryFailed(product);
+            Product response = client.lROs().putAsyncRetryFailed(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Failed", e.getMessage());
@@ -176,7 +166,7 @@ public class LROsTests {
         Product product = new Product();
         product.withLocation("West US");
         try {
-            ServiceResponse<Product> response = client.lROs().putAsyncNoRetrycanceled(product);
+            Product response = client.lROs().putAsyncNoRetrycanceled(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Canceled", e.getMessage());
@@ -187,110 +177,95 @@ public class LROsTests {
     public void putAsyncNoHeaderInRetry() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().putAsyncNoHeaderInRetry(product);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROs().putAsyncNoHeaderInRetry(product);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putNonResource() throws Exception {
         Sku sku = new Sku();
-        ServiceResponse<Sku> response = client.lROs().putNonResource(sku);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("100", response.getBody().id());
+        Sku response = client.lROs().putNonResource(sku);
+        Assert.assertEquals("100", response.id());
     }
 
     @Test
     public void putAsyncNonResource() throws Exception {
         Sku sku = new Sku();
-        ServiceResponse<Sku> response = client.lROs().putAsyncNonResource(sku);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("100", response.getBody().id());
+        Sku response = client.lROs().putAsyncNonResource(sku);
+        Assert.assertEquals("100", response.id());
     }
 
     @Test
     public void putSubResource() throws Exception {
         SubProduct subProduct = new SubProduct();
-        ServiceResponse<SubProduct> response = client.lROs().putSubResource(subProduct);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        SubProduct response = client.lROs().putSubResource(subProduct);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void putAsyncSubResource() throws Exception {
         SubProduct subProduct = new SubProduct();
-        ServiceResponse<SubProduct> response = client.lROs().putAsyncSubResource(subProduct);
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        SubProduct response = client.lROs().putAsyncSubResource(subProduct);
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void deleteProvisioning202Accepted200Succeeded() throws Exception {
-        ServiceResponse<Product> response = client.lROs().deleteProvisioning202Accepted200Succeeded();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Succeeded", response.getBody().provisioningState());
+        Product response = client.lROs().deleteProvisioning202Accepted200Succeeded();
+        Assert.assertEquals("Succeeded", response.provisioningState());
     }
 
     @Test
     public void deleteProvisioning202DeletingFailed200() throws Exception {
-        ServiceResponse<Product> response = client.lROs().deleteProvisioning202DeletingFailed200();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Failed", response.getBody().provisioningState());
+        Product response = client.lROs().deleteProvisioning202DeletingFailed200();
+        Assert.assertEquals("Failed", response.provisioningState());
     }
 
     @Test
     public void deleteProvisioning202Deletingcanceled200() throws Exception {
-        ServiceResponse<Product> response = client.lROs().deleteProvisioning202Deletingcanceled200();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("Canceled", response.getBody().provisioningState());
+        Product response = client.lROs().deleteProvisioning202Deletingcanceled200();
+        Assert.assertEquals("Canceled", response.provisioningState());
     }
 
     @Test
     public void delete204Succeeded() throws Exception {
-        ServiceResponse<Void> response = client.lROs().delete204Succeeded();
-        Assert.assertEquals(204, response.getResponse().code());
+        client.lROs().delete204Succeeded();
     }
 
     @Test
     public void delete202Retry200() throws Exception {
-        ServiceResponse<Product> response = client.lROs().delete202Retry200();
-        Assert.assertEquals(200, response.getResponse().code());
+        Product response = client.lROs().delete202Retry200();
     }
 
     @Test
     public void delete202NoRetry204() throws Exception {
-        ServiceResponse<Product> response = client.lROs().delete202NoRetry204();
-        Assert.assertEquals(204, response.getResponse().code());
+        Product response = client.lROs().delete202NoRetry204();
     }
 
     @Test
     public void deleteNoHeaderInRetry() throws Exception {
-        ServiceResponse<Void> response = client.lROs().deleteNoHeaderInRetry();
-        Assert.assertEquals(204, response.getResponse().code());
+        client.lROs().deleteNoHeaderInRetry();
     }
 
     @Test
     public void deleteAsyncNoHeaderInRetry() throws Exception {
-        ServiceResponse<Void> response = client.lROs().deleteAsyncNoHeaderInRetry();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROs().deleteAsyncNoHeaderInRetry();
     }
 
     @Test
     public void deleteAsyncRetrySucceeded() throws Exception {
-        ServiceResponse<Void> response = client.lROs().deleteAsyncRetrySucceeded();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROs().deleteAsyncRetrySucceeded();
     }
 
     @Test
     public void deleteAsyncNoRetrySucceeded() throws Exception {
-        ServiceResponse<Void> response = client.lROs().deleteAsyncNoRetrySucceeded();
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROs().deleteAsyncNoRetrySucceeded();
     }
 
     @Test
     public void deleteAsyncRetryFailed() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROs().deleteAsyncRetryFailed();
+            client.lROs().deleteAsyncRetryFailed();
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Failed", e.getMessage());
@@ -300,7 +275,7 @@ public class LROsTests {
     @Test
     public void deleteAsyncRetrycanceled() throws Exception {
         try {
-            ServiceResponse<Void> response = client.lROs().deleteAsyncRetrycanceled();
+            client.lROs().deleteAsyncRetrycanceled();
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Canceled", e.getMessage());
@@ -309,41 +284,36 @@ public class LROsTests {
 
     @Test
     public void post200WithPayload() throws Exception {
-        ServiceResponse<Sku> response = client.lROs().post200WithPayload();
-        Assert.assertEquals(200, response.getResponse().code());
-        Assert.assertEquals("1", response.getBody().id());
+        Sku response = client.lROs().post200WithPayload();
+        Assert.assertEquals("1", response.id());
     }
 
     @Test
     public void post202Retry200() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Void> response = client.lROs().post202Retry200(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.lROs().post202Retry200(product);
     }
 
     @Test
     public void post202NoRetry204() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().post202NoRetry204(product);
-        Assert.assertEquals(204, response.getResponse().code());
+        Product response = client.lROs().post202NoRetry204(product);
     }
 
     @Test
     public void postAsyncRetrySucceeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().postAsyncRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        Product response = client.lROs().postAsyncRetrySucceeded(product);
     }
 
     @Test
     public void postAsyncNoRetrySucceeded() throws Exception {
         Product product = new Product();
         product.withLocation("West US");
-        ServiceResponse<Product> response = client.lROs().postAsyncNoRetrySucceeded(product);
-        Assert.assertEquals(200, response.getResponse().code());
+        Product response = client.lROs().postAsyncNoRetrySucceeded(product);
     }
 
     @Test
@@ -351,7 +321,7 @@ public class LROsTests {
         try {
             Product product = new Product();
             product.withLocation("West US");
-            ServiceResponse<Void> response = client.lROs().postAsyncRetryFailed(product);
+            client.lROs().postAsyncRetryFailed(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Failed", e.getMessage());
@@ -363,7 +333,7 @@ public class LROsTests {
         try {
             Product product = new Product();
             product.withLocation("West US");
-            ServiceResponse<Void> response = client.lROs().postAsyncRetrycanceled(product);
+            client.lROs().postAsyncRetrycanceled(product);
             fail();
         } catch (CloudException e) {
             Assert.assertEquals("Async operation failed with provisioning state: Canceled", e.getMessage());

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/paging/PagingTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/paging/PagingTests.java
@@ -28,13 +28,13 @@ public class PagingTests {
 
     @Test
     public void getSinglePages() throws Exception {
-        List<Product> response = client.pagings().getSinglePages().getBody();
+        List<Product> response = client.pagings().getSinglePages();
         Assert.assertEquals(1, response.size());
     }
 
     @Test
     public void getMultiplePages() throws Exception {
-        List<Product> response = client.pagings().getMultiplePages().getBody();
+        List<Product> response = client.pagings().getMultiplePages();
         Product p1 = new Product();
         p1.withProperties(new ProductProperties());
         response.add(p1);
@@ -55,7 +55,7 @@ public class PagingTests {
 
     @Test
     public void getOdataMultiplePages() throws Exception {
-        List<Product> response = client.pagings().getOdataMultiplePages().getBody();
+        List<Product> response = client.pagings().getOdataMultiplePages();
         Assert.assertEquals(10, response.size());
     }
 
@@ -63,7 +63,7 @@ public class PagingTests {
     public void getMultiplePagesWithOffset() throws Exception {
         PagingGetMultiplePagesWithOffsetOptions options = new PagingGetMultiplePagesWithOffsetOptions();
         options.withOffset(100);
-        List<Product> response = client.pagings().getMultiplePagesWithOffset(options, "client-id").getBody();
+        List<Product> response = client.pagings().getMultiplePagesWithOffset(options, "client-id");
         Assert.assertEquals(10, response.size());
         Assert.assertEquals(110, (int) response.get(response.size() - 1).properties().id());
     }
@@ -96,20 +96,20 @@ public class PagingTests {
 
     @Test
     public void getMultiplePagesRetryFirst() throws Exception {
-        List<Product> response = client.pagings().getMultiplePagesRetryFirst().getBody();
+        List<Product> response = client.pagings().getMultiplePagesRetryFirst();
         Assert.assertEquals(10, response.size());
     }
 
     @Test
     public void getMultiplePagesRetrySecond() throws Exception {
-        List<Product> response = client.pagings().getMultiplePagesRetrySecond().getBody();
+        List<Product> response = client.pagings().getMultiplePagesRetrySecond();
         Assert.assertEquals(10, response.size());
     }
 
     @Test
     public void getSinglePagesFailure() throws Exception {
         try {
-            List<Product> response = client.pagings().getSinglePagesFailure().getBody();
+            List<Product> response = client.pagings().getSinglePagesFailure();
             fail();
         } catch (CloudException ex) {
             Assert.assertNotNull(ex.getResponse());
@@ -119,7 +119,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesFailure() throws Exception {
         try {
-            List<Product> response = client.pagings().getMultiplePagesFailure().getBody();
+            List<Product> response = client.pagings().getMultiplePagesFailure();
             response.size();
             fail();
         } catch (CloudException ex) {
@@ -130,7 +130,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesFailureUri() throws Exception {
         try {
-            List<Product> response = client.pagings().getMultiplePagesFailureUri().getBody();
+            List<Product> response = client.pagings().getMultiplePagesFailureUri();
             response.size();
             fail();
         } catch (CloudException ex) {

--- a/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/subscriptionidapiversion/GroupTests.java
+++ b/src/generator/AutoRest.Java.Azure.Tests/src/test/java/fixtures/subscriptionidapiversion/GroupTests.java
@@ -1,12 +1,13 @@
 package fixtures.subscriptionidapiversion;
 
-import fixtures.subscriptionidapiversion.implementation.MicrosoftAzureTestUrlImpl;
-import fixtures.subscriptionidapiversion.models.SampleResourceGroup;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.UUID;
+
+import fixtures.subscriptionidapiversion.implementation.MicrosoftAzureTestUrlImpl;
+import fixtures.subscriptionidapiversion.models.SampleResourceGroup;
 
 public class GroupTests {
     private static MicrosoftAzureTestUrlImpl client;
@@ -19,7 +20,7 @@ public class GroupTests {
     @Test
     public void getSampleResourceGroup() throws Exception {
         client.withSubscriptionId(UUID.randomUUID().toString());
-        SampleResourceGroup group = client.groups().getSampleResourceGroup("testgroup101").getBody();
+        SampleResourceGroup group = client.groups().getSampleResourceGroup("testgroup101");
         Assert.assertEquals("testgroup101", group.name());
         Assert.assertEquals("West US", group.location());
     }

--- a/src/generator/AutoRest.Java.Azure/TemplateModels/AzureMethodTemplateModel.cs
+++ b/src/generator/AutoRest.Java.Azure/TemplateModels/AzureMethodTemplateModel.cs
@@ -754,6 +754,7 @@ namespace AutoRest.Java.Azure.TemplateModels
                 }
                 if (this.IsPagingOperation || this.IsPagingNextOperation)
                 {
+                    imports.Remove("java.util.ArrayList");
                     imports.Remove("com.microsoft.rest.ServiceCallback");
                     imports.Add("com.microsoft.rest.RestException");
                     imports.Add("com.microsoft.azure.ListOperationCallback");

--- a/src/generator/AutoRest.Java.Azure/TemplateModels/AzureMethodTemplateModel.cs
+++ b/src/generator/AutoRest.Java.Azure/TemplateModels/AzureMethodTemplateModel.cs
@@ -570,11 +570,16 @@ namespace AutoRest.Java.Azure.TemplateModels
             return base.SuccessCallback();
         }
 
-        private AzureMethodTemplateModel GetPagingNextMethodWithInvocation(out string invocation, bool async = false)
+        private AzureMethodTemplateModel GetPagingNextMethodWithInvocation(out string invocation, bool async = false, bool singlePage = true)
         {
+            String methodSuffixString = "WithServiceResponse";
+            if (singlePage)
+            {
+                methodSuffixString = "SinglePage";
+            }
             if (IsPagingNextOperation)
             {
-                invocation = Name + "SinglePage" + (async ? "Async" : "");
+                invocation = Name + methodSuffixString + (async ? "Async" : "");
                 return this;
             }
             string name = ((string)this.Extensions["nextMethodName"]).ToCamelCase();
@@ -584,7 +589,7 @@ namespace AutoRest.Java.Azure.TemplateModels
                     (group == null ? m.Group == null : group.Equals(m.Group, StringComparison.OrdinalIgnoreCase))
                     && m.Name.Equals(name, StringComparison.OrdinalIgnoreCase)), ServiceClient);
             group = group.ToPascalCase();
-            name = name + "SinglePage";
+            name = name + methodSuffixString;
             if (async)
             {
                 name = name + "Async";
@@ -600,10 +605,10 @@ namespace AutoRest.Java.Azure.TemplateModels
             return methodModel;
         }
 
-        public string GetPagingNextMethodInvocation(bool async = false)
+        public string GetPagingNextMethodInvocation(bool async = false, bool singlePage = true)
         {
             string invocation;
-            GetPagingNextMethodWithInvocation(out invocation, async);
+            GetPagingNextMethodWithInvocation(out invocation, async, singlePage);
             return invocation;
         }
 

--- a/src/generator/AutoRest.Java.Azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/generator/AutoRest.Java.Azure/Templates/AzureMethodTemplate.cshtml
@@ -37,15 +37,18 @@ if (Model.LocalParameters.Any(p => !p.IsConstant && !p.IsRequired))
 }
 @if (Model.ReturnType.Body != null)
 {
-@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object wrapped in @Model.ReturnTypeModel.ClientResponseType if successful.
+@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object  if successful.
+}
+ */
+public @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString {
+@if (@Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name == "void")
+{
+@:    @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().last().getBody();
 }
 else
 {
-@: * @@return the @Model.ReturnTypeModel.ClientResponseType object if successful.
+@:    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().last().getBody();
 }
- */
-public @Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString {
-    return @(Model.Name)Async(@Model.MethodRequiredParameterInvocation).toBlocking().last();
 }
 @EmptyLine
 /**
@@ -66,7 +69,7 @@ public @Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.Meth
  * @@return the {@@link ServiceCall} object
  */
 public ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclarationWithCallback) {
-    return ServiceCall.@(Model.ServiceCallFactoryMethod)(@(Model.Name)Async(@Model.MethodRequiredParameterInvocation), serviceCallback);
+    return ServiceCall.@(Model.ServiceCallFactoryMethod)(@(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation), serviceCallback);
 }
 @EmptyLine
 /**
@@ -85,7 +88,32 @@ public ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(M
 }
  * @@return the observable for the request
  */
-public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration) {
+public Observable<@Model.ReturnTypeModel.GenericBodyClientTypeString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration) {
+    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).map(new Func1<@Model.ReturnTypeModel.ClientResponseTypeString, @Model.ReturnTypeModel.GenericBodyClientTypeString>() {
+        @@Override
+        public @Model.ReturnTypeModel.GenericBodyClientTypeString call(@Model.ReturnTypeModel.ClientResponseTypeString response) {
+            return response.getBody();
+        }
+    });
+}
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
+{
+@: * @@param @param.Name @((param.Documentation ?? "the " + param.Type.ToString() + " value").EscapeXmlComment().Trim())
+}
+ * @@return the observable for the request
+ */
+public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterDeclaration) {
 @foreach (var param in Model.RequiredNullableParameters)
 {
 @:    if (@param.Name == null) {
@@ -136,15 +164,18 @@ public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)
 }
 @if (Model.ReturnType.Body != null)
 {
-@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object wrapped in @Model.ReturnTypeModel.ClientResponseType if successful.
+@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object if successful.
+}
+ */
+public @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString {
+@if (@Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name == "void")
+{
+@:    @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().last().getBody();
 }
 else
 {
-@: * @@return the @Model.ReturnTypeModel.ClientResponseType object if successful.
+@:    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().last().getBody();
 }
- */
-public @Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString {
-    return @(Model.Name)Async(@Model.MethodParameterInvocation).toBlocking().last();
 }
 @EmptyLine
 /**
@@ -165,7 +196,7 @@ public @Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.Meth
  * @@return the {@@link ServiceCall} object
  */
 public ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(Model.Name)Async(@Model.MethodParameterDeclarationWithCallback) {
-    return ServiceCall.@(Model.ServiceCallFactoryMethod)(@(Model.Name)Async(@Model.MethodParameterInvocation), serviceCallback);
+    return ServiceCall.@(Model.ServiceCallFactoryMethod)(@(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation), serviceCallback);
 }
 @EmptyLine
 /**
@@ -184,7 +215,32 @@ public ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(M
 }
  * @@return the observable for the request
  */
-public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)Async(@Model.MethodParameterDeclaration) {
+public Observable<@Model.ReturnTypeModel.GenericBodyClientTypeString> @(Model.Name)Async(@Model.MethodParameterDeclaration) {
+    return @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation).map(new Func1<@Model.ReturnTypeModel.ClientResponseTypeString, @Model.ReturnTypeModel.GenericBodyClientTypeString>() {
+        @@Override
+        public @Model.ReturnTypeModel.GenericBodyClientTypeString call(@Model.ReturnTypeModel.ClientResponseTypeString response) {
+            return response.getBody();
+        }
+    });
+}
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+{
+@: * @@param @param.Name @((param.Documentation ?? "the " + param.Type.ToString() + " value").EscapeXmlComment().Trim())
+}
+ * @@return the observable for the request
+ */
+public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterDeclaration) {
 @foreach (var param in Model.RequiredNullableParameters)
 {
 @:    if (@param.Name == null) {

--- a/src/generator/AutoRest.Java.Azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/generator/AutoRest.Java.Azure/Templates/AzureMethodTemplate.cshtml
@@ -170,11 +170,11 @@ public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)
 public @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString {
 @if (@Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name == "void")
 {
-@:    @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().last().getBody();
+@:    @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation).toBlocking().last().getBody();
 }
 else
 {
-@:    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().last().getBody();
+@:    return @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation).toBlocking().last().getBody();
 }
 }
 @EmptyLine

--- a/src/generator/AutoRest.Java.Azure/Templates/PagingMethodTemplate.cshtml
+++ b/src/generator/AutoRest.Java.Azure/Templates/PagingMethodTemplate.cshtml
@@ -28,23 +28,18 @@
 }
 @if (Model.ReturnType.Body != null)
 {
-@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object wrapped in {@@link @Model.ReturnTypeModel.ClientResponseType} if successful.
-}
-else
-{
-@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object if successful.
 }
  */
-public @Model.ReturnTypeModel.GenericBodyClientTypeStringWrapped @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString {
+public @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString {
     @Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped response = @(Model.Name)SinglePageAsync(@Model.MethodRequiredParameterInvocation).toBlocking().single();
-    @Model.ReturnTypeModel.GenericBodyClientTypeString pagedList = new @(Model.ReturnTypeModel.GenericBodyClientTypeString)(response.getBody()) {
+    return new @(Model.ReturnTypeModel.GenericBodyClientTypeString)(response.getBody()) {
         @@Override
         public @Model.ReturnTypeModel.ServiceResponseGenericParameterString nextPage(String @Model.PagingNextPageLinkParameterName) throws RestException, IOException {
             @Model.PagingGroupedParameterTransformation(true)
             return @(Model.GetPagingNextMethodInvocation(true))(@Model.NextMethodParameterInvocation(true)).toBlocking().single().getBody();
         }
     };
-    return @(Model.ReturnTypeModel.ServiceResponseCreation(Model.ReturnTypeModel.GenericBodyClientTypeStringWrapped, "pagedList", "response"));
 }
 @EmptyLine
 /**
@@ -100,14 +95,50 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration) {
+public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration) {
+    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation)
+        .map(new Func1<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped, @Model.ReturnTypeModel.ServiceResponseGenericParameterString>() {
+            @@Override
+            public @Model.ReturnTypeModel.ServiceResponseGenericParameterString call(@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped response) {
+                return response.getBody();
+            }
+        });
+}
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
+}
+@if (Model.ReturnType.Body != null)
+{
+@: * @@return the observable to the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+}
+ */
+public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterDeclaration) {
     return @(Model.Name)SinglePageAsync(@Model.MethodRequiredParameterInvocation)
         .concatMap(new Func1<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped, Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped>>() {
             @@Override
             public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> call(@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped page) {
                 String @Model.PagingNextPageLinkParameterName = page.getBody().getNextPageLink();
+                if (@Model.PagingNextPageLinkParameterName == null) {
+                    return Observable.just(page);
+                }
                 @Model.PagingGroupedParameterTransformation(true)
-                return @(Model.GetPagingNextMethodInvocation(true))(@Model.NextMethodParameterInvocation(true));
+                return Observable.just(page).concatWith(@(Model.GetPagingNextMethodInvocation(true, false))(@Model.NextMethodParameterInvocation(true)));
             }
         });
 }
@@ -201,23 +232,18 @@ public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWr
 }
 @if (Model.ReturnType.Body != null)
 {
-@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object wrapped in {@@link @Model.ReturnTypeModel.ClientResponseType} if successful.
-}
-else
-{
-@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object if successful.
 }
  */
-public @Model.ReturnTypeModel.GenericBodyClientTypeStringWrapped @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString {
+public @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString {
     @Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped response = @(Model.Name)SinglePageAsync(@Model.MethodParameterInvocation).toBlocking().single();
-    @Model.ReturnTypeModel.GenericBodyClientTypeString pagedList = new @(Model.ReturnTypeModel.GenericBodyClientTypeString)(response.getBody()) {
+    return new @(Model.ReturnTypeModel.GenericBodyClientTypeString)(response.getBody()) {
         @@Override
         public @Model.ReturnTypeModel.ServiceResponseGenericParameterString nextPage(String @Model.PagingNextPageLinkParameterName) throws RestException, IOException {
             @Model.PagingGroupedParameterTransformation()
             return @(Model.GetPagingNextMethodInvocation(true))(@Model.NextMethodParameterInvocation()).toBlocking().single().getBody();
         }
     };
-    return @(Model.ReturnTypeModel.ServiceResponseCreation(Model.ReturnTypeModel.GenericBodyClientTypeStringWrapped, "pagedList", "response"));
 }
 @EmptyLine
 /**
@@ -273,14 +299,50 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)Async(@Model.MethodParameterDeclaration) {
+public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterString> @(Model.Name)Async(@Model.MethodParameterDeclaration) {
+    return @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation)
+        .map(new Func1<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped, @Model.ReturnTypeModel.ServiceResponseGenericParameterString>() {
+            @@Override
+            public @Model.ReturnTypeModel.ServiceResponseGenericParameterString call(@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped response) {
+                return response.getBody();
+            }
+        });
+}
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
+}
+@if (Model.ReturnType.Body != null)
+{
+@: * @@return the observable to the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+}
+ */
+public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterDeclaration) {
     return @(Model.Name)SinglePageAsync(@Model.MethodParameterInvocation)
         .concatMap(new Func1<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped, Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped>>() {
             @@Override
             public Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> call(@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped page) {
                 String @Model.PagingNextPageLinkParameterName = page.getBody().getNextPageLink();
+                if (@Model.PagingNextPageLinkParameterName == null) {
+                    return Observable.just(page);
+                }
                 @Model.PagingGroupedParameterTransformation()
-                return @(Model.GetPagingNextMethodInvocation(true))(@Model.NextMethodParameterInvocation());
+                return Observable.just(page).concatWith(@(Model.GetPagingNextMethodInvocation(true, false))(@Model.NextMethodParameterInvocation()));
             }
         });
 }

--- a/src/generator/AutoRest.Java.Azure/TypeModels/AzureResponseModel.cs
+++ b/src/generator/AutoRest.Java.Azure/TypeModels/AzureResponseModel.cs
@@ -21,6 +21,22 @@ namespace AutoRest.Java.Azure.TypeModels
         {
         }
 
+        public override ITypeModel BodyClientType
+        {
+            get
+            {
+                var bodySequenceType = base.BodyClientType as AzureSequenceTypeModel;
+                if (bodySequenceType != null && (_method.IsPagingOperation || _method.IsPagingNextOperation))
+                {
+                    return new AzureSequenceTypeModel(new SequenceType { NameFormat = "PagedList<{0}>", ElementType = bodySequenceType.ElementType })
+                    {
+                        PageImplType = bodySequenceType.PageImplType
+                    };
+                }
+                return base.BodyClientType;
+            }
+        }
+
         public override string GenericBodyClientTypeString
         {
             get

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyarray/Arrays.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyarray/Arrays.java
@@ -36,7 +36,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Integer>> getNull() throws ErrorException, IOException;
+    List<Integer> getNull() throws ErrorException, IOException;
 
     /**
      * Get null array value.
@@ -51,7 +51,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getNullAsync();
+    Observable<List<Integer>> getNullAsync();
+
+    /**
+     * Get null array value.
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Observable<ServiceResponse<List<Integer>>> getNullAsyncWithServiceResponse();
 
     /**
      * Get invalid array [1, 2, 3.
@@ -60,7 +67,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Integer>> getInvalid() throws ErrorException, IOException;
+    List<Integer> getInvalid() throws ErrorException, IOException;
 
     /**
      * Get invalid array [1, 2, 3.
@@ -75,7 +82,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getInvalidAsync();
+    Observable<List<Integer>> getInvalidAsync();
+
+    /**
+     * Get invalid array [1, 2, 3.
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Observable<ServiceResponse<List<Integer>>> getInvalidAsyncWithServiceResponse();
 
     /**
      * Get empty array value [].
@@ -84,7 +98,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Integer>> getEmpty() throws ErrorException, IOException;
+    List<Integer> getEmpty() throws ErrorException, IOException;
 
     /**
      * Get empty array value [].
@@ -99,7 +113,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getEmptyAsync();
+    Observable<List<Integer>> getEmptyAsync();
+
+    /**
+     * Get empty array value [].
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Observable<ServiceResponse<List<Integer>>> getEmptyAsyncWithServiceResponse();
 
     /**
      * Set array value empty [].
@@ -110,7 +131,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putEmpty(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putEmpty(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value empty [].
@@ -127,7 +148,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsync(List<String> arrayBody);
+    Observable<Void> putEmptyAsync(List<String> arrayBody);
+
+    /**
+     * Set array value empty [].
+     *
+     * @param arrayBody the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(List<String> arrayBody);
 
     /**
      * Get boolean array value [true, false, false, true].
@@ -136,7 +165,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Boolean>> getBooleanTfft() throws ErrorException, IOException;
+    List<Boolean> getBooleanTfft() throws ErrorException, IOException;
 
     /**
      * Get boolean array value [true, false, false, true].
@@ -151,7 +180,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    Observable<ServiceResponse<List<Boolean>>> getBooleanTfftAsync();
+    Observable<List<Boolean>> getBooleanTfftAsync();
+
+    /**
+     * Get boolean array value [true, false, false, true].
+     *
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    Observable<ServiceResponse<List<Boolean>>> getBooleanTfftAsyncWithServiceResponse();
 
     /**
      * Set array value empty [true, false, false, true].
@@ -162,7 +198,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBooleanTfft(List<Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putBooleanTfft(List<Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value empty [true, false, false, true].
@@ -179,7 +215,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;Boolean&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBooleanTfftAsync(List<Boolean> arrayBody);
+    Observable<Void> putBooleanTfftAsync(List<Boolean> arrayBody);
+
+    /**
+     * Set array value empty [true, false, false, true].
+     *
+     * @param arrayBody the List&lt;Boolean&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBooleanTfftAsyncWithServiceResponse(List<Boolean> arrayBody);
 
     /**
      * Get boolean array value [true, null, false].
@@ -188,7 +232,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Boolean>> getBooleanInvalidNull() throws ErrorException, IOException;
+    List<Boolean> getBooleanInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get boolean array value [true, null, false].
@@ -203,7 +247,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidNullAsync();
+    Observable<List<Boolean>> getBooleanInvalidNullAsync();
+
+    /**
+     * Get boolean array value [true, null, false].
+     *
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get boolean array value [true, 'boolean', false].
@@ -212,7 +263,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Boolean>> getBooleanInvalidString() throws ErrorException, IOException;
+    List<Boolean> getBooleanInvalidString() throws ErrorException, IOException;
 
     /**
      * Get boolean array value [true, 'boolean', false].
@@ -227,7 +278,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidStringAsync();
+    Observable<List<Boolean>> getBooleanInvalidStringAsync();
+
+    /**
+     * Get boolean array value [true, 'boolean', false].
+     *
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get integer array value [1, -1, 3, 300].
@@ -236,7 +294,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Integer>> getIntegerValid() throws ErrorException, IOException;
+    List<Integer> getIntegerValid() throws ErrorException, IOException;
 
     /**
      * Get integer array value [1, -1, 3, 300].
@@ -251,7 +309,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getIntegerValidAsync();
+    Observable<List<Integer>> getIntegerValidAsync();
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Observable<ServiceResponse<List<Integer>>> getIntegerValidAsyncWithServiceResponse();
 
     /**
      * Set array value empty [1, -1, 3, 300].
@@ -262,7 +327,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putIntegerValid(List<Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putIntegerValid(List<Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value empty [1, -1, 3, 300].
@@ -279,7 +344,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;Integer&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putIntegerValidAsync(List<Integer> arrayBody);
+    Observable<Void> putIntegerValidAsync(List<Integer> arrayBody);
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody the List&lt;Integer&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putIntegerValidAsyncWithServiceResponse(List<Integer> arrayBody);
 
     /**
      * Get integer array value [1, null, 0].
@@ -288,7 +361,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Integer>> getIntInvalidNull() throws ErrorException, IOException;
+    List<Integer> getIntInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get integer array value [1, null, 0].
@@ -303,7 +376,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getIntInvalidNullAsync();
+    Observable<List<Integer>> getIntInvalidNullAsync();
+
+    /**
+     * Get integer array value [1, null, 0].
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Observable<ServiceResponse<List<Integer>>> getIntInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get integer array value [1, 'integer', 0].
@@ -312,7 +392,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Integer>> getIntInvalidString() throws ErrorException, IOException;
+    List<Integer> getIntInvalidString() throws ErrorException, IOException;
 
     /**
      * Get integer array value [1, 'integer', 0].
@@ -327,7 +407,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getIntInvalidStringAsync();
+    Observable<List<Integer>> getIntInvalidStringAsync();
+
+    /**
+     * Get integer array value [1, 'integer', 0].
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Observable<ServiceResponse<List<Integer>>> getIntInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get integer array value [1, -1, 3, 300].
@@ -336,7 +423,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Long>> getLongValid() throws ErrorException, IOException;
+    List<Long> getLongValid() throws ErrorException, IOException;
 
     /**
      * Get integer array value [1, -1, 3, 300].
@@ -351,7 +438,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    Observable<ServiceResponse<List<Long>>> getLongValidAsync();
+    Observable<List<Long>> getLongValidAsync();
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    Observable<ServiceResponse<List<Long>>> getLongValidAsyncWithServiceResponse();
 
     /**
      * Set array value empty [1, -1, 3, 300].
@@ -362,7 +456,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putLongValid(List<Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putLongValid(List<Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value empty [1, -1, 3, 300].
@@ -379,7 +473,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;Long&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLongValidAsync(List<Long> arrayBody);
+    Observable<Void> putLongValidAsync(List<Long> arrayBody);
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody the List&lt;Long&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putLongValidAsyncWithServiceResponse(List<Long> arrayBody);
 
     /**
      * Get long array value [1, null, 0].
@@ -388,7 +490,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Long>> getLongInvalidNull() throws ErrorException, IOException;
+    List<Long> getLongInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get long array value [1, null, 0].
@@ -403,7 +505,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    Observable<ServiceResponse<List<Long>>> getLongInvalidNullAsync();
+    Observable<List<Long>> getLongInvalidNullAsync();
+
+    /**
+     * Get long array value [1, null, 0].
+     *
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    Observable<ServiceResponse<List<Long>>> getLongInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get long array value [1, 'integer', 0].
@@ -412,7 +521,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Long>> getLongInvalidString() throws ErrorException, IOException;
+    List<Long> getLongInvalidString() throws ErrorException, IOException;
 
     /**
      * Get long array value [1, 'integer', 0].
@@ -427,7 +536,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    Observable<ServiceResponse<List<Long>>> getLongInvalidStringAsync();
+    Observable<List<Long>> getLongInvalidStringAsync();
+
+    /**
+     * Get long array value [1, 'integer', 0].
+     *
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    Observable<ServiceResponse<List<Long>>> getLongInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get float array value [0, -0.01, 1.2e20].
@@ -436,7 +552,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Double>> getFloatValid() throws ErrorException, IOException;
+    List<Double> getFloatValid() throws ErrorException, IOException;
 
     /**
      * Get float array value [0, -0.01, 1.2e20].
@@ -451,7 +567,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getFloatValidAsync();
+    Observable<List<Double>> getFloatValidAsync();
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Observable<ServiceResponse<List<Double>>> getFloatValidAsyncWithServiceResponse();
 
     /**
      * Set array value [0, -0.01, 1.2e20].
@@ -462,7 +585,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putFloatValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putFloatValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value [0, -0.01, 1.2e20].
@@ -479,7 +602,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putFloatValidAsync(List<Double> arrayBody);
+    Observable<Void> putFloatValidAsync(List<Double> arrayBody);
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody the List&lt;Double&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putFloatValidAsyncWithServiceResponse(List<Double> arrayBody);
 
     /**
      * Get float array value [0.0, null, -1.2e20].
@@ -488,7 +619,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Double>> getFloatInvalidNull() throws ErrorException, IOException;
+    List<Double> getFloatInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get float array value [0.0, null, -1.2e20].
@@ -503,7 +634,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getFloatInvalidNullAsync();
+    Observable<List<Double>> getFloatInvalidNullAsync();
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Observable<ServiceResponse<List<Double>>> getFloatInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get boolean array value [1.0, 'number', 0.0].
@@ -512,7 +650,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Double>> getFloatInvalidString() throws ErrorException, IOException;
+    List<Double> getFloatInvalidString() throws ErrorException, IOException;
 
     /**
      * Get boolean array value [1.0, 'number', 0.0].
@@ -527,7 +665,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getFloatInvalidStringAsync();
+    Observable<List<Double>> getFloatInvalidStringAsync();
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Observable<ServiceResponse<List<Double>>> getFloatInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get float array value [0, -0.01, 1.2e20].
@@ -536,7 +681,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Double>> getDoubleValid() throws ErrorException, IOException;
+    List<Double> getDoubleValid() throws ErrorException, IOException;
 
     /**
      * Get float array value [0, -0.01, 1.2e20].
@@ -551,7 +696,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getDoubleValidAsync();
+    Observable<List<Double>> getDoubleValidAsync();
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Observable<ServiceResponse<List<Double>>> getDoubleValidAsyncWithServiceResponse();
 
     /**
      * Set array value [0, -0.01, 1.2e20].
@@ -562,7 +714,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDoubleValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDoubleValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value [0, -0.01, 1.2e20].
@@ -579,7 +731,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDoubleValidAsync(List<Double> arrayBody);
+    Observable<Void> putDoubleValidAsync(List<Double> arrayBody);
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody the List&lt;Double&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDoubleValidAsyncWithServiceResponse(List<Double> arrayBody);
 
     /**
      * Get float array value [0.0, null, -1.2e20].
@@ -588,7 +748,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Double>> getDoubleInvalidNull() throws ErrorException, IOException;
+    List<Double> getDoubleInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get float array value [0.0, null, -1.2e20].
@@ -603,7 +763,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getDoubleInvalidNullAsync();
+    Observable<List<Double>> getDoubleInvalidNullAsync();
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Observable<ServiceResponse<List<Double>>> getDoubleInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get boolean array value [1.0, 'number', 0.0].
@@ -612,7 +779,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Double>> getDoubleInvalidString() throws ErrorException, IOException;
+    List<Double> getDoubleInvalidString() throws ErrorException, IOException;
 
     /**
      * Get boolean array value [1.0, 'number', 0.0].
@@ -627,7 +794,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getDoubleInvalidStringAsync();
+    Observable<List<Double>> getDoubleInvalidStringAsync();
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Observable<ServiceResponse<List<Double>>> getDoubleInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get string array value ['foo1', 'foo2', 'foo3'].
@@ -636,7 +810,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<String>> getStringValid() throws ErrorException, IOException;
+    List<String> getStringValid() throws ErrorException, IOException;
 
     /**
      * Get string array value ['foo1', 'foo2', 'foo3'].
@@ -651,7 +825,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    Observable<ServiceResponse<List<String>>> getStringValidAsync();
+    Observable<List<String>> getStringValidAsync();
+
+    /**
+     * Get string array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @return the observable to the List&lt;String&gt; object
+     */
+    Observable<ServiceResponse<List<String>>> getStringValidAsyncWithServiceResponse();
 
     /**
      * Set array value ['foo1', 'foo2', 'foo3'].
@@ -662,7 +843,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putStringValid(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putStringValid(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value ['foo1', 'foo2', 'foo3'].
@@ -679,7 +860,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putStringValidAsync(List<String> arrayBody);
+    Observable<Void> putStringValidAsync(List<String> arrayBody);
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putStringValidAsyncWithServiceResponse(List<String> arrayBody);
 
     /**
      * Get string array value ['foo', null, 'foo2'].
@@ -688,7 +877,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<String>> getStringWithNull() throws ErrorException, IOException;
+    List<String> getStringWithNull() throws ErrorException, IOException;
 
     /**
      * Get string array value ['foo', null, 'foo2'].
@@ -703,7 +892,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    Observable<ServiceResponse<List<String>>> getStringWithNullAsync();
+    Observable<List<String>> getStringWithNullAsync();
+
+    /**
+     * Get string array value ['foo', null, 'foo2'].
+     *
+     * @return the observable to the List&lt;String&gt; object
+     */
+    Observable<ServiceResponse<List<String>>> getStringWithNullAsyncWithServiceResponse();
 
     /**
      * Get string array value ['foo', 123, 'foo2'].
@@ -712,7 +908,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<String>> getStringWithInvalid() throws ErrorException, IOException;
+    List<String> getStringWithInvalid() throws ErrorException, IOException;
 
     /**
      * Get string array value ['foo', 123, 'foo2'].
@@ -727,7 +923,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    Observable<ServiceResponse<List<String>>> getStringWithInvalidAsync();
+    Observable<List<String>> getStringWithInvalidAsync();
+
+    /**
+     * Get string array value ['foo', 123, 'foo2'].
+     *
+     * @return the observable to the List&lt;String&gt; object
+     */
+    Observable<ServiceResponse<List<String>>> getStringWithInvalidAsyncWithServiceResponse();
 
     /**
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
@@ -736,7 +939,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;UUID&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<UUID>> getUuidValid() throws ErrorException, IOException;
+    List<UUID> getUuidValid() throws ErrorException, IOException;
 
     /**
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
@@ -751,7 +954,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;UUID&gt; object
      */
-    Observable<ServiceResponse<List<UUID>>> getUuidValidAsync();
+    Observable<List<UUID>> getUuidValidAsync();
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @return the observable to the List&lt;UUID&gt; object
+     */
+    Observable<ServiceResponse<List<UUID>>> getUuidValidAsyncWithServiceResponse();
 
     /**
      * Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
@@ -762,7 +972,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putUuidValid(List<UUID> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putUuidValid(List<UUID> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
@@ -779,7 +989,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;UUID&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUuidValidAsync(List<UUID> arrayBody);
+    Observable<Void> putUuidValidAsync(List<UUID> arrayBody);
+
+    /**
+     * Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @param arrayBody the List&lt;UUID&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putUuidValidAsyncWithServiceResponse(List<UUID> arrayBody);
 
     /**
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
@@ -788,7 +1006,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;UUID&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<UUID>> getUuidInvalidChars() throws ErrorException, IOException;
+    List<UUID> getUuidInvalidChars() throws ErrorException, IOException;
 
     /**
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
@@ -803,7 +1021,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;UUID&gt; object
      */
-    Observable<ServiceResponse<List<UUID>>> getUuidInvalidCharsAsync();
+    Observable<List<UUID>> getUuidInvalidCharsAsync();
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
+     *
+     * @return the observable to the List&lt;UUID&gt; object
+     */
+    Observable<ServiceResponse<List<UUID>>> getUuidInvalidCharsAsyncWithServiceResponse();
 
     /**
      * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
@@ -812,7 +1037,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<LocalDate>> getDateValid() throws ErrorException, IOException;
+    List<LocalDate> getDateValid() throws ErrorException, IOException;
 
     /**
      * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
@@ -827,7 +1052,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    Observable<ServiceResponse<List<LocalDate>>> getDateValidAsync();
+    Observable<List<LocalDate>> getDateValidAsync();
+
+    /**
+     * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    Observable<ServiceResponse<List<LocalDate>>> getDateValidAsyncWithServiceResponse();
 
     /**
      * Set array value  ['2000-12-01', '1980-01-02', '1492-10-12'].
@@ -838,7 +1070,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDateValid(List<LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDateValid(List<LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value  ['2000-12-01', '1980-01-02', '1492-10-12'].
@@ -855,7 +1087,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;LocalDate&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateValidAsync(List<LocalDate> arrayBody);
+    Observable<Void> putDateValidAsync(List<LocalDate> arrayBody);
+
+    /**
+     * Set array value  ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @param arrayBody the List&lt;LocalDate&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateValidAsyncWithServiceResponse(List<LocalDate> arrayBody);
 
     /**
      * Get date array value ['2012-01-01', null, '1776-07-04'].
@@ -864,7 +1104,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<LocalDate>> getDateInvalidNull() throws ErrorException, IOException;
+    List<LocalDate> getDateInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get date array value ['2012-01-01', null, '1776-07-04'].
@@ -879,7 +1119,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    Observable<ServiceResponse<List<LocalDate>>> getDateInvalidNullAsync();
+    Observable<List<LocalDate>> getDateInvalidNullAsync();
+
+    /**
+     * Get date array value ['2012-01-01', null, '1776-07-04'].
+     *
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    Observable<ServiceResponse<List<LocalDate>>> getDateInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get date array value ['2011-03-22', 'date'].
@@ -888,7 +1135,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<LocalDate>> getDateInvalidChars() throws ErrorException, IOException;
+    List<LocalDate> getDateInvalidChars() throws ErrorException, IOException;
 
     /**
      * Get date array value ['2011-03-22', 'date'].
@@ -903,7 +1150,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    Observable<ServiceResponse<List<LocalDate>>> getDateInvalidCharsAsync();
+    Observable<List<LocalDate>> getDateInvalidCharsAsync();
+
+    /**
+     * Get date array value ['2011-03-22', 'date'].
+     *
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    Observable<ServiceResponse<List<LocalDate>>> getDateInvalidCharsAsyncWithServiceResponse();
 
     /**
      * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
@@ -912,7 +1166,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<DateTime>> getDateTimeValid() throws ErrorException, IOException;
+    List<DateTime> getDateTimeValid() throws ErrorException, IOException;
 
     /**
      * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
@@ -927,7 +1181,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    Observable<ServiceResponse<List<DateTime>>> getDateTimeValidAsync();
+    Observable<List<DateTime>> getDateTimeValidAsync();
+
+    /**
+     * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    Observable<ServiceResponse<List<DateTime>>> getDateTimeValidAsyncWithServiceResponse();
 
     /**
      * Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
@@ -938,7 +1199,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDateTimeValid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDateTimeValid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
@@ -955,7 +1216,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;DateTime&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeValidAsync(List<DateTime> arrayBody);
+    Observable<Void> putDateTimeValidAsync(List<DateTime> arrayBody);
+
+    /**
+     * Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @param arrayBody the List&lt;DateTime&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateTimeValidAsyncWithServiceResponse(List<DateTime> arrayBody);
 
     /**
      * Get date array value ['2000-12-01t00:00:01z', null].
@@ -964,7 +1233,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<DateTime>> getDateTimeInvalidNull() throws ErrorException, IOException;
+    List<DateTime> getDateTimeInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get date array value ['2000-12-01t00:00:01z', null].
@@ -979,7 +1248,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidNullAsync();
+    Observable<List<DateTime>> getDateTimeInvalidNullAsync();
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', null].
+     *
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
@@ -988,7 +1264,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<DateTime>> getDateTimeInvalidChars() throws ErrorException, IOException;
+    List<DateTime> getDateTimeInvalidChars() throws ErrorException, IOException;
 
     /**
      * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
@@ -1003,7 +1279,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidCharsAsync();
+    Observable<List<DateTime>> getDateTimeInvalidCharsAsync();
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
+     *
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidCharsAsyncWithServiceResponse();
 
     /**
      * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
@@ -1012,7 +1295,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<DateTime>> getDateTimeRfc1123Valid() throws ErrorException, IOException;
+    List<DateTime> getDateTimeRfc1123Valid() throws ErrorException, IOException;
 
     /**
      * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
@@ -1027,7 +1310,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    Observable<ServiceResponse<List<DateTime>>> getDateTimeRfc1123ValidAsync();
+    Observable<List<DateTime>> getDateTimeRfc1123ValidAsync();
+
+    /**
+     * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
+     *
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    Observable<ServiceResponse<List<DateTime>>> getDateTimeRfc1123ValidAsyncWithServiceResponse();
 
     /**
      * Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
@@ -1038,7 +1328,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDateTimeRfc1123Valid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDateTimeRfc1123Valid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
@@ -1055,7 +1345,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody);
+    Observable<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody);
+
+    /**
+     * Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
+     *
+     * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsyncWithServiceResponse(List<DateTime> arrayBody);
 
     /**
      * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
@@ -1064,7 +1362,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Period&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Period>> getDurationValid() throws ErrorException, IOException;
+    List<Period> getDurationValid() throws ErrorException, IOException;
 
     /**
      * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
@@ -1079,7 +1377,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Period&gt; object
      */
-    Observable<ServiceResponse<List<Period>>> getDurationValidAsync();
+    Observable<List<Period>> getDurationValidAsync();
+
+    /**
+     * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @return the observable to the List&lt;Period&gt; object
+     */
+    Observable<ServiceResponse<List<Period>>> getDurationValidAsyncWithServiceResponse();
 
     /**
      * Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
@@ -1090,7 +1395,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDurationValid(List<Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDurationValid(List<Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
@@ -1107,7 +1412,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;Period&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDurationValidAsync(List<Period> arrayBody);
+    Observable<Void> putDurationValidAsync(List<Period> arrayBody);
+
+    /**
+     * Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @param arrayBody the List&lt;Period&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDurationValidAsyncWithServiceResponse(List<Period> arrayBody);
 
     /**
      * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
@@ -1116,7 +1429,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<byte[]>> getByteValid() throws ErrorException, IOException;
+    List<byte[]> getByteValid() throws ErrorException, IOException;
 
     /**
      * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
@@ -1131,7 +1444,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    Observable<ServiceResponse<List<byte[]>>> getByteValidAsync();
+    Observable<List<byte[]>> getByteValidAsync();
+
+    /**
+     * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
+     *
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    Observable<ServiceResponse<List<byte[]>>> getByteValidAsyncWithServiceResponse();
 
     /**
      * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
@@ -1142,7 +1462,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putByteValid(List<byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putByteValid(List<byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
@@ -1159,7 +1479,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;byte[]&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putByteValidAsync(List<byte[]> arrayBody);
+    Observable<Void> putByteValidAsync(List<byte[]> arrayBody);
+
+    /**
+     * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
+     *
+     * @param arrayBody the List&lt;byte[]&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putByteValidAsyncWithServiceResponse(List<byte[]> arrayBody);
 
     /**
      * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
@@ -1168,7 +1496,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<byte[]>> getByteInvalidNull() throws ErrorException, IOException;
+    List<byte[]> getByteInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
@@ -1183,7 +1511,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    Observable<ServiceResponse<List<byte[]>>> getByteInvalidNullAsync();
+    Observable<List<byte[]>> getByteInvalidNullAsync();
+
+    /**
+     * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
+     *
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    Observable<ServiceResponse<List<byte[]>>> getByteInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded.
@@ -1192,7 +1527,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<byte[]>> getBase64Url() throws ErrorException, IOException;
+    List<byte[]> getBase64Url() throws ErrorException, IOException;
 
     /**
      * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded.
@@ -1207,7 +1542,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    Observable<ServiceResponse<List<byte[]>>> getBase64UrlAsync();
+    Observable<List<byte[]>> getBase64UrlAsync();
+
+    /**
+     * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded.
+     *
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    Observable<ServiceResponse<List<byte[]>>> getBase64UrlAsyncWithServiceResponse();
 
     /**
      * Get array of complex type null value.
@@ -1216,7 +1558,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Product>> getComplexNull() throws ErrorException, IOException;
+    List<Product> getComplexNull() throws ErrorException, IOException;
 
     /**
      * Get array of complex type null value.
@@ -1231,7 +1573,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexNullAsync();
+    Observable<List<Product>> getComplexNullAsync();
+
+    /**
+     * Get array of complex type null value.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<List<Product>>> getComplexNullAsyncWithServiceResponse();
 
     /**
      * Get empty array of complex type [].
@@ -1240,7 +1589,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Product>> getComplexEmpty() throws ErrorException, IOException;
+    List<Product> getComplexEmpty() throws ErrorException, IOException;
 
     /**
      * Get empty array of complex type [].
@@ -1255,7 +1604,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexEmptyAsync();
+    Observable<List<Product>> getComplexEmptyAsync();
+
+    /**
+     * Get empty array of complex type [].
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<List<Product>>> getComplexEmptyAsyncWithServiceResponse();
 
     /**
      * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
@@ -1264,7 +1620,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Product>> getComplexItemNull() throws ErrorException, IOException;
+    List<Product> getComplexItemNull() throws ErrorException, IOException;
 
     /**
      * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
@@ -1279,7 +1635,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexItemNullAsync();
+    Observable<List<Product>> getComplexItemNullAsync();
+
+    /**
+     * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<List<Product>>> getComplexItemNullAsyncWithServiceResponse();
 
     /**
      * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
@@ -1288,7 +1651,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Product>> getComplexItemEmpty() throws ErrorException, IOException;
+    List<Product> getComplexItemEmpty() throws ErrorException, IOException;
 
     /**
      * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
@@ -1303,7 +1666,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexItemEmptyAsync();
+    Observable<List<Product>> getComplexItemEmptyAsync();
+
+    /**
+     * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<List<Product>>> getComplexItemEmptyAsyncWithServiceResponse();
 
     /**
      * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
@@ -1312,7 +1682,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Product>> getComplexValid() throws ErrorException, IOException;
+    List<Product> getComplexValid() throws ErrorException, IOException;
 
     /**
      * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
@@ -1327,7 +1697,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexValidAsync();
+    Observable<List<Product>> getComplexValidAsync();
+
+    /**
+     * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Observable<ServiceResponse<List<Product>>> getComplexValidAsyncWithServiceResponse();
 
     /**
      * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
@@ -1338,7 +1715,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putComplexValid(List<Product> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putComplexValid(List<Product> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
@@ -1355,7 +1732,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;Product&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putComplexValidAsync(List<Product> arrayBody);
+    Observable<Void> putComplexValidAsync(List<Product> arrayBody);
+
+    /**
+     * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
+     *
+     * @param arrayBody the List&lt;Product&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putComplexValidAsyncWithServiceResponse(List<Product> arrayBody);
 
     /**
      * Get a null array.
@@ -1364,7 +1749,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<List<String>>> getArrayNull() throws ErrorException, IOException;
+    List<List<String>> getArrayNull() throws ErrorException, IOException;
 
     /**
      * Get a null array.
@@ -1379,7 +1764,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayNullAsync();
+    Observable<List<List<String>>> getArrayNullAsync();
+
+    /**
+     * Get a null array.
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<List<String>>>> getArrayNullAsyncWithServiceResponse();
 
     /**
      * Get an empty array [].
@@ -1388,7 +1780,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<List<String>>> getArrayEmpty() throws ErrorException, IOException;
+    List<List<String>> getArrayEmpty() throws ErrorException, IOException;
 
     /**
      * Get an empty array [].
@@ -1403,7 +1795,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayEmptyAsync();
+    Observable<List<List<String>>> getArrayEmptyAsync();
+
+    /**
+     * Get an empty array [].
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<List<String>>>> getArrayEmptyAsyncWithServiceResponse();
 
     /**
      * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
@@ -1412,7 +1811,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<List<String>>> getArrayItemNull() throws ErrorException, IOException;
+    List<List<String>> getArrayItemNull() throws ErrorException, IOException;
 
     /**
      * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
@@ -1427,7 +1826,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayItemNullAsync();
+    Observable<List<List<String>>> getArrayItemNullAsync();
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<List<String>>>> getArrayItemNullAsyncWithServiceResponse();
 
     /**
      * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
@@ -1436,7 +1842,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<List<String>>> getArrayItemEmpty() throws ErrorException, IOException;
+    List<List<String>> getArrayItemEmpty() throws ErrorException, IOException;
 
     /**
      * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
@@ -1451,7 +1857,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayItemEmptyAsync();
+    Observable<List<List<String>>> getArrayItemEmptyAsync();
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<List<String>>>> getArrayItemEmptyAsyncWithServiceResponse();
 
     /**
      * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
@@ -1460,7 +1873,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<List<String>>> getArrayValid() throws ErrorException, IOException;
+    List<List<String>> getArrayValid() throws ErrorException, IOException;
 
     /**
      * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
@@ -1475,7 +1888,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayValidAsync();
+    Observable<List<List<String>>> getArrayValidAsync();
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<List<String>>>> getArrayValidAsyncWithServiceResponse();
 
     /**
      * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
@@ -1486,7 +1906,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putArrayValid(List<List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putArrayValid(List<List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
@@ -1503,7 +1923,15 @@ public interface Arrays {
      * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayValidAsync(List<List<String>> arrayBody);
+    Observable<Void> putArrayValidAsync(List<List<String>> arrayBody);
+
+    /**
+     * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putArrayValidAsyncWithServiceResponse(List<List<String>> arrayBody);
 
     /**
      * Get an array of Dictionaries with value null.
@@ -1512,7 +1940,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Map<String, String>>> getDictionaryNull() throws ErrorException, IOException;
+    List<Map<String, String>> getDictionaryNull() throws ErrorException, IOException;
 
     /**
      * Get an array of Dictionaries with value null.
@@ -1527,7 +1955,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryNullAsync();
+    Observable<List<Map<String, String>>> getDictionaryNullAsync();
+
+    /**
+     * Get an array of Dictionaries with value null.
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryNullAsyncWithServiceResponse();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
@@ -1536,7 +1971,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Map<String, String>>> getDictionaryEmpty() throws ErrorException, IOException;
+    List<Map<String, String>> getDictionaryEmpty() throws ErrorException, IOException;
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
@@ -1551,7 +1986,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryEmptyAsync();
+    Observable<List<Map<String, String>>> getDictionaryEmptyAsync();
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryEmptyAsyncWithServiceResponse();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -1560,7 +2002,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Map<String, String>>> getDictionaryItemNull() throws ErrorException, IOException;
+    List<Map<String, String>> getDictionaryItemNull() throws ErrorException, IOException;
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -1575,7 +2017,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemNullAsync();
+    Observable<List<Map<String, String>>> getDictionaryItemNullAsync();
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemNullAsyncWithServiceResponse();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -1584,7 +2033,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Map<String, String>>> getDictionaryItemEmpty() throws ErrorException, IOException;
+    List<Map<String, String>> getDictionaryItemEmpty() throws ErrorException, IOException;
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -1599,7 +2048,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemEmptyAsync();
+    Observable<List<Map<String, String>>> getDictionaryItemEmptyAsync();
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemEmptyAsyncWithServiceResponse();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -1608,7 +2064,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<Map<String, String>>> getDictionaryValid() throws ErrorException, IOException;
+    List<Map<String, String>> getDictionaryValid() throws ErrorException, IOException;
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -1623,7 +2079,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryValidAsync();
+    Observable<List<Map<String, String>>> getDictionaryValidAsync();
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryValidAsyncWithServiceResponse();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -1634,7 +2097,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDictionaryValid(List<Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDictionaryValid(List<Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -1651,6 +2114,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryValidAsync(List<Map<String, String>> arrayBody);
+    Observable<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody);
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDictionaryValidAsyncWithServiceResponse(List<Map<String, String>> arrayBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyarray/Arrays.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyarray/Arrays.java
@@ -34,7 +34,7 @@ public interface Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     List<Integer> getNull() throws ErrorException, IOException;
 
@@ -58,14 +58,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Integer>>> getNullWithServiceResponseAsync();
 
     /**
      * Get invalid array [1, 2, 3.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     List<Integer> getInvalid() throws ErrorException, IOException;
 
@@ -89,14 +89,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Integer>>> getInvalidWithServiceResponseAsync();
 
     /**
      * Get empty array value [].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     List<Integer> getEmpty() throws ErrorException, IOException;
 
@@ -120,7 +120,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Integer>>> getEmptyWithServiceResponseAsync();
 
     /**
      * Set array value empty [].
@@ -129,7 +129,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putEmpty(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -156,14 +155,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(List<String> arrayBody);
+    Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(List<String> arrayBody);
 
     /**
      * Get boolean array value [true, false, false, true].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Boolean&gt; object if successful.
      */
     List<Boolean> getBooleanTfft() throws ErrorException, IOException;
 
@@ -187,7 +186,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    Observable<ServiceResponse<List<Boolean>>> getBooleanTfftAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Boolean>>> getBooleanTfftWithServiceResponseAsync();
 
     /**
      * Set array value empty [true, false, false, true].
@@ -196,7 +195,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBooleanTfft(List<Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -223,14 +221,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;Boolean&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBooleanTfftAsyncWithServiceResponse(List<Boolean> arrayBody);
+    Observable<ServiceResponse<Void>> putBooleanTfftWithServiceResponseAsync(List<Boolean> arrayBody);
 
     /**
      * Get boolean array value [true, null, false].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Boolean&gt; object if successful.
      */
     List<Boolean> getBooleanInvalidNull() throws ErrorException, IOException;
 
@@ -254,14 +252,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidNullWithServiceResponseAsync();
 
     /**
      * Get boolean array value [true, 'boolean', false].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Boolean&gt; object if successful.
      */
     List<Boolean> getBooleanInvalidString() throws ErrorException, IOException;
 
@@ -285,14 +283,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidStringWithServiceResponseAsync();
 
     /**
      * Get integer array value [1, -1, 3, 300].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     List<Integer> getIntegerValid() throws ErrorException, IOException;
 
@@ -316,7 +314,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getIntegerValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Integer>>> getIntegerValidWithServiceResponseAsync();
 
     /**
      * Set array value empty [1, -1, 3, 300].
@@ -325,7 +323,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putIntegerValid(List<Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -352,14 +349,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;Integer&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putIntegerValidAsyncWithServiceResponse(List<Integer> arrayBody);
+    Observable<ServiceResponse<Void>> putIntegerValidWithServiceResponseAsync(List<Integer> arrayBody);
 
     /**
      * Get integer array value [1, null, 0].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     List<Integer> getIntInvalidNull() throws ErrorException, IOException;
 
@@ -383,14 +380,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getIntInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Integer>>> getIntInvalidNullWithServiceResponseAsync();
 
     /**
      * Get integer array value [1, 'integer', 0].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     List<Integer> getIntInvalidString() throws ErrorException, IOException;
 
@@ -414,14 +411,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    Observable<ServiceResponse<List<Integer>>> getIntInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Integer>>> getIntInvalidStringWithServiceResponseAsync();
 
     /**
      * Get integer array value [1, -1, 3, 300].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Long&gt; object if successful.
      */
     List<Long> getLongValid() throws ErrorException, IOException;
 
@@ -445,7 +442,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    Observable<ServiceResponse<List<Long>>> getLongValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Long>>> getLongValidWithServiceResponseAsync();
 
     /**
      * Set array value empty [1, -1, 3, 300].
@@ -454,7 +451,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putLongValid(List<Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -481,14 +477,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;Long&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLongValidAsyncWithServiceResponse(List<Long> arrayBody);
+    Observable<ServiceResponse<Void>> putLongValidWithServiceResponseAsync(List<Long> arrayBody);
 
     /**
      * Get long array value [1, null, 0].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Long&gt; object if successful.
      */
     List<Long> getLongInvalidNull() throws ErrorException, IOException;
 
@@ -512,14 +508,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    Observable<ServiceResponse<List<Long>>> getLongInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Long>>> getLongInvalidNullWithServiceResponseAsync();
 
     /**
      * Get long array value [1, 'integer', 0].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Long&gt; object if successful.
      */
     List<Long> getLongInvalidString() throws ErrorException, IOException;
 
@@ -543,14 +539,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    Observable<ServiceResponse<List<Long>>> getLongInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Long>>> getLongInvalidStringWithServiceResponseAsync();
 
     /**
      * Get float array value [0, -0.01, 1.2e20].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     List<Double> getFloatValid() throws ErrorException, IOException;
 
@@ -574,7 +570,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getFloatValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Double>>> getFloatValidWithServiceResponseAsync();
 
     /**
      * Set array value [0, -0.01, 1.2e20].
@@ -583,7 +579,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putFloatValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -610,14 +605,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putFloatValidAsyncWithServiceResponse(List<Double> arrayBody);
+    Observable<ServiceResponse<Void>> putFloatValidWithServiceResponseAsync(List<Double> arrayBody);
 
     /**
      * Get float array value [0.0, null, -1.2e20].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     List<Double> getFloatInvalidNull() throws ErrorException, IOException;
 
@@ -641,14 +636,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getFloatInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Double>>> getFloatInvalidNullWithServiceResponseAsync();
 
     /**
      * Get boolean array value [1.0, 'number', 0.0].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     List<Double> getFloatInvalidString() throws ErrorException, IOException;
 
@@ -672,14 +667,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getFloatInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Double>>> getFloatInvalidStringWithServiceResponseAsync();
 
     /**
      * Get float array value [0, -0.01, 1.2e20].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     List<Double> getDoubleValid() throws ErrorException, IOException;
 
@@ -703,7 +698,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getDoubleValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Double>>> getDoubleValidWithServiceResponseAsync();
 
     /**
      * Set array value [0, -0.01, 1.2e20].
@@ -712,7 +707,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDoubleValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -739,14 +733,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDoubleValidAsyncWithServiceResponse(List<Double> arrayBody);
+    Observable<ServiceResponse<Void>> putDoubleValidWithServiceResponseAsync(List<Double> arrayBody);
 
     /**
      * Get float array value [0.0, null, -1.2e20].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     List<Double> getDoubleInvalidNull() throws ErrorException, IOException;
 
@@ -770,14 +764,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getDoubleInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Double>>> getDoubleInvalidNullWithServiceResponseAsync();
 
     /**
      * Get boolean array value [1.0, 'number', 0.0].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     List<Double> getDoubleInvalidString() throws ErrorException, IOException;
 
@@ -801,14 +795,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    Observable<ServiceResponse<List<Double>>> getDoubleInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Double>>> getDoubleInvalidStringWithServiceResponseAsync();
 
     /**
      * Get string array value ['foo1', 'foo2', 'foo3'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;String&gt; object if successful.
      */
     List<String> getStringValid() throws ErrorException, IOException;
 
@@ -832,7 +826,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    Observable<ServiceResponse<List<String>>> getStringValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<String>>> getStringValidWithServiceResponseAsync();
 
     /**
      * Set array value ['foo1', 'foo2', 'foo3'].
@@ -841,7 +835,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putStringValid(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -868,14 +861,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putStringValidAsyncWithServiceResponse(List<String> arrayBody);
+    Observable<ServiceResponse<Void>> putStringValidWithServiceResponseAsync(List<String> arrayBody);
 
     /**
      * Get string array value ['foo', null, 'foo2'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;String&gt; object if successful.
      */
     List<String> getStringWithNull() throws ErrorException, IOException;
 
@@ -899,14 +892,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    Observable<ServiceResponse<List<String>>> getStringWithNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<String>>> getStringWithNullWithServiceResponseAsync();
 
     /**
      * Get string array value ['foo', 123, 'foo2'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;String&gt; object if successful.
      */
     List<String> getStringWithInvalid() throws ErrorException, IOException;
 
@@ -930,14 +923,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    Observable<ServiceResponse<List<String>>> getStringWithInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<String>>> getStringWithInvalidWithServiceResponseAsync();
 
     /**
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;UUID&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;UUID&gt; object if successful.
      */
     List<UUID> getUuidValid() throws ErrorException, IOException;
 
@@ -961,7 +954,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;UUID&gt; object
      */
-    Observable<ServiceResponse<List<UUID>>> getUuidValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<UUID>>> getUuidValidWithServiceResponseAsync();
 
     /**
      * Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
@@ -970,7 +963,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putUuidValid(List<UUID> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -997,14 +989,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;UUID&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUuidValidAsyncWithServiceResponse(List<UUID> arrayBody);
+    Observable<ServiceResponse<Void>> putUuidValidWithServiceResponseAsync(List<UUID> arrayBody);
 
     /**
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;UUID&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;UUID&gt; object if successful.
      */
     List<UUID> getUuidInvalidChars() throws ErrorException, IOException;
 
@@ -1028,14 +1020,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;UUID&gt; object
      */
-    Observable<ServiceResponse<List<UUID>>> getUuidInvalidCharsAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<UUID>>> getUuidInvalidCharsWithServiceResponseAsync();
 
     /**
      * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;LocalDate&gt; object if successful.
      */
     List<LocalDate> getDateValid() throws ErrorException, IOException;
 
@@ -1059,7 +1051,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    Observable<ServiceResponse<List<LocalDate>>> getDateValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<LocalDate>>> getDateValidWithServiceResponseAsync();
 
     /**
      * Set array value  ['2000-12-01', '1980-01-02', '1492-10-12'].
@@ -1068,7 +1060,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDateValid(List<LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1095,14 +1086,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;LocalDate&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateValidAsyncWithServiceResponse(List<LocalDate> arrayBody);
+    Observable<ServiceResponse<Void>> putDateValidWithServiceResponseAsync(List<LocalDate> arrayBody);
 
     /**
      * Get date array value ['2012-01-01', null, '1776-07-04'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;LocalDate&gt; object if successful.
      */
     List<LocalDate> getDateInvalidNull() throws ErrorException, IOException;
 
@@ -1126,14 +1117,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    Observable<ServiceResponse<List<LocalDate>>> getDateInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<LocalDate>>> getDateInvalidNullWithServiceResponseAsync();
 
     /**
      * Get date array value ['2011-03-22', 'date'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;LocalDate&gt; object if successful.
      */
     List<LocalDate> getDateInvalidChars() throws ErrorException, IOException;
 
@@ -1157,14 +1148,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    Observable<ServiceResponse<List<LocalDate>>> getDateInvalidCharsAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<LocalDate>>> getDateInvalidCharsWithServiceResponseAsync();
 
     /**
      * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;DateTime&gt; object if successful.
      */
     List<DateTime> getDateTimeValid() throws ErrorException, IOException;
 
@@ -1188,7 +1179,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    Observable<ServiceResponse<List<DateTime>>> getDateTimeValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<DateTime>>> getDateTimeValidWithServiceResponseAsync();
 
     /**
      * Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
@@ -1197,7 +1188,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDateTimeValid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1224,14 +1214,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;DateTime&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeValidAsyncWithServiceResponse(List<DateTime> arrayBody);
+    Observable<ServiceResponse<Void>> putDateTimeValidWithServiceResponseAsync(List<DateTime> arrayBody);
 
     /**
      * Get date array value ['2000-12-01t00:00:01z', null].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;DateTime&gt; object if successful.
      */
     List<DateTime> getDateTimeInvalidNull() throws ErrorException, IOException;
 
@@ -1255,14 +1245,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidNullWithServiceResponseAsync();
 
     /**
      * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;DateTime&gt; object if successful.
      */
     List<DateTime> getDateTimeInvalidChars() throws ErrorException, IOException;
 
@@ -1286,14 +1276,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidCharsAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidCharsWithServiceResponseAsync();
 
     /**
      * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;DateTime&gt; object if successful.
      */
     List<DateTime> getDateTimeRfc1123Valid() throws ErrorException, IOException;
 
@@ -1317,7 +1307,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    Observable<ServiceResponse<List<DateTime>>> getDateTimeRfc1123ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<DateTime>>> getDateTimeRfc1123ValidWithServiceResponseAsync();
 
     /**
      * Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
@@ -1326,7 +1316,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDateTimeRfc1123Valid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1353,14 +1342,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsyncWithServiceResponse(List<DateTime> arrayBody);
+    Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidWithServiceResponseAsync(List<DateTime> arrayBody);
 
     /**
      * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Period&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Period&gt; object if successful.
      */
     List<Period> getDurationValid() throws ErrorException, IOException;
 
@@ -1384,7 +1373,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Period&gt; object
      */
-    Observable<ServiceResponse<List<Period>>> getDurationValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Period>>> getDurationValidWithServiceResponseAsync();
 
     /**
      * Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
@@ -1393,7 +1382,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDurationValid(List<Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1420,14 +1408,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;Period&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDurationValidAsyncWithServiceResponse(List<Period> arrayBody);
+    Observable<ServiceResponse<Void>> putDurationValidWithServiceResponseAsync(List<Period> arrayBody);
 
     /**
      * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;byte[]&gt; object if successful.
      */
     List<byte[]> getByteValid() throws ErrorException, IOException;
 
@@ -1451,7 +1439,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    Observable<ServiceResponse<List<byte[]>>> getByteValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<byte[]>>> getByteValidWithServiceResponseAsync();
 
     /**
      * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
@@ -1460,7 +1448,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putByteValid(List<byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1487,14 +1474,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;byte[]&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putByteValidAsyncWithServiceResponse(List<byte[]> arrayBody);
+    Observable<ServiceResponse<Void>> putByteValidWithServiceResponseAsync(List<byte[]> arrayBody);
 
     /**
      * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;byte[]&gt; object if successful.
      */
     List<byte[]> getByteInvalidNull() throws ErrorException, IOException;
 
@@ -1518,14 +1505,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    Observable<ServiceResponse<List<byte[]>>> getByteInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<byte[]>>> getByteInvalidNullWithServiceResponseAsync();
 
     /**
      * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;byte[]&gt; object if successful.
      */
     List<byte[]> getBase64Url() throws ErrorException, IOException;
 
@@ -1549,14 +1536,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    Observable<ServiceResponse<List<byte[]>>> getBase64UrlAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<byte[]>>> getBase64UrlWithServiceResponseAsync();
 
     /**
      * Get array of complex type null value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     List<Product> getComplexNull() throws ErrorException, IOException;
 
@@ -1580,14 +1567,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Product>>> getComplexNullWithServiceResponseAsync();
 
     /**
      * Get empty array of complex type [].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     List<Product> getComplexEmpty() throws ErrorException, IOException;
 
@@ -1611,14 +1598,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Product>>> getComplexEmptyWithServiceResponseAsync();
 
     /**
      * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     List<Product> getComplexItemNull() throws ErrorException, IOException;
 
@@ -1642,14 +1629,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexItemNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Product>>> getComplexItemNullWithServiceResponseAsync();
 
     /**
      * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     List<Product> getComplexItemEmpty() throws ErrorException, IOException;
 
@@ -1673,14 +1660,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexItemEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Product>>> getComplexItemEmptyWithServiceResponseAsync();
 
     /**
      * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     List<Product> getComplexValid() throws ErrorException, IOException;
 
@@ -1704,7 +1691,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    Observable<ServiceResponse<List<Product>>> getComplexValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Product>>> getComplexValidWithServiceResponseAsync();
 
     /**
      * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
@@ -1713,7 +1700,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putComplexValid(List<Product> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1740,14 +1726,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;Product&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putComplexValidAsyncWithServiceResponse(List<Product> arrayBody);
+    Observable<ServiceResponse<Void>> putComplexValidWithServiceResponseAsync(List<Product> arrayBody);
 
     /**
      * Get a null array.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     List<List<String>> getArrayNull() throws ErrorException, IOException;
 
@@ -1771,14 +1757,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<List<String>>>> getArrayNullWithServiceResponseAsync();
 
     /**
      * Get an empty array [].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     List<List<String>> getArrayEmpty() throws ErrorException, IOException;
 
@@ -1802,14 +1788,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<List<String>>>> getArrayEmptyWithServiceResponseAsync();
 
     /**
      * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     List<List<String>> getArrayItemNull() throws ErrorException, IOException;
 
@@ -1833,14 +1819,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayItemNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<List<String>>>> getArrayItemNullWithServiceResponseAsync();
 
     /**
      * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     List<List<String>> getArrayItemEmpty() throws ErrorException, IOException;
 
@@ -1864,14 +1850,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayItemEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<List<String>>>> getArrayItemEmptyWithServiceResponseAsync();
 
     /**
      * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     List<List<String>> getArrayValid() throws ErrorException, IOException;
 
@@ -1895,7 +1881,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<List<String>>>> getArrayValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<List<String>>>> getArrayValidWithServiceResponseAsync();
 
     /**
      * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
@@ -1904,7 +1890,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putArrayValid(List<List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1931,14 +1916,14 @@ public interface Arrays {
      * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayValidAsyncWithServiceResponse(List<List<String>> arrayBody);
+    Observable<ServiceResponse<Void>> putArrayValidWithServiceResponseAsync(List<List<String>> arrayBody);
 
     /**
      * Get an array of Dictionaries with value null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     List<Map<String, String>> getDictionaryNull() throws ErrorException, IOException;
 
@@ -1962,14 +1947,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryNullWithServiceResponseAsync();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     List<Map<String, String>> getDictionaryEmpty() throws ErrorException, IOException;
 
@@ -1993,14 +1978,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryEmptyWithServiceResponseAsync();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     List<Map<String, String>> getDictionaryItemNull() throws ErrorException, IOException;
 
@@ -2024,14 +2009,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemNullWithServiceResponseAsync();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     List<Map<String, String>> getDictionaryItemEmpty() throws ErrorException, IOException;
 
@@ -2055,14 +2040,14 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemEmptyWithServiceResponseAsync();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     List<Map<String, String>> getDictionaryValid() throws ErrorException, IOException;
 
@@ -2086,7 +2071,7 @@ public interface Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryValidWithServiceResponseAsync();
 
     /**
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
@@ -2095,7 +2080,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDictionaryValid(List<Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -2122,6 +2106,6 @@ public interface Arrays {
      * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryValidAsyncWithServiceResponse(List<Map<String, String>> arrayBody);
+    Observable<ServiceResponse<Void>> putDictionaryValidWithServiceResponseAsync(List<Map<String, String>> arrayBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyarray/implementation/ArraysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyarray/implementation/ArraysImpl.java
@@ -332,10 +332,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     public List<Integer> getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -345,7 +345,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getNullAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -354,12 +354,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     public Observable<List<Integer>> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
             @Override
             public List<Integer> call(ServiceResponse<List<Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -367,7 +367,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Integer>>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -394,10 +394,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     public List<Integer> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -407,7 +407,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getInvalidAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -416,12 +416,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     public Observable<List<Integer>> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
             @Override
             public List<Integer> call(ServiceResponse<List<Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -429,7 +429,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Integer>>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -456,10 +456,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     public List<Integer> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -469,7 +469,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getEmptyAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -478,12 +478,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     public Observable<List<Integer>> getEmptyAsync() {
-        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+        return getEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
             @Override
             public List<Integer> call(ServiceResponse<List<Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -491,7 +491,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Integer>>> getEmptyWithServiceResponseAsync() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -520,10 +520,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putEmpty(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putEmptyAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putEmptyWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -534,7 +533,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(List<String> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putEmptyWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -544,12 +543,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putEmptyAsync(List<String> arrayBody) {
-        return putEmptyAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putEmptyWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -558,7 +557,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(List<String> arrayBody) {
+    public Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(List<String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -589,10 +588,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Boolean&gt; object if successful.
      */
     public List<Boolean> getBooleanTfft() throws ErrorException, IOException {
-        return getBooleanTfftAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBooleanTfftWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -602,7 +601,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Boolean>> getBooleanTfftAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanTfftAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanTfftWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -611,12 +610,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Boolean&gt; object
      */
     public Observable<List<Boolean>> getBooleanTfftAsync() {
-        return getBooleanTfftAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
+        return getBooleanTfftWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
             @Override
             public List<Boolean> call(ServiceResponse<List<Boolean>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -624,7 +623,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    public Observable<ServiceResponse<List<Boolean>>> getBooleanTfftAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Boolean>>> getBooleanTfftWithServiceResponseAsync() {
         return service.getBooleanTfft()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Boolean>>>>() {
                 @Override
@@ -653,10 +652,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBooleanTfft(List<Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putBooleanTfftAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putBooleanTfftWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -667,7 +665,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBooleanTfftAsync(List<Boolean> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBooleanTfftAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putBooleanTfftWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -677,12 +675,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBooleanTfftAsync(List<Boolean> arrayBody) {
-        return putBooleanTfftAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBooleanTfftWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -691,7 +689,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Boolean&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBooleanTfftAsyncWithServiceResponse(List<Boolean> arrayBody) {
+    public Observable<ServiceResponse<Void>> putBooleanTfftWithServiceResponseAsync(List<Boolean> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -722,10 +720,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Boolean&gt; object if successful.
      */
     public List<Boolean> getBooleanInvalidNull() throws ErrorException, IOException {
-        return getBooleanInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBooleanInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -735,7 +733,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Boolean>> getBooleanInvalidNullAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -744,12 +742,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Boolean&gt; object
      */
     public Observable<List<Boolean>> getBooleanInvalidNullAsync() {
-        return getBooleanInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
+        return getBooleanInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
             @Override
             public List<Boolean> call(ServiceResponse<List<Boolean>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -757,7 +755,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    public Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidNullWithServiceResponseAsync() {
         return service.getBooleanInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Boolean>>>>() {
                 @Override
@@ -784,10 +782,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Boolean&gt; object if successful.
      */
     public List<Boolean> getBooleanInvalidString() throws ErrorException, IOException {
-        return getBooleanInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBooleanInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -797,7 +795,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Boolean>> getBooleanInvalidStringAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -806,12 +804,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Boolean&gt; object
      */
     public Observable<List<Boolean>> getBooleanInvalidStringAsync() {
-        return getBooleanInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
+        return getBooleanInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
             @Override
             public List<Boolean> call(ServiceResponse<List<Boolean>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -819,7 +817,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    public Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidStringWithServiceResponseAsync() {
         return service.getBooleanInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Boolean>>>>() {
                 @Override
@@ -846,10 +844,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     public List<Integer> getIntegerValid() throws ErrorException, IOException {
-        return getIntegerValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getIntegerValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -859,7 +857,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getIntegerValidAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getIntegerValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntegerValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -868,12 +866,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     public Observable<List<Integer>> getIntegerValidAsync() {
-        return getIntegerValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+        return getIntegerValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
             @Override
             public List<Integer> call(ServiceResponse<List<Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -881,7 +879,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getIntegerValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Integer>>> getIntegerValidWithServiceResponseAsync() {
         return service.getIntegerValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -910,10 +908,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putIntegerValid(List<Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putIntegerValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putIntegerValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -924,7 +921,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putIntegerValidAsync(List<Integer> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putIntegerValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putIntegerValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -934,12 +931,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putIntegerValidAsync(List<Integer> arrayBody) {
-        return putIntegerValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putIntegerValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -948,7 +945,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Integer&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putIntegerValidAsyncWithServiceResponse(List<Integer> arrayBody) {
+    public Observable<ServiceResponse<Void>> putIntegerValidWithServiceResponseAsync(List<Integer> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -979,10 +976,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     public List<Integer> getIntInvalidNull() throws ErrorException, IOException {
-        return getIntInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getIntInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -992,7 +989,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getIntInvalidNullAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getIntInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1001,12 +998,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     public Observable<List<Integer>> getIntInvalidNullAsync() {
-        return getIntInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+        return getIntInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
             @Override
             public List<Integer> call(ServiceResponse<List<Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1014,7 +1011,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getIntInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Integer>>> getIntInvalidNullWithServiceResponseAsync() {
         return service.getIntInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -1041,10 +1038,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Integer&gt; object if successful.
      */
     public List<Integer> getIntInvalidString() throws ErrorException, IOException {
-        return getIntInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getIntInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1054,7 +1051,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getIntInvalidStringAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getIntInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1063,12 +1060,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     public Observable<List<Integer>> getIntInvalidStringAsync() {
-        return getIntInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+        return getIntInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
             @Override
             public List<Integer> call(ServiceResponse<List<Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1076,7 +1073,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getIntInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Integer>>> getIntInvalidStringWithServiceResponseAsync() {
         return service.getIntInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -1103,10 +1100,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Long&gt; object if successful.
      */
     public List<Long> getLongValid() throws ErrorException, IOException {
-        return getLongValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLongValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1116,7 +1113,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Long>> getLongValidAsync(final ServiceCallback<List<Long>> serviceCallback) {
-        return ServiceCall.create(getLongValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLongValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1125,12 +1122,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Long&gt; object
      */
     public Observable<List<Long>> getLongValidAsync() {
-        return getLongValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
+        return getLongValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
             @Override
             public List<Long> call(ServiceResponse<List<Long>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1138,7 +1135,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    public Observable<ServiceResponse<List<Long>>> getLongValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Long>>> getLongValidWithServiceResponseAsync() {
         return service.getLongValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Long>>>>() {
                 @Override
@@ -1167,10 +1164,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putLongValid(List<Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putLongValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putLongValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1181,7 +1177,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLongValidAsync(List<Long> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLongValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putLongValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -1191,12 +1187,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putLongValidAsync(List<Long> arrayBody) {
-        return putLongValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putLongValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1205,7 +1201,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Long&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLongValidAsyncWithServiceResponse(List<Long> arrayBody) {
+    public Observable<ServiceResponse<Void>> putLongValidWithServiceResponseAsync(List<Long> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1236,10 +1232,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Long&gt; object if successful.
      */
     public List<Long> getLongInvalidNull() throws ErrorException, IOException {
-        return getLongInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLongInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1249,7 +1245,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Long>> getLongInvalidNullAsync(final ServiceCallback<List<Long>> serviceCallback) {
-        return ServiceCall.create(getLongInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLongInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1258,12 +1254,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Long&gt; object
      */
     public Observable<List<Long>> getLongInvalidNullAsync() {
-        return getLongInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
+        return getLongInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
             @Override
             public List<Long> call(ServiceResponse<List<Long>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1271,7 +1267,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    public Observable<ServiceResponse<List<Long>>> getLongInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Long>>> getLongInvalidNullWithServiceResponseAsync() {
         return service.getLongInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Long>>>>() {
                 @Override
@@ -1298,10 +1294,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Long&gt; object if successful.
      */
     public List<Long> getLongInvalidString() throws ErrorException, IOException {
-        return getLongInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLongInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1311,7 +1307,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Long>> getLongInvalidStringAsync(final ServiceCallback<List<Long>> serviceCallback) {
-        return ServiceCall.create(getLongInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLongInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1320,12 +1316,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Long&gt; object
      */
     public Observable<List<Long>> getLongInvalidStringAsync() {
-        return getLongInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
+        return getLongInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
             @Override
             public List<Long> call(ServiceResponse<List<Long>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1333,7 +1329,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    public Observable<ServiceResponse<List<Long>>> getLongInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Long>>> getLongInvalidStringWithServiceResponseAsync() {
         return service.getLongInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Long>>>>() {
                 @Override
@@ -1360,10 +1356,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     public List<Double> getFloatValid() throws ErrorException, IOException {
-        return getFloatValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFloatValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1373,7 +1369,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getFloatValidAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getFloatValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFloatValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1382,12 +1378,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     public Observable<List<Double>> getFloatValidAsync() {
-        return getFloatValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+        return getFloatValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
             @Override
             public List<Double> call(ServiceResponse<List<Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1395,7 +1391,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getFloatValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Double>>> getFloatValidWithServiceResponseAsync() {
         return service.getFloatValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1424,10 +1420,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putFloatValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putFloatValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putFloatValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1438,7 +1433,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putFloatValidAsync(List<Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putFloatValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putFloatValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -1448,12 +1443,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putFloatValidAsync(List<Double> arrayBody) {
-        return putFloatValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putFloatValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1462,7 +1457,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putFloatValidAsyncWithServiceResponse(List<Double> arrayBody) {
+    public Observable<ServiceResponse<Void>> putFloatValidWithServiceResponseAsync(List<Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1493,10 +1488,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     public List<Double> getFloatInvalidNull() throws ErrorException, IOException {
-        return getFloatInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFloatInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1506,7 +1501,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getFloatInvalidNullAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getFloatInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFloatInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1515,12 +1510,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     public Observable<List<Double>> getFloatInvalidNullAsync() {
-        return getFloatInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+        return getFloatInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
             @Override
             public List<Double> call(ServiceResponse<List<Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1528,7 +1523,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getFloatInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Double>>> getFloatInvalidNullWithServiceResponseAsync() {
         return service.getFloatInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1555,10 +1550,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     public List<Double> getFloatInvalidString() throws ErrorException, IOException {
-        return getFloatInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFloatInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1568,7 +1563,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getFloatInvalidStringAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getFloatInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFloatInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1577,12 +1572,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     public Observable<List<Double>> getFloatInvalidStringAsync() {
-        return getFloatInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+        return getFloatInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
             @Override
             public List<Double> call(ServiceResponse<List<Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1590,7 +1585,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getFloatInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Double>>> getFloatInvalidStringWithServiceResponseAsync() {
         return service.getFloatInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1617,10 +1612,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     public List<Double> getDoubleValid() throws ErrorException, IOException {
-        return getDoubleValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDoubleValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1630,7 +1625,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getDoubleValidAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDoubleValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1639,12 +1634,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     public Observable<List<Double>> getDoubleValidAsync() {
-        return getDoubleValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+        return getDoubleValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
             @Override
             public List<Double> call(ServiceResponse<List<Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1652,7 +1647,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getDoubleValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Double>>> getDoubleValidWithServiceResponseAsync() {
         return service.getDoubleValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1681,10 +1676,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDoubleValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDoubleValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDoubleValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1695,7 +1689,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDoubleValidAsync(List<Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDoubleValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDoubleValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -1705,12 +1699,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDoubleValidAsync(List<Double> arrayBody) {
-        return putDoubleValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDoubleValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1719,7 +1713,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDoubleValidAsyncWithServiceResponse(List<Double> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDoubleValidWithServiceResponseAsync(List<Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1750,10 +1744,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     public List<Double> getDoubleInvalidNull() throws ErrorException, IOException {
-        return getDoubleInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDoubleInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1763,7 +1757,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getDoubleInvalidNullAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDoubleInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1772,12 +1766,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     public Observable<List<Double>> getDoubleInvalidNullAsync() {
-        return getDoubleInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+        return getDoubleInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
             @Override
             public List<Double> call(ServiceResponse<List<Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1785,7 +1779,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getDoubleInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Double>>> getDoubleInvalidNullWithServiceResponseAsync() {
         return service.getDoubleInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1812,10 +1806,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Double&gt; object if successful.
      */
     public List<Double> getDoubleInvalidString() throws ErrorException, IOException {
-        return getDoubleInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDoubleInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1825,7 +1819,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getDoubleInvalidStringAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDoubleInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1834,12 +1828,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     public Observable<List<Double>> getDoubleInvalidStringAsync() {
-        return getDoubleInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+        return getDoubleInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
             @Override
             public List<Double> call(ServiceResponse<List<Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1847,7 +1841,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getDoubleInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Double>>> getDoubleInvalidStringWithServiceResponseAsync() {
         return service.getDoubleInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1874,10 +1868,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;String&gt; object if successful.
      */
     public List<String> getStringValid() throws ErrorException, IOException {
-        return getStringValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getStringValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1887,7 +1881,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<String>> getStringValidAsync(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceCall.create(getStringValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getStringValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1896,12 +1890,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;String&gt; object
      */
     public Observable<List<String>> getStringValidAsync() {
-        return getStringValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
+        return getStringValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
             @Override
             public List<String> call(ServiceResponse<List<String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1909,7 +1903,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    public Observable<ServiceResponse<List<String>>> getStringValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<String>>> getStringValidWithServiceResponseAsync() {
         return service.getStringValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<String>>>>() {
                 @Override
@@ -1938,10 +1932,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putStringValid(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putStringValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putStringValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1952,7 +1945,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putStringValidAsync(List<String> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putStringValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putStringValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -1962,12 +1955,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putStringValidAsync(List<String> arrayBody) {
-        return putStringValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putStringValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1976,7 +1969,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putStringValidAsyncWithServiceResponse(List<String> arrayBody) {
+    public Observable<ServiceResponse<Void>> putStringValidWithServiceResponseAsync(List<String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2007,10 +2000,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;String&gt; object if successful.
      */
     public List<String> getStringWithNull() throws ErrorException, IOException {
-        return getStringWithNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getStringWithNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2020,7 +2013,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<String>> getStringWithNullAsync(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceCall.create(getStringWithNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getStringWithNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2029,12 +2022,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;String&gt; object
      */
     public Observable<List<String>> getStringWithNullAsync() {
-        return getStringWithNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
+        return getStringWithNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
             @Override
             public List<String> call(ServiceResponse<List<String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2042,7 +2035,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    public Observable<ServiceResponse<List<String>>> getStringWithNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<String>>> getStringWithNullWithServiceResponseAsync() {
         return service.getStringWithNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<String>>>>() {
                 @Override
@@ -2069,10 +2062,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;String&gt; object if successful.
      */
     public List<String> getStringWithInvalid() throws ErrorException, IOException {
-        return getStringWithInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getStringWithInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2082,7 +2075,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<String>> getStringWithInvalidAsync(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceCall.create(getStringWithInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getStringWithInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2091,12 +2084,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;String&gt; object
      */
     public Observable<List<String>> getStringWithInvalidAsync() {
-        return getStringWithInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
+        return getStringWithInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
             @Override
             public List<String> call(ServiceResponse<List<String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2104,7 +2097,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    public Observable<ServiceResponse<List<String>>> getStringWithInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<String>>> getStringWithInvalidWithServiceResponseAsync() {
         return service.getStringWithInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<String>>>>() {
                 @Override
@@ -2131,10 +2124,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;UUID&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;UUID&gt; object if successful.
      */
     public List<UUID> getUuidValid() throws ErrorException, IOException {
-        return getUuidValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUuidValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2144,7 +2137,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<UUID>> getUuidValidAsync(final ServiceCallback<List<UUID>> serviceCallback) {
-        return ServiceCall.create(getUuidValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUuidValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2153,12 +2146,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;UUID&gt; object
      */
     public Observable<List<UUID>> getUuidValidAsync() {
-        return getUuidValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<UUID>>, List<UUID>>() {
+        return getUuidValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<UUID>>, List<UUID>>() {
             @Override
             public List<UUID> call(ServiceResponse<List<UUID>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2166,7 +2159,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;UUID&gt; object
      */
-    public Observable<ServiceResponse<List<UUID>>> getUuidValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<UUID>>> getUuidValidWithServiceResponseAsync() {
         return service.getUuidValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<UUID>>>>() {
                 @Override
@@ -2195,10 +2188,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putUuidValid(List<UUID> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putUuidValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putUuidValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2209,7 +2201,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUuidValidAsync(List<UUID> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUuidValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putUuidValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -2219,12 +2211,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putUuidValidAsync(List<UUID> arrayBody) {
-        return putUuidValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putUuidValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2233,7 +2225,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;UUID&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUuidValidAsyncWithServiceResponse(List<UUID> arrayBody) {
+    public Observable<ServiceResponse<Void>> putUuidValidWithServiceResponseAsync(List<UUID> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2264,10 +2256,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;UUID&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;UUID&gt; object if successful.
      */
     public List<UUID> getUuidInvalidChars() throws ErrorException, IOException {
-        return getUuidInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUuidInvalidCharsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2277,7 +2269,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<UUID>> getUuidInvalidCharsAsync(final ServiceCallback<List<UUID>> serviceCallback) {
-        return ServiceCall.create(getUuidInvalidCharsAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUuidInvalidCharsWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2286,12 +2278,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;UUID&gt; object
      */
     public Observable<List<UUID>> getUuidInvalidCharsAsync() {
-        return getUuidInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<UUID>>, List<UUID>>() {
+        return getUuidInvalidCharsWithServiceResponseAsync().map(new Func1<ServiceResponse<List<UUID>>, List<UUID>>() {
             @Override
             public List<UUID> call(ServiceResponse<List<UUID>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2299,7 +2291,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;UUID&gt; object
      */
-    public Observable<ServiceResponse<List<UUID>>> getUuidInvalidCharsAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<UUID>>> getUuidInvalidCharsWithServiceResponseAsync() {
         return service.getUuidInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<UUID>>>>() {
                 @Override
@@ -2326,10 +2318,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;LocalDate&gt; object if successful.
      */
     public List<LocalDate> getDateValid() throws ErrorException, IOException {
-        return getDateValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2339,7 +2331,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<LocalDate>> getDateValidAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2348,12 +2340,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;LocalDate&gt; object
      */
     public Observable<List<LocalDate>> getDateValidAsync() {
-        return getDateValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
+        return getDateValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
             @Override
             public List<LocalDate> call(ServiceResponse<List<LocalDate>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2361,7 +2353,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    public Observable<ServiceResponse<List<LocalDate>>> getDateValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<LocalDate>>> getDateValidWithServiceResponseAsync() {
         return service.getDateValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<LocalDate>>>>() {
                 @Override
@@ -2390,10 +2382,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDateValid(List<LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDateValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2404,7 +2395,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateValidAsync(List<LocalDate> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -2414,12 +2405,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateValidAsync(List<LocalDate> arrayBody) {
-        return putDateValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2428,7 +2419,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;LocalDate&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateValidAsyncWithServiceResponse(List<LocalDate> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDateValidWithServiceResponseAsync(List<LocalDate> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2459,10 +2450,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;LocalDate&gt; object if successful.
      */
     public List<LocalDate> getDateInvalidNull() throws ErrorException, IOException {
-        return getDateInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2472,7 +2463,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<LocalDate>> getDateInvalidNullAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2481,12 +2472,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;LocalDate&gt; object
      */
     public Observable<List<LocalDate>> getDateInvalidNullAsync() {
-        return getDateInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
+        return getDateInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
             @Override
             public List<LocalDate> call(ServiceResponse<List<LocalDate>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2494,7 +2485,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    public Observable<ServiceResponse<List<LocalDate>>> getDateInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<LocalDate>>> getDateInvalidNullWithServiceResponseAsync() {
         return service.getDateInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<LocalDate>>>>() {
                 @Override
@@ -2521,10 +2512,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;LocalDate&gt; object if successful.
      */
     public List<LocalDate> getDateInvalidChars() throws ErrorException, IOException {
-        return getDateInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateInvalidCharsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2534,7 +2525,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<LocalDate>> getDateInvalidCharsAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateInvalidCharsAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateInvalidCharsWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2543,12 +2534,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;LocalDate&gt; object
      */
     public Observable<List<LocalDate>> getDateInvalidCharsAsync() {
-        return getDateInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
+        return getDateInvalidCharsWithServiceResponseAsync().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
             @Override
             public List<LocalDate> call(ServiceResponse<List<LocalDate>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2556,7 +2547,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    public Observable<ServiceResponse<List<LocalDate>>> getDateInvalidCharsAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<LocalDate>>> getDateInvalidCharsWithServiceResponseAsync() {
         return service.getDateInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<LocalDate>>>>() {
                 @Override
@@ -2583,10 +2574,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;DateTime&gt; object if successful.
      */
     public List<DateTime> getDateTimeValid() throws ErrorException, IOException {
-        return getDateTimeValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2596,7 +2587,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<DateTime>> getDateTimeValidAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2605,12 +2596,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;DateTime&gt; object
      */
     public Observable<List<DateTime>> getDateTimeValidAsync() {
-        return getDateTimeValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
+        return getDateTimeValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
             @Override
             public List<DateTime> call(ServiceResponse<List<DateTime>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2618,7 +2609,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    public Observable<ServiceResponse<List<DateTime>>> getDateTimeValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<DateTime>>> getDateTimeValidWithServiceResponseAsync() {
         return service.getDateTimeValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<DateTime>>>>() {
                 @Override
@@ -2647,10 +2638,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDateTimeValid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateTimeValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDateTimeValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2661,7 +2651,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeValidAsync(List<DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateTimeValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -2671,12 +2661,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateTimeValidAsync(List<DateTime> arrayBody) {
-        return putDateTimeValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateTimeValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2685,7 +2675,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;DateTime&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeValidAsyncWithServiceResponse(List<DateTime> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDateTimeValidWithServiceResponseAsync(List<DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2716,10 +2706,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;DateTime&gt; object if successful.
      */
     public List<DateTime> getDateTimeInvalidNull() throws ErrorException, IOException {
-        return getDateTimeInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2729,7 +2719,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<DateTime>> getDateTimeInvalidNullAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2738,12 +2728,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;DateTime&gt; object
      */
     public Observable<List<DateTime>> getDateTimeInvalidNullAsync() {
-        return getDateTimeInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
+        return getDateTimeInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
             @Override
             public List<DateTime> call(ServiceResponse<List<DateTime>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2751,7 +2741,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    public Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidNullWithServiceResponseAsync() {
         return service.getDateTimeInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<DateTime>>>>() {
                 @Override
@@ -2778,10 +2768,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;DateTime&gt; object if successful.
      */
     public List<DateTime> getDateTimeInvalidChars() throws ErrorException, IOException {
-        return getDateTimeInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeInvalidCharsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2791,7 +2781,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<DateTime>> getDateTimeInvalidCharsAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeInvalidCharsAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeInvalidCharsWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2800,12 +2790,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;DateTime&gt; object
      */
     public Observable<List<DateTime>> getDateTimeInvalidCharsAsync() {
-        return getDateTimeInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
+        return getDateTimeInvalidCharsWithServiceResponseAsync().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
             @Override
             public List<DateTime> call(ServiceResponse<List<DateTime>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2813,7 +2803,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    public Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidCharsAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidCharsWithServiceResponseAsync() {
         return service.getDateTimeInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<DateTime>>>>() {
                 @Override
@@ -2840,10 +2830,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;DateTime&gt; object if successful.
      */
     public List<DateTime> getDateTimeRfc1123Valid() throws ErrorException, IOException {
-        return getDateTimeRfc1123ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeRfc1123ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2853,7 +2843,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<DateTime>> getDateTimeRfc1123ValidAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeRfc1123ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeRfc1123ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2862,12 +2852,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;DateTime&gt; object
      */
     public Observable<List<DateTime>> getDateTimeRfc1123ValidAsync() {
-        return getDateTimeRfc1123ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
+        return getDateTimeRfc1123ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
             @Override
             public List<DateTime> call(ServiceResponse<List<DateTime>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2875,7 +2865,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    public Observable<ServiceResponse<List<DateTime>>> getDateTimeRfc1123ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<DateTime>>> getDateTimeRfc1123ValidWithServiceResponseAsync() {
         return service.getDateTimeRfc1123Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<DateTime>>>>() {
                 @Override
@@ -2914,10 +2904,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDateTimeRfc1123Valid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDateTimeRfc1123ValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2928,7 +2917,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateTimeRfc1123ValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -2938,12 +2927,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody) {
-        return putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateTimeRfc1123ValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2952,7 +2941,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsyncWithServiceResponse(List<DateTime> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidWithServiceResponseAsync(List<DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2988,10 +2977,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Period&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Period&gt; object if successful.
      */
     public List<Period> getDurationValid() throws ErrorException, IOException {
-        return getDurationValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDurationValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3001,7 +2990,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Period>> getDurationValidAsync(final ServiceCallback<List<Period>> serviceCallback) {
-        return ServiceCall.create(getDurationValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDurationValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3010,12 +2999,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Period&gt; object
      */
     public Observable<List<Period>> getDurationValidAsync() {
-        return getDurationValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Period>>, List<Period>>() {
+        return getDurationValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Period>>, List<Period>>() {
             @Override
             public List<Period> call(ServiceResponse<List<Period>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3023,7 +3012,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Period&gt; object
      */
-    public Observable<ServiceResponse<List<Period>>> getDurationValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Period>>> getDurationValidWithServiceResponseAsync() {
         return service.getDurationValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Period>>>>() {
                 @Override
@@ -3052,10 +3041,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDurationValid(List<Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDurationValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDurationValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3066,7 +3054,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDurationValidAsync(List<Period> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDurationValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDurationValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -3076,12 +3064,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDurationValidAsync(List<Period> arrayBody) {
-        return putDurationValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDurationValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3090,7 +3078,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Period&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDurationValidAsyncWithServiceResponse(List<Period> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDurationValidWithServiceResponseAsync(List<Period> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3121,10 +3109,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;byte[]&gt; object if successful.
      */
     public List<byte[]> getByteValid() throws ErrorException, IOException {
-        return getByteValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getByteValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3134,7 +3122,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<byte[]>> getByteValidAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
-        return ServiceCall.create(getByteValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getByteValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3143,12 +3131,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;byte[]&gt; object
      */
     public Observable<List<byte[]>> getByteValidAsync() {
-        return getByteValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
+        return getByteValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
             @Override
             public List<byte[]> call(ServiceResponse<List<byte[]>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3156,7 +3144,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    public Observable<ServiceResponse<List<byte[]>>> getByteValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<byte[]>>> getByteValidWithServiceResponseAsync() {
         return service.getByteValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<byte[]>>>>() {
                 @Override
@@ -3185,10 +3173,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putByteValid(List<byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putByteValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putByteValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3199,7 +3186,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putByteValidAsync(List<byte[]> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putByteValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putByteValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -3209,12 +3196,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putByteValidAsync(List<byte[]> arrayBody) {
-        return putByteValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putByteValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3223,7 +3210,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;byte[]&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putByteValidAsyncWithServiceResponse(List<byte[]> arrayBody) {
+    public Observable<ServiceResponse<Void>> putByteValidWithServiceResponseAsync(List<byte[]> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3254,10 +3241,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;byte[]&gt; object if successful.
      */
     public List<byte[]> getByteInvalidNull() throws ErrorException, IOException {
-        return getByteInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getByteInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3267,7 +3254,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<byte[]>> getByteInvalidNullAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
-        return ServiceCall.create(getByteInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getByteInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3276,12 +3263,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;byte[]&gt; object
      */
     public Observable<List<byte[]>> getByteInvalidNullAsync() {
-        return getByteInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
+        return getByteInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
             @Override
             public List<byte[]> call(ServiceResponse<List<byte[]>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3289,7 +3276,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    public Observable<ServiceResponse<List<byte[]>>> getByteInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<byte[]>>> getByteInvalidNullWithServiceResponseAsync() {
         return service.getByteInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<byte[]>>>>() {
                 @Override
@@ -3316,10 +3303,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;byte[]&gt; object if successful.
      */
     public List<byte[]> getBase64Url() throws ErrorException, IOException {
-        return getBase64UrlAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBase64UrlWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3329,7 +3316,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<byte[]>> getBase64UrlAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
-        return ServiceCall.create(getBase64UrlAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBase64UrlWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3338,12 +3325,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;byte[]&gt; object
      */
     public Observable<List<byte[]>> getBase64UrlAsync() {
-        return getBase64UrlAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
+        return getBase64UrlWithServiceResponseAsync().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
             @Override
             public List<byte[]> call(ServiceResponse<List<byte[]>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3351,7 +3338,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    public Observable<ServiceResponse<List<byte[]>>> getBase64UrlAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<byte[]>>> getBase64UrlWithServiceResponseAsync() {
         return service.getBase64Url()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<byte[]>>>>() {
                 @Override
@@ -3388,10 +3375,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     public List<Product> getComplexNull() throws ErrorException, IOException {
-        return getComplexNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3401,7 +3388,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexNullAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3410,12 +3397,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     public Observable<List<Product>> getComplexNullAsync() {
-        return getComplexNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+        return getComplexNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
             @Override
             public List<Product> call(ServiceResponse<List<Product>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3423,7 +3410,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Product>>> getComplexNullWithServiceResponseAsync() {
         return service.getComplexNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -3450,10 +3437,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     public List<Product> getComplexEmpty() throws ErrorException, IOException {
-        return getComplexEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3463,7 +3450,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexEmptyAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3472,12 +3459,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     public Observable<List<Product>> getComplexEmptyAsync() {
-        return getComplexEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+        return getComplexEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
             @Override
             public List<Product> call(ServiceResponse<List<Product>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3485,7 +3472,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Product>>> getComplexEmptyWithServiceResponseAsync() {
         return service.getComplexEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -3512,10 +3499,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     public List<Product> getComplexItemNull() throws ErrorException, IOException {
-        return getComplexItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexItemNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3525,7 +3512,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexItemNullAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexItemNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexItemNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3534,12 +3521,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     public Observable<List<Product>> getComplexItemNullAsync() {
-        return getComplexItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+        return getComplexItemNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
             @Override
             public List<Product> call(ServiceResponse<List<Product>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3547,7 +3534,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexItemNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Product>>> getComplexItemNullWithServiceResponseAsync() {
         return service.getComplexItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -3574,10 +3561,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     public List<Product> getComplexItemEmpty() throws ErrorException, IOException {
-        return getComplexItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexItemEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3587,7 +3574,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexItemEmptyAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexItemEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexItemEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3596,12 +3583,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     public Observable<List<Product>> getComplexItemEmptyAsync() {
-        return getComplexItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+        return getComplexItemEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
             @Override
             public List<Product> call(ServiceResponse<List<Product>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3609,7 +3596,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexItemEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Product>>> getComplexItemEmptyWithServiceResponseAsync() {
         return service.getComplexItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -3636,10 +3623,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Product&gt; object if successful.
      */
     public List<Product> getComplexValid() throws ErrorException, IOException {
-        return getComplexValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3649,7 +3636,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexValidAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3658,12 +3645,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     public Observable<List<Product>> getComplexValidAsync() {
-        return getComplexValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+        return getComplexValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
             @Override
             public List<Product> call(ServiceResponse<List<Product>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3671,7 +3658,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Product>>> getComplexValidWithServiceResponseAsync() {
         return service.getComplexValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -3700,10 +3687,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putComplexValid(List<Product> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putComplexValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putComplexValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3714,7 +3700,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putComplexValidAsync(List<Product> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putComplexValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putComplexValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -3724,12 +3710,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putComplexValidAsync(List<Product> arrayBody) {
-        return putComplexValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putComplexValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3738,7 +3724,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Product&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putComplexValidAsyncWithServiceResponse(List<Product> arrayBody) {
+    public Observable<ServiceResponse<Void>> putComplexValidWithServiceResponseAsync(List<Product> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3769,10 +3755,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     public List<List<String>> getArrayNull() throws ErrorException, IOException {
-        return getArrayNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3782,7 +3768,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayNullAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3791,12 +3777,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     public Observable<List<List<String>>> getArrayNullAsync() {
-        return getArrayNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+        return getArrayNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
             @Override
             public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3804,7 +3790,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<List<String>>>> getArrayNullWithServiceResponseAsync() {
         return service.getArrayNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -3831,10 +3817,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     public List<List<String>> getArrayEmpty() throws ErrorException, IOException {
-        return getArrayEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3844,7 +3830,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayEmptyAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3853,12 +3839,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     public Observable<List<List<String>>> getArrayEmptyAsync() {
-        return getArrayEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+        return getArrayEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
             @Override
             public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3866,7 +3852,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<List<String>>>> getArrayEmptyWithServiceResponseAsync() {
         return service.getArrayEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -3893,10 +3879,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     public List<List<String>> getArrayItemNull() throws ErrorException, IOException {
-        return getArrayItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayItemNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3906,7 +3892,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayItemNullAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayItemNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayItemNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3915,12 +3901,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     public Observable<List<List<String>>> getArrayItemNullAsync() {
-        return getArrayItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+        return getArrayItemNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
             @Override
             public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3928,7 +3914,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayItemNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<List<String>>>> getArrayItemNullWithServiceResponseAsync() {
         return service.getArrayItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -3955,10 +3941,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     public List<List<String>> getArrayItemEmpty() throws ErrorException, IOException {
-        return getArrayItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayItemEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3968,7 +3954,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayItemEmptyAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayItemEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayItemEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3977,12 +3963,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     public Observable<List<List<String>>> getArrayItemEmptyAsync() {
-        return getArrayItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+        return getArrayItemEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
             @Override
             public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3990,7 +3976,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayItemEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<List<String>>>> getArrayItemEmptyWithServiceResponseAsync() {
         return service.getArrayItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -4017,10 +4003,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;List&lt;String&gt;&gt; object if successful.
      */
     public List<List<String>> getArrayValid() throws ErrorException, IOException {
-        return getArrayValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4030,7 +4016,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayValidAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4039,12 +4025,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     public Observable<List<List<String>>> getArrayValidAsync() {
-        return getArrayValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+        return getArrayValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
             @Override
             public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4052,7 +4038,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<List<String>>>> getArrayValidWithServiceResponseAsync() {
         return service.getArrayValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -4081,10 +4067,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putArrayValid(List<List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putArrayValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putArrayValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -4095,7 +4080,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayValidAsync(List<List<String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putArrayValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -4105,12 +4090,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putArrayValidAsync(List<List<String>> arrayBody) {
-        return putArrayValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putArrayValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4119,7 +4104,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayValidAsyncWithServiceResponse(List<List<String>> arrayBody) {
+    public Observable<ServiceResponse<Void>> putArrayValidWithServiceResponseAsync(List<List<String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -4150,10 +4135,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     public List<Map<String, String>> getDictionaryNull() throws ErrorException, IOException {
-        return getDictionaryNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4163,7 +4148,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryNullAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4172,12 +4157,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     public Observable<List<Map<String, String>>> getDictionaryNullAsync() {
-        return getDictionaryNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+        return getDictionaryNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
             @Override
             public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4185,7 +4170,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryNullWithServiceResponseAsync() {
         return service.getDictionaryNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -4212,10 +4197,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     public List<Map<String, String>> getDictionaryEmpty() throws ErrorException, IOException {
-        return getDictionaryEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4225,7 +4210,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryEmptyAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4234,12 +4219,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     public Observable<List<Map<String, String>>> getDictionaryEmptyAsync() {
-        return getDictionaryEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+        return getDictionaryEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
             @Override
             public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4247,7 +4232,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryEmptyWithServiceResponseAsync() {
         return service.getDictionaryEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -4274,10 +4259,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     public List<Map<String, String>> getDictionaryItemNull() throws ErrorException, IOException {
-        return getDictionaryItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryItemNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4287,7 +4272,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryItemNullAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryItemNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryItemNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4296,12 +4281,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     public Observable<List<Map<String, String>>> getDictionaryItemNullAsync() {
-        return getDictionaryItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+        return getDictionaryItemNullWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
             @Override
             public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4309,7 +4294,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemNullWithServiceResponseAsync() {
         return service.getDictionaryItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -4336,10 +4321,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     public List<Map<String, String>> getDictionaryItemEmpty() throws ErrorException, IOException {
-        return getDictionaryItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryItemEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4349,7 +4334,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryItemEmptyAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryItemEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryItemEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4358,12 +4343,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     public Observable<List<Map<String, String>>> getDictionaryItemEmptyAsync() {
-        return getDictionaryItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+        return getDictionaryItemEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
             @Override
             public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4371,7 +4356,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemEmptyWithServiceResponseAsync() {
         return service.getDictionaryItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -4398,10 +4383,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;Map&lt;String, String&gt;&gt; object if successful.
      */
     public List<Map<String, String>> getDictionaryValid() throws ErrorException, IOException {
-        return getDictionaryValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4411,7 +4396,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryValidAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4420,12 +4405,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     public Observable<List<Map<String, String>>> getDictionaryValidAsync() {
-        return getDictionaryValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+        return getDictionaryValidWithServiceResponseAsync().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
             @Override
             public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4433,7 +4418,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryValidWithServiceResponseAsync() {
         return service.getDictionaryValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -4462,10 +4447,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDictionaryValid(List<Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDictionaryValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDictionaryValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -4476,7 +4460,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDictionaryValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -4486,12 +4470,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody) {
-        return putDictionaryValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDictionaryValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4500,7 +4484,7 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryValidAsyncWithServiceResponse(List<Map<String, String>> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDictionaryValidWithServiceResponseAsync(List<Map<String, String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyarray/implementation/ArraysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyarray/implementation/ArraysImpl.java
@@ -334,8 +334,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Integer>> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public List<Integer> getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -345,7 +345,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getNullAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -353,7 +353,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getNullAsync() {
+    public Observable<List<Integer>> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+            @Override
+            public List<Integer> call(ServiceResponse<List<Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null array value.
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    public Observable<ServiceResponse<List<Integer>>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -382,8 +396,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Integer>> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public List<Integer> getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -393,7 +407,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getInvalidAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -401,7 +415,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getInvalidAsync() {
+    public Observable<List<Integer>> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+            @Override
+            public List<Integer> call(ServiceResponse<List<Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid array [1, 2, 3.
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    public Observable<ServiceResponse<List<Integer>>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -430,8 +458,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Integer>> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsync().toBlocking().single();
+    public List<Integer> getEmpty() throws ErrorException, IOException {
+        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -441,7 +469,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getEmptyAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -449,7 +477,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getEmptyAsync() {
+    public Observable<List<Integer>> getEmptyAsync() {
+        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+            @Override
+            public List<Integer> call(ServiceResponse<List<Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty array value [].
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    public Observable<ServiceResponse<List<Integer>>> getEmptyAsyncWithServiceResponse() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -480,8 +522,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putEmpty(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putEmptyAsync(arrayBody).toBlocking().single();
+    public void putEmpty(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putEmptyAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -492,7 +534,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(List<String> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putEmptyAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -501,7 +543,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsync(List<String> arrayBody) {
+    public Observable<Void> putEmptyAsync(List<String> arrayBody) {
+        return putEmptyAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value empty [].
+     *
+     * @param arrayBody the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(List<String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -534,8 +591,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Boolean>> getBooleanTfft() throws ErrorException, IOException {
-        return getBooleanTfftAsync().toBlocking().single();
+    public List<Boolean> getBooleanTfft() throws ErrorException, IOException {
+        return getBooleanTfftAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -545,7 +602,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Boolean>> getBooleanTfftAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanTfftAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanTfftAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -553,7 +610,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    public Observable<ServiceResponse<List<Boolean>>> getBooleanTfftAsync() {
+    public Observable<List<Boolean>> getBooleanTfftAsync() {
+        return getBooleanTfftAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
+            @Override
+            public List<Boolean> call(ServiceResponse<List<Boolean>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean array value [true, false, false, true].
+     *
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    public Observable<ServiceResponse<List<Boolean>>> getBooleanTfftAsyncWithServiceResponse() {
         return service.getBooleanTfft()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Boolean>>>>() {
                 @Override
@@ -584,8 +655,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBooleanTfft(List<Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putBooleanTfftAsync(arrayBody).toBlocking().single();
+    public void putBooleanTfft(List<Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putBooleanTfftAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -596,7 +667,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBooleanTfftAsync(List<Boolean> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBooleanTfftAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putBooleanTfftAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -605,7 +676,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Boolean&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBooleanTfftAsync(List<Boolean> arrayBody) {
+    public Observable<Void> putBooleanTfftAsync(List<Boolean> arrayBody) {
+        return putBooleanTfftAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value empty [true, false, false, true].
+     *
+     * @param arrayBody the List&lt;Boolean&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBooleanTfftAsyncWithServiceResponse(List<Boolean> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -638,8 +724,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Boolean>> getBooleanInvalidNull() throws ErrorException, IOException {
-        return getBooleanInvalidNullAsync().toBlocking().single();
+    public List<Boolean> getBooleanInvalidNull() throws ErrorException, IOException {
+        return getBooleanInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -649,7 +735,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Boolean>> getBooleanInvalidNullAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -657,7 +743,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    public Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidNullAsync() {
+    public Observable<List<Boolean>> getBooleanInvalidNullAsync() {
+        return getBooleanInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
+            @Override
+            public List<Boolean> call(ServiceResponse<List<Boolean>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean array value [true, null, false].
+     *
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    public Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidNullAsyncWithServiceResponse() {
         return service.getBooleanInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Boolean>>>>() {
                 @Override
@@ -686,8 +786,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Boolean>> getBooleanInvalidString() throws ErrorException, IOException {
-        return getBooleanInvalidStringAsync().toBlocking().single();
+    public List<Boolean> getBooleanInvalidString() throws ErrorException, IOException {
+        return getBooleanInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -697,7 +797,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Boolean>> getBooleanInvalidStringAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -705,7 +805,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Boolean&gt; object
      */
-    public Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidStringAsync() {
+    public Observable<List<Boolean>> getBooleanInvalidStringAsync() {
+        return getBooleanInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Boolean>>, List<Boolean>>() {
+            @Override
+            public List<Boolean> call(ServiceResponse<List<Boolean>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean array value [true, 'boolean', false].
+     *
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    public Observable<ServiceResponse<List<Boolean>>> getBooleanInvalidStringAsyncWithServiceResponse() {
         return service.getBooleanInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Boolean>>>>() {
                 @Override
@@ -734,8 +848,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Integer>> getIntegerValid() throws ErrorException, IOException {
-        return getIntegerValidAsync().toBlocking().single();
+    public List<Integer> getIntegerValid() throws ErrorException, IOException {
+        return getIntegerValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -745,7 +859,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getIntegerValidAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getIntegerValidAsync(), serviceCallback);
+        return ServiceCall.create(getIntegerValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -753,7 +867,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getIntegerValidAsync() {
+    public Observable<List<Integer>> getIntegerValidAsync() {
+        return getIntegerValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+            @Override
+            public List<Integer> call(ServiceResponse<List<Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    public Observable<ServiceResponse<List<Integer>>> getIntegerValidAsyncWithServiceResponse() {
         return service.getIntegerValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -784,8 +912,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putIntegerValid(List<Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putIntegerValidAsync(arrayBody).toBlocking().single();
+    public void putIntegerValid(List<Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putIntegerValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -796,7 +924,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putIntegerValidAsync(List<Integer> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putIntegerValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putIntegerValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -805,7 +933,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Integer&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putIntegerValidAsync(List<Integer> arrayBody) {
+    public Observable<Void> putIntegerValidAsync(List<Integer> arrayBody) {
+        return putIntegerValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody the List&lt;Integer&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putIntegerValidAsyncWithServiceResponse(List<Integer> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -838,8 +981,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Integer>> getIntInvalidNull() throws ErrorException, IOException {
-        return getIntInvalidNullAsync().toBlocking().single();
+    public List<Integer> getIntInvalidNull() throws ErrorException, IOException {
+        return getIntInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -849,7 +992,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getIntInvalidNullAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getIntInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getIntInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -857,7 +1000,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getIntInvalidNullAsync() {
+    public Observable<List<Integer>> getIntInvalidNullAsync() {
+        return getIntInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+            @Override
+            public List<Integer> call(ServiceResponse<List<Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer array value [1, null, 0].
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    public Observable<ServiceResponse<List<Integer>>> getIntInvalidNullAsyncWithServiceResponse() {
         return service.getIntInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -886,8 +1043,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Integer>> getIntInvalidString() throws ErrorException, IOException {
-        return getIntInvalidStringAsync().toBlocking().single();
+    public List<Integer> getIntInvalidString() throws ErrorException, IOException {
+        return getIntInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -897,7 +1054,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Integer>> getIntInvalidStringAsync(final ServiceCallback<List<Integer>> serviceCallback) {
-        return ServiceCall.create(getIntInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getIntInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -905,7 +1062,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Integer&gt; object
      */
-    public Observable<ServiceResponse<List<Integer>>> getIntInvalidStringAsync() {
+    public Observable<List<Integer>> getIntInvalidStringAsync() {
+        return getIntInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Integer>>, List<Integer>>() {
+            @Override
+            public List<Integer> call(ServiceResponse<List<Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer array value [1, 'integer', 0].
+     *
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    public Observable<ServiceResponse<List<Integer>>> getIntInvalidStringAsyncWithServiceResponse() {
         return service.getIntInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Integer>>>>() {
                 @Override
@@ -934,8 +1105,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Long>> getLongValid() throws ErrorException, IOException {
-        return getLongValidAsync().toBlocking().single();
+    public List<Long> getLongValid() throws ErrorException, IOException {
+        return getLongValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -945,7 +1116,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Long>> getLongValidAsync(final ServiceCallback<List<Long>> serviceCallback) {
-        return ServiceCall.create(getLongValidAsync(), serviceCallback);
+        return ServiceCall.create(getLongValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -953,7 +1124,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    public Observable<ServiceResponse<List<Long>>> getLongValidAsync() {
+    public Observable<List<Long>> getLongValidAsync() {
+        return getLongValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
+            @Override
+            public List<Long> call(ServiceResponse<List<Long>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    public Observable<ServiceResponse<List<Long>>> getLongValidAsyncWithServiceResponse() {
         return service.getLongValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Long>>>>() {
                 @Override
@@ -984,8 +1169,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putLongValid(List<Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putLongValidAsync(arrayBody).toBlocking().single();
+    public void putLongValid(List<Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putLongValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -996,7 +1181,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLongValidAsync(List<Long> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLongValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putLongValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1005,7 +1190,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Long&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLongValidAsync(List<Long> arrayBody) {
+    public Observable<Void> putLongValidAsync(List<Long> arrayBody) {
+        return putLongValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody the List&lt;Long&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putLongValidAsyncWithServiceResponse(List<Long> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1038,8 +1238,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Long>> getLongInvalidNull() throws ErrorException, IOException {
-        return getLongInvalidNullAsync().toBlocking().single();
+    public List<Long> getLongInvalidNull() throws ErrorException, IOException {
+        return getLongInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1049,7 +1249,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Long>> getLongInvalidNullAsync(final ServiceCallback<List<Long>> serviceCallback) {
-        return ServiceCall.create(getLongInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getLongInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1057,7 +1257,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    public Observable<ServiceResponse<List<Long>>> getLongInvalidNullAsync() {
+    public Observable<List<Long>> getLongInvalidNullAsync() {
+        return getLongInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
+            @Override
+            public List<Long> call(ServiceResponse<List<Long>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get long array value [1, null, 0].
+     *
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    public Observable<ServiceResponse<List<Long>>> getLongInvalidNullAsyncWithServiceResponse() {
         return service.getLongInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Long>>>>() {
                 @Override
@@ -1086,8 +1300,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Long>> getLongInvalidString() throws ErrorException, IOException {
-        return getLongInvalidStringAsync().toBlocking().single();
+    public List<Long> getLongInvalidString() throws ErrorException, IOException {
+        return getLongInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1097,7 +1311,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Long>> getLongInvalidStringAsync(final ServiceCallback<List<Long>> serviceCallback) {
-        return ServiceCall.create(getLongInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getLongInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1105,7 +1319,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Long&gt; object
      */
-    public Observable<ServiceResponse<List<Long>>> getLongInvalidStringAsync() {
+    public Observable<List<Long>> getLongInvalidStringAsync() {
+        return getLongInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Long>>, List<Long>>() {
+            @Override
+            public List<Long> call(ServiceResponse<List<Long>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get long array value [1, 'integer', 0].
+     *
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    public Observable<ServiceResponse<List<Long>>> getLongInvalidStringAsyncWithServiceResponse() {
         return service.getLongInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Long>>>>() {
                 @Override
@@ -1134,8 +1362,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Double>> getFloatValid() throws ErrorException, IOException {
-        return getFloatValidAsync().toBlocking().single();
+    public List<Double> getFloatValid() throws ErrorException, IOException {
+        return getFloatValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1145,7 +1373,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getFloatValidAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getFloatValidAsync(), serviceCallback);
+        return ServiceCall.create(getFloatValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1153,7 +1381,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getFloatValidAsync() {
+    public Observable<List<Double>> getFloatValidAsync() {
+        return getFloatValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+            @Override
+            public List<Double> call(ServiceResponse<List<Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    public Observable<ServiceResponse<List<Double>>> getFloatValidAsyncWithServiceResponse() {
         return service.getFloatValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1184,8 +1426,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putFloatValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putFloatValidAsync(arrayBody).toBlocking().single();
+    public void putFloatValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putFloatValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1196,7 +1438,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putFloatValidAsync(List<Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putFloatValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putFloatValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1205,7 +1447,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putFloatValidAsync(List<Double> arrayBody) {
+    public Observable<Void> putFloatValidAsync(List<Double> arrayBody) {
+        return putFloatValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody the List&lt;Double&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putFloatValidAsyncWithServiceResponse(List<Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1238,8 +1495,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Double>> getFloatInvalidNull() throws ErrorException, IOException {
-        return getFloatInvalidNullAsync().toBlocking().single();
+    public List<Double> getFloatInvalidNull() throws ErrorException, IOException {
+        return getFloatInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1249,7 +1506,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getFloatInvalidNullAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getFloatInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getFloatInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1257,7 +1514,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getFloatInvalidNullAsync() {
+    public Observable<List<Double>> getFloatInvalidNullAsync() {
+        return getFloatInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+            @Override
+            public List<Double> call(ServiceResponse<List<Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    public Observable<ServiceResponse<List<Double>>> getFloatInvalidNullAsyncWithServiceResponse() {
         return service.getFloatInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1286,8 +1557,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Double>> getFloatInvalidString() throws ErrorException, IOException {
-        return getFloatInvalidStringAsync().toBlocking().single();
+    public List<Double> getFloatInvalidString() throws ErrorException, IOException {
+        return getFloatInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1297,7 +1568,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getFloatInvalidStringAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getFloatInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getFloatInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1305,7 +1576,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getFloatInvalidStringAsync() {
+    public Observable<List<Double>> getFloatInvalidStringAsync() {
+        return getFloatInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+            @Override
+            public List<Double> call(ServiceResponse<List<Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    public Observable<ServiceResponse<List<Double>>> getFloatInvalidStringAsyncWithServiceResponse() {
         return service.getFloatInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1334,8 +1619,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Double>> getDoubleValid() throws ErrorException, IOException {
-        return getDoubleValidAsync().toBlocking().single();
+    public List<Double> getDoubleValid() throws ErrorException, IOException {
+        return getDoubleValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1345,7 +1630,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getDoubleValidAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleValidAsync(), serviceCallback);
+        return ServiceCall.create(getDoubleValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1353,7 +1638,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getDoubleValidAsync() {
+    public Observable<List<Double>> getDoubleValidAsync() {
+        return getDoubleValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+            @Override
+            public List<Double> call(ServiceResponse<List<Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    public Observable<ServiceResponse<List<Double>>> getDoubleValidAsyncWithServiceResponse() {
         return service.getDoubleValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1384,8 +1683,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDoubleValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDoubleValidAsync(arrayBody).toBlocking().single();
+    public void putDoubleValid(List<Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDoubleValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1396,7 +1695,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDoubleValidAsync(List<Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDoubleValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDoubleValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1405,7 +1704,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDoubleValidAsync(List<Double> arrayBody) {
+    public Observable<Void> putDoubleValidAsync(List<Double> arrayBody) {
+        return putDoubleValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody the List&lt;Double&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDoubleValidAsyncWithServiceResponse(List<Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1438,8 +1752,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Double>> getDoubleInvalidNull() throws ErrorException, IOException {
-        return getDoubleInvalidNullAsync().toBlocking().single();
+    public List<Double> getDoubleInvalidNull() throws ErrorException, IOException {
+        return getDoubleInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1449,7 +1763,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getDoubleInvalidNullAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getDoubleInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1457,7 +1771,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getDoubleInvalidNullAsync() {
+    public Observable<List<Double>> getDoubleInvalidNullAsync() {
+        return getDoubleInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+            @Override
+            public List<Double> call(ServiceResponse<List<Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    public Observable<ServiceResponse<List<Double>>> getDoubleInvalidNullAsyncWithServiceResponse() {
         return service.getDoubleInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1486,8 +1814,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Double>> getDoubleInvalidString() throws ErrorException, IOException {
-        return getDoubleInvalidStringAsync().toBlocking().single();
+    public List<Double> getDoubleInvalidString() throws ErrorException, IOException {
+        return getDoubleInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1497,7 +1825,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Double>> getDoubleInvalidStringAsync(final ServiceCallback<List<Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getDoubleInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1505,7 +1833,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Double&gt; object
      */
-    public Observable<ServiceResponse<List<Double>>> getDoubleInvalidStringAsync() {
+    public Observable<List<Double>> getDoubleInvalidStringAsync() {
+        return getDoubleInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Double>>, List<Double>>() {
+            @Override
+            public List<Double> call(ServiceResponse<List<Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    public Observable<ServiceResponse<List<Double>>> getDoubleInvalidStringAsyncWithServiceResponse() {
         return service.getDoubleInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Double>>>>() {
                 @Override
@@ -1534,8 +1876,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<String>> getStringValid() throws ErrorException, IOException {
-        return getStringValidAsync().toBlocking().single();
+    public List<String> getStringValid() throws ErrorException, IOException {
+        return getStringValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1545,7 +1887,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<String>> getStringValidAsync(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceCall.create(getStringValidAsync(), serviceCallback);
+        return ServiceCall.create(getStringValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1553,7 +1895,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    public Observable<ServiceResponse<List<String>>> getStringValidAsync() {
+    public Observable<List<String>> getStringValidAsync() {
+        return getStringValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
+            @Override
+            public List<String> call(ServiceResponse<List<String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get string array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @return the observable to the List&lt;String&gt; object
+     */
+    public Observable<ServiceResponse<List<String>>> getStringValidAsyncWithServiceResponse() {
         return service.getStringValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<String>>>>() {
                 @Override
@@ -1584,8 +1940,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putStringValid(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putStringValidAsync(arrayBody).toBlocking().single();
+    public void putStringValid(List<String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putStringValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1596,7 +1952,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putStringValidAsync(List<String> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putStringValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putStringValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1605,7 +1961,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putStringValidAsync(List<String> arrayBody) {
+    public Observable<Void> putStringValidAsync(List<String> arrayBody) {
+        return putStringValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putStringValidAsyncWithServiceResponse(List<String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1638,8 +2009,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<String>> getStringWithNull() throws ErrorException, IOException {
-        return getStringWithNullAsync().toBlocking().single();
+    public List<String> getStringWithNull() throws ErrorException, IOException {
+        return getStringWithNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1649,7 +2020,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<String>> getStringWithNullAsync(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceCall.create(getStringWithNullAsync(), serviceCallback);
+        return ServiceCall.create(getStringWithNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1657,7 +2028,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    public Observable<ServiceResponse<List<String>>> getStringWithNullAsync() {
+    public Observable<List<String>> getStringWithNullAsync() {
+        return getStringWithNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
+            @Override
+            public List<String> call(ServiceResponse<List<String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get string array value ['foo', null, 'foo2'].
+     *
+     * @return the observable to the List&lt;String&gt; object
+     */
+    public Observable<ServiceResponse<List<String>>> getStringWithNullAsyncWithServiceResponse() {
         return service.getStringWithNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<String>>>>() {
                 @Override
@@ -1686,8 +2071,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<String>> getStringWithInvalid() throws ErrorException, IOException {
-        return getStringWithInvalidAsync().toBlocking().single();
+    public List<String> getStringWithInvalid() throws ErrorException, IOException {
+        return getStringWithInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1697,7 +2082,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<String>> getStringWithInvalidAsync(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceCall.create(getStringWithInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getStringWithInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1705,7 +2090,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    public Observable<ServiceResponse<List<String>>> getStringWithInvalidAsync() {
+    public Observable<List<String>> getStringWithInvalidAsync() {
+        return getStringWithInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<String>>, List<String>>() {
+            @Override
+            public List<String> call(ServiceResponse<List<String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get string array value ['foo', 123, 'foo2'].
+     *
+     * @return the observable to the List&lt;String&gt; object
+     */
+    public Observable<ServiceResponse<List<String>>> getStringWithInvalidAsyncWithServiceResponse() {
         return service.getStringWithInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<String>>>>() {
                 @Override
@@ -1734,8 +2133,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;UUID&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<UUID>> getUuidValid() throws ErrorException, IOException {
-        return getUuidValidAsync().toBlocking().single();
+    public List<UUID> getUuidValid() throws ErrorException, IOException {
+        return getUuidValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1745,7 +2144,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<UUID>> getUuidValidAsync(final ServiceCallback<List<UUID>> serviceCallback) {
-        return ServiceCall.create(getUuidValidAsync(), serviceCallback);
+        return ServiceCall.create(getUuidValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1753,7 +2152,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;UUID&gt; object
      */
-    public Observable<ServiceResponse<List<UUID>>> getUuidValidAsync() {
+    public Observable<List<UUID>> getUuidValidAsync() {
+        return getUuidValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<UUID>>, List<UUID>>() {
+            @Override
+            public List<UUID> call(ServiceResponse<List<UUID>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @return the observable to the List&lt;UUID&gt; object
+     */
+    public Observable<ServiceResponse<List<UUID>>> getUuidValidAsyncWithServiceResponse() {
         return service.getUuidValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<UUID>>>>() {
                 @Override
@@ -1784,8 +2197,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putUuidValid(List<UUID> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putUuidValidAsync(arrayBody).toBlocking().single();
+    public void putUuidValid(List<UUID> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putUuidValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1796,7 +2209,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUuidValidAsync(List<UUID> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUuidValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putUuidValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1805,7 +2218,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;UUID&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUuidValidAsync(List<UUID> arrayBody) {
+    public Observable<Void> putUuidValidAsync(List<UUID> arrayBody) {
+        return putUuidValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @param arrayBody the List&lt;UUID&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putUuidValidAsyncWithServiceResponse(List<UUID> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1838,8 +2266,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;UUID&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<UUID>> getUuidInvalidChars() throws ErrorException, IOException {
-        return getUuidInvalidCharsAsync().toBlocking().single();
+    public List<UUID> getUuidInvalidChars() throws ErrorException, IOException {
+        return getUuidInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1849,7 +2277,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<UUID>> getUuidInvalidCharsAsync(final ServiceCallback<List<UUID>> serviceCallback) {
-        return ServiceCall.create(getUuidInvalidCharsAsync(), serviceCallback);
+        return ServiceCall.create(getUuidInvalidCharsAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1857,7 +2285,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;UUID&gt; object
      */
-    public Observable<ServiceResponse<List<UUID>>> getUuidInvalidCharsAsync() {
+    public Observable<List<UUID>> getUuidInvalidCharsAsync() {
+        return getUuidInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<UUID>>, List<UUID>>() {
+            @Override
+            public List<UUID> call(ServiceResponse<List<UUID>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
+     *
+     * @return the observable to the List&lt;UUID&gt; object
+     */
+    public Observable<ServiceResponse<List<UUID>>> getUuidInvalidCharsAsyncWithServiceResponse() {
         return service.getUuidInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<UUID>>>>() {
                 @Override
@@ -1886,8 +2328,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<LocalDate>> getDateValid() throws ErrorException, IOException {
-        return getDateValidAsync().toBlocking().single();
+    public List<LocalDate> getDateValid() throws ErrorException, IOException {
+        return getDateValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1897,7 +2339,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<LocalDate>> getDateValidAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateValidAsync(), serviceCallback);
+        return ServiceCall.create(getDateValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1905,7 +2347,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    public Observable<ServiceResponse<List<LocalDate>>> getDateValidAsync() {
+    public Observable<List<LocalDate>> getDateValidAsync() {
+        return getDateValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
+            @Override
+            public List<LocalDate> call(ServiceResponse<List<LocalDate>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    public Observable<ServiceResponse<List<LocalDate>>> getDateValidAsyncWithServiceResponse() {
         return service.getDateValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<LocalDate>>>>() {
                 @Override
@@ -1936,8 +2392,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDateValid(List<LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateValidAsync(arrayBody).toBlocking().single();
+    public void putDateValid(List<LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1948,7 +2404,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateValidAsync(List<LocalDate> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1957,7 +2413,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;LocalDate&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateValidAsync(List<LocalDate> arrayBody) {
+    public Observable<Void> putDateValidAsync(List<LocalDate> arrayBody) {
+        return putDateValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value  ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @param arrayBody the List&lt;LocalDate&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateValidAsyncWithServiceResponse(List<LocalDate> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1990,8 +2461,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<LocalDate>> getDateInvalidNull() throws ErrorException, IOException {
-        return getDateInvalidNullAsync().toBlocking().single();
+    public List<LocalDate> getDateInvalidNull() throws ErrorException, IOException {
+        return getDateInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2001,7 +2472,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<LocalDate>> getDateInvalidNullAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getDateInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2009,7 +2480,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    public Observable<ServiceResponse<List<LocalDate>>> getDateInvalidNullAsync() {
+    public Observable<List<LocalDate>> getDateInvalidNullAsync() {
+        return getDateInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
+            @Override
+            public List<LocalDate> call(ServiceResponse<List<LocalDate>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date array value ['2012-01-01', null, '1776-07-04'].
+     *
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    public Observable<ServiceResponse<List<LocalDate>>> getDateInvalidNullAsyncWithServiceResponse() {
         return service.getDateInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<LocalDate>>>>() {
                 @Override
@@ -2038,8 +2523,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<LocalDate>> getDateInvalidChars() throws ErrorException, IOException {
-        return getDateInvalidCharsAsync().toBlocking().single();
+    public List<LocalDate> getDateInvalidChars() throws ErrorException, IOException {
+        return getDateInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2049,7 +2534,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<LocalDate>> getDateInvalidCharsAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateInvalidCharsAsync(), serviceCallback);
+        return ServiceCall.create(getDateInvalidCharsAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2057,7 +2542,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;LocalDate&gt; object
      */
-    public Observable<ServiceResponse<List<LocalDate>>> getDateInvalidCharsAsync() {
+    public Observable<List<LocalDate>> getDateInvalidCharsAsync() {
+        return getDateInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<LocalDate>>, List<LocalDate>>() {
+            @Override
+            public List<LocalDate> call(ServiceResponse<List<LocalDate>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date array value ['2011-03-22', 'date'].
+     *
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    public Observable<ServiceResponse<List<LocalDate>>> getDateInvalidCharsAsyncWithServiceResponse() {
         return service.getDateInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<LocalDate>>>>() {
                 @Override
@@ -2086,8 +2585,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<DateTime>> getDateTimeValid() throws ErrorException, IOException {
-        return getDateTimeValidAsync().toBlocking().single();
+    public List<DateTime> getDateTimeValid() throws ErrorException, IOException {
+        return getDateTimeValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2097,7 +2596,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<DateTime>> getDateTimeValidAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeValidAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2105,7 +2604,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    public Observable<ServiceResponse<List<DateTime>>> getDateTimeValidAsync() {
+    public Observable<List<DateTime>> getDateTimeValidAsync() {
+        return getDateTimeValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
+            @Override
+            public List<DateTime> call(ServiceResponse<List<DateTime>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    public Observable<ServiceResponse<List<DateTime>>> getDateTimeValidAsyncWithServiceResponse() {
         return service.getDateTimeValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<DateTime>>>>() {
                 @Override
@@ -2136,8 +2649,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDateTimeValid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateTimeValidAsync(arrayBody).toBlocking().single();
+    public void putDateTimeValid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateTimeValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2148,7 +2661,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeValidAsync(List<DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateTimeValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2157,7 +2670,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;DateTime&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeValidAsync(List<DateTime> arrayBody) {
+    public Observable<Void> putDateTimeValidAsync(List<DateTime> arrayBody) {
+        return putDateTimeValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @param arrayBody the List&lt;DateTime&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateTimeValidAsyncWithServiceResponse(List<DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2190,8 +2718,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<DateTime>> getDateTimeInvalidNull() throws ErrorException, IOException {
-        return getDateTimeInvalidNullAsync().toBlocking().single();
+    public List<DateTime> getDateTimeInvalidNull() throws ErrorException, IOException {
+        return getDateTimeInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2201,7 +2729,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<DateTime>> getDateTimeInvalidNullAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2209,7 +2737,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    public Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidNullAsync() {
+    public Observable<List<DateTime>> getDateTimeInvalidNullAsync() {
+        return getDateTimeInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
+            @Override
+            public List<DateTime> call(ServiceResponse<List<DateTime>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', null].
+     *
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    public Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidNullAsyncWithServiceResponse() {
         return service.getDateTimeInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<DateTime>>>>() {
                 @Override
@@ -2238,8 +2780,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<DateTime>> getDateTimeInvalidChars() throws ErrorException, IOException {
-        return getDateTimeInvalidCharsAsync().toBlocking().single();
+    public List<DateTime> getDateTimeInvalidChars() throws ErrorException, IOException {
+        return getDateTimeInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2249,7 +2791,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<DateTime>> getDateTimeInvalidCharsAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeInvalidCharsAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeInvalidCharsAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2257,7 +2799,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    public Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidCharsAsync() {
+    public Observable<List<DateTime>> getDateTimeInvalidCharsAsync() {
+        return getDateTimeInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
+            @Override
+            public List<DateTime> call(ServiceResponse<List<DateTime>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
+     *
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    public Observable<ServiceResponse<List<DateTime>>> getDateTimeInvalidCharsAsyncWithServiceResponse() {
         return service.getDateTimeInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<DateTime>>>>() {
                 @Override
@@ -2286,8 +2842,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<DateTime>> getDateTimeRfc1123Valid() throws ErrorException, IOException {
-        return getDateTimeRfc1123ValidAsync().toBlocking().single();
+    public List<DateTime> getDateTimeRfc1123Valid() throws ErrorException, IOException {
+        return getDateTimeRfc1123ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2297,7 +2853,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<DateTime>> getDateTimeRfc1123ValidAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeRfc1123ValidAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeRfc1123ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2305,7 +2861,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;DateTime&gt; object
      */
-    public Observable<ServiceResponse<List<DateTime>>> getDateTimeRfc1123ValidAsync() {
+    public Observable<List<DateTime>> getDateTimeRfc1123ValidAsync() {
+        return getDateTimeRfc1123ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<DateTime>>, List<DateTime>>() {
+            @Override
+            public List<DateTime> call(ServiceResponse<List<DateTime>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
+     *
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    public Observable<ServiceResponse<List<DateTime>>> getDateTimeRfc1123ValidAsyncWithServiceResponse() {
         return service.getDateTimeRfc1123Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<DateTime>>>>() {
                 @Override
@@ -2346,8 +2916,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDateTimeRfc1123Valid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateTimeRfc1123ValidAsync(arrayBody).toBlocking().single();
+    public void putDateTimeRfc1123Valid(List<DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2358,7 +2928,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeRfc1123ValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2367,7 +2937,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody) {
+    public Observable<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody) {
+        return putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
+     *
+     * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsyncWithServiceResponse(List<DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2405,8 +2990,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Period&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Period>> getDurationValid() throws ErrorException, IOException {
-        return getDurationValidAsync().toBlocking().single();
+    public List<Period> getDurationValid() throws ErrorException, IOException {
+        return getDurationValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2416,7 +3001,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Period>> getDurationValidAsync(final ServiceCallback<List<Period>> serviceCallback) {
-        return ServiceCall.create(getDurationValidAsync(), serviceCallback);
+        return ServiceCall.create(getDurationValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2424,7 +3009,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Period&gt; object
      */
-    public Observable<ServiceResponse<List<Period>>> getDurationValidAsync() {
+    public Observable<List<Period>> getDurationValidAsync() {
+        return getDurationValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Period>>, List<Period>>() {
+            @Override
+            public List<Period> call(ServiceResponse<List<Period>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @return the observable to the List&lt;Period&gt; object
+     */
+    public Observable<ServiceResponse<List<Period>>> getDurationValidAsyncWithServiceResponse() {
         return service.getDurationValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Period>>>>() {
                 @Override
@@ -2455,8 +3054,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDurationValid(List<Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDurationValidAsync(arrayBody).toBlocking().single();
+    public void putDurationValid(List<Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDurationValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2467,7 +3066,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDurationValidAsync(List<Period> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDurationValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDurationValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2476,7 +3075,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Period&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDurationValidAsync(List<Period> arrayBody) {
+    public Observable<Void> putDurationValidAsync(List<Period> arrayBody) {
+        return putDurationValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @param arrayBody the List&lt;Period&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDurationValidAsyncWithServiceResponse(List<Period> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2509,8 +3123,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<byte[]>> getByteValid() throws ErrorException, IOException {
-        return getByteValidAsync().toBlocking().single();
+    public List<byte[]> getByteValid() throws ErrorException, IOException {
+        return getByteValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2520,7 +3134,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<byte[]>> getByteValidAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
-        return ServiceCall.create(getByteValidAsync(), serviceCallback);
+        return ServiceCall.create(getByteValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2528,7 +3142,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    public Observable<ServiceResponse<List<byte[]>>> getByteValidAsync() {
+    public Observable<List<byte[]>> getByteValidAsync() {
+        return getByteValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
+            @Override
+            public List<byte[]> call(ServiceResponse<List<byte[]>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
+     *
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    public Observable<ServiceResponse<List<byte[]>>> getByteValidAsyncWithServiceResponse() {
         return service.getByteValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<byte[]>>>>() {
                 @Override
@@ -2559,8 +3187,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putByteValid(List<byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putByteValidAsync(arrayBody).toBlocking().single();
+    public void putByteValid(List<byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putByteValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2571,7 +3199,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putByteValidAsync(List<byte[]> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putByteValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putByteValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2580,7 +3208,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;byte[]&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putByteValidAsync(List<byte[]> arrayBody) {
+    public Observable<Void> putByteValidAsync(List<byte[]> arrayBody) {
+        return putByteValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
+     *
+     * @param arrayBody the List&lt;byte[]&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putByteValidAsyncWithServiceResponse(List<byte[]> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2613,8 +3256,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<byte[]>> getByteInvalidNull() throws ErrorException, IOException {
-        return getByteInvalidNullAsync().toBlocking().single();
+    public List<byte[]> getByteInvalidNull() throws ErrorException, IOException {
+        return getByteInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2624,7 +3267,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<byte[]>> getByteInvalidNullAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
-        return ServiceCall.create(getByteInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getByteInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2632,7 +3275,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    public Observable<ServiceResponse<List<byte[]>>> getByteInvalidNullAsync() {
+    public Observable<List<byte[]>> getByteInvalidNullAsync() {
+        return getByteInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
+            @Override
+            public List<byte[]> call(ServiceResponse<List<byte[]>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
+     *
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    public Observable<ServiceResponse<List<byte[]>>> getByteInvalidNullAsyncWithServiceResponse() {
         return service.getByteInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<byte[]>>>>() {
                 @Override
@@ -2661,8 +3318,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<byte[]>> getBase64Url() throws ErrorException, IOException {
-        return getBase64UrlAsync().toBlocking().single();
+    public List<byte[]> getBase64Url() throws ErrorException, IOException {
+        return getBase64UrlAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2672,7 +3329,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<byte[]>> getBase64UrlAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
-        return ServiceCall.create(getBase64UrlAsync(), serviceCallback);
+        return ServiceCall.create(getBase64UrlAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2680,7 +3337,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;byte[]&gt; object
      */
-    public Observable<ServiceResponse<List<byte[]>>> getBase64UrlAsync() {
+    public Observable<List<byte[]>> getBase64UrlAsync() {
+        return getBase64UrlAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<byte[]>>, List<byte[]>>() {
+            @Override
+            public List<byte[]> call(ServiceResponse<List<byte[]>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded.
+     *
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    public Observable<ServiceResponse<List<byte[]>>> getBase64UrlAsyncWithServiceResponse() {
         return service.getBase64Url()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<byte[]>>>>() {
                 @Override
@@ -2719,8 +3390,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Product>> getComplexNull() throws ErrorException, IOException {
-        return getComplexNullAsync().toBlocking().single();
+    public List<Product> getComplexNull() throws ErrorException, IOException {
+        return getComplexNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2730,7 +3401,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexNullAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexNullAsync(), serviceCallback);
+        return ServiceCall.create(getComplexNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2738,7 +3409,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexNullAsync() {
+    public Observable<List<Product>> getComplexNullAsync() {
+        return getComplexNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+            @Override
+            public List<Product> call(ServiceResponse<List<Product>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get array of complex type null value.
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<List<Product>>> getComplexNullAsyncWithServiceResponse() {
         return service.getComplexNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -2767,8 +3452,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Product>> getComplexEmpty() throws ErrorException, IOException {
-        return getComplexEmptyAsync().toBlocking().single();
+    public List<Product> getComplexEmpty() throws ErrorException, IOException {
+        return getComplexEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2778,7 +3463,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexEmptyAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getComplexEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2786,7 +3471,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexEmptyAsync() {
+    public Observable<List<Product>> getComplexEmptyAsync() {
+        return getComplexEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+            @Override
+            public List<Product> call(ServiceResponse<List<Product>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty array of complex type [].
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<List<Product>>> getComplexEmptyAsyncWithServiceResponse() {
         return service.getComplexEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -2815,8 +3514,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Product>> getComplexItemNull() throws ErrorException, IOException {
-        return getComplexItemNullAsync().toBlocking().single();
+    public List<Product> getComplexItemNull() throws ErrorException, IOException {
+        return getComplexItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2826,7 +3525,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexItemNullAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexItemNullAsync(), serviceCallback);
+        return ServiceCall.create(getComplexItemNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2834,7 +3533,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexItemNullAsync() {
+    public Observable<List<Product>> getComplexItemNullAsync() {
+        return getComplexItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+            @Override
+            public List<Product> call(ServiceResponse<List<Product>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<List<Product>>> getComplexItemNullAsyncWithServiceResponse() {
         return service.getComplexItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -2863,8 +3576,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Product>> getComplexItemEmpty() throws ErrorException, IOException {
-        return getComplexItemEmptyAsync().toBlocking().single();
+    public List<Product> getComplexItemEmpty() throws ErrorException, IOException {
+        return getComplexItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2874,7 +3587,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexItemEmptyAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexItemEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getComplexItemEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2882,7 +3595,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexItemEmptyAsync() {
+    public Observable<List<Product>> getComplexItemEmptyAsync() {
+        return getComplexItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+            @Override
+            public List<Product> call(ServiceResponse<List<Product>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<List<Product>>> getComplexItemEmptyAsyncWithServiceResponse() {
         return service.getComplexItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -2911,8 +3638,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Product&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Product>> getComplexValid() throws ErrorException, IOException {
-        return getComplexValidAsync().toBlocking().single();
+    public List<Product> getComplexValid() throws ErrorException, IOException {
+        return getComplexValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2922,7 +3649,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Product>> getComplexValidAsync(final ServiceCallback<List<Product>> serviceCallback) {
-        return ServiceCall.create(getComplexValidAsync(), serviceCallback);
+        return ServiceCall.create(getComplexValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2930,7 +3657,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Product&gt; object
      */
-    public Observable<ServiceResponse<List<Product>>> getComplexValidAsync() {
+    public Observable<List<Product>> getComplexValidAsync() {
+        return getComplexValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Product>>, List<Product>>() {
+            @Override
+            public List<Product> call(ServiceResponse<List<Product>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
+     *
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    public Observable<ServiceResponse<List<Product>>> getComplexValidAsyncWithServiceResponse() {
         return service.getComplexValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Product>>>>() {
                 @Override
@@ -2961,8 +3702,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putComplexValid(List<Product> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putComplexValidAsync(arrayBody).toBlocking().single();
+    public void putComplexValid(List<Product> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putComplexValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2973,7 +3714,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putComplexValidAsync(List<Product> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putComplexValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putComplexValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2982,7 +3723,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Product&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putComplexValidAsync(List<Product> arrayBody) {
+    public Observable<Void> putComplexValidAsync(List<Product> arrayBody) {
+        return putComplexValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
+     *
+     * @param arrayBody the List&lt;Product&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putComplexValidAsyncWithServiceResponse(List<Product> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3015,8 +3771,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<List<String>>> getArrayNull() throws ErrorException, IOException {
-        return getArrayNullAsync().toBlocking().single();
+    public List<List<String>> getArrayNull() throws ErrorException, IOException {
+        return getArrayNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3026,7 +3782,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayNullAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayNullAsync(), serviceCallback);
+        return ServiceCall.create(getArrayNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3034,7 +3790,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayNullAsync() {
+    public Observable<List<List<String>>> getArrayNullAsync() {
+        return getArrayNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+            @Override
+            public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a null array.
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<List<String>>>> getArrayNullAsyncWithServiceResponse() {
         return service.getArrayNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -3063,8 +3833,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<List<String>>> getArrayEmpty() throws ErrorException, IOException {
-        return getArrayEmptyAsync().toBlocking().single();
+    public List<List<String>> getArrayEmpty() throws ErrorException, IOException {
+        return getArrayEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3074,7 +3844,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayEmptyAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getArrayEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3082,7 +3852,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayEmptyAsync() {
+    public Observable<List<List<String>>> getArrayEmptyAsync() {
+        return getArrayEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+            @Override
+            public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an empty array [].
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<List<String>>>> getArrayEmptyAsyncWithServiceResponse() {
         return service.getArrayEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -3111,8 +3895,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<List<String>>> getArrayItemNull() throws ErrorException, IOException {
-        return getArrayItemNullAsync().toBlocking().single();
+    public List<List<String>> getArrayItemNull() throws ErrorException, IOException {
+        return getArrayItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3122,7 +3906,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayItemNullAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayItemNullAsync(), serviceCallback);
+        return ServiceCall.create(getArrayItemNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3130,7 +3914,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayItemNullAsync() {
+    public Observable<List<List<String>>> getArrayItemNullAsync() {
+        return getArrayItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+            @Override
+            public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<List<String>>>> getArrayItemNullAsyncWithServiceResponse() {
         return service.getArrayItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -3159,8 +3957,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<List<String>>> getArrayItemEmpty() throws ErrorException, IOException {
-        return getArrayItemEmptyAsync().toBlocking().single();
+    public List<List<String>> getArrayItemEmpty() throws ErrorException, IOException {
+        return getArrayItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3170,7 +3968,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayItemEmptyAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayItemEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getArrayItemEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3178,7 +3976,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayItemEmptyAsync() {
+    public Observable<List<List<String>>> getArrayItemEmptyAsync() {
+        return getArrayItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+            @Override
+            public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<List<String>>>> getArrayItemEmptyAsyncWithServiceResponse() {
         return service.getArrayItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -3207,8 +4019,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<List<String>>> getArrayValid() throws ErrorException, IOException {
-        return getArrayValidAsync().toBlocking().single();
+    public List<List<String>> getArrayValid() throws ErrorException, IOException {
+        return getArrayValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3218,7 +4030,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<List<String>>> getArrayValidAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayValidAsync(), serviceCallback);
+        return ServiceCall.create(getArrayValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3226,7 +4038,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<List<String>>>> getArrayValidAsync() {
+    public Observable<List<List<String>>> getArrayValidAsync() {
+        return getArrayValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<List<String>>>, List<List<String>>>() {
+            @Override
+            public List<List<String>> call(ServiceResponse<List<List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<List<String>>>> getArrayValidAsyncWithServiceResponse() {
         return service.getArrayValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<List<String>>>>>() {
                 @Override
@@ -3257,8 +4083,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putArrayValid(List<List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putArrayValidAsync(arrayBody).toBlocking().single();
+    public void putArrayValid(List<List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putArrayValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3269,7 +4095,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayValidAsync(List<List<String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putArrayValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -3278,7 +4104,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayValidAsync(List<List<String>> arrayBody) {
+    public Observable<Void> putArrayValidAsync(List<List<String>> arrayBody) {
+        return putArrayValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putArrayValidAsyncWithServiceResponse(List<List<String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3311,8 +4152,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Map<String, String>>> getDictionaryNull() throws ErrorException, IOException {
-        return getDictionaryNullAsync().toBlocking().single();
+    public List<Map<String, String>> getDictionaryNull() throws ErrorException, IOException {
+        return getDictionaryNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3322,7 +4163,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryNullAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryNullAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3330,7 +4171,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryNullAsync() {
+    public Observable<List<Map<String, String>>> getDictionaryNullAsync() {
+        return getDictionaryNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+            @Override
+            public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of Dictionaries with value null.
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryNullAsyncWithServiceResponse() {
         return service.getDictionaryNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -3359,8 +4214,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Map<String, String>>> getDictionaryEmpty() throws ErrorException, IOException {
-        return getDictionaryEmptyAsync().toBlocking().single();
+    public List<Map<String, String>> getDictionaryEmpty() throws ErrorException, IOException {
+        return getDictionaryEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3370,7 +4225,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryEmptyAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3378,7 +4233,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryEmptyAsync() {
+    public Observable<List<Map<String, String>>> getDictionaryEmptyAsync() {
+        return getDictionaryEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+            @Override
+            public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryEmptyAsyncWithServiceResponse() {
         return service.getDictionaryEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -3407,8 +4276,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Map<String, String>>> getDictionaryItemNull() throws ErrorException, IOException {
-        return getDictionaryItemNullAsync().toBlocking().single();
+    public List<Map<String, String>> getDictionaryItemNull() throws ErrorException, IOException {
+        return getDictionaryItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3418,7 +4287,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryItemNullAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryItemNullAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryItemNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3426,7 +4295,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemNullAsync() {
+    public Observable<List<Map<String, String>>> getDictionaryItemNullAsync() {
+        return getDictionaryItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+            @Override
+            public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemNullAsyncWithServiceResponse() {
         return service.getDictionaryItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -3455,8 +4338,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Map<String, String>>> getDictionaryItemEmpty() throws ErrorException, IOException {
-        return getDictionaryItemEmptyAsync().toBlocking().single();
+    public List<Map<String, String>> getDictionaryItemEmpty() throws ErrorException, IOException {
+        return getDictionaryItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3466,7 +4349,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryItemEmptyAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryItemEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryItemEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3474,7 +4357,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemEmptyAsync() {
+    public Observable<List<Map<String, String>>> getDictionaryItemEmptyAsync() {
+        return getDictionaryItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+            @Override
+            public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryItemEmptyAsyncWithServiceResponse() {
         return service.getDictionaryItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -3503,8 +4400,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<Map<String, String>>> getDictionaryValid() throws ErrorException, IOException {
-        return getDictionaryValidAsync().toBlocking().single();
+    public List<Map<String, String>> getDictionaryValid() throws ErrorException, IOException {
+        return getDictionaryValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3514,7 +4411,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<Map<String, String>>> getDictionaryValidAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryValidAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3522,7 +4419,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryValidAsync() {
+    public Observable<List<Map<String, String>>> getDictionaryValidAsync() {
+        return getDictionaryValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<Map<String, String>>>, List<Map<String, String>>>() {
+            @Override
+            public List<Map<String, String>> call(ServiceResponse<List<Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<List<Map<String, String>>>> getDictionaryValidAsyncWithServiceResponse() {
         return service.getDictionaryValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<Map<String, String>>>>>() {
                 @Override
@@ -3553,8 +4464,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDictionaryValid(List<Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDictionaryValidAsync(arrayBody).toBlocking().single();
+    public void putDictionaryValid(List<Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDictionaryValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3565,7 +4476,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDictionaryValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -3574,7 +4485,22 @@ public final class ArraysImpl implements Arrays {
      * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryValidAsync(List<Map<String, String>> arrayBody) {
+    public Observable<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody) {
+        return putDictionaryValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDictionaryValidAsyncWithServiceResponse(List<Map<String, String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -27,7 +27,7 @@ public interface Bools {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean getTrue() throws ErrorException, IOException;
 
@@ -51,7 +51,7 @@ public interface Bools {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getTrueAsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> getTrueWithServiceResponseAsync();
 
     /**
      * Set Boolean value true.
@@ -59,7 +59,6 @@ public interface Bools {
      * @param boolBody the boolean value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putTrue(boolean boolBody) throws ErrorException, IOException;
 
@@ -86,14 +85,14 @@ public interface Bools {
      * @param boolBody the boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putTrueAsyncWithServiceResponse(boolean boolBody);
+    Observable<ServiceResponse<Void>> putTrueWithServiceResponseAsync(boolean boolBody);
 
     /**
      * Get false Boolean value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean getFalse() throws ErrorException, IOException;
 
@@ -117,7 +116,7 @@ public interface Bools {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getFalseAsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> getFalseWithServiceResponseAsync();
 
     /**
      * Set Boolean value false.
@@ -125,7 +124,6 @@ public interface Bools {
      * @param boolBody the boolean value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putFalse(boolean boolBody) throws ErrorException, IOException;
 
@@ -152,14 +150,14 @@ public interface Bools {
      * @param boolBody the boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putFalseAsyncWithServiceResponse(boolean boolBody);
+    Observable<ServiceResponse<Void>> putFalseWithServiceResponseAsync(boolean boolBody);
 
     /**
      * Get null Boolean value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean getNull() throws ErrorException, IOException;
 
@@ -183,14 +181,14 @@ public interface Bools {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> getNullWithServiceResponseAsync();
 
     /**
      * Get invalid Boolean value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean getInvalid() throws ErrorException, IOException;
 
@@ -214,6 +212,6 @@ public interface Bools {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> getInvalidWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -29,7 +29,7 @@ public interface Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> getTrue() throws ErrorException, IOException;
+    boolean getTrue() throws ErrorException, IOException;
 
     /**
      * Get true Boolean value.
@@ -44,7 +44,14 @@ public interface Bools {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getTrueAsync();
+    Observable<Boolean> getTrueAsync();
+
+    /**
+     * Get true Boolean value.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> getTrueAsyncWithServiceResponse();
 
     /**
      * Set Boolean value true.
@@ -54,7 +61,7 @@ public interface Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putTrue(boolean boolBody) throws ErrorException, IOException;
+    void putTrue(boolean boolBody) throws ErrorException, IOException;
 
     /**
      * Set Boolean value true.
@@ -71,7 +78,15 @@ public interface Bools {
      * @param boolBody the boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putTrueAsync(boolean boolBody);
+    Observable<Void> putTrueAsync(boolean boolBody);
+
+    /**
+     * Set Boolean value true.
+     *
+     * @param boolBody the boolean value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putTrueAsyncWithServiceResponse(boolean boolBody);
 
     /**
      * Get false Boolean value.
@@ -80,7 +95,7 @@ public interface Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> getFalse() throws ErrorException, IOException;
+    boolean getFalse() throws ErrorException, IOException;
 
     /**
      * Get false Boolean value.
@@ -95,7 +110,14 @@ public interface Bools {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getFalseAsync();
+    Observable<Boolean> getFalseAsync();
+
+    /**
+     * Get false Boolean value.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> getFalseAsyncWithServiceResponse();
 
     /**
      * Set Boolean value false.
@@ -105,7 +127,7 @@ public interface Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putFalse(boolean boolBody) throws ErrorException, IOException;
+    void putFalse(boolean boolBody) throws ErrorException, IOException;
 
     /**
      * Set Boolean value false.
@@ -122,7 +144,15 @@ public interface Bools {
      * @param boolBody the boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putFalseAsync(boolean boolBody);
+    Observable<Void> putFalseAsync(boolean boolBody);
+
+    /**
+     * Set Boolean value false.
+     *
+     * @param boolBody the boolean value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putFalseAsyncWithServiceResponse(boolean boolBody);
 
     /**
      * Get null Boolean value.
@@ -131,7 +161,7 @@ public interface Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> getNull() throws ErrorException, IOException;
+    boolean getNull() throws ErrorException, IOException;
 
     /**
      * Get null Boolean value.
@@ -146,7 +176,14 @@ public interface Bools {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getNullAsync();
+    Observable<Boolean> getNullAsync();
+
+    /**
+     * Get null Boolean value.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> getNullAsyncWithServiceResponse();
 
     /**
      * Get invalid Boolean value.
@@ -155,7 +192,7 @@ public interface Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> getInvalid() throws ErrorException, IOException;
+    boolean getInvalid() throws ErrorException, IOException;
 
     /**
      * Get invalid Boolean value.
@@ -170,6 +207,13 @@ public interface Bools {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getInvalidAsync();
+    Observable<Boolean> getInvalidAsync();
+
+    /**
+     * Get invalid Boolean value.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> getInvalidAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyboolean/implementation/BoolsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyboolean/implementation/BoolsImpl.java
@@ -87,8 +87,8 @@ public final class BoolsImpl implements Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Boolean> getTrue() throws ErrorException, IOException {
-        return getTrueAsync().toBlocking().single();
+    public boolean getTrue() throws ErrorException, IOException {
+        return getTrueAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -98,7 +98,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getTrueAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getTrueAsync(), serviceCallback);
+        return ServiceCall.create(getTrueAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -106,7 +106,21 @@ public final class BoolsImpl implements Bools {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getTrueAsync() {
+    public Observable<Boolean> getTrueAsync() {
+        return getTrueAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get true Boolean value.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> getTrueAsyncWithServiceResponse() {
         return service.getTrue()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -136,8 +150,8 @@ public final class BoolsImpl implements Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putTrue(boolean boolBody) throws ErrorException, IOException {
-        return putTrueAsync(boolBody).toBlocking().single();
+    public void putTrue(boolean boolBody) throws ErrorException, IOException {
+        putTrueAsyncWithServiceResponse(boolBody).toBlocking().single().getBody();
     }
 
     /**
@@ -148,7 +162,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putTrueAsync(boolean boolBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putTrueAsync(boolBody), serviceCallback);
+        return ServiceCall.create(putTrueAsyncWithServiceResponse(boolBody), serviceCallback);
     }
 
     /**
@@ -157,7 +171,22 @@ public final class BoolsImpl implements Bools {
      * @param boolBody the boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putTrueAsync(boolean boolBody) {
+    public Observable<Void> putTrueAsync(boolean boolBody) {
+        return putTrueAsyncWithServiceResponse(boolBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set Boolean value true.
+     *
+     * @param boolBody the boolean value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putTrueAsyncWithServiceResponse(boolean boolBody) {
         return service.putTrue(boolBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -186,8 +215,8 @@ public final class BoolsImpl implements Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Boolean> getFalse() throws ErrorException, IOException {
-        return getFalseAsync().toBlocking().single();
+    public boolean getFalse() throws ErrorException, IOException {
+        return getFalseAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -197,7 +226,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getFalseAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getFalseAsync(), serviceCallback);
+        return ServiceCall.create(getFalseAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -205,7 +234,21 @@ public final class BoolsImpl implements Bools {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getFalseAsync() {
+    public Observable<Boolean> getFalseAsync() {
+        return getFalseAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get false Boolean value.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> getFalseAsyncWithServiceResponse() {
         return service.getFalse()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -235,8 +278,8 @@ public final class BoolsImpl implements Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putFalse(boolean boolBody) throws ErrorException, IOException {
-        return putFalseAsync(boolBody).toBlocking().single();
+    public void putFalse(boolean boolBody) throws ErrorException, IOException {
+        putFalseAsyncWithServiceResponse(boolBody).toBlocking().single().getBody();
     }
 
     /**
@@ -247,7 +290,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putFalseAsync(boolean boolBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putFalseAsync(boolBody), serviceCallback);
+        return ServiceCall.create(putFalseAsyncWithServiceResponse(boolBody), serviceCallback);
     }
 
     /**
@@ -256,7 +299,22 @@ public final class BoolsImpl implements Bools {
      * @param boolBody the boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putFalseAsync(boolean boolBody) {
+    public Observable<Void> putFalseAsync(boolean boolBody) {
+        return putFalseAsyncWithServiceResponse(boolBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set Boolean value false.
+     *
+     * @param boolBody the boolean value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putFalseAsyncWithServiceResponse(boolean boolBody) {
         return service.putFalse(boolBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -285,8 +343,8 @@ public final class BoolsImpl implements Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Boolean> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public boolean getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -296,7 +354,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getNullAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -304,7 +362,21 @@ public final class BoolsImpl implements Bools {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getNullAsync() {
+    public Observable<Boolean> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null Boolean value.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -333,8 +405,8 @@ public final class BoolsImpl implements Bools {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Boolean> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public boolean getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -344,7 +416,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getInvalidAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -352,7 +424,21 @@ public final class BoolsImpl implements Bools {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getInvalidAsync() {
+    public Observable<Boolean> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid Boolean value.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyboolean/implementation/BoolsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyboolean/implementation/BoolsImpl.java
@@ -85,10 +85,10 @@ public final class BoolsImpl implements Bools {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     public boolean getTrue() throws ErrorException, IOException {
-        return getTrueAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getTrueWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -98,7 +98,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getTrueAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getTrueAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getTrueWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -107,12 +107,12 @@ public final class BoolsImpl implements Bools {
      * @return the observable to the boolean object
      */
     public Observable<Boolean> getTrueAsync() {
-        return getTrueAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+        return getTrueWithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
             @Override
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -120,7 +120,7 @@ public final class BoolsImpl implements Bools {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getTrueAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Boolean>> getTrueWithServiceResponseAsync() {
         return service.getTrue()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -148,10 +148,9 @@ public final class BoolsImpl implements Bools {
      * @param boolBody the boolean value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putTrue(boolean boolBody) throws ErrorException, IOException {
-        putTrueAsyncWithServiceResponse(boolBody).toBlocking().single().getBody();
+        putTrueWithServiceResponseAsync(boolBody).toBlocking().single().getBody();
     }
 
     /**
@@ -162,7 +161,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putTrueAsync(boolean boolBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putTrueAsyncWithServiceResponse(boolBody), serviceCallback);
+        return ServiceCall.create(putTrueWithServiceResponseAsync(boolBody), serviceCallback);
     }
 
     /**
@@ -172,12 +171,12 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putTrueAsync(boolean boolBody) {
-        return putTrueAsyncWithServiceResponse(boolBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putTrueWithServiceResponseAsync(boolBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -186,7 +185,7 @@ public final class BoolsImpl implements Bools {
      * @param boolBody the boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putTrueAsyncWithServiceResponse(boolean boolBody) {
+    public Observable<ServiceResponse<Void>> putTrueWithServiceResponseAsync(boolean boolBody) {
         return service.putTrue(boolBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -213,10 +212,10 @@ public final class BoolsImpl implements Bools {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     public boolean getFalse() throws ErrorException, IOException {
-        return getFalseAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFalseWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -226,7 +225,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getFalseAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getFalseAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFalseWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -235,12 +234,12 @@ public final class BoolsImpl implements Bools {
      * @return the observable to the boolean object
      */
     public Observable<Boolean> getFalseAsync() {
-        return getFalseAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+        return getFalseWithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
             @Override
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -248,7 +247,7 @@ public final class BoolsImpl implements Bools {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getFalseAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Boolean>> getFalseWithServiceResponseAsync() {
         return service.getFalse()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -276,10 +275,9 @@ public final class BoolsImpl implements Bools {
      * @param boolBody the boolean value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putFalse(boolean boolBody) throws ErrorException, IOException {
-        putFalseAsyncWithServiceResponse(boolBody).toBlocking().single().getBody();
+        putFalseWithServiceResponseAsync(boolBody).toBlocking().single().getBody();
     }
 
     /**
@@ -290,7 +288,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putFalseAsync(boolean boolBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putFalseAsyncWithServiceResponse(boolBody), serviceCallback);
+        return ServiceCall.create(putFalseWithServiceResponseAsync(boolBody), serviceCallback);
     }
 
     /**
@@ -300,12 +298,12 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putFalseAsync(boolean boolBody) {
-        return putFalseAsyncWithServiceResponse(boolBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putFalseWithServiceResponseAsync(boolBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -314,7 +312,7 @@ public final class BoolsImpl implements Bools {
      * @param boolBody the boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putFalseAsyncWithServiceResponse(boolean boolBody) {
+    public Observable<ServiceResponse<Void>> putFalseWithServiceResponseAsync(boolean boolBody) {
         return service.putFalse(boolBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -341,10 +339,10 @@ public final class BoolsImpl implements Bools {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     public boolean getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -354,7 +352,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getNullAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -363,12 +361,12 @@ public final class BoolsImpl implements Bools {
      * @return the observable to the boolean object
      */
     public Observable<Boolean> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
             @Override
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -376,7 +374,7 @@ public final class BoolsImpl implements Bools {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Boolean>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -403,10 +401,10 @@ public final class BoolsImpl implements Bools {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     public boolean getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -416,7 +414,7 @@ public final class BoolsImpl implements Bools {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getInvalidAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -425,12 +423,12 @@ public final class BoolsImpl implements Bools {
      * @return the observable to the boolean object
      */
     public Observable<Boolean> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
             @Override
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -438,7 +436,7 @@ public final class BoolsImpl implements Bools {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Boolean>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodybyte/Bytes.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodybyte/Bytes.java
@@ -29,7 +29,7 @@ public interface Bytes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<byte[]> getNull() throws ErrorException, IOException;
+    byte[] getNull() throws ErrorException, IOException;
 
     /**
      * Get null byte value.
@@ -44,7 +44,14 @@ public interface Bytes {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getNullAsync();
+    Observable<byte[]> getNullAsync();
+
+    /**
+     * Get null byte value.
+     *
+     * @return the observable to the byte[] object
+     */
+    Observable<ServiceResponse<byte[]>> getNullAsyncWithServiceResponse();
 
     /**
      * Get empty byte value ''.
@@ -53,7 +60,7 @@ public interface Bytes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<byte[]> getEmpty() throws ErrorException, IOException;
+    byte[] getEmpty() throws ErrorException, IOException;
 
     /**
      * Get empty byte value ''.
@@ -68,7 +75,14 @@ public interface Bytes {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getEmptyAsync();
+    Observable<byte[]> getEmptyAsync();
+
+    /**
+     * Get empty byte value ''.
+     *
+     * @return the observable to the byte[] object
+     */
+    Observable<ServiceResponse<byte[]>> getEmptyAsyncWithServiceResponse();
 
     /**
      * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
@@ -77,7 +91,7 @@ public interface Bytes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<byte[]> getNonAscii() throws ErrorException, IOException;
+    byte[] getNonAscii() throws ErrorException, IOException;
 
     /**
      * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
@@ -92,7 +106,14 @@ public interface Bytes {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getNonAsciiAsync();
+    Observable<byte[]> getNonAsciiAsync();
+
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @return the observable to the byte[] object
+     */
+    Observable<ServiceResponse<byte[]>> getNonAsciiAsyncWithServiceResponse();
 
     /**
      * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
@@ -103,7 +124,7 @@ public interface Bytes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putNonAscii(byte[] byteBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putNonAscii(byte[] byteBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
@@ -120,7 +141,15 @@ public interface Bytes {
      * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putNonAsciiAsync(byte[] byteBody);
+    Observable<Void> putNonAsciiAsync(byte[] byteBody);
+
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putNonAsciiAsyncWithServiceResponse(byte[] byteBody);
 
     /**
      * Get invalid byte value ':::SWAGGER::::'.
@@ -129,7 +158,7 @@ public interface Bytes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<byte[]> getInvalid() throws ErrorException, IOException;
+    byte[] getInvalid() throws ErrorException, IOException;
 
     /**
      * Get invalid byte value ':::SWAGGER::::'.
@@ -144,6 +173,13 @@ public interface Bytes {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getInvalidAsync();
+    Observable<byte[]> getInvalidAsync();
+
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     *
+     * @return the observable to the byte[] object
+     */
+    Observable<ServiceResponse<byte[]>> getInvalidAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodybyte/Bytes.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodybyte/Bytes.java
@@ -27,7 +27,7 @@ public interface Bytes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     byte[] getNull() throws ErrorException, IOException;
 
@@ -51,14 +51,14 @@ public interface Bytes {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<byte[]>> getNullWithServiceResponseAsync();
 
     /**
      * Get empty byte value ''.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     byte[] getEmpty() throws ErrorException, IOException;
 
@@ -82,14 +82,14 @@ public interface Bytes {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<byte[]>> getEmptyWithServiceResponseAsync();
 
     /**
      * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     byte[] getNonAscii() throws ErrorException, IOException;
 
@@ -113,7 +113,7 @@ public interface Bytes {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getNonAsciiAsyncWithServiceResponse();
+    Observable<ServiceResponse<byte[]>> getNonAsciiWithServiceResponseAsync();
 
     /**
      * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
@@ -122,7 +122,6 @@ public interface Bytes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putNonAscii(byte[] byteBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -149,14 +148,14 @@ public interface Bytes {
      * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putNonAsciiAsyncWithServiceResponse(byte[] byteBody);
+    Observable<ServiceResponse<Void>> putNonAsciiWithServiceResponseAsync(byte[] byteBody);
 
     /**
      * Get invalid byte value ':::SWAGGER::::'.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     byte[] getInvalid() throws ErrorException, IOException;
 
@@ -180,6 +179,6 @@ public interface Bytes {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<byte[]>> getInvalidWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodybyte/implementation/BytesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodybyte/implementation/BytesImpl.java
@@ -81,10 +81,10 @@ public final class BytesImpl implements Bytes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     public byte[] getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -94,7 +94,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getNullAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -103,12 +103,12 @@ public final class BytesImpl implements Bytes {
      * @return the observable to the byte[] object
      */
     public Observable<byte[]> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
             @Override
             public byte[] call(ServiceResponse<byte[]> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -116,7 +116,7 @@ public final class BytesImpl implements Bytes {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<byte[]>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -143,10 +143,10 @@ public final class BytesImpl implements Bytes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     public byte[] getEmpty() throws ErrorException, IOException {
-        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -156,7 +156,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getEmptyAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -165,12 +165,12 @@ public final class BytesImpl implements Bytes {
      * @return the observable to the byte[] object
      */
     public Observable<byte[]> getEmptyAsync() {
-        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+        return getEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
             @Override
             public byte[] call(ServiceResponse<byte[]> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -178,7 +178,7 @@ public final class BytesImpl implements Bytes {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<byte[]>> getEmptyWithServiceResponseAsync() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -205,10 +205,10 @@ public final class BytesImpl implements Bytes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     public byte[] getNonAscii() throws ErrorException, IOException {
-        return getNonAsciiAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNonAsciiWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -218,7 +218,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getNonAsciiAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getNonAsciiAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNonAsciiWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -227,12 +227,12 @@ public final class BytesImpl implements Bytes {
      * @return the observable to the byte[] object
      */
     public Observable<byte[]> getNonAsciiAsync() {
-        return getNonAsciiAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+        return getNonAsciiWithServiceResponseAsync().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
             @Override
             public byte[] call(ServiceResponse<byte[]> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -240,7 +240,7 @@ public final class BytesImpl implements Bytes {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getNonAsciiAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<byte[]>> getNonAsciiWithServiceResponseAsync() {
         return service.getNonAscii()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -269,10 +269,9 @@ public final class BytesImpl implements Bytes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putNonAscii(byte[] byteBody) throws ErrorException, IOException, IllegalArgumentException {
-        putNonAsciiAsyncWithServiceResponse(byteBody).toBlocking().single().getBody();
+        putNonAsciiWithServiceResponseAsync(byteBody).toBlocking().single().getBody();
     }
 
     /**
@@ -283,7 +282,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putNonAsciiAsync(byte[] byteBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putNonAsciiAsyncWithServiceResponse(byteBody), serviceCallback);
+        return ServiceCall.create(putNonAsciiWithServiceResponseAsync(byteBody), serviceCallback);
     }
 
     /**
@@ -293,12 +292,12 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putNonAsciiAsync(byte[] byteBody) {
-        return putNonAsciiAsyncWithServiceResponse(byteBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putNonAsciiWithServiceResponseAsync(byteBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -307,7 +306,7 @@ public final class BytesImpl implements Bytes {
      * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putNonAsciiAsyncWithServiceResponse(byte[] byteBody) {
+    public Observable<ServiceResponse<Void>> putNonAsciiWithServiceResponseAsync(byte[] byteBody) {
         if (byteBody == null) {
             throw new IllegalArgumentException("Parameter byteBody is required and cannot be null.");
         }
@@ -337,10 +336,10 @@ public final class BytesImpl implements Bytes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     public byte[] getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -350,7 +349,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getInvalidAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -359,12 +358,12 @@ public final class BytesImpl implements Bytes {
      * @return the observable to the byte[] object
      */
     public Observable<byte[]> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
             @Override
             public byte[] call(ServiceResponse<byte[]> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -372,7 +371,7 @@ public final class BytesImpl implements Bytes {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<byte[]>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodybyte/implementation/BytesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodybyte/implementation/BytesImpl.java
@@ -83,8 +83,8 @@ public final class BytesImpl implements Bytes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<byte[]> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public byte[] getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -94,7 +94,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getNullAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -102,7 +102,21 @@ public final class BytesImpl implements Bytes {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getNullAsync() {
+    public Observable<byte[]> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+            @Override
+            public byte[] call(ServiceResponse<byte[]> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null byte value.
+     *
+     * @return the observable to the byte[] object
+     */
+    public Observable<ServiceResponse<byte[]>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -131,8 +145,8 @@ public final class BytesImpl implements Bytes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<byte[]> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsync().toBlocking().single();
+    public byte[] getEmpty() throws ErrorException, IOException {
+        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -142,7 +156,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getEmptyAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -150,7 +164,21 @@ public final class BytesImpl implements Bytes {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getEmptyAsync() {
+    public Observable<byte[]> getEmptyAsync() {
+        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+            @Override
+            public byte[] call(ServiceResponse<byte[]> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty byte value ''.
+     *
+     * @return the observable to the byte[] object
+     */
+    public Observable<ServiceResponse<byte[]>> getEmptyAsyncWithServiceResponse() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -179,8 +207,8 @@ public final class BytesImpl implements Bytes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<byte[]> getNonAscii() throws ErrorException, IOException {
-        return getNonAsciiAsync().toBlocking().single();
+    public byte[] getNonAscii() throws ErrorException, IOException {
+        return getNonAsciiAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -190,7 +218,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getNonAsciiAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getNonAsciiAsync(), serviceCallback);
+        return ServiceCall.create(getNonAsciiAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -198,7 +226,21 @@ public final class BytesImpl implements Bytes {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getNonAsciiAsync() {
+    public Observable<byte[]> getNonAsciiAsync() {
+        return getNonAsciiAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+            @Override
+            public byte[] call(ServiceResponse<byte[]> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @return the observable to the byte[] object
+     */
+    public Observable<ServiceResponse<byte[]>> getNonAsciiAsyncWithServiceResponse() {
         return service.getNonAscii()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -229,8 +271,8 @@ public final class BytesImpl implements Bytes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putNonAscii(byte[] byteBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putNonAsciiAsync(byteBody).toBlocking().single();
+    public void putNonAscii(byte[] byteBody) throws ErrorException, IOException, IllegalArgumentException {
+        putNonAsciiAsyncWithServiceResponse(byteBody).toBlocking().single().getBody();
     }
 
     /**
@@ -241,7 +283,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putNonAsciiAsync(byte[] byteBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putNonAsciiAsync(byteBody), serviceCallback);
+        return ServiceCall.create(putNonAsciiAsyncWithServiceResponse(byteBody), serviceCallback);
     }
 
     /**
@@ -250,7 +292,22 @@ public final class BytesImpl implements Bytes {
      * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putNonAsciiAsync(byte[] byteBody) {
+    public Observable<Void> putNonAsciiAsync(byte[] byteBody) {
+        return putNonAsciiAsyncWithServiceResponse(byteBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putNonAsciiAsyncWithServiceResponse(byte[] byteBody) {
         if (byteBody == null) {
             throw new IllegalArgumentException("Parameter byteBody is required and cannot be null.");
         }
@@ -282,8 +339,8 @@ public final class BytesImpl implements Bytes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<byte[]> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public byte[] getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -293,7 +350,7 @@ public final class BytesImpl implements Bytes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getInvalidAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -301,7 +358,21 @@ public final class BytesImpl implements Bytes {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getInvalidAsync() {
+    public Observable<byte[]> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+            @Override
+            public byte[] call(ServiceResponse<byte[]> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     *
+     * @return the observable to the byte[] object
+     */
+    public Observable<ServiceResponse<byte[]>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Arrays.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Arrays.java
@@ -28,7 +28,7 @@ public interface Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the ArrayWrapper object if successful.
      */
     ArrayWrapper getValid() throws ErrorException, IOException;
 
@@ -52,7 +52,7 @@ public interface Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    Observable<ServiceResponse<ArrayWrapper>> getValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<ArrayWrapper>> getValidWithServiceResponseAsync();
 
     /**
      * Put complex types with array property.
@@ -61,7 +61,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putValid(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -88,14 +87,14 @@ public interface Arrays {
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(ArrayWrapper complexBody);
+    Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(ArrayWrapper complexBody);
 
     /**
      * Get complex types with array property which is empty.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the ArrayWrapper object if successful.
      */
     ArrayWrapper getEmpty() throws ErrorException, IOException;
 
@@ -119,7 +118,7 @@ public interface Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    Observable<ServiceResponse<ArrayWrapper>> getEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<ArrayWrapper>> getEmptyWithServiceResponseAsync();
 
     /**
      * Put complex types with array property which is empty.
@@ -128,7 +127,6 @@ public interface Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putEmpty(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -155,14 +153,14 @@ public interface Arrays {
      * @param complexBody Please put an empty array
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(ArrayWrapper complexBody);
+    Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(ArrayWrapper complexBody);
 
     /**
      * Get complex types with array property while server doesn't provide a response payload.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the ArrayWrapper object if successful.
      */
     ArrayWrapper getNotProvided() throws ErrorException, IOException;
 
@@ -186,6 +184,6 @@ public interface Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    Observable<ServiceResponse<ArrayWrapper>> getNotProvidedAsyncWithServiceResponse();
+    Observable<ServiceResponse<ArrayWrapper>> getNotProvidedWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Arrays.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Arrays.java
@@ -30,7 +30,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<ArrayWrapper> getValid() throws ErrorException, IOException;
+    ArrayWrapper getValid() throws ErrorException, IOException;
 
     /**
      * Get complex types with array property.
@@ -45,7 +45,14 @@ public interface Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    Observable<ServiceResponse<ArrayWrapper>> getValidAsync();
+    Observable<ArrayWrapper> getValidAsync();
+
+    /**
+     * Get complex types with array property.
+     *
+     * @return the observable to the ArrayWrapper object
+     */
+    Observable<ServiceResponse<ArrayWrapper>> getValidAsyncWithServiceResponse();
 
     /**
      * Put complex types with array property.
@@ -56,7 +63,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putValid(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putValid(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with array property.
@@ -73,7 +80,15 @@ public interface Arrays {
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsync(ArrayWrapper complexBody);
+    Observable<Void> putValidAsync(ArrayWrapper complexBody);
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(ArrayWrapper complexBody);
 
     /**
      * Get complex types with array property which is empty.
@@ -82,7 +97,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<ArrayWrapper> getEmpty() throws ErrorException, IOException;
+    ArrayWrapper getEmpty() throws ErrorException, IOException;
 
     /**
      * Get complex types with array property which is empty.
@@ -97,7 +112,14 @@ public interface Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    Observable<ServiceResponse<ArrayWrapper>> getEmptyAsync();
+    Observable<ArrayWrapper> getEmptyAsync();
+
+    /**
+     * Get complex types with array property which is empty.
+     *
+     * @return the observable to the ArrayWrapper object
+     */
+    Observable<ServiceResponse<ArrayWrapper>> getEmptyAsyncWithServiceResponse();
 
     /**
      * Put complex types with array property which is empty.
@@ -108,7 +130,7 @@ public interface Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putEmpty(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putEmpty(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with array property which is empty.
@@ -125,7 +147,15 @@ public interface Arrays {
      * @param complexBody Please put an empty array
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsync(ArrayWrapper complexBody);
+    Observable<Void> putEmptyAsync(ArrayWrapper complexBody);
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(ArrayWrapper complexBody);
 
     /**
      * Get complex types with array property while server doesn't provide a response payload.
@@ -134,7 +164,7 @@ public interface Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<ArrayWrapper> getNotProvided() throws ErrorException, IOException;
+    ArrayWrapper getNotProvided() throws ErrorException, IOException;
 
     /**
      * Get complex types with array property while server doesn't provide a response payload.
@@ -149,6 +179,13 @@ public interface Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    Observable<ServiceResponse<ArrayWrapper>> getNotProvidedAsync();
+    Observable<ArrayWrapper> getNotProvidedAsync();
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
+     * @return the observable to the ArrayWrapper object
+     */
+    Observable<ServiceResponse<ArrayWrapper>> getNotProvidedAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Basics.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Basics.java
@@ -28,7 +28,7 @@ public interface Basics {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     Basic getValid() throws ErrorException, IOException;
 
@@ -52,7 +52,7 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Basic>> getValidWithServiceResponseAsync();
 
     /**
      * Please put {id: 2, name: 'abc', color: 'Magenta'}.
@@ -61,7 +61,6 @@ public interface Basics {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putValid(Basic complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -88,14 +87,14 @@ public interface Basics {
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Basic complexBody);
+    Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(Basic complexBody);
 
     /**
      * Get a basic complex type that is invalid for the local strong type.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     Basic getInvalid() throws ErrorException, IOException;
 
@@ -119,14 +118,14 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Basic>> getInvalidWithServiceResponseAsync();
 
     /**
      * Get a basic complex type that is empty.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     Basic getEmpty() throws ErrorException, IOException;
 
@@ -150,14 +149,14 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Basic>> getEmptyWithServiceResponseAsync();
 
     /**
      * Get a basic complex type whose properties are null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     Basic getNull() throws ErrorException, IOException;
 
@@ -181,14 +180,14 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Basic>> getNullWithServiceResponseAsync();
 
     /**
      * Get a basic complex type while the server doesn't provide a response payload.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     Basic getNotProvided() throws ErrorException, IOException;
 
@@ -212,6 +211,6 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getNotProvidedAsyncWithServiceResponse();
+    Observable<ServiceResponse<Basic>> getNotProvidedWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Basics.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Basics.java
@@ -30,7 +30,7 @@ public interface Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Basic> getValid() throws ErrorException, IOException;
+    Basic getValid() throws ErrorException, IOException;
 
     /**
      * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
@@ -45,7 +45,14 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getValidAsync();
+    Observable<Basic> getValidAsync();
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
+     * @return the observable to the Basic object
+     */
+    Observable<ServiceResponse<Basic>> getValidAsyncWithServiceResponse();
 
     /**
      * Please put {id: 2, name: 'abc', color: 'Magenta'}.
@@ -56,7 +63,7 @@ public interface Basics {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putValid(Basic complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putValid(Basic complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Please put {id: 2, name: 'abc', color: 'Magenta'}.
@@ -73,7 +80,15 @@ public interface Basics {
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsync(Basic complexBody);
+    Observable<Void> putValidAsync(Basic complexBody);
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Basic complexBody);
 
     /**
      * Get a basic complex type that is invalid for the local strong type.
@@ -82,7 +97,7 @@ public interface Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Basic> getInvalid() throws ErrorException, IOException;
+    Basic getInvalid() throws ErrorException, IOException;
 
     /**
      * Get a basic complex type that is invalid for the local strong type.
@@ -97,7 +112,14 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getInvalidAsync();
+    Observable<Basic> getInvalidAsync();
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
+     * @return the observable to the Basic object
+     */
+    Observable<ServiceResponse<Basic>> getInvalidAsyncWithServiceResponse();
 
     /**
      * Get a basic complex type that is empty.
@@ -106,7 +128,7 @@ public interface Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Basic> getEmpty() throws ErrorException, IOException;
+    Basic getEmpty() throws ErrorException, IOException;
 
     /**
      * Get a basic complex type that is empty.
@@ -121,7 +143,14 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getEmptyAsync();
+    Observable<Basic> getEmptyAsync();
+
+    /**
+     * Get a basic complex type that is empty.
+     *
+     * @return the observable to the Basic object
+     */
+    Observable<ServiceResponse<Basic>> getEmptyAsyncWithServiceResponse();
 
     /**
      * Get a basic complex type whose properties are null.
@@ -130,7 +159,7 @@ public interface Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Basic> getNull() throws ErrorException, IOException;
+    Basic getNull() throws ErrorException, IOException;
 
     /**
      * Get a basic complex type whose properties are null.
@@ -145,7 +174,14 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getNullAsync();
+    Observable<Basic> getNullAsync();
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
+     * @return the observable to the Basic object
+     */
+    Observable<ServiceResponse<Basic>> getNullAsyncWithServiceResponse();
 
     /**
      * Get a basic complex type while the server doesn't provide a response payload.
@@ -154,7 +190,7 @@ public interface Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Basic> getNotProvided() throws ErrorException, IOException;
+    Basic getNotProvided() throws ErrorException, IOException;
 
     /**
      * Get a basic complex type while the server doesn't provide a response payload.
@@ -169,6 +205,13 @@ public interface Basics {
      *
      * @return the observable to the Basic object
      */
-    Observable<ServiceResponse<Basic>> getNotProvidedAsync();
+    Observable<Basic> getNotProvidedAsync();
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
+     * @return the observable to the Basic object
+     */
+    Observable<ServiceResponse<Basic>> getNotProvidedAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Dictionarys.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Dictionarys.java
@@ -28,7 +28,7 @@ public interface Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DictionaryWrapper object if successful.
      */
     DictionaryWrapper getValid() throws ErrorException, IOException;
 
@@ -52,7 +52,7 @@ public interface Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    Observable<ServiceResponse<DictionaryWrapper>> getValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<DictionaryWrapper>> getValidWithServiceResponseAsync();
 
     /**
      * Put complex types with dictionary property.
@@ -61,7 +61,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putValid(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -88,14 +87,14 @@ public interface Dictionarys {
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(DictionaryWrapper complexBody);
+    Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(DictionaryWrapper complexBody);
 
     /**
      * Get complex types with dictionary property which is empty.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DictionaryWrapper object if successful.
      */
     DictionaryWrapper getEmpty() throws ErrorException, IOException;
 
@@ -119,7 +118,7 @@ public interface Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    Observable<ServiceResponse<DictionaryWrapper>> getEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<DictionaryWrapper>> getEmptyWithServiceResponseAsync();
 
     /**
      * Put complex types with dictionary property which is empty.
@@ -128,7 +127,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putEmpty(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -155,14 +153,14 @@ public interface Dictionarys {
      * @param complexBody Please put an empty dictionary
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(DictionaryWrapper complexBody);
+    Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(DictionaryWrapper complexBody);
 
     /**
      * Get complex types with dictionary property which is null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DictionaryWrapper object if successful.
      */
     DictionaryWrapper getNull() throws ErrorException, IOException;
 
@@ -186,14 +184,14 @@ public interface Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    Observable<ServiceResponse<DictionaryWrapper>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<DictionaryWrapper>> getNullWithServiceResponseAsync();
 
     /**
      * Get complex types with dictionary property while server doesn't provide a response payload.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DictionaryWrapper object if successful.
      */
     DictionaryWrapper getNotProvided() throws ErrorException, IOException;
 
@@ -217,6 +215,6 @@ public interface Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    Observable<ServiceResponse<DictionaryWrapper>> getNotProvidedAsyncWithServiceResponse();
+    Observable<ServiceResponse<DictionaryWrapper>> getNotProvidedWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Dictionarys.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Dictionarys.java
@@ -30,7 +30,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DictionaryWrapper> getValid() throws ErrorException, IOException;
+    DictionaryWrapper getValid() throws ErrorException, IOException;
 
     /**
      * Get complex types with dictionary property.
@@ -45,7 +45,14 @@ public interface Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    Observable<ServiceResponse<DictionaryWrapper>> getValidAsync();
+    Observable<DictionaryWrapper> getValidAsync();
+
+    /**
+     * Get complex types with dictionary property.
+     *
+     * @return the observable to the DictionaryWrapper object
+     */
+    Observable<ServiceResponse<DictionaryWrapper>> getValidAsyncWithServiceResponse();
 
     /**
      * Put complex types with dictionary property.
@@ -56,7 +63,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putValid(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putValid(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with dictionary property.
@@ -73,7 +80,15 @@ public interface Dictionarys {
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsync(DictionaryWrapper complexBody);
+    Observable<Void> putValidAsync(DictionaryWrapper complexBody);
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(DictionaryWrapper complexBody);
 
     /**
      * Get complex types with dictionary property which is empty.
@@ -82,7 +97,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DictionaryWrapper> getEmpty() throws ErrorException, IOException;
+    DictionaryWrapper getEmpty() throws ErrorException, IOException;
 
     /**
      * Get complex types with dictionary property which is empty.
@@ -97,7 +112,14 @@ public interface Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    Observable<ServiceResponse<DictionaryWrapper>> getEmptyAsync();
+    Observable<DictionaryWrapper> getEmptyAsync();
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
+     * @return the observable to the DictionaryWrapper object
+     */
+    Observable<ServiceResponse<DictionaryWrapper>> getEmptyAsyncWithServiceResponse();
 
     /**
      * Put complex types with dictionary property which is empty.
@@ -108,7 +130,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putEmpty(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putEmpty(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with dictionary property which is empty.
@@ -125,7 +147,15 @@ public interface Dictionarys {
      * @param complexBody Please put an empty dictionary
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsync(DictionaryWrapper complexBody);
+    Observable<Void> putEmptyAsync(DictionaryWrapper complexBody);
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(DictionaryWrapper complexBody);
 
     /**
      * Get complex types with dictionary property which is null.
@@ -134,7 +164,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DictionaryWrapper> getNull() throws ErrorException, IOException;
+    DictionaryWrapper getNull() throws ErrorException, IOException;
 
     /**
      * Get complex types with dictionary property which is null.
@@ -149,7 +179,14 @@ public interface Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    Observable<ServiceResponse<DictionaryWrapper>> getNullAsync();
+    Observable<DictionaryWrapper> getNullAsync();
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
+     * @return the observable to the DictionaryWrapper object
+     */
+    Observable<ServiceResponse<DictionaryWrapper>> getNullAsyncWithServiceResponse();
 
     /**
      * Get complex types with dictionary property while server doesn't provide a response payload.
@@ -158,7 +195,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DictionaryWrapper> getNotProvided() throws ErrorException, IOException;
+    DictionaryWrapper getNotProvided() throws ErrorException, IOException;
 
     /**
      * Get complex types with dictionary property while server doesn't provide a response payload.
@@ -173,6 +210,13 @@ public interface Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    Observable<ServiceResponse<DictionaryWrapper>> getNotProvidedAsync();
+    Observable<DictionaryWrapper> getNotProvidedAsync();
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
+     * @return the observable to the DictionaryWrapper object
+     */
+    Observable<ServiceResponse<DictionaryWrapper>> getNotProvidedAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Inheritances.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Inheritances.java
@@ -30,7 +30,7 @@ public interface Inheritances {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Siamese object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Siamese> getValid() throws ErrorException, IOException;
+    Siamese getValid() throws ErrorException, IOException;
 
     /**
      * Get complex types that extend others.
@@ -45,7 +45,14 @@ public interface Inheritances {
      *
      * @return the observable to the Siamese object
      */
-    Observable<ServiceResponse<Siamese>> getValidAsync();
+    Observable<Siamese> getValidAsync();
+
+    /**
+     * Get complex types that extend others.
+     *
+     * @return the observable to the Siamese object
+     */
+    Observable<ServiceResponse<Siamese>> getValidAsyncWithServiceResponse();
 
     /**
      * Put complex types that extend others.
@@ -56,7 +63,7 @@ public interface Inheritances {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putValid(Siamese complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putValid(Siamese complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types that extend others.
@@ -73,6 +80,14 @@ public interface Inheritances {
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsync(Siamese complexBody);
+    Observable<Void> putValidAsync(Siamese complexBody);
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Siamese complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Inheritances.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Inheritances.java
@@ -28,7 +28,7 @@ public interface Inheritances {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Siamese object wrapped in {@link ServiceResponse} if successful.
+     * @return the Siamese object if successful.
      */
     Siamese getValid() throws ErrorException, IOException;
 
@@ -52,7 +52,7 @@ public interface Inheritances {
      *
      * @return the observable to the Siamese object
      */
-    Observable<ServiceResponse<Siamese>> getValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Siamese>> getValidWithServiceResponseAsync();
 
     /**
      * Put complex types that extend others.
@@ -61,7 +61,6 @@ public interface Inheritances {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putValid(Siamese complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -88,6 +87,6 @@ public interface Inheritances {
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Siamese complexBody);
+    Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(Siamese complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
@@ -28,7 +28,7 @@ public interface Polymorphicrecursives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Fish object wrapped in {@link ServiceResponse} if successful.
+     * @return the Fish object if successful.
      */
     Fish getValid() throws ErrorException, IOException;
 
@@ -52,7 +52,7 @@ public interface Polymorphicrecursives {
      *
      * @return the observable to the Fish object
      */
-    Observable<ServiceResponse<Fish>> getValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Fish>> getValidWithServiceResponseAsync();
 
     /**
      * Put complex types that are polymorphic and have recursive references.
@@ -113,7 +113,6 @@ public interface Polymorphicrecursives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -296,6 +295,6 @@ public interface Polymorphicrecursives {
      }
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Fish complexBody);
+    Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(Fish complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
@@ -30,7 +30,7 @@ public interface Polymorphicrecursives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Fish object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Fish> getValid() throws ErrorException, IOException;
+    Fish getValid() throws ErrorException, IOException;
 
     /**
      * Get complex types that are polymorphic and have recursive references.
@@ -45,7 +45,14 @@ public interface Polymorphicrecursives {
      *
      * @return the observable to the Fish object
      */
-    Observable<ServiceResponse<Fish>> getValidAsync();
+    Observable<Fish> getValidAsync();
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
+     * @return the observable to the Fish object
+     */
+    Observable<ServiceResponse<Fish>> getValidAsyncWithServiceResponse();
 
     /**
      * Put complex types that are polymorphic and have recursive references.
@@ -108,7 +115,7 @@ public interface Polymorphicrecursives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types that are polymorphic and have recursive references.
@@ -229,6 +236,66 @@ public interface Polymorphicrecursives {
      }
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsync(Fish complexBody);
+    Observable<Void> putValidAsync(Fish complexBody);
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this:
+     {
+         "fishtype": "salmon",
+         "species": "king",
+         "length": 1,
+         "age": 1,
+         "location": "alaska",
+         "iswild": true,
+         "siblings": [
+             {
+                 "fishtype": "shark",
+                 "species": "predator",
+                 "length": 20,
+                 "age": 6,
+                 "siblings": [
+                     {
+                         "fishtype": "salmon",
+                         "species": "coho",
+                         "length": 2,
+                         "age": 2,
+                         "location": "atlantic",
+                         "iswild": true,
+                         "siblings": [
+                             {
+                                 "fishtype": "shark",
+                                 "species": "predator",
+                                 "length": 20,
+                                 "age": 6
+                             },
+                             {
+                                 "fishtype": "sawshark",
+                                 "species": "dangerous",
+                                 "length": 10,
+                                 "age": 105
+                             }
+                         ]
+                     },
+                     {
+                         "fishtype": "sawshark",
+                         "species": "dangerous",
+                         "length": 10,
+                         "age": 105
+                     }
+                 ]
+             },
+             {
+                 "fishtype": "sawshark",
+                 "species": "dangerous",
+                 "length": 10,
+                 "age": 105
+             }
+         ]
+     }
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Fish complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
@@ -28,7 +28,7 @@ public interface Polymorphisms {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Fish object wrapped in {@link ServiceResponse} if successful.
+     * @return the Fish object if successful.
      */
     Fish getValid() throws ErrorException, IOException;
 
@@ -52,7 +52,7 @@ public interface Polymorphisms {
      *
      * @return the observable to the Fish object
      */
-    Observable<ServiceResponse<Fish>> getValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Fish>> getValidWithServiceResponseAsync();
 
     /**
      * Put complex types that are polymorphic.
@@ -93,7 +93,6 @@ public interface Polymorphisms {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -216,7 +215,7 @@ public interface Polymorphisms {
            };
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Fish complexBody);
+    Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(Fish complexBody);
 
     /**
      * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
@@ -250,7 +249,6 @@ public interface Polymorphisms {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putValidMissingRequired(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -352,6 +350,6 @@ public interface Polymorphisms {
      }
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidMissingRequiredAsyncWithServiceResponse(Fish complexBody);
+    Observable<ServiceResponse<Void>> putValidMissingRequiredWithServiceResponseAsync(Fish complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
@@ -30,7 +30,7 @@ public interface Polymorphisms {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Fish object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Fish> getValid() throws ErrorException, IOException;
+    Fish getValid() throws ErrorException, IOException;
 
     /**
      * Get complex types that are polymorphic.
@@ -45,7 +45,14 @@ public interface Polymorphisms {
      *
      * @return the observable to the Fish object
      */
-    Observable<ServiceResponse<Fish>> getValidAsync();
+    Observable<Fish> getValidAsync();
+
+    /**
+     * Get complex types that are polymorphic.
+     *
+     * @return the observable to the Fish object
+     */
+    Observable<ServiceResponse<Fish>> getValidAsyncWithServiceResponse();
 
     /**
      * Put complex types that are polymorphic.
@@ -88,7 +95,7 @@ public interface Polymorphisms {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types that are polymorphic.
@@ -169,7 +176,47 @@ public interface Polymorphisms {
            };
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsync(Fish complexBody);
+    Observable<Void> putValidAsync(Fish complexBody);
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this:
+     {
+             'fishtype':'Salmon',
+             'location':'alaska',
+             'iswild':true,
+             'species':'king',
+             'length':1.0,
+             'siblings':[
+               {
+                 'fishtype':'Shark',
+                 'age':6,
+                 'birthday': '2012-01-05T01:00:00Z',
+                 'length':20.0,
+                 'species':'predator',
+               },
+               {
+                 'fishtype':'Sawshark',
+                 'age':105,
+                 'birthday': '1900-01-05T01:00:00Z',
+                 'length':10.0,
+                 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                 'species':'dangerous',
+               },
+               {
+                 'fishtype': 'goblin',
+                 'age': 1,
+                 'birthday': '2015-08-08T00:00:00Z',
+                 'length': 30.0,
+                 'species': 'scary',
+                 'jawsize': 5
+               }
+             ]
+           };
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Fish complexBody);
 
     /**
      * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
@@ -205,7 +252,7 @@ public interface Polymorphisms {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putValidMissingRequired(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putValidMissingRequired(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
@@ -272,6 +319,39 @@ public interface Polymorphisms {
      }
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidMissingRequiredAsync(Fish complexBody);
+    Observable<Void> putValidMissingRequiredAsync(Fish complexBody);
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
+     {
+         "fishtype": "sawshark",
+         "species": "snaggle toothed",
+         "length": 18.5,
+         "age": 2,
+         "birthday": "2013-06-01T01:00:00Z",
+         "location": "alaska",
+         "picture": base64(FF FF FF FF FE),
+         "siblings": [
+             {
+                 "fishtype": "shark",
+                 "species": "predator",
+                 "birthday": "2012-01-05T01:00:00Z",
+                 "length": 20,
+                 "age": 6
+             },
+             {
+                 "fishtype": "sawshark",
+                 "species": "dangerous",
+                 "picture": base64(FF FF FF FF FE),
+                 "length": 10,
+                 "age": 105
+             }
+         ]
+     }
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putValidMissingRequiredAsyncWithServiceResponse(Fish complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Primitives.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Primitives.java
@@ -40,7 +40,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the IntWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<IntWrapper> getInt() throws ErrorException, IOException;
+    IntWrapper getInt() throws ErrorException, IOException;
 
     /**
      * Get complex types with integer properties.
@@ -55,7 +55,14 @@ public interface Primitives {
      *
      * @return the observable to the IntWrapper object
      */
-    Observable<ServiceResponse<IntWrapper>> getIntAsync();
+    Observable<IntWrapper> getIntAsync();
+
+    /**
+     * Get complex types with integer properties.
+     *
+     * @return the observable to the IntWrapper object
+     */
+    Observable<ServiceResponse<IntWrapper>> getIntAsyncWithServiceResponse();
 
     /**
      * Put complex types with integer properties.
@@ -66,7 +73,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putInt(IntWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putInt(IntWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with integer properties.
@@ -83,7 +90,15 @@ public interface Primitives {
      * @param complexBody Please put -1 and 2
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putIntAsync(IntWrapper complexBody);
+    Observable<Void> putIntAsync(IntWrapper complexBody);
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putIntAsyncWithServiceResponse(IntWrapper complexBody);
 
     /**
      * Get complex types with long properties.
@@ -92,7 +107,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LongWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<LongWrapper> getLong() throws ErrorException, IOException;
+    LongWrapper getLong() throws ErrorException, IOException;
 
     /**
      * Get complex types with long properties.
@@ -107,7 +122,14 @@ public interface Primitives {
      *
      * @return the observable to the LongWrapper object
      */
-    Observable<ServiceResponse<LongWrapper>> getLongAsync();
+    Observable<LongWrapper> getLongAsync();
+
+    /**
+     * Get complex types with long properties.
+     *
+     * @return the observable to the LongWrapper object
+     */
+    Observable<ServiceResponse<LongWrapper>> getLongAsyncWithServiceResponse();
 
     /**
      * Put complex types with long properties.
@@ -118,7 +140,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putLong(LongWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putLong(LongWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with long properties.
@@ -135,7 +157,15 @@ public interface Primitives {
      * @param complexBody Please put 1099511627775 and -999511627788
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLongAsync(LongWrapper complexBody);
+    Observable<Void> putLongAsync(LongWrapper complexBody);
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putLongAsyncWithServiceResponse(LongWrapper complexBody);
 
     /**
      * Get complex types with float properties.
@@ -144,7 +174,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the FloatWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<FloatWrapper> getFloat() throws ErrorException, IOException;
+    FloatWrapper getFloat() throws ErrorException, IOException;
 
     /**
      * Get complex types with float properties.
@@ -159,7 +189,14 @@ public interface Primitives {
      *
      * @return the observable to the FloatWrapper object
      */
-    Observable<ServiceResponse<FloatWrapper>> getFloatAsync();
+    Observable<FloatWrapper> getFloatAsync();
+
+    /**
+     * Get complex types with float properties.
+     *
+     * @return the observable to the FloatWrapper object
+     */
+    Observable<ServiceResponse<FloatWrapper>> getFloatAsyncWithServiceResponse();
 
     /**
      * Put complex types with float properties.
@@ -170,7 +207,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putFloat(FloatWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putFloat(FloatWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with float properties.
@@ -187,7 +224,15 @@ public interface Primitives {
      * @param complexBody Please put 1.05 and -0.003
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putFloatAsync(FloatWrapper complexBody);
+    Observable<Void> putFloatAsync(FloatWrapper complexBody);
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putFloatAsyncWithServiceResponse(FloatWrapper complexBody);
 
     /**
      * Get complex types with double properties.
@@ -196,7 +241,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DoubleWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DoubleWrapper> getDouble() throws ErrorException, IOException;
+    DoubleWrapper getDouble() throws ErrorException, IOException;
 
     /**
      * Get complex types with double properties.
@@ -211,7 +256,14 @@ public interface Primitives {
      *
      * @return the observable to the DoubleWrapper object
      */
-    Observable<ServiceResponse<DoubleWrapper>> getDoubleAsync();
+    Observable<DoubleWrapper> getDoubleAsync();
+
+    /**
+     * Get complex types with double properties.
+     *
+     * @return the observable to the DoubleWrapper object
+     */
+    Observable<ServiceResponse<DoubleWrapper>> getDoubleAsyncWithServiceResponse();
 
     /**
      * Put complex types with double properties.
@@ -222,7 +274,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDouble(DoubleWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDouble(DoubleWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with double properties.
@@ -239,7 +291,15 @@ public interface Primitives {
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDoubleAsync(DoubleWrapper complexBody);
+    Observable<Void> putDoubleAsync(DoubleWrapper complexBody);
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDoubleAsyncWithServiceResponse(DoubleWrapper complexBody);
 
     /**
      * Get complex types with bool properties.
@@ -248,7 +308,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BooleanWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<BooleanWrapper> getBool() throws ErrorException, IOException;
+    BooleanWrapper getBool() throws ErrorException, IOException;
 
     /**
      * Get complex types with bool properties.
@@ -263,7 +323,14 @@ public interface Primitives {
      *
      * @return the observable to the BooleanWrapper object
      */
-    Observable<ServiceResponse<BooleanWrapper>> getBoolAsync();
+    Observable<BooleanWrapper> getBoolAsync();
+
+    /**
+     * Get complex types with bool properties.
+     *
+     * @return the observable to the BooleanWrapper object
+     */
+    Observable<ServiceResponse<BooleanWrapper>> getBoolAsyncWithServiceResponse();
 
     /**
      * Put complex types with bool properties.
@@ -274,7 +341,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBool(BooleanWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putBool(BooleanWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with bool properties.
@@ -291,7 +358,15 @@ public interface Primitives {
      * @param complexBody Please put true and false
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBoolAsync(BooleanWrapper complexBody);
+    Observable<Void> putBoolAsync(BooleanWrapper complexBody);
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBoolAsyncWithServiceResponse(BooleanWrapper complexBody);
 
     /**
      * Get complex types with string properties.
@@ -300,7 +375,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the StringWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<StringWrapper> getString() throws ErrorException, IOException;
+    StringWrapper getString() throws ErrorException, IOException;
 
     /**
      * Get complex types with string properties.
@@ -315,7 +390,14 @@ public interface Primitives {
      *
      * @return the observable to the StringWrapper object
      */
-    Observable<ServiceResponse<StringWrapper>> getStringAsync();
+    Observable<StringWrapper> getStringAsync();
+
+    /**
+     * Get complex types with string properties.
+     *
+     * @return the observable to the StringWrapper object
+     */
+    Observable<ServiceResponse<StringWrapper>> getStringAsyncWithServiceResponse();
 
     /**
      * Put complex types with string properties.
@@ -326,7 +408,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putString(StringWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putString(StringWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with string properties.
@@ -343,7 +425,15 @@ public interface Primitives {
      * @param complexBody Please put 'goodrequest', '', and null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putStringAsync(StringWrapper complexBody);
+    Observable<Void> putStringAsync(StringWrapper complexBody);
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putStringAsyncWithServiceResponse(StringWrapper complexBody);
 
     /**
      * Get complex types with date properties.
@@ -352,7 +442,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateWrapper> getDate() throws ErrorException, IOException;
+    DateWrapper getDate() throws ErrorException, IOException;
 
     /**
      * Get complex types with date properties.
@@ -367,7 +457,14 @@ public interface Primitives {
      *
      * @return the observable to the DateWrapper object
      */
-    Observable<ServiceResponse<DateWrapper>> getDateAsync();
+    Observable<DateWrapper> getDateAsync();
+
+    /**
+     * Get complex types with date properties.
+     *
+     * @return the observable to the DateWrapper object
+     */
+    Observable<ServiceResponse<DateWrapper>> getDateAsyncWithServiceResponse();
 
     /**
      * Put complex types with date properties.
@@ -378,7 +475,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDate(DateWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDate(DateWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with date properties.
@@ -395,7 +492,15 @@ public interface Primitives {
      * @param complexBody Please put '0001-01-01' and '2016-02-29'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateAsync(DateWrapper complexBody);
+    Observable<Void> putDateAsync(DateWrapper complexBody);
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateAsyncWithServiceResponse(DateWrapper complexBody);
 
     /**
      * Get complex types with datetime properties.
@@ -404,7 +509,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DatetimeWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DatetimeWrapper> getDateTime() throws ErrorException, IOException;
+    DatetimeWrapper getDateTime() throws ErrorException, IOException;
 
     /**
      * Get complex types with datetime properties.
@@ -419,7 +524,14 @@ public interface Primitives {
      *
      * @return the observable to the DatetimeWrapper object
      */
-    Observable<ServiceResponse<DatetimeWrapper>> getDateTimeAsync();
+    Observable<DatetimeWrapper> getDateTimeAsync();
+
+    /**
+     * Get complex types with datetime properties.
+     *
+     * @return the observable to the DatetimeWrapper object
+     */
+    Observable<ServiceResponse<DatetimeWrapper>> getDateTimeAsyncWithServiceResponse();
 
     /**
      * Put complex types with datetime properties.
@@ -430,7 +542,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDateTime(DatetimeWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDateTime(DatetimeWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with datetime properties.
@@ -447,7 +559,15 @@ public interface Primitives {
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeAsync(DatetimeWrapper complexBody);
+    Observable<Void> putDateTimeAsync(DatetimeWrapper complexBody);
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateTimeAsyncWithServiceResponse(DatetimeWrapper complexBody);
 
     /**
      * Get complex types with datetimeRfc1123 properties.
@@ -456,7 +576,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Datetimerfc1123Wrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Datetimerfc1123Wrapper> getDateTimeRfc1123() throws ErrorException, IOException;
+    Datetimerfc1123Wrapper getDateTimeRfc1123() throws ErrorException, IOException;
 
     /**
      * Get complex types with datetimeRfc1123 properties.
@@ -471,7 +591,14 @@ public interface Primitives {
      *
      * @return the observable to the Datetimerfc1123Wrapper object
      */
-    Observable<ServiceResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123Async();
+    Observable<Datetimerfc1123Wrapper> getDateTimeRfc1123Async();
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
+     * @return the observable to the Datetimerfc1123Wrapper object
+     */
+    Observable<ServiceResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123AsyncWithServiceResponse();
 
     /**
      * Put complex types with datetimeRfc1123 properties.
@@ -482,7 +609,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with datetimeRfc1123 properties.
@@ -499,7 +626,15 @@ public interface Primitives {
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody);
+    Observable<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody);
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateTimeRfc1123AsyncWithServiceResponse(Datetimerfc1123Wrapper complexBody);
 
     /**
      * Get complex types with duration properties.
@@ -508,7 +643,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DurationWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DurationWrapper> getDuration() throws ErrorException, IOException;
+    DurationWrapper getDuration() throws ErrorException, IOException;
 
     /**
      * Get complex types with duration properties.
@@ -523,7 +658,14 @@ public interface Primitives {
      *
      * @return the observable to the DurationWrapper object
      */
-    Observable<ServiceResponse<DurationWrapper>> getDurationAsync();
+    Observable<DurationWrapper> getDurationAsync();
+
+    /**
+     * Get complex types with duration properties.
+     *
+     * @return the observable to the DurationWrapper object
+     */
+    Observable<ServiceResponse<DurationWrapper>> getDurationAsyncWithServiceResponse();
 
     /**
      * Put complex types with duration properties.
@@ -534,7 +676,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDuration(DurationWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDuration(DurationWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with duration properties.
@@ -551,7 +693,15 @@ public interface Primitives {
      * @param complexBody Please put 'P123DT22H14M12.011S'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDurationAsync(DurationWrapper complexBody);
+    Observable<Void> putDurationAsync(DurationWrapper complexBody);
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDurationAsyncWithServiceResponse(DurationWrapper complexBody);
 
     /**
      * Get complex types with byte properties.
@@ -560,7 +710,7 @@ public interface Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ByteWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<ByteWrapper> getByte() throws ErrorException, IOException;
+    ByteWrapper getByte() throws ErrorException, IOException;
 
     /**
      * Get complex types with byte properties.
@@ -575,7 +725,14 @@ public interface Primitives {
      *
      * @return the observable to the ByteWrapper object
      */
-    Observable<ServiceResponse<ByteWrapper>> getByteAsync();
+    Observable<ByteWrapper> getByteAsync();
+
+    /**
+     * Get complex types with byte properties.
+     *
+     * @return the observable to the ByteWrapper object
+     */
+    Observable<ServiceResponse<ByteWrapper>> getByteAsyncWithServiceResponse();
 
     /**
      * Put complex types with byte properties.
@@ -586,7 +743,7 @@ public interface Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putByte(ByteWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putByte(ByteWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types with byte properties.
@@ -603,6 +760,14 @@ public interface Primitives {
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putByteAsync(ByteWrapper complexBody);
+    Observable<Void> putByteAsync(ByteWrapper complexBody);
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putByteAsyncWithServiceResponse(ByteWrapper complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Primitives.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Primitives.java
@@ -38,7 +38,7 @@ public interface Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the IntWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the IntWrapper object if successful.
      */
     IntWrapper getInt() throws ErrorException, IOException;
 
@@ -62,7 +62,7 @@ public interface Primitives {
      *
      * @return the observable to the IntWrapper object
      */
-    Observable<ServiceResponse<IntWrapper>> getIntAsyncWithServiceResponse();
+    Observable<ServiceResponse<IntWrapper>> getIntWithServiceResponseAsync();
 
     /**
      * Put complex types with integer properties.
@@ -71,7 +71,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putInt(IntWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -98,14 +97,14 @@ public interface Primitives {
      * @param complexBody Please put -1 and 2
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putIntAsyncWithServiceResponse(IntWrapper complexBody);
+    Observable<ServiceResponse<Void>> putIntWithServiceResponseAsync(IntWrapper complexBody);
 
     /**
      * Get complex types with long properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LongWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the LongWrapper object if successful.
      */
     LongWrapper getLong() throws ErrorException, IOException;
 
@@ -129,7 +128,7 @@ public interface Primitives {
      *
      * @return the observable to the LongWrapper object
      */
-    Observable<ServiceResponse<LongWrapper>> getLongAsyncWithServiceResponse();
+    Observable<ServiceResponse<LongWrapper>> getLongWithServiceResponseAsync();
 
     /**
      * Put complex types with long properties.
@@ -138,7 +137,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putLong(LongWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -165,14 +163,14 @@ public interface Primitives {
      * @param complexBody Please put 1099511627775 and -999511627788
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLongAsyncWithServiceResponse(LongWrapper complexBody);
+    Observable<ServiceResponse<Void>> putLongWithServiceResponseAsync(LongWrapper complexBody);
 
     /**
      * Get complex types with float properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the FloatWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the FloatWrapper object if successful.
      */
     FloatWrapper getFloat() throws ErrorException, IOException;
 
@@ -196,7 +194,7 @@ public interface Primitives {
      *
      * @return the observable to the FloatWrapper object
      */
-    Observable<ServiceResponse<FloatWrapper>> getFloatAsyncWithServiceResponse();
+    Observable<ServiceResponse<FloatWrapper>> getFloatWithServiceResponseAsync();
 
     /**
      * Put complex types with float properties.
@@ -205,7 +203,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putFloat(FloatWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -232,14 +229,14 @@ public interface Primitives {
      * @param complexBody Please put 1.05 and -0.003
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putFloatAsyncWithServiceResponse(FloatWrapper complexBody);
+    Observable<ServiceResponse<Void>> putFloatWithServiceResponseAsync(FloatWrapper complexBody);
 
     /**
      * Get complex types with double properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DoubleWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DoubleWrapper object if successful.
      */
     DoubleWrapper getDouble() throws ErrorException, IOException;
 
@@ -263,7 +260,7 @@ public interface Primitives {
      *
      * @return the observable to the DoubleWrapper object
      */
-    Observable<ServiceResponse<DoubleWrapper>> getDoubleAsyncWithServiceResponse();
+    Observable<ServiceResponse<DoubleWrapper>> getDoubleWithServiceResponseAsync();
 
     /**
      * Put complex types with double properties.
@@ -272,7 +269,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDouble(DoubleWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -299,14 +295,14 @@ public interface Primitives {
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDoubleAsyncWithServiceResponse(DoubleWrapper complexBody);
+    Observable<ServiceResponse<Void>> putDoubleWithServiceResponseAsync(DoubleWrapper complexBody);
 
     /**
      * Get complex types with bool properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BooleanWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the BooleanWrapper object if successful.
      */
     BooleanWrapper getBool() throws ErrorException, IOException;
 
@@ -330,7 +326,7 @@ public interface Primitives {
      *
      * @return the observable to the BooleanWrapper object
      */
-    Observable<ServiceResponse<BooleanWrapper>> getBoolAsyncWithServiceResponse();
+    Observable<ServiceResponse<BooleanWrapper>> getBoolWithServiceResponseAsync();
 
     /**
      * Put complex types with bool properties.
@@ -339,7 +335,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBool(BooleanWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -366,14 +361,14 @@ public interface Primitives {
      * @param complexBody Please put true and false
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBoolAsyncWithServiceResponse(BooleanWrapper complexBody);
+    Observable<ServiceResponse<Void>> putBoolWithServiceResponseAsync(BooleanWrapper complexBody);
 
     /**
      * Get complex types with string properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the StringWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the StringWrapper object if successful.
      */
     StringWrapper getString() throws ErrorException, IOException;
 
@@ -397,7 +392,7 @@ public interface Primitives {
      *
      * @return the observable to the StringWrapper object
      */
-    Observable<ServiceResponse<StringWrapper>> getStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<StringWrapper>> getStringWithServiceResponseAsync();
 
     /**
      * Put complex types with string properties.
@@ -406,7 +401,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putString(StringWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -433,14 +427,14 @@ public interface Primitives {
      * @param complexBody Please put 'goodrequest', '', and null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putStringAsyncWithServiceResponse(StringWrapper complexBody);
+    Observable<ServiceResponse<Void>> putStringWithServiceResponseAsync(StringWrapper complexBody);
 
     /**
      * Get complex types with date properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateWrapper object if successful.
      */
     DateWrapper getDate() throws ErrorException, IOException;
 
@@ -464,7 +458,7 @@ public interface Primitives {
      *
      * @return the observable to the DateWrapper object
      */
-    Observable<ServiceResponse<DateWrapper>> getDateAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateWrapper>> getDateWithServiceResponseAsync();
 
     /**
      * Put complex types with date properties.
@@ -473,7 +467,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDate(DateWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -500,14 +493,14 @@ public interface Primitives {
      * @param complexBody Please put '0001-01-01' and '2016-02-29'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateAsyncWithServiceResponse(DateWrapper complexBody);
+    Observable<ServiceResponse<Void>> putDateWithServiceResponseAsync(DateWrapper complexBody);
 
     /**
      * Get complex types with datetime properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DatetimeWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DatetimeWrapper object if successful.
      */
     DatetimeWrapper getDateTime() throws ErrorException, IOException;
 
@@ -531,7 +524,7 @@ public interface Primitives {
      *
      * @return the observable to the DatetimeWrapper object
      */
-    Observable<ServiceResponse<DatetimeWrapper>> getDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DatetimeWrapper>> getDateTimeWithServiceResponseAsync();
 
     /**
      * Put complex types with datetime properties.
@@ -540,7 +533,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDateTime(DatetimeWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -567,14 +559,14 @@ public interface Primitives {
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeAsyncWithServiceResponse(DatetimeWrapper complexBody);
+    Observable<ServiceResponse<Void>> putDateTimeWithServiceResponseAsync(DatetimeWrapper complexBody);
 
     /**
      * Get complex types with datetimeRfc1123 properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Datetimerfc1123Wrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the Datetimerfc1123Wrapper object if successful.
      */
     Datetimerfc1123Wrapper getDateTimeRfc1123() throws ErrorException, IOException;
 
@@ -598,7 +590,7 @@ public interface Primitives {
      *
      * @return the observable to the Datetimerfc1123Wrapper object
      */
-    Observable<ServiceResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123AsyncWithServiceResponse();
+    Observable<ServiceResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123WithServiceResponseAsync();
 
     /**
      * Put complex types with datetimeRfc1123 properties.
@@ -607,7 +599,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -634,14 +625,14 @@ public interface Primitives {
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeRfc1123AsyncWithServiceResponse(Datetimerfc1123Wrapper complexBody);
+    Observable<ServiceResponse<Void>> putDateTimeRfc1123WithServiceResponseAsync(Datetimerfc1123Wrapper complexBody);
 
     /**
      * Get complex types with duration properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DurationWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DurationWrapper object if successful.
      */
     DurationWrapper getDuration() throws ErrorException, IOException;
 
@@ -665,7 +656,7 @@ public interface Primitives {
      *
      * @return the observable to the DurationWrapper object
      */
-    Observable<ServiceResponse<DurationWrapper>> getDurationAsyncWithServiceResponse();
+    Observable<ServiceResponse<DurationWrapper>> getDurationWithServiceResponseAsync();
 
     /**
      * Put complex types with duration properties.
@@ -674,7 +665,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDuration(DurationWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -701,14 +691,14 @@ public interface Primitives {
      * @param complexBody Please put 'P123DT22H14M12.011S'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDurationAsyncWithServiceResponse(DurationWrapper complexBody);
+    Observable<ServiceResponse<Void>> putDurationWithServiceResponseAsync(DurationWrapper complexBody);
 
     /**
      * Get complex types with byte properties.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ByteWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the ByteWrapper object if successful.
      */
     ByteWrapper getByte() throws ErrorException, IOException;
 
@@ -732,7 +722,7 @@ public interface Primitives {
      *
      * @return the observable to the ByteWrapper object
      */
-    Observable<ServiceResponse<ByteWrapper>> getByteAsyncWithServiceResponse();
+    Observable<ServiceResponse<ByteWrapper>> getByteWithServiceResponseAsync();
 
     /**
      * Put complex types with byte properties.
@@ -741,7 +731,6 @@ public interface Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putByte(ByteWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -768,6 +757,6 @@ public interface Primitives {
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putByteAsyncWithServiceResponse(ByteWrapper complexBody);
+    Observable<ServiceResponse<Void>> putByteWithServiceResponseAsync(ByteWrapper complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
@@ -28,7 +28,7 @@ public interface Readonlypropertys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ReadonlyObj object wrapped in {@link ServiceResponse} if successful.
+     * @return the ReadonlyObj object if successful.
      */
     ReadonlyObj getValid() throws ErrorException, IOException;
 
@@ -52,7 +52,7 @@ public interface Readonlypropertys {
      *
      * @return the observable to the ReadonlyObj object
      */
-    Observable<ServiceResponse<ReadonlyObj>> getValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<ReadonlyObj>> getValidWithServiceResponseAsync();
 
     /**
      * Put complex types that have readonly properties.
@@ -61,7 +61,6 @@ public interface Readonlypropertys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putValid(ReadonlyObj complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -88,6 +87,6 @@ public interface Readonlypropertys {
      * @param complexBody the ReadonlyObj value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(ReadonlyObj complexBody);
+    Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(ReadonlyObj complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
@@ -30,7 +30,7 @@ public interface Readonlypropertys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ReadonlyObj object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<ReadonlyObj> getValid() throws ErrorException, IOException;
+    ReadonlyObj getValid() throws ErrorException, IOException;
 
     /**
      * Get complex types that have readonly properties.
@@ -45,7 +45,14 @@ public interface Readonlypropertys {
      *
      * @return the observable to the ReadonlyObj object
      */
-    Observable<ServiceResponse<ReadonlyObj>> getValidAsync();
+    Observable<ReadonlyObj> getValidAsync();
+
+    /**
+     * Get complex types that have readonly properties.
+     *
+     * @return the observable to the ReadonlyObj object
+     */
+    Observable<ServiceResponse<ReadonlyObj>> getValidAsyncWithServiceResponse();
 
     /**
      * Put complex types that have readonly properties.
@@ -56,7 +63,7 @@ public interface Readonlypropertys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putValid(ReadonlyObj complexBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putValid(ReadonlyObj complexBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put complex types that have readonly properties.
@@ -73,6 +80,14 @@ public interface Readonlypropertys {
      * @param complexBody the ReadonlyObj value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putValidAsync(ReadonlyObj complexBody);
+    Observable<Void> putValidAsync(ReadonlyObj complexBody);
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody the ReadonlyObj value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(ReadonlyObj complexBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
@@ -85,8 +85,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<ArrayWrapper> getValid() throws ErrorException, IOException {
-        return getValidAsync().toBlocking().single();
+    public ArrayWrapper getValid() throws ErrorException, IOException {
+        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -96,7 +96,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ArrayWrapper> getValidAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
-        return ServiceCall.create(getValidAsync(), serviceCallback);
+        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -104,7 +104,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    public Observable<ServiceResponse<ArrayWrapper>> getValidAsync() {
+    public Observable<ArrayWrapper> getValidAsync() {
+        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
+            @Override
+            public ArrayWrapper call(ServiceResponse<ArrayWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with array property.
+     *
+     * @return the observable to the ArrayWrapper object
+     */
+    public Observable<ServiceResponse<ArrayWrapper>> getValidAsyncWithServiceResponse() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ArrayWrapper>>>() {
                 @Override
@@ -135,8 +149,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putValid(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putValidAsync(complexBody).toBlocking().single();
+    public void putValid(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -147,7 +161,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(ArrayWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -156,7 +170,22 @@ public final class ArraysImpl implements Arrays {
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsync(ArrayWrapper complexBody) {
+    public Observable<Void> putValidAsync(ArrayWrapper complexBody) {
+        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(ArrayWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -189,8 +218,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<ArrayWrapper> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsync().toBlocking().single();
+    public ArrayWrapper getEmpty() throws ErrorException, IOException {
+        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -200,7 +229,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ArrayWrapper> getEmptyAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -208,7 +237,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    public Observable<ServiceResponse<ArrayWrapper>> getEmptyAsync() {
+    public Observable<ArrayWrapper> getEmptyAsync() {
+        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
+            @Override
+            public ArrayWrapper call(ServiceResponse<ArrayWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with array property which is empty.
+     *
+     * @return the observable to the ArrayWrapper object
+     */
+    public Observable<ServiceResponse<ArrayWrapper>> getEmptyAsyncWithServiceResponse() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ArrayWrapper>>>() {
                 @Override
@@ -239,8 +282,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putEmpty(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putEmptyAsync(complexBody).toBlocking().single();
+    public void putEmpty(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putEmptyAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -251,7 +294,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(ArrayWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putEmptyAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -260,7 +303,22 @@ public final class ArraysImpl implements Arrays {
      * @param complexBody Please put an empty array
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsync(ArrayWrapper complexBody) {
+    public Observable<Void> putEmptyAsync(ArrayWrapper complexBody) {
+        return putEmptyAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(ArrayWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -293,8 +351,8 @@ public final class ArraysImpl implements Arrays {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<ArrayWrapper> getNotProvided() throws ErrorException, IOException {
-        return getNotProvidedAsync().toBlocking().single();
+    public ArrayWrapper getNotProvided() throws ErrorException, IOException {
+        return getNotProvidedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -304,7 +362,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ArrayWrapper> getNotProvidedAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
-        return ServiceCall.create(getNotProvidedAsync(), serviceCallback);
+        return ServiceCall.create(getNotProvidedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -312,7 +370,21 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    public Observable<ServiceResponse<ArrayWrapper>> getNotProvidedAsync() {
+    public Observable<ArrayWrapper> getNotProvidedAsync() {
+        return getNotProvidedAsyncWithServiceResponse().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
+            @Override
+            public ArrayWrapper call(ServiceResponse<ArrayWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
+     * @return the observable to the ArrayWrapper object
+     */
+    public Observable<ServiceResponse<ArrayWrapper>> getNotProvidedAsyncWithServiceResponse() {
         return service.getNotProvided()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ArrayWrapper>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
@@ -83,10 +83,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the ArrayWrapper object if successful.
      */
     public ArrayWrapper getValid() throws ErrorException, IOException {
-        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -96,7 +96,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ArrayWrapper> getValidAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
-        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -105,12 +105,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the ArrayWrapper object
      */
     public Observable<ArrayWrapper> getValidAsync() {
-        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
+        return getValidWithServiceResponseAsync().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
             @Override
             public ArrayWrapper call(ServiceResponse<ArrayWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -118,7 +118,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    public Observable<ServiceResponse<ArrayWrapper>> getValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<ArrayWrapper>> getValidWithServiceResponseAsync() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ArrayWrapper>>>() {
                 @Override
@@ -147,10 +147,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putValid(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putValidWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -161,7 +160,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(ArrayWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putValidWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -171,12 +170,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putValidAsync(ArrayWrapper complexBody) {
-        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putValidWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -185,7 +184,7 @@ public final class ArraysImpl implements Arrays {
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(ArrayWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(ArrayWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -216,10 +215,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the ArrayWrapper object if successful.
      */
     public ArrayWrapper getEmpty() throws ErrorException, IOException {
-        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -229,7 +228,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ArrayWrapper> getEmptyAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -238,12 +237,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the ArrayWrapper object
      */
     public Observable<ArrayWrapper> getEmptyAsync() {
-        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
+        return getEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
             @Override
             public ArrayWrapper call(ServiceResponse<ArrayWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -251,7 +250,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    public Observable<ServiceResponse<ArrayWrapper>> getEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<ArrayWrapper>> getEmptyWithServiceResponseAsync() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ArrayWrapper>>>() {
                 @Override
@@ -280,10 +279,9 @@ public final class ArraysImpl implements Arrays {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putEmpty(ArrayWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putEmptyAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putEmptyWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -294,7 +292,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(ArrayWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putEmptyWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -304,12 +302,12 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putEmptyAsync(ArrayWrapper complexBody) {
-        return putEmptyAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putEmptyWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -318,7 +316,7 @@ public final class ArraysImpl implements Arrays {
      * @param complexBody Please put an empty array
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(ArrayWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(ArrayWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -349,10 +347,10 @@ public final class ArraysImpl implements Arrays {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ArrayWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the ArrayWrapper object if successful.
      */
     public ArrayWrapper getNotProvided() throws ErrorException, IOException {
-        return getNotProvidedAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNotProvidedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -362,7 +360,7 @@ public final class ArraysImpl implements Arrays {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ArrayWrapper> getNotProvidedAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
-        return ServiceCall.create(getNotProvidedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNotProvidedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -371,12 +369,12 @@ public final class ArraysImpl implements Arrays {
      * @return the observable to the ArrayWrapper object
      */
     public Observable<ArrayWrapper> getNotProvidedAsync() {
-        return getNotProvidedAsyncWithServiceResponse().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
+        return getNotProvidedWithServiceResponseAsync().map(new Func1<ServiceResponse<ArrayWrapper>, ArrayWrapper>() {
             @Override
             public ArrayWrapper call(ServiceResponse<ArrayWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -384,7 +382,7 @@ public final class ArraysImpl implements Arrays {
      *
      * @return the observable to the ArrayWrapper object
      */
-    public Observable<ServiceResponse<ArrayWrapper>> getNotProvidedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<ArrayWrapper>> getNotProvidedWithServiceResponseAsync() {
         return service.getNotProvided()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ArrayWrapper>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
@@ -90,8 +90,8 @@ public final class BasicsImpl implements Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Basic> getValid() throws ErrorException, IOException {
-        return getValidAsync().toBlocking().single();
+    public Basic getValid() throws ErrorException, IOException {
+        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -101,7 +101,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getValidAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getValidAsync(), serviceCallback);
+        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -109,7 +109,21 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getValidAsync() {
+    public Observable<Basic> getValidAsync() {
+        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+            @Override
+            public Basic call(ServiceResponse<Basic> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
+     * @return the observable to the Basic object
+     */
+    public Observable<ServiceResponse<Basic>> getValidAsyncWithServiceResponse() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override
@@ -140,8 +154,8 @@ public final class BasicsImpl implements Basics {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putValid(Basic complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putValidAsync(complexBody).toBlocking().single();
+    public void putValid(Basic complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -152,7 +166,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(Basic complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -161,7 +175,22 @@ public final class BasicsImpl implements Basics {
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsync(Basic complexBody) {
+    public Observable<Void> putValidAsync(Basic complexBody) {
+        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Basic complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -194,8 +223,8 @@ public final class BasicsImpl implements Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Basic> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public Basic getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -205,7 +234,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getInvalidAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -213,7 +242,21 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getInvalidAsync() {
+    public Observable<Basic> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+            @Override
+            public Basic call(ServiceResponse<Basic> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
+     * @return the observable to the Basic object
+     */
+    public Observable<ServiceResponse<Basic>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override
@@ -242,8 +285,8 @@ public final class BasicsImpl implements Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Basic> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsync().toBlocking().single();
+    public Basic getEmpty() throws ErrorException, IOException {
+        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -253,7 +296,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getEmptyAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -261,7 +304,21 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getEmptyAsync() {
+    public Observable<Basic> getEmptyAsync() {
+        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+            @Override
+            public Basic call(ServiceResponse<Basic> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a basic complex type that is empty.
+     *
+     * @return the observable to the Basic object
+     */
+    public Observable<ServiceResponse<Basic>> getEmptyAsyncWithServiceResponse() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override
@@ -290,8 +347,8 @@ public final class BasicsImpl implements Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Basic> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public Basic getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -301,7 +358,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getNullAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -309,7 +366,21 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getNullAsync() {
+    public Observable<Basic> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+            @Override
+            public Basic call(ServiceResponse<Basic> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
+     * @return the observable to the Basic object
+     */
+    public Observable<ServiceResponse<Basic>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override
@@ -338,8 +409,8 @@ public final class BasicsImpl implements Basics {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Basic object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Basic> getNotProvided() throws ErrorException, IOException {
-        return getNotProvidedAsync().toBlocking().single();
+    public Basic getNotProvided() throws ErrorException, IOException {
+        return getNotProvidedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -349,7 +420,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getNotProvidedAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getNotProvidedAsync(), serviceCallback);
+        return ServiceCall.create(getNotProvidedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -357,7 +428,21 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getNotProvidedAsync() {
+    public Observable<Basic> getNotProvidedAsync() {
+        return getNotProvidedAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+            @Override
+            public Basic call(ServiceResponse<Basic> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
+     * @return the observable to the Basic object
+     */
+    public Observable<ServiceResponse<Basic>> getNotProvidedAsyncWithServiceResponse() {
         return service.getNotProvided()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
@@ -88,10 +88,10 @@ public final class BasicsImpl implements Basics {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     public Basic getValid() throws ErrorException, IOException {
-        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -101,7 +101,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getValidAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -110,12 +110,12 @@ public final class BasicsImpl implements Basics {
      * @return the observable to the Basic object
      */
     public Observable<Basic> getValidAsync() {
-        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+        return getValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Basic>, Basic>() {
             @Override
             public Basic call(ServiceResponse<Basic> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -123,7 +123,7 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Basic>> getValidWithServiceResponseAsync() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override
@@ -152,10 +152,9 @@ public final class BasicsImpl implements Basics {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putValid(Basic complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putValidWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -166,7 +165,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(Basic complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putValidWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -176,12 +175,12 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putValidAsync(Basic complexBody) {
-        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putValidWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -190,7 +189,7 @@ public final class BasicsImpl implements Basics {
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Basic complexBody) {
+    public Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(Basic complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -221,10 +220,10 @@ public final class BasicsImpl implements Basics {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     public Basic getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -234,7 +233,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getInvalidAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -243,12 +242,12 @@ public final class BasicsImpl implements Basics {
      * @return the observable to the Basic object
      */
     public Observable<Basic> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Basic>, Basic>() {
             @Override
             public Basic call(ServiceResponse<Basic> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -256,7 +255,7 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Basic>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override
@@ -283,10 +282,10 @@ public final class BasicsImpl implements Basics {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     public Basic getEmpty() throws ErrorException, IOException {
-        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -296,7 +295,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getEmptyAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -305,12 +304,12 @@ public final class BasicsImpl implements Basics {
      * @return the observable to the Basic object
      */
     public Observable<Basic> getEmptyAsync() {
-        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+        return getEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Basic>, Basic>() {
             @Override
             public Basic call(ServiceResponse<Basic> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -318,7 +317,7 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Basic>> getEmptyWithServiceResponseAsync() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override
@@ -345,10 +344,10 @@ public final class BasicsImpl implements Basics {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     public Basic getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -358,7 +357,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getNullAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -367,12 +366,12 @@ public final class BasicsImpl implements Basics {
      * @return the observable to the Basic object
      */
     public Observable<Basic> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Basic>, Basic>() {
             @Override
             public Basic call(ServiceResponse<Basic> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -380,7 +379,7 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Basic>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override
@@ -407,10 +406,10 @@ public final class BasicsImpl implements Basics {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Basic object wrapped in {@link ServiceResponse} if successful.
+     * @return the Basic object if successful.
      */
     public Basic getNotProvided() throws ErrorException, IOException {
-        return getNotProvidedAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNotProvidedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -420,7 +419,7 @@ public final class BasicsImpl implements Basics {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Basic> getNotProvidedAsync(final ServiceCallback<Basic> serviceCallback) {
-        return ServiceCall.create(getNotProvidedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNotProvidedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -429,12 +428,12 @@ public final class BasicsImpl implements Basics {
      * @return the observable to the Basic object
      */
     public Observable<Basic> getNotProvidedAsync() {
-        return getNotProvidedAsyncWithServiceResponse().map(new Func1<ServiceResponse<Basic>, Basic>() {
+        return getNotProvidedWithServiceResponseAsync().map(new Func1<ServiceResponse<Basic>, Basic>() {
             @Override
             public Basic call(ServiceResponse<Basic> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -442,7 +441,7 @@ public final class BasicsImpl implements Basics {
      *
      * @return the observable to the Basic object
      */
-    public Observable<ServiceResponse<Basic>> getNotProvidedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Basic>> getNotProvidedWithServiceResponseAsync() {
         return service.getNotProvided()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Basic>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/DictionarysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/DictionarysImpl.java
@@ -89,8 +89,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DictionaryWrapper> getValid() throws ErrorException, IOException {
-        return getValidAsync().toBlocking().single();
+    public DictionaryWrapper getValid() throws ErrorException, IOException {
+        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -100,7 +100,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DictionaryWrapper> getValidAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
-        return ServiceCall.create(getValidAsync(), serviceCallback);
+        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -108,7 +108,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    public Observable<ServiceResponse<DictionaryWrapper>> getValidAsync() {
+    public Observable<DictionaryWrapper> getValidAsync() {
+        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
+            @Override
+            public DictionaryWrapper call(ServiceResponse<DictionaryWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with dictionary property.
+     *
+     * @return the observable to the DictionaryWrapper object
+     */
+    public Observable<ServiceResponse<DictionaryWrapper>> getValidAsyncWithServiceResponse() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DictionaryWrapper>>>() {
                 @Override
@@ -139,8 +153,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putValid(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putValidAsync(complexBody).toBlocking().single();
+    public void putValid(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -151,7 +165,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(DictionaryWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -160,7 +174,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsync(DictionaryWrapper complexBody) {
+    public Observable<Void> putValidAsync(DictionaryWrapper complexBody) {
+        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(DictionaryWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -193,8 +222,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DictionaryWrapper> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsync().toBlocking().single();
+    public DictionaryWrapper getEmpty() throws ErrorException, IOException {
+        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -204,7 +233,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DictionaryWrapper> getEmptyAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -212,7 +241,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    public Observable<ServiceResponse<DictionaryWrapper>> getEmptyAsync() {
+    public Observable<DictionaryWrapper> getEmptyAsync() {
+        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
+            @Override
+            public DictionaryWrapper call(ServiceResponse<DictionaryWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
+     * @return the observable to the DictionaryWrapper object
+     */
+    public Observable<ServiceResponse<DictionaryWrapper>> getEmptyAsyncWithServiceResponse() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DictionaryWrapper>>>() {
                 @Override
@@ -243,8 +286,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putEmpty(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putEmptyAsync(complexBody).toBlocking().single();
+    public void putEmpty(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putEmptyAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -255,7 +298,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(DictionaryWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putEmptyAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -264,7 +307,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param complexBody Please put an empty dictionary
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsync(DictionaryWrapper complexBody) {
+    public Observable<Void> putEmptyAsync(DictionaryWrapper complexBody) {
+        return putEmptyAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(DictionaryWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -297,8 +355,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DictionaryWrapper> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public DictionaryWrapper getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -308,7 +366,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DictionaryWrapper> getNullAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -316,7 +374,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    public Observable<ServiceResponse<DictionaryWrapper>> getNullAsync() {
+    public Observable<DictionaryWrapper> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
+            @Override
+            public DictionaryWrapper call(ServiceResponse<DictionaryWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
+     * @return the observable to the DictionaryWrapper object
+     */
+    public Observable<ServiceResponse<DictionaryWrapper>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DictionaryWrapper>>>() {
                 @Override
@@ -345,8 +417,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DictionaryWrapper> getNotProvided() throws ErrorException, IOException {
-        return getNotProvidedAsync().toBlocking().single();
+    public DictionaryWrapper getNotProvided() throws ErrorException, IOException {
+        return getNotProvidedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -356,7 +428,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DictionaryWrapper> getNotProvidedAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
-        return ServiceCall.create(getNotProvidedAsync(), serviceCallback);
+        return ServiceCall.create(getNotProvidedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -364,7 +436,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    public Observable<ServiceResponse<DictionaryWrapper>> getNotProvidedAsync() {
+    public Observable<DictionaryWrapper> getNotProvidedAsync() {
+        return getNotProvidedAsyncWithServiceResponse().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
+            @Override
+            public DictionaryWrapper call(ServiceResponse<DictionaryWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
+     * @return the observable to the DictionaryWrapper object
+     */
+    public Observable<ServiceResponse<DictionaryWrapper>> getNotProvidedAsyncWithServiceResponse() {
         return service.getNotProvided()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DictionaryWrapper>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/DictionarysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/DictionarysImpl.java
@@ -87,10 +87,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DictionaryWrapper object if successful.
      */
     public DictionaryWrapper getValid() throws ErrorException, IOException {
-        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -100,7 +100,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DictionaryWrapper> getValidAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
-        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -109,12 +109,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the DictionaryWrapper object
      */
     public Observable<DictionaryWrapper> getValidAsync() {
-        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
+        return getValidWithServiceResponseAsync().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
             @Override
             public DictionaryWrapper call(ServiceResponse<DictionaryWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -122,7 +122,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    public Observable<ServiceResponse<DictionaryWrapper>> getValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DictionaryWrapper>> getValidWithServiceResponseAsync() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DictionaryWrapper>>>() {
                 @Override
@@ -151,10 +151,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putValid(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putValidWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -165,7 +164,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(DictionaryWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putValidWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -175,12 +174,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putValidAsync(DictionaryWrapper complexBody) {
-        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putValidWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -189,7 +188,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(DictionaryWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(DictionaryWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -220,10 +219,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DictionaryWrapper object if successful.
      */
     public DictionaryWrapper getEmpty() throws ErrorException, IOException {
-        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -233,7 +232,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DictionaryWrapper> getEmptyAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -242,12 +241,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the DictionaryWrapper object
      */
     public Observable<DictionaryWrapper> getEmptyAsync() {
-        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
+        return getEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
             @Override
             public DictionaryWrapper call(ServiceResponse<DictionaryWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -255,7 +254,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    public Observable<ServiceResponse<DictionaryWrapper>> getEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DictionaryWrapper>> getEmptyWithServiceResponseAsync() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DictionaryWrapper>>>() {
                 @Override
@@ -284,10 +283,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putEmpty(DictionaryWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putEmptyAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putEmptyWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -298,7 +296,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(DictionaryWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putEmptyWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -308,12 +306,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putEmptyAsync(DictionaryWrapper complexBody) {
-        return putEmptyAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putEmptyWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -322,7 +320,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param complexBody Please put an empty dictionary
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(DictionaryWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(DictionaryWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -353,10 +351,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DictionaryWrapper object if successful.
      */
     public DictionaryWrapper getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -366,7 +364,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DictionaryWrapper> getNullAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -375,12 +373,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the DictionaryWrapper object
      */
     public Observable<DictionaryWrapper> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
             @Override
             public DictionaryWrapper call(ServiceResponse<DictionaryWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -388,7 +386,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    public Observable<ServiceResponse<DictionaryWrapper>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DictionaryWrapper>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DictionaryWrapper>>>() {
                 @Override
@@ -415,10 +413,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DictionaryWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DictionaryWrapper object if successful.
      */
     public DictionaryWrapper getNotProvided() throws ErrorException, IOException {
-        return getNotProvidedAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNotProvidedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -428,7 +426,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DictionaryWrapper> getNotProvidedAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
-        return ServiceCall.create(getNotProvidedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNotProvidedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -437,12 +435,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the DictionaryWrapper object
      */
     public Observable<DictionaryWrapper> getNotProvidedAsync() {
-        return getNotProvidedAsyncWithServiceResponse().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
+        return getNotProvidedWithServiceResponseAsync().map(new Func1<ServiceResponse<DictionaryWrapper>, DictionaryWrapper>() {
             @Override
             public DictionaryWrapper call(ServiceResponse<DictionaryWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -450,7 +448,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the DictionaryWrapper object
      */
-    public Observable<ServiceResponse<DictionaryWrapper>> getNotProvidedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DictionaryWrapper>> getNotProvidedWithServiceResponseAsync() {
         return service.getNotProvided()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DictionaryWrapper>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
@@ -71,10 +71,10 @@ public final class InheritancesImpl implements Inheritances {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Siamese object wrapped in {@link ServiceResponse} if successful.
+     * @return the Siamese object if successful.
      */
     public Siamese getValid() throws ErrorException, IOException {
-        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +84,7 @@ public final class InheritancesImpl implements Inheritances {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Siamese> getValidAsync(final ServiceCallback<Siamese> serviceCallback) {
-        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -93,12 +93,12 @@ public final class InheritancesImpl implements Inheritances {
      * @return the observable to the Siamese object
      */
     public Observable<Siamese> getValidAsync() {
-        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Siamese>, Siamese>() {
+        return getValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Siamese>, Siamese>() {
             @Override
             public Siamese call(ServiceResponse<Siamese> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -106,7 +106,7 @@ public final class InheritancesImpl implements Inheritances {
      *
      * @return the observable to the Siamese object
      */
-    public Observable<ServiceResponse<Siamese>> getValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Siamese>> getValidWithServiceResponseAsync() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Siamese>>>() {
                 @Override
@@ -135,10 +135,9 @@ public final class InheritancesImpl implements Inheritances {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putValid(Siamese complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putValidWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -149,7 +148,7 @@ public final class InheritancesImpl implements Inheritances {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(Siamese complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putValidWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -159,12 +158,12 @@ public final class InheritancesImpl implements Inheritances {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putValidAsync(Siamese complexBody) {
-        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putValidWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -173,7 +172,7 @@ public final class InheritancesImpl implements Inheritances {
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Siamese complexBody) {
+    public Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(Siamese complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
@@ -73,8 +73,8 @@ public final class InheritancesImpl implements Inheritances {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Siamese object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Siamese> getValid() throws ErrorException, IOException {
-        return getValidAsync().toBlocking().single();
+    public Siamese getValid() throws ErrorException, IOException {
+        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +84,7 @@ public final class InheritancesImpl implements Inheritances {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Siamese> getValidAsync(final ServiceCallback<Siamese> serviceCallback) {
-        return ServiceCall.create(getValidAsync(), serviceCallback);
+        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -92,7 +92,21 @@ public final class InheritancesImpl implements Inheritances {
      *
      * @return the observable to the Siamese object
      */
-    public Observable<ServiceResponse<Siamese>> getValidAsync() {
+    public Observable<Siamese> getValidAsync() {
+        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Siamese>, Siamese>() {
+            @Override
+            public Siamese call(ServiceResponse<Siamese> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types that extend others.
+     *
+     * @return the observable to the Siamese object
+     */
+    public Observable<ServiceResponse<Siamese>> getValidAsyncWithServiceResponse() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Siamese>>>() {
                 @Override
@@ -123,8 +137,8 @@ public final class InheritancesImpl implements Inheritances {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putValid(Siamese complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putValidAsync(complexBody).toBlocking().single();
+    public void putValid(Siamese complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -135,7 +149,7 @@ public final class InheritancesImpl implements Inheritances {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(Siamese complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -144,7 +158,22 @@ public final class InheritancesImpl implements Inheritances {
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsync(Siamese complexBody) {
+    public Observable<Void> putValidAsync(Siamese complexBody) {
+        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Siamese complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
@@ -71,10 +71,10 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Fish object wrapped in {@link ServiceResponse} if successful.
+     * @return the Fish object if successful.
      */
     public Fish getValid() throws ErrorException, IOException {
-        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +84,7 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Fish> getValidAsync(final ServiceCallback<Fish> serviceCallback) {
-        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -93,12 +93,12 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @return the observable to the Fish object
      */
     public Observable<Fish> getValidAsync() {
-        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Fish>, Fish>() {
+        return getValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Fish>, Fish>() {
             @Override
             public Fish call(ServiceResponse<Fish> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -106,7 +106,7 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      *
      * @return the observable to the Fish object
      */
-    public Observable<ServiceResponse<Fish>> getValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Fish>> getValidWithServiceResponseAsync() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Fish>>>() {
                 @Override
@@ -187,10 +187,9 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putValidWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -253,7 +252,7 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putValidWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -315,12 +314,12 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putValidAsync(Fish complexBody) {
-        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putValidWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -381,7 +380,7 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      }
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Fish complexBody) {
+    public Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
@@ -73,8 +73,8 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Fish object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Fish> getValid() throws ErrorException, IOException {
-        return getValidAsync().toBlocking().single();
+    public Fish getValid() throws ErrorException, IOException {
+        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +84,7 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Fish> getValidAsync(final ServiceCallback<Fish> serviceCallback) {
-        return ServiceCall.create(getValidAsync(), serviceCallback);
+        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -92,7 +92,21 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      *
      * @return the observable to the Fish object
      */
-    public Observable<ServiceResponse<Fish>> getValidAsync() {
+    public Observable<Fish> getValidAsync() {
+        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Fish>, Fish>() {
+            @Override
+            public Fish call(ServiceResponse<Fish> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
+     * @return the observable to the Fish object
+     */
+    public Observable<ServiceResponse<Fish>> getValidAsyncWithServiceResponse() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Fish>>>() {
                 @Override
@@ -175,8 +189,8 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putValidAsync(complexBody).toBlocking().single();
+    public void putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -239,7 +253,7 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -300,7 +314,74 @@ public final class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      }
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsync(Fish complexBody) {
+    public Observable<Void> putValidAsync(Fish complexBody) {
+        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this:
+     {
+         "fishtype": "salmon",
+         "species": "king",
+         "length": 1,
+         "age": 1,
+         "location": "alaska",
+         "iswild": true,
+         "siblings": [
+             {
+                 "fishtype": "shark",
+                 "species": "predator",
+                 "length": 20,
+                 "age": 6,
+                 "siblings": [
+                     {
+                         "fishtype": "salmon",
+                         "species": "coho",
+                         "length": 2,
+                         "age": 2,
+                         "location": "atlantic",
+                         "iswild": true,
+                         "siblings": [
+                             {
+                                 "fishtype": "shark",
+                                 "species": "predator",
+                                 "length": 20,
+                                 "age": 6
+                             },
+                             {
+                                 "fishtype": "sawshark",
+                                 "species": "dangerous",
+                                 "length": 10,
+                                 "age": 105
+                             }
+                         ]
+                     },
+                     {
+                         "fishtype": "sawshark",
+                         "species": "dangerous",
+                         "length": 10,
+                         "age": 105
+                     }
+                 ]
+             },
+             {
+                 "fishtype": "sawshark",
+                 "species": "dangerous",
+                 "length": 10,
+                 "age": 105
+             }
+         ]
+     }
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
@@ -77,8 +77,8 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Fish object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Fish> getValid() throws ErrorException, IOException {
-        return getValidAsync().toBlocking().single();
+    public Fish getValid() throws ErrorException, IOException {
+        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -88,7 +88,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Fish> getValidAsync(final ServiceCallback<Fish> serviceCallback) {
-        return ServiceCall.create(getValidAsync(), serviceCallback);
+        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -96,7 +96,21 @@ public final class PolymorphismsImpl implements Polymorphisms {
      *
      * @return the observable to the Fish object
      */
-    public Observable<ServiceResponse<Fish>> getValidAsync() {
+    public Observable<Fish> getValidAsync() {
+        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Fish>, Fish>() {
+            @Override
+            public Fish call(ServiceResponse<Fish> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types that are polymorphic.
+     *
+     * @return the observable to the Fish object
+     */
+    public Observable<ServiceResponse<Fish>> getValidAsyncWithServiceResponse() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Fish>>>() {
                 @Override
@@ -159,8 +173,8 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putValidAsync(complexBody).toBlocking().single();
+    public void putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -203,7 +217,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -244,7 +258,54 @@ public final class PolymorphismsImpl implements Polymorphisms {
            };
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsync(Fish complexBody) {
+    public Observable<Void> putValidAsync(Fish complexBody) {
+        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this:
+     {
+             'fishtype':'Salmon',
+             'location':'alaska',
+             'iswild':true,
+             'species':'king',
+             'length':1.0,
+             'siblings':[
+               {
+                 'fishtype':'Shark',
+                 'age':6,
+                 'birthday': '2012-01-05T01:00:00Z',
+                 'length':20.0,
+                 'species':'predator',
+               },
+               {
+                 'fishtype':'Sawshark',
+                 'age':105,
+                 'birthday': '1900-01-05T01:00:00Z',
+                 'length':10.0,
+                 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                 'species':'dangerous',
+               },
+               {
+                 'fishtype': 'goblin',
+                 'age': 1,
+                 'birthday': '2015-08-08T00:00:00Z',
+                 'length': 30.0,
+                 'species': 'scary',
+                 'jawsize': 5
+               }
+             ]
+           };
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -304,8 +365,8 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putValidMissingRequired(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putValidMissingRequiredAsync(complexBody).toBlocking().single();
+    public void putValidMissingRequired(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putValidMissingRequiredAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -341,7 +402,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidMissingRequiredAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidMissingRequiredAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putValidMissingRequiredAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -375,7 +436,47 @@ public final class PolymorphismsImpl implements Polymorphisms {
      }
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidMissingRequiredAsync(Fish complexBody) {
+    public Observable<Void> putValidMissingRequiredAsync(Fish complexBody) {
+        return putValidMissingRequiredAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
+     {
+         "fishtype": "sawshark",
+         "species": "snaggle toothed",
+         "length": 18.5,
+         "age": 2,
+         "birthday": "2013-06-01T01:00:00Z",
+         "location": "alaska",
+         "picture": base64(FF FF FF FF FE),
+         "siblings": [
+             {
+                 "fishtype": "shark",
+                 "species": "predator",
+                 "birthday": "2012-01-05T01:00:00Z",
+                 "length": 20,
+                 "age": 6
+             },
+             {
+                 "fishtype": "sawshark",
+                 "species": "dangerous",
+                 "picture": base64(FF FF FF FF FE),
+                 "length": 10,
+                 "age": 105
+             }
+         ]
+     }
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putValidMissingRequiredAsyncWithServiceResponse(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
@@ -75,10 +75,10 @@ public final class PolymorphismsImpl implements Polymorphisms {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Fish object wrapped in {@link ServiceResponse} if successful.
+     * @return the Fish object if successful.
      */
     public Fish getValid() throws ErrorException, IOException {
-        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -88,7 +88,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Fish> getValidAsync(final ServiceCallback<Fish> serviceCallback) {
-        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -97,12 +97,12 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the observable to the Fish object
      */
     public Observable<Fish> getValidAsync() {
-        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Fish>, Fish>() {
+        return getValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Fish>, Fish>() {
             @Override
             public Fish call(ServiceResponse<Fish> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -110,7 +110,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
      *
      * @return the observable to the Fish object
      */
-    public Observable<ServiceResponse<Fish>> getValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Fish>> getValidWithServiceResponseAsync() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Fish>>>() {
                 @Override
@@ -171,10 +171,9 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putValid(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putValidWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -217,7 +216,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putValidWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -259,12 +258,12 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putValidAsync(Fish complexBody) {
-        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putValidWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -305,7 +304,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
            };
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(Fish complexBody) {
+    public Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -363,10 +362,9 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putValidMissingRequired(Fish complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putValidMissingRequiredAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putValidMissingRequiredWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -402,7 +400,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidMissingRequiredAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidMissingRequiredAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putValidMissingRequiredWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -437,12 +435,12 @@ public final class PolymorphismsImpl implements Polymorphisms {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putValidMissingRequiredAsync(Fish complexBody) {
-        return putValidMissingRequiredAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putValidMissingRequiredWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -476,7 +474,7 @@ public final class PolymorphismsImpl implements Polymorphisms {
      }
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidMissingRequiredAsyncWithServiceResponse(Fish complexBody) {
+    public Observable<ServiceResponse<Void>> putValidMissingRequiredWithServiceResponseAsync(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
@@ -161,10 +161,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the IntWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the IntWrapper object if successful.
      */
     public IntWrapper getInt() throws ErrorException, IOException {
-        return getIntAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getIntWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -174,7 +174,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<IntWrapper> getIntAsync(final ServiceCallback<IntWrapper> serviceCallback) {
-        return ServiceCall.create(getIntAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -183,12 +183,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the IntWrapper object
      */
     public Observable<IntWrapper> getIntAsync() {
-        return getIntAsyncWithServiceResponse().map(new Func1<ServiceResponse<IntWrapper>, IntWrapper>() {
+        return getIntWithServiceResponseAsync().map(new Func1<ServiceResponse<IntWrapper>, IntWrapper>() {
             @Override
             public IntWrapper call(ServiceResponse<IntWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -196,7 +196,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the IntWrapper object
      */
-    public Observable<ServiceResponse<IntWrapper>> getIntAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<IntWrapper>> getIntWithServiceResponseAsync() {
         return service.getInt()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<IntWrapper>>>() {
                 @Override
@@ -225,10 +225,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putInt(IntWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putIntAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putIntWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -239,7 +238,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putIntAsync(IntWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putIntAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putIntWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -249,12 +248,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putIntAsync(IntWrapper complexBody) {
-        return putIntAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putIntWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -263,7 +262,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put -1 and 2
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putIntAsyncWithServiceResponse(IntWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putIntWithServiceResponseAsync(IntWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -294,10 +293,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LongWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the LongWrapper object if successful.
      */
     public LongWrapper getLong() throws ErrorException, IOException {
-        return getLongAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLongWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -307,7 +306,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LongWrapper> getLongAsync(final ServiceCallback<LongWrapper> serviceCallback) {
-        return ServiceCall.create(getLongAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLongWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -316,12 +315,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the LongWrapper object
      */
     public Observable<LongWrapper> getLongAsync() {
-        return getLongAsyncWithServiceResponse().map(new Func1<ServiceResponse<LongWrapper>, LongWrapper>() {
+        return getLongWithServiceResponseAsync().map(new Func1<ServiceResponse<LongWrapper>, LongWrapper>() {
             @Override
             public LongWrapper call(ServiceResponse<LongWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -329,7 +328,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the LongWrapper object
      */
-    public Observable<ServiceResponse<LongWrapper>> getLongAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<LongWrapper>> getLongWithServiceResponseAsync() {
         return service.getLong()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LongWrapper>>>() {
                 @Override
@@ -358,10 +357,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putLong(LongWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putLongAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putLongWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -372,7 +370,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLongAsync(LongWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLongAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putLongWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -382,12 +380,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putLongAsync(LongWrapper complexBody) {
-        return putLongAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putLongWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -396,7 +394,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 1099511627775 and -999511627788
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLongAsyncWithServiceResponse(LongWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putLongWithServiceResponseAsync(LongWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -427,10 +425,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the FloatWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the FloatWrapper object if successful.
      */
     public FloatWrapper getFloat() throws ErrorException, IOException {
-        return getFloatAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFloatWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -440,7 +438,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<FloatWrapper> getFloatAsync(final ServiceCallback<FloatWrapper> serviceCallback) {
-        return ServiceCall.create(getFloatAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFloatWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -449,12 +447,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the FloatWrapper object
      */
     public Observable<FloatWrapper> getFloatAsync() {
-        return getFloatAsyncWithServiceResponse().map(new Func1<ServiceResponse<FloatWrapper>, FloatWrapper>() {
+        return getFloatWithServiceResponseAsync().map(new Func1<ServiceResponse<FloatWrapper>, FloatWrapper>() {
             @Override
             public FloatWrapper call(ServiceResponse<FloatWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -462,7 +460,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the FloatWrapper object
      */
-    public Observable<ServiceResponse<FloatWrapper>> getFloatAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<FloatWrapper>> getFloatWithServiceResponseAsync() {
         return service.getFloat()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<FloatWrapper>>>() {
                 @Override
@@ -491,10 +489,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putFloat(FloatWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putFloatAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putFloatWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -505,7 +502,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putFloatAsync(FloatWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putFloatAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putFloatWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -515,12 +512,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putFloatAsync(FloatWrapper complexBody) {
-        return putFloatAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putFloatWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -529,7 +526,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 1.05 and -0.003
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putFloatAsyncWithServiceResponse(FloatWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putFloatWithServiceResponseAsync(FloatWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -560,10 +557,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DoubleWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DoubleWrapper object if successful.
      */
     public DoubleWrapper getDouble() throws ErrorException, IOException {
-        return getDoubleAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDoubleWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -573,7 +570,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DoubleWrapper> getDoubleAsync(final ServiceCallback<DoubleWrapper> serviceCallback) {
-        return ServiceCall.create(getDoubleAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDoubleWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -582,12 +579,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the DoubleWrapper object
      */
     public Observable<DoubleWrapper> getDoubleAsync() {
-        return getDoubleAsyncWithServiceResponse().map(new Func1<ServiceResponse<DoubleWrapper>, DoubleWrapper>() {
+        return getDoubleWithServiceResponseAsync().map(new Func1<ServiceResponse<DoubleWrapper>, DoubleWrapper>() {
             @Override
             public DoubleWrapper call(ServiceResponse<DoubleWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -595,7 +592,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the DoubleWrapper object
      */
-    public Observable<ServiceResponse<DoubleWrapper>> getDoubleAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DoubleWrapper>> getDoubleWithServiceResponseAsync() {
         return service.getDouble()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DoubleWrapper>>>() {
                 @Override
@@ -624,10 +621,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDouble(DoubleWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDoubleAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putDoubleWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -638,7 +634,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDoubleAsync(DoubleWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDoubleAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putDoubleWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -648,12 +644,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDoubleAsync(DoubleWrapper complexBody) {
-        return putDoubleAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDoubleWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -662,7 +658,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDoubleAsyncWithServiceResponse(DoubleWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putDoubleWithServiceResponseAsync(DoubleWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -693,10 +689,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BooleanWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the BooleanWrapper object if successful.
      */
     public BooleanWrapper getBool() throws ErrorException, IOException {
-        return getBoolAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBoolWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -706,7 +702,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BooleanWrapper> getBoolAsync(final ServiceCallback<BooleanWrapper> serviceCallback) {
-        return ServiceCall.create(getBoolAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBoolWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -715,12 +711,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the BooleanWrapper object
      */
     public Observable<BooleanWrapper> getBoolAsync() {
-        return getBoolAsyncWithServiceResponse().map(new Func1<ServiceResponse<BooleanWrapper>, BooleanWrapper>() {
+        return getBoolWithServiceResponseAsync().map(new Func1<ServiceResponse<BooleanWrapper>, BooleanWrapper>() {
             @Override
             public BooleanWrapper call(ServiceResponse<BooleanWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -728,7 +724,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the BooleanWrapper object
      */
-    public Observable<ServiceResponse<BooleanWrapper>> getBoolAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<BooleanWrapper>> getBoolWithServiceResponseAsync() {
         return service.getBool()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BooleanWrapper>>>() {
                 @Override
@@ -757,10 +753,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBool(BooleanWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putBoolAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putBoolWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -771,7 +766,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBoolAsync(BooleanWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBoolAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putBoolWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -781,12 +776,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBoolAsync(BooleanWrapper complexBody) {
-        return putBoolAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBoolWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -795,7 +790,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put true and false
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBoolAsyncWithServiceResponse(BooleanWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putBoolWithServiceResponseAsync(BooleanWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -826,10 +821,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the StringWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the StringWrapper object if successful.
      */
     public StringWrapper getString() throws ErrorException, IOException {
-        return getStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -839,7 +834,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<StringWrapper> getStringAsync(final ServiceCallback<StringWrapper> serviceCallback) {
-        return ServiceCall.create(getStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -848,12 +843,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the StringWrapper object
      */
     public Observable<StringWrapper> getStringAsync() {
-        return getStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<StringWrapper>, StringWrapper>() {
+        return getStringWithServiceResponseAsync().map(new Func1<ServiceResponse<StringWrapper>, StringWrapper>() {
             @Override
             public StringWrapper call(ServiceResponse<StringWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -861,7 +856,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the StringWrapper object
      */
-    public Observable<ServiceResponse<StringWrapper>> getStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<StringWrapper>> getStringWithServiceResponseAsync() {
         return service.getString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<StringWrapper>>>() {
                 @Override
@@ -890,10 +885,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putString(StringWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putStringAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putStringWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -904,7 +898,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putStringAsync(StringWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putStringAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putStringWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -914,12 +908,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putStringAsync(StringWrapper complexBody) {
-        return putStringAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putStringWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -928,7 +922,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 'goodrequest', '', and null
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putStringAsyncWithServiceResponse(StringWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putStringWithServiceResponseAsync(StringWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -959,10 +953,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateWrapper object if successful.
      */
     public DateWrapper getDate() throws ErrorException, IOException {
-        return getDateAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -972,7 +966,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateWrapper> getDateAsync(final ServiceCallback<DateWrapper> serviceCallback) {
-        return ServiceCall.create(getDateAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -981,12 +975,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the DateWrapper object
      */
     public Observable<DateWrapper> getDateAsync() {
-        return getDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateWrapper>, DateWrapper>() {
+        return getDateWithServiceResponseAsync().map(new Func1<ServiceResponse<DateWrapper>, DateWrapper>() {
             @Override
             public DateWrapper call(ServiceResponse<DateWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -994,7 +988,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the DateWrapper object
      */
-    public Observable<ServiceResponse<DateWrapper>> getDateAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateWrapper>> getDateWithServiceResponseAsync() {
         return service.getDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateWrapper>>>() {
                 @Override
@@ -1023,10 +1017,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDate(DateWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putDateWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1037,7 +1030,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateAsync(DateWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putDateWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -1047,12 +1040,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateAsync(DateWrapper complexBody) {
-        return putDateAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1061,7 +1054,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put '0001-01-01' and '2016-02-29'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateAsyncWithServiceResponse(DateWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putDateWithServiceResponseAsync(DateWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -1092,10 +1085,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DatetimeWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DatetimeWrapper object if successful.
      */
     public DatetimeWrapper getDateTime() throws ErrorException, IOException {
-        return getDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1105,7 +1098,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DatetimeWrapper> getDateTimeAsync(final ServiceCallback<DatetimeWrapper> serviceCallback) {
-        return ServiceCall.create(getDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1114,12 +1107,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the DatetimeWrapper object
      */
     public Observable<DatetimeWrapper> getDateTimeAsync() {
-        return getDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DatetimeWrapper>, DatetimeWrapper>() {
+        return getDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DatetimeWrapper>, DatetimeWrapper>() {
             @Override
             public DatetimeWrapper call(ServiceResponse<DatetimeWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1127,7 +1120,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the DatetimeWrapper object
      */
-    public Observable<ServiceResponse<DatetimeWrapper>> getDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DatetimeWrapper>> getDateTimeWithServiceResponseAsync() {
         return service.getDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DatetimeWrapper>>>() {
                 @Override
@@ -1156,10 +1149,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDateTime(DatetimeWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateTimeAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putDateTimeWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1170,7 +1162,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeAsync(DatetimeWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putDateTimeWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -1180,12 +1172,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateTimeAsync(DatetimeWrapper complexBody) {
-        return putDateTimeAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateTimeWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1194,7 +1186,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeAsyncWithServiceResponse(DatetimeWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putDateTimeWithServiceResponseAsync(DatetimeWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -1225,10 +1217,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Datetimerfc1123Wrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the Datetimerfc1123Wrapper object if successful.
      */
     public Datetimerfc1123Wrapper getDateTimeRfc1123() throws ErrorException, IOException {
-        return getDateTimeRfc1123AsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeRfc1123WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1238,7 +1230,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Datetimerfc1123Wrapper> getDateTimeRfc1123Async(final ServiceCallback<Datetimerfc1123Wrapper> serviceCallback) {
-        return ServiceCall.create(getDateTimeRfc1123AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeRfc1123WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1247,12 +1239,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the Datetimerfc1123Wrapper object
      */
     public Observable<Datetimerfc1123Wrapper> getDateTimeRfc1123Async() {
-        return getDateTimeRfc1123AsyncWithServiceResponse().map(new Func1<ServiceResponse<Datetimerfc1123Wrapper>, Datetimerfc1123Wrapper>() {
+        return getDateTimeRfc1123WithServiceResponseAsync().map(new Func1<ServiceResponse<Datetimerfc1123Wrapper>, Datetimerfc1123Wrapper>() {
             @Override
             public Datetimerfc1123Wrapper call(ServiceResponse<Datetimerfc1123Wrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1260,7 +1252,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the Datetimerfc1123Wrapper object
      */
-    public Observable<ServiceResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123WithServiceResponseAsync() {
         return service.getDateTimeRfc1123()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Datetimerfc1123Wrapper>>>() {
                 @Override
@@ -1289,10 +1281,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateTimeRfc1123AsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putDateTimeRfc1123WithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1303,7 +1294,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeRfc1123AsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putDateTimeRfc1123WithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -1313,12 +1304,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody) {
-        return putDateTimeRfc1123AsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateTimeRfc1123WithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1327,7 +1318,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeRfc1123AsyncWithServiceResponse(Datetimerfc1123Wrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putDateTimeRfc1123WithServiceResponseAsync(Datetimerfc1123Wrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -1358,10 +1349,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DurationWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the DurationWrapper object if successful.
      */
     public DurationWrapper getDuration() throws ErrorException, IOException {
-        return getDurationAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDurationWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1371,7 +1362,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DurationWrapper> getDurationAsync(final ServiceCallback<DurationWrapper> serviceCallback) {
-        return ServiceCall.create(getDurationAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDurationWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1380,12 +1371,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the DurationWrapper object
      */
     public Observable<DurationWrapper> getDurationAsync() {
-        return getDurationAsyncWithServiceResponse().map(new Func1<ServiceResponse<DurationWrapper>, DurationWrapper>() {
+        return getDurationWithServiceResponseAsync().map(new Func1<ServiceResponse<DurationWrapper>, DurationWrapper>() {
             @Override
             public DurationWrapper call(ServiceResponse<DurationWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1393,7 +1384,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the DurationWrapper object
      */
-    public Observable<ServiceResponse<DurationWrapper>> getDurationAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DurationWrapper>> getDurationWithServiceResponseAsync() {
         return service.getDuration()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DurationWrapper>>>() {
                 @Override
@@ -1422,10 +1413,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDuration(DurationWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDurationAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putDurationWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1436,7 +1426,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDurationAsync(DurationWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDurationAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putDurationWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -1446,12 +1436,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDurationAsync(DurationWrapper complexBody) {
-        return putDurationAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDurationWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1460,7 +1450,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 'P123DT22H14M12.011S'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDurationAsyncWithServiceResponse(DurationWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putDurationWithServiceResponseAsync(DurationWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -1491,10 +1481,10 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ByteWrapper object wrapped in {@link ServiceResponse} if successful.
+     * @return the ByteWrapper object if successful.
      */
     public ByteWrapper getByte() throws ErrorException, IOException {
-        return getByteAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getByteWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1504,7 +1494,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ByteWrapper> getByteAsync(final ServiceCallback<ByteWrapper> serviceCallback) {
-        return ServiceCall.create(getByteAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getByteWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1513,12 +1503,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the observable to the ByteWrapper object
      */
     public Observable<ByteWrapper> getByteAsync() {
-        return getByteAsyncWithServiceResponse().map(new Func1<ServiceResponse<ByteWrapper>, ByteWrapper>() {
+        return getByteWithServiceResponseAsync().map(new Func1<ServiceResponse<ByteWrapper>, ByteWrapper>() {
             @Override
             public ByteWrapper call(ServiceResponse<ByteWrapper> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1526,7 +1516,7 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the ByteWrapper object
      */
-    public Observable<ServiceResponse<ByteWrapper>> getByteAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<ByteWrapper>> getByteWithServiceResponseAsync() {
         return service.getByte()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ByteWrapper>>>() {
                 @Override
@@ -1555,10 +1545,9 @@ public final class PrimitivesImpl implements Primitives {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putByte(ByteWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putByteAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putByteWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1569,7 +1558,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putByteAsync(ByteWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putByteAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putByteWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -1579,12 +1568,12 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putByteAsync(ByteWrapper complexBody) {
-        return putByteAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putByteWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1593,7 +1582,7 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putByteAsyncWithServiceResponse(ByteWrapper complexBody) {
+    public Observable<ServiceResponse<Void>> putByteWithServiceResponseAsync(ByteWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
@@ -163,8 +163,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the IntWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<IntWrapper> getInt() throws ErrorException, IOException {
-        return getIntAsync().toBlocking().single();
+    public IntWrapper getInt() throws ErrorException, IOException {
+        return getIntAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -174,7 +174,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<IntWrapper> getIntAsync(final ServiceCallback<IntWrapper> serviceCallback) {
-        return ServiceCall.create(getIntAsync(), serviceCallback);
+        return ServiceCall.create(getIntAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -182,7 +182,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the IntWrapper object
      */
-    public Observable<ServiceResponse<IntWrapper>> getIntAsync() {
+    public Observable<IntWrapper> getIntAsync() {
+        return getIntAsyncWithServiceResponse().map(new Func1<ServiceResponse<IntWrapper>, IntWrapper>() {
+            @Override
+            public IntWrapper call(ServiceResponse<IntWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with integer properties.
+     *
+     * @return the observable to the IntWrapper object
+     */
+    public Observable<ServiceResponse<IntWrapper>> getIntAsyncWithServiceResponse() {
         return service.getInt()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<IntWrapper>>>() {
                 @Override
@@ -213,8 +227,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putInt(IntWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putIntAsync(complexBody).toBlocking().single();
+    public void putInt(IntWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putIntAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -225,7 +239,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putIntAsync(IntWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putIntAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putIntAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -234,7 +248,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put -1 and 2
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putIntAsync(IntWrapper complexBody) {
+    public Observable<Void> putIntAsync(IntWrapper complexBody) {
+        return putIntAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putIntAsyncWithServiceResponse(IntWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -267,8 +296,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LongWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<LongWrapper> getLong() throws ErrorException, IOException {
-        return getLongAsync().toBlocking().single();
+    public LongWrapper getLong() throws ErrorException, IOException {
+        return getLongAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -278,7 +307,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LongWrapper> getLongAsync(final ServiceCallback<LongWrapper> serviceCallback) {
-        return ServiceCall.create(getLongAsync(), serviceCallback);
+        return ServiceCall.create(getLongAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -286,7 +315,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the LongWrapper object
      */
-    public Observable<ServiceResponse<LongWrapper>> getLongAsync() {
+    public Observable<LongWrapper> getLongAsync() {
+        return getLongAsyncWithServiceResponse().map(new Func1<ServiceResponse<LongWrapper>, LongWrapper>() {
+            @Override
+            public LongWrapper call(ServiceResponse<LongWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with long properties.
+     *
+     * @return the observable to the LongWrapper object
+     */
+    public Observable<ServiceResponse<LongWrapper>> getLongAsyncWithServiceResponse() {
         return service.getLong()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LongWrapper>>>() {
                 @Override
@@ -317,8 +360,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putLong(LongWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putLongAsync(complexBody).toBlocking().single();
+    public void putLong(LongWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putLongAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -329,7 +372,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLongAsync(LongWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLongAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putLongAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -338,7 +381,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 1099511627775 and -999511627788
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLongAsync(LongWrapper complexBody) {
+    public Observable<Void> putLongAsync(LongWrapper complexBody) {
+        return putLongAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putLongAsyncWithServiceResponse(LongWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -371,8 +429,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the FloatWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<FloatWrapper> getFloat() throws ErrorException, IOException {
-        return getFloatAsync().toBlocking().single();
+    public FloatWrapper getFloat() throws ErrorException, IOException {
+        return getFloatAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -382,7 +440,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<FloatWrapper> getFloatAsync(final ServiceCallback<FloatWrapper> serviceCallback) {
-        return ServiceCall.create(getFloatAsync(), serviceCallback);
+        return ServiceCall.create(getFloatAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -390,7 +448,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the FloatWrapper object
      */
-    public Observable<ServiceResponse<FloatWrapper>> getFloatAsync() {
+    public Observable<FloatWrapper> getFloatAsync() {
+        return getFloatAsyncWithServiceResponse().map(new Func1<ServiceResponse<FloatWrapper>, FloatWrapper>() {
+            @Override
+            public FloatWrapper call(ServiceResponse<FloatWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with float properties.
+     *
+     * @return the observable to the FloatWrapper object
+     */
+    public Observable<ServiceResponse<FloatWrapper>> getFloatAsyncWithServiceResponse() {
         return service.getFloat()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<FloatWrapper>>>() {
                 @Override
@@ -421,8 +493,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putFloat(FloatWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putFloatAsync(complexBody).toBlocking().single();
+    public void putFloat(FloatWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putFloatAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -433,7 +505,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putFloatAsync(FloatWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putFloatAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putFloatAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -442,7 +514,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 1.05 and -0.003
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putFloatAsync(FloatWrapper complexBody) {
+    public Observable<Void> putFloatAsync(FloatWrapper complexBody) {
+        return putFloatAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putFloatAsyncWithServiceResponse(FloatWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -475,8 +562,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DoubleWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DoubleWrapper> getDouble() throws ErrorException, IOException {
-        return getDoubleAsync().toBlocking().single();
+    public DoubleWrapper getDouble() throws ErrorException, IOException {
+        return getDoubleAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -486,7 +573,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DoubleWrapper> getDoubleAsync(final ServiceCallback<DoubleWrapper> serviceCallback) {
-        return ServiceCall.create(getDoubleAsync(), serviceCallback);
+        return ServiceCall.create(getDoubleAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -494,7 +581,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the DoubleWrapper object
      */
-    public Observable<ServiceResponse<DoubleWrapper>> getDoubleAsync() {
+    public Observable<DoubleWrapper> getDoubleAsync() {
+        return getDoubleAsyncWithServiceResponse().map(new Func1<ServiceResponse<DoubleWrapper>, DoubleWrapper>() {
+            @Override
+            public DoubleWrapper call(ServiceResponse<DoubleWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with double properties.
+     *
+     * @return the observable to the DoubleWrapper object
+     */
+    public Observable<ServiceResponse<DoubleWrapper>> getDoubleAsyncWithServiceResponse() {
         return service.getDouble()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DoubleWrapper>>>() {
                 @Override
@@ -525,8 +626,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDouble(DoubleWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDoubleAsync(complexBody).toBlocking().single();
+    public void putDouble(DoubleWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDoubleAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -537,7 +638,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDoubleAsync(DoubleWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDoubleAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putDoubleAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -546,7 +647,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDoubleAsync(DoubleWrapper complexBody) {
+    public Observable<Void> putDoubleAsync(DoubleWrapper complexBody) {
+        return putDoubleAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDoubleAsyncWithServiceResponse(DoubleWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -579,8 +695,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BooleanWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<BooleanWrapper> getBool() throws ErrorException, IOException {
-        return getBoolAsync().toBlocking().single();
+    public BooleanWrapper getBool() throws ErrorException, IOException {
+        return getBoolAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -590,7 +706,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BooleanWrapper> getBoolAsync(final ServiceCallback<BooleanWrapper> serviceCallback) {
-        return ServiceCall.create(getBoolAsync(), serviceCallback);
+        return ServiceCall.create(getBoolAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -598,7 +714,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the BooleanWrapper object
      */
-    public Observable<ServiceResponse<BooleanWrapper>> getBoolAsync() {
+    public Observable<BooleanWrapper> getBoolAsync() {
+        return getBoolAsyncWithServiceResponse().map(new Func1<ServiceResponse<BooleanWrapper>, BooleanWrapper>() {
+            @Override
+            public BooleanWrapper call(ServiceResponse<BooleanWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with bool properties.
+     *
+     * @return the observable to the BooleanWrapper object
+     */
+    public Observable<ServiceResponse<BooleanWrapper>> getBoolAsyncWithServiceResponse() {
         return service.getBool()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BooleanWrapper>>>() {
                 @Override
@@ -629,8 +759,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBool(BooleanWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putBoolAsync(complexBody).toBlocking().single();
+    public void putBool(BooleanWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putBoolAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -641,7 +771,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBoolAsync(BooleanWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBoolAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putBoolAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -650,7 +780,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put true and false
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBoolAsync(BooleanWrapper complexBody) {
+    public Observable<Void> putBoolAsync(BooleanWrapper complexBody) {
+        return putBoolAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBoolAsyncWithServiceResponse(BooleanWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -683,8 +828,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the StringWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<StringWrapper> getString() throws ErrorException, IOException {
-        return getStringAsync().toBlocking().single();
+    public StringWrapper getString() throws ErrorException, IOException {
+        return getStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -694,7 +839,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<StringWrapper> getStringAsync(final ServiceCallback<StringWrapper> serviceCallback) {
-        return ServiceCall.create(getStringAsync(), serviceCallback);
+        return ServiceCall.create(getStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -702,7 +847,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the StringWrapper object
      */
-    public Observable<ServiceResponse<StringWrapper>> getStringAsync() {
+    public Observable<StringWrapper> getStringAsync() {
+        return getStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<StringWrapper>, StringWrapper>() {
+            @Override
+            public StringWrapper call(ServiceResponse<StringWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with string properties.
+     *
+     * @return the observable to the StringWrapper object
+     */
+    public Observable<ServiceResponse<StringWrapper>> getStringAsyncWithServiceResponse() {
         return service.getString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<StringWrapper>>>() {
                 @Override
@@ -733,8 +892,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putString(StringWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putStringAsync(complexBody).toBlocking().single();
+    public void putString(StringWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putStringAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -745,7 +904,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putStringAsync(StringWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putStringAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putStringAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -754,7 +913,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 'goodrequest', '', and null
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putStringAsync(StringWrapper complexBody) {
+    public Observable<Void> putStringAsync(StringWrapper complexBody) {
+        return putStringAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putStringAsyncWithServiceResponse(StringWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -787,8 +961,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateWrapper> getDate() throws ErrorException, IOException {
-        return getDateAsync().toBlocking().single();
+    public DateWrapper getDate() throws ErrorException, IOException {
+        return getDateAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -798,7 +972,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateWrapper> getDateAsync(final ServiceCallback<DateWrapper> serviceCallback) {
-        return ServiceCall.create(getDateAsync(), serviceCallback);
+        return ServiceCall.create(getDateAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -806,7 +980,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the DateWrapper object
      */
-    public Observable<ServiceResponse<DateWrapper>> getDateAsync() {
+    public Observable<DateWrapper> getDateAsync() {
+        return getDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateWrapper>, DateWrapper>() {
+            @Override
+            public DateWrapper call(ServiceResponse<DateWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with date properties.
+     *
+     * @return the observable to the DateWrapper object
+     */
+    public Observable<ServiceResponse<DateWrapper>> getDateAsyncWithServiceResponse() {
         return service.getDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateWrapper>>>() {
                 @Override
@@ -837,8 +1025,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDate(DateWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateAsync(complexBody).toBlocking().single();
+    public void putDate(DateWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -849,7 +1037,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateAsync(DateWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putDateAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -858,7 +1046,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put '0001-01-01' and '2016-02-29'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateAsync(DateWrapper complexBody) {
+    public Observable<Void> putDateAsync(DateWrapper complexBody) {
+        return putDateAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateAsyncWithServiceResponse(DateWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -891,8 +1094,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DatetimeWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DatetimeWrapper> getDateTime() throws ErrorException, IOException {
-        return getDateTimeAsync().toBlocking().single();
+    public DatetimeWrapper getDateTime() throws ErrorException, IOException {
+        return getDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -902,7 +1105,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DatetimeWrapper> getDateTimeAsync(final ServiceCallback<DatetimeWrapper> serviceCallback) {
-        return ServiceCall.create(getDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -910,7 +1113,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the DatetimeWrapper object
      */
-    public Observable<ServiceResponse<DatetimeWrapper>> getDateTimeAsync() {
+    public Observable<DatetimeWrapper> getDateTimeAsync() {
+        return getDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DatetimeWrapper>, DatetimeWrapper>() {
+            @Override
+            public DatetimeWrapper call(ServiceResponse<DatetimeWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with datetime properties.
+     *
+     * @return the observable to the DatetimeWrapper object
+     */
+    public Observable<ServiceResponse<DatetimeWrapper>> getDateTimeAsyncWithServiceResponse() {
         return service.getDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DatetimeWrapper>>>() {
                 @Override
@@ -941,8 +1158,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDateTime(DatetimeWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateTimeAsync(complexBody).toBlocking().single();
+    public void putDateTime(DatetimeWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateTimeAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -953,7 +1170,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeAsync(DatetimeWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putDateTimeAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -962,7 +1179,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeAsync(DatetimeWrapper complexBody) {
+    public Observable<Void> putDateTimeAsync(DatetimeWrapper complexBody) {
+        return putDateTimeAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateTimeAsyncWithServiceResponse(DatetimeWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -995,8 +1227,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Datetimerfc1123Wrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Datetimerfc1123Wrapper> getDateTimeRfc1123() throws ErrorException, IOException {
-        return getDateTimeRfc1123Async().toBlocking().single();
+    public Datetimerfc1123Wrapper getDateTimeRfc1123() throws ErrorException, IOException {
+        return getDateTimeRfc1123AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1006,7 +1238,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Datetimerfc1123Wrapper> getDateTimeRfc1123Async(final ServiceCallback<Datetimerfc1123Wrapper> serviceCallback) {
-        return ServiceCall.create(getDateTimeRfc1123Async(), serviceCallback);
+        return ServiceCall.create(getDateTimeRfc1123AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1014,7 +1246,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the Datetimerfc1123Wrapper object
      */
-    public Observable<ServiceResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123Async() {
+    public Observable<Datetimerfc1123Wrapper> getDateTimeRfc1123Async() {
+        return getDateTimeRfc1123AsyncWithServiceResponse().map(new Func1<ServiceResponse<Datetimerfc1123Wrapper>, Datetimerfc1123Wrapper>() {
+            @Override
+            public Datetimerfc1123Wrapper call(ServiceResponse<Datetimerfc1123Wrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
+     * @return the observable to the Datetimerfc1123Wrapper object
+     */
+    public Observable<ServiceResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123AsyncWithServiceResponse() {
         return service.getDateTimeRfc1123()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Datetimerfc1123Wrapper>>>() {
                 @Override
@@ -1045,8 +1291,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateTimeRfc1123Async(complexBody).toBlocking().single();
+    public void putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateTimeRfc1123AsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1057,7 +1303,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeRfc1123Async(complexBody), serviceCallback);
+        return ServiceCall.create(putDateTimeRfc1123AsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -1066,7 +1312,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody) {
+    public Observable<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody) {
+        return putDateTimeRfc1123AsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateTimeRfc1123AsyncWithServiceResponse(Datetimerfc1123Wrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -1099,8 +1360,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DurationWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DurationWrapper> getDuration() throws ErrorException, IOException {
-        return getDurationAsync().toBlocking().single();
+    public DurationWrapper getDuration() throws ErrorException, IOException {
+        return getDurationAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1110,7 +1371,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DurationWrapper> getDurationAsync(final ServiceCallback<DurationWrapper> serviceCallback) {
-        return ServiceCall.create(getDurationAsync(), serviceCallback);
+        return ServiceCall.create(getDurationAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1118,7 +1379,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the DurationWrapper object
      */
-    public Observable<ServiceResponse<DurationWrapper>> getDurationAsync() {
+    public Observable<DurationWrapper> getDurationAsync() {
+        return getDurationAsyncWithServiceResponse().map(new Func1<ServiceResponse<DurationWrapper>, DurationWrapper>() {
+            @Override
+            public DurationWrapper call(ServiceResponse<DurationWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with duration properties.
+     *
+     * @return the observable to the DurationWrapper object
+     */
+    public Observable<ServiceResponse<DurationWrapper>> getDurationAsyncWithServiceResponse() {
         return service.getDuration()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DurationWrapper>>>() {
                 @Override
@@ -1149,8 +1424,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDuration(DurationWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDurationAsync(complexBody).toBlocking().single();
+    public void putDuration(DurationWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDurationAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1161,7 +1436,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDurationAsync(DurationWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDurationAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putDurationAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -1170,7 +1445,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put 'P123DT22H14M12.011S'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDurationAsync(DurationWrapper complexBody) {
+    public Observable<Void> putDurationAsync(DurationWrapper complexBody) {
+        return putDurationAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDurationAsyncWithServiceResponse(DurationWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
@@ -1203,8 +1493,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ByteWrapper object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<ByteWrapper> getByte() throws ErrorException, IOException {
-        return getByteAsync().toBlocking().single();
+    public ByteWrapper getByte() throws ErrorException, IOException {
+        return getByteAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1214,7 +1504,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ByteWrapper> getByteAsync(final ServiceCallback<ByteWrapper> serviceCallback) {
-        return ServiceCall.create(getByteAsync(), serviceCallback);
+        return ServiceCall.create(getByteAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1222,7 +1512,21 @@ public final class PrimitivesImpl implements Primitives {
      *
      * @return the observable to the ByteWrapper object
      */
-    public Observable<ServiceResponse<ByteWrapper>> getByteAsync() {
+    public Observable<ByteWrapper> getByteAsync() {
+        return getByteAsyncWithServiceResponse().map(new Func1<ServiceResponse<ByteWrapper>, ByteWrapper>() {
+            @Override
+            public ByteWrapper call(ServiceResponse<ByteWrapper> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types with byte properties.
+     *
+     * @return the observable to the ByteWrapper object
+     */
+    public Observable<ServiceResponse<ByteWrapper>> getByteAsyncWithServiceResponse() {
         return service.getByte()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ByteWrapper>>>() {
                 @Override
@@ -1253,8 +1557,8 @@ public final class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putByte(ByteWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putByteAsync(complexBody).toBlocking().single();
+    public void putByte(ByteWrapper complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putByteAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1265,7 +1569,7 @@ public final class PrimitivesImpl implements Primitives {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putByteAsync(ByteWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putByteAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putByteAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -1274,7 +1578,22 @@ public final class PrimitivesImpl implements Primitives {
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putByteAsync(ByteWrapper complexBody) {
+    public Observable<Void> putByteAsync(ByteWrapper complexBody) {
+        return putByteAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putByteAsyncWithServiceResponse(ByteWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertysImpl.java
@@ -71,10 +71,10 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ReadonlyObj object wrapped in {@link ServiceResponse} if successful.
+     * @return the ReadonlyObj object if successful.
      */
     public ReadonlyObj getValid() throws ErrorException, IOException {
-        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +84,7 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ReadonlyObj> getValidAsync(final ServiceCallback<ReadonlyObj> serviceCallback) {
-        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -93,12 +93,12 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @return the observable to the ReadonlyObj object
      */
     public Observable<ReadonlyObj> getValidAsync() {
-        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<ReadonlyObj>, ReadonlyObj>() {
+        return getValidWithServiceResponseAsync().map(new Func1<ServiceResponse<ReadonlyObj>, ReadonlyObj>() {
             @Override
             public ReadonlyObj call(ServiceResponse<ReadonlyObj> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -106,7 +106,7 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      *
      * @return the observable to the ReadonlyObj object
      */
-    public Observable<ServiceResponse<ReadonlyObj>> getValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<ReadonlyObj>> getValidWithServiceResponseAsync() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ReadonlyObj>>>() {
                 @Override
@@ -135,10 +135,9 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putValid(ReadonlyObj complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
+        putValidWithServiceResponseAsync(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -149,7 +148,7 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(ReadonlyObj complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
+        return ServiceCall.create(putValidWithServiceResponseAsync(complexBody), serviceCallback);
     }
 
     /**
@@ -159,12 +158,12 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putValidAsync(ReadonlyObj complexBody) {
-        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putValidWithServiceResponseAsync(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -173,7 +172,7 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @param complexBody the ReadonlyObj value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(ReadonlyObj complexBody) {
+    public Observable<ServiceResponse<Void>> putValidWithServiceResponseAsync(ReadonlyObj complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertysImpl.java
@@ -73,8 +73,8 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ReadonlyObj object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<ReadonlyObj> getValid() throws ErrorException, IOException {
-        return getValidAsync().toBlocking().single();
+    public ReadonlyObj getValid() throws ErrorException, IOException {
+        return getValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -84,7 +84,7 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ReadonlyObj> getValidAsync(final ServiceCallback<ReadonlyObj> serviceCallback) {
-        return ServiceCall.create(getValidAsync(), serviceCallback);
+        return ServiceCall.create(getValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -92,7 +92,21 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      *
      * @return the observable to the ReadonlyObj object
      */
-    public Observable<ServiceResponse<ReadonlyObj>> getValidAsync() {
+    public Observable<ReadonlyObj> getValidAsync() {
+        return getValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<ReadonlyObj>, ReadonlyObj>() {
+            @Override
+            public ReadonlyObj call(ServiceResponse<ReadonlyObj> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get complex types that have readonly properties.
+     *
+     * @return the observable to the ReadonlyObj object
+     */
+    public Observable<ServiceResponse<ReadonlyObj>> getValidAsyncWithServiceResponse() {
         return service.getValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ReadonlyObj>>>() {
                 @Override
@@ -123,8 +137,8 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putValid(ReadonlyObj complexBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putValidAsync(complexBody).toBlocking().single();
+    public void putValid(ReadonlyObj complexBody) throws ErrorException, IOException, IllegalArgumentException {
+        putValidAsyncWithServiceResponse(complexBody).toBlocking().single().getBody();
     }
 
     /**
@@ -135,7 +149,7 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putValidAsync(ReadonlyObj complexBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putValidAsync(complexBody), serviceCallback);
+        return ServiceCall.create(putValidAsyncWithServiceResponse(complexBody), serviceCallback);
     }
 
     /**
@@ -144,7 +158,22 @@ public final class ReadonlypropertysImpl implements Readonlypropertys {
      * @param complexBody the ReadonlyObj value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putValidAsync(ReadonlyObj complexBody) {
+    public Observable<Void> putValidAsync(ReadonlyObj complexBody) {
+        return putValidAsyncWithServiceResponse(complexBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody the ReadonlyObj value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putValidAsyncWithServiceResponse(ReadonlyObj complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydate/Dates.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydate/Dates.java
@@ -30,7 +30,7 @@ public interface Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<LocalDate> getNull() throws ErrorException, IOException;
+    LocalDate getNull() throws ErrorException, IOException;
 
     /**
      * Get null date value.
@@ -45,7 +45,14 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getNullAsync();
+    Observable<LocalDate> getNullAsync();
+
+    /**
+     * Get null date value.
+     *
+     * @return the observable to the LocalDate object
+     */
+    Observable<ServiceResponse<LocalDate>> getNullAsyncWithServiceResponse();
 
     /**
      * Get invalid date value.
@@ -54,7 +61,7 @@ public interface Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<LocalDate> getInvalidDate() throws ErrorException, IOException;
+    LocalDate getInvalidDate() throws ErrorException, IOException;
 
     /**
      * Get invalid date value.
@@ -69,7 +76,14 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getInvalidDateAsync();
+    Observable<LocalDate> getInvalidDateAsync();
+
+    /**
+     * Get invalid date value.
+     *
+     * @return the observable to the LocalDate object
+     */
+    Observable<ServiceResponse<LocalDate>> getInvalidDateAsyncWithServiceResponse();
 
     /**
      * Get overflow date value.
@@ -78,7 +92,7 @@ public interface Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<LocalDate> getOverflowDate() throws ErrorException, IOException;
+    LocalDate getOverflowDate() throws ErrorException, IOException;
 
     /**
      * Get overflow date value.
@@ -93,7 +107,14 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getOverflowDateAsync();
+    Observable<LocalDate> getOverflowDateAsync();
+
+    /**
+     * Get overflow date value.
+     *
+     * @return the observable to the LocalDate object
+     */
+    Observable<ServiceResponse<LocalDate>> getOverflowDateAsyncWithServiceResponse();
 
     /**
      * Get underflow date value.
@@ -102,7 +123,7 @@ public interface Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<LocalDate> getUnderflowDate() throws ErrorException, IOException;
+    LocalDate getUnderflowDate() throws ErrorException, IOException;
 
     /**
      * Get underflow date value.
@@ -117,7 +138,14 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getUnderflowDateAsync();
+    Observable<LocalDate> getUnderflowDateAsync();
+
+    /**
+     * Get underflow date value.
+     *
+     * @return the observable to the LocalDate object
+     */
+    Observable<ServiceResponse<LocalDate>> getUnderflowDateAsyncWithServiceResponse();
 
     /**
      * Put max date value 9999-12-31.
@@ -128,7 +156,7 @@ public interface Dates {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putMaxDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putMaxDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put max date value 9999-12-31.
@@ -145,7 +173,15 @@ public interface Dates {
      * @param dateBody the LocalDate value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMaxDateAsync(LocalDate dateBody);
+    Observable<Void> putMaxDateAsync(LocalDate dateBody);
+
+    /**
+     * Put max date value 9999-12-31.
+     *
+     * @param dateBody the LocalDate value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putMaxDateAsyncWithServiceResponse(LocalDate dateBody);
 
     /**
      * Get max date value 9999-12-31.
@@ -154,7 +190,7 @@ public interface Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<LocalDate> getMaxDate() throws ErrorException, IOException;
+    LocalDate getMaxDate() throws ErrorException, IOException;
 
     /**
      * Get max date value 9999-12-31.
@@ -169,7 +205,14 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getMaxDateAsync();
+    Observable<LocalDate> getMaxDateAsync();
+
+    /**
+     * Get max date value 9999-12-31.
+     *
+     * @return the observable to the LocalDate object
+     */
+    Observable<ServiceResponse<LocalDate>> getMaxDateAsyncWithServiceResponse();
 
     /**
      * Put min date value 0000-01-01.
@@ -180,7 +223,7 @@ public interface Dates {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putMinDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putMinDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put min date value 0000-01-01.
@@ -197,7 +240,15 @@ public interface Dates {
      * @param dateBody the LocalDate value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMinDateAsync(LocalDate dateBody);
+    Observable<Void> putMinDateAsync(LocalDate dateBody);
+
+    /**
+     * Put min date value 0000-01-01.
+     *
+     * @param dateBody the LocalDate value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putMinDateAsyncWithServiceResponse(LocalDate dateBody);
 
     /**
      * Get min date value 0000-01-01.
@@ -206,7 +257,7 @@ public interface Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<LocalDate> getMinDate() throws ErrorException, IOException;
+    LocalDate getMinDate() throws ErrorException, IOException;
 
     /**
      * Get min date value 0000-01-01.
@@ -221,6 +272,13 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getMinDateAsync();
+    Observable<LocalDate> getMinDateAsync();
+
+    /**
+     * Get min date value 0000-01-01.
+     *
+     * @return the observable to the LocalDate object
+     */
+    Observable<ServiceResponse<LocalDate>> getMinDateAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydate/Dates.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydate/Dates.java
@@ -28,7 +28,7 @@ public interface Dates {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     LocalDate getNull() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<LocalDate>> getNullWithServiceResponseAsync();
 
     /**
      * Get invalid date value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     LocalDate getInvalidDate() throws ErrorException, IOException;
 
@@ -83,14 +83,14 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getInvalidDateAsyncWithServiceResponse();
+    Observable<ServiceResponse<LocalDate>> getInvalidDateWithServiceResponseAsync();
 
     /**
      * Get overflow date value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     LocalDate getOverflowDate() throws ErrorException, IOException;
 
@@ -114,14 +114,14 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getOverflowDateAsyncWithServiceResponse();
+    Observable<ServiceResponse<LocalDate>> getOverflowDateWithServiceResponseAsync();
 
     /**
      * Get underflow date value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     LocalDate getUnderflowDate() throws ErrorException, IOException;
 
@@ -145,7 +145,7 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getUnderflowDateAsyncWithServiceResponse();
+    Observable<ServiceResponse<LocalDate>> getUnderflowDateWithServiceResponseAsync();
 
     /**
      * Put max date value 9999-12-31.
@@ -154,7 +154,6 @@ public interface Dates {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putMaxDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -181,14 +180,14 @@ public interface Dates {
      * @param dateBody the LocalDate value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMaxDateAsyncWithServiceResponse(LocalDate dateBody);
+    Observable<ServiceResponse<Void>> putMaxDateWithServiceResponseAsync(LocalDate dateBody);
 
     /**
      * Get max date value 9999-12-31.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     LocalDate getMaxDate() throws ErrorException, IOException;
 
@@ -212,7 +211,7 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getMaxDateAsyncWithServiceResponse();
+    Observable<ServiceResponse<LocalDate>> getMaxDateWithServiceResponseAsync();
 
     /**
      * Put min date value 0000-01-01.
@@ -221,7 +220,6 @@ public interface Dates {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putMinDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -248,14 +246,14 @@ public interface Dates {
      * @param dateBody the LocalDate value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMinDateAsyncWithServiceResponse(LocalDate dateBody);
+    Observable<ServiceResponse<Void>> putMinDateWithServiceResponseAsync(LocalDate dateBody);
 
     /**
      * Get min date value 0000-01-01.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     LocalDate getMinDate() throws ErrorException, IOException;
 
@@ -279,6 +277,6 @@ public interface Dates {
      *
      * @return the observable to the LocalDate object
      */
-    Observable<ServiceResponse<LocalDate>> getMinDateAsyncWithServiceResponse();
+    Observable<ServiceResponse<LocalDate>> getMinDateWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydate/implementation/DatesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydate/implementation/DatesImpl.java
@@ -94,10 +94,10 @@ public final class DatesImpl implements Dates {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     public LocalDate getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -107,7 +107,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getNullAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -116,12 +116,12 @@ public final class DatesImpl implements Dates {
      * @return the observable to the LocalDate object
      */
     public Observable<LocalDate> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
             @Override
             public LocalDate call(ServiceResponse<LocalDate> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -129,7 +129,7 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<LocalDate>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -156,10 +156,10 @@ public final class DatesImpl implements Dates {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     public LocalDate getInvalidDate() throws ErrorException, IOException {
-        return getInvalidDateAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidDateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -169,7 +169,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getInvalidDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getInvalidDateAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidDateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -178,12 +178,12 @@ public final class DatesImpl implements Dates {
      * @return the observable to the LocalDate object
      */
     public Observable<LocalDate> getInvalidDateAsync() {
-        return getInvalidDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+        return getInvalidDateWithServiceResponseAsync().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
             @Override
             public LocalDate call(ServiceResponse<LocalDate> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -191,7 +191,7 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getInvalidDateAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<LocalDate>> getInvalidDateWithServiceResponseAsync() {
         return service.getInvalidDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -218,10 +218,10 @@ public final class DatesImpl implements Dates {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     public LocalDate getOverflowDate() throws ErrorException, IOException {
-        return getOverflowDateAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getOverflowDateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -231,7 +231,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getOverflowDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getOverflowDateAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getOverflowDateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -240,12 +240,12 @@ public final class DatesImpl implements Dates {
      * @return the observable to the LocalDate object
      */
     public Observable<LocalDate> getOverflowDateAsync() {
-        return getOverflowDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+        return getOverflowDateWithServiceResponseAsync().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
             @Override
             public LocalDate call(ServiceResponse<LocalDate> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -253,7 +253,7 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getOverflowDateAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<LocalDate>> getOverflowDateWithServiceResponseAsync() {
         return service.getOverflowDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -280,10 +280,10 @@ public final class DatesImpl implements Dates {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     public LocalDate getUnderflowDate() throws ErrorException, IOException {
-        return getUnderflowDateAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUnderflowDateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -293,7 +293,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getUnderflowDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getUnderflowDateAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUnderflowDateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -302,12 +302,12 @@ public final class DatesImpl implements Dates {
      * @return the observable to the LocalDate object
      */
     public Observable<LocalDate> getUnderflowDateAsync() {
-        return getUnderflowDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+        return getUnderflowDateWithServiceResponseAsync().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
             @Override
             public LocalDate call(ServiceResponse<LocalDate> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -315,7 +315,7 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getUnderflowDateAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<LocalDate>> getUnderflowDateWithServiceResponseAsync() {
         return service.getUnderflowDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -344,10 +344,9 @@ public final class DatesImpl implements Dates {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putMaxDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException {
-        putMaxDateAsyncWithServiceResponse(dateBody).toBlocking().single().getBody();
+        putMaxDateWithServiceResponseAsync(dateBody).toBlocking().single().getBody();
     }
 
     /**
@@ -358,7 +357,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMaxDateAsync(LocalDate dateBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMaxDateAsyncWithServiceResponse(dateBody), serviceCallback);
+        return ServiceCall.create(putMaxDateWithServiceResponseAsync(dateBody), serviceCallback);
     }
 
     /**
@@ -368,12 +367,12 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putMaxDateAsync(LocalDate dateBody) {
-        return putMaxDateAsyncWithServiceResponse(dateBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putMaxDateWithServiceResponseAsync(dateBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -382,7 +381,7 @@ public final class DatesImpl implements Dates {
      * @param dateBody the LocalDate value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMaxDateAsyncWithServiceResponse(LocalDate dateBody) {
+    public Observable<ServiceResponse<Void>> putMaxDateWithServiceResponseAsync(LocalDate dateBody) {
         if (dateBody == null) {
             throw new IllegalArgumentException("Parameter dateBody is required and cannot be null.");
         }
@@ -412,10 +411,10 @@ public final class DatesImpl implements Dates {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     public LocalDate getMaxDate() throws ErrorException, IOException {
-        return getMaxDateAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getMaxDateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -425,7 +424,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getMaxDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getMaxDateAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getMaxDateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -434,12 +433,12 @@ public final class DatesImpl implements Dates {
      * @return the observable to the LocalDate object
      */
     public Observable<LocalDate> getMaxDateAsync() {
-        return getMaxDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+        return getMaxDateWithServiceResponseAsync().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
             @Override
             public LocalDate call(ServiceResponse<LocalDate> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -447,7 +446,7 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getMaxDateAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<LocalDate>> getMaxDateWithServiceResponseAsync() {
         return service.getMaxDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -476,10 +475,9 @@ public final class DatesImpl implements Dates {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putMinDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException {
-        putMinDateAsyncWithServiceResponse(dateBody).toBlocking().single().getBody();
+        putMinDateWithServiceResponseAsync(dateBody).toBlocking().single().getBody();
     }
 
     /**
@@ -490,7 +488,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMinDateAsync(LocalDate dateBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMinDateAsyncWithServiceResponse(dateBody), serviceCallback);
+        return ServiceCall.create(putMinDateWithServiceResponseAsync(dateBody), serviceCallback);
     }
 
     /**
@@ -500,12 +498,12 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putMinDateAsync(LocalDate dateBody) {
-        return putMinDateAsyncWithServiceResponse(dateBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putMinDateWithServiceResponseAsync(dateBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -514,7 +512,7 @@ public final class DatesImpl implements Dates {
      * @param dateBody the LocalDate value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMinDateAsyncWithServiceResponse(LocalDate dateBody) {
+    public Observable<ServiceResponse<Void>> putMinDateWithServiceResponseAsync(LocalDate dateBody) {
         if (dateBody == null) {
             throw new IllegalArgumentException("Parameter dateBody is required and cannot be null.");
         }
@@ -544,10 +542,10 @@ public final class DatesImpl implements Dates {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
+     * @return the LocalDate object if successful.
      */
     public LocalDate getMinDate() throws ErrorException, IOException {
-        return getMinDateAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getMinDateWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -557,7 +555,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getMinDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getMinDateAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getMinDateWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -566,12 +564,12 @@ public final class DatesImpl implements Dates {
      * @return the observable to the LocalDate object
      */
     public Observable<LocalDate> getMinDateAsync() {
-        return getMinDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+        return getMinDateWithServiceResponseAsync().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
             @Override
             public LocalDate call(ServiceResponse<LocalDate> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -579,7 +577,7 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getMinDateAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<LocalDate>> getMinDateWithServiceResponseAsync() {
         return service.getMinDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydate/implementation/DatesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydate/implementation/DatesImpl.java
@@ -96,8 +96,8 @@ public final class DatesImpl implements Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<LocalDate> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public LocalDate getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -107,7 +107,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getNullAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -115,7 +115,21 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getNullAsync() {
+    public Observable<LocalDate> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+            @Override
+            public LocalDate call(ServiceResponse<LocalDate> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null date value.
+     *
+     * @return the observable to the LocalDate object
+     */
+    public Observable<ServiceResponse<LocalDate>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -144,8 +158,8 @@ public final class DatesImpl implements Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<LocalDate> getInvalidDate() throws ErrorException, IOException {
-        return getInvalidDateAsync().toBlocking().single();
+    public LocalDate getInvalidDate() throws ErrorException, IOException {
+        return getInvalidDateAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -155,7 +169,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getInvalidDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getInvalidDateAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidDateAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -163,7 +177,21 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getInvalidDateAsync() {
+    public Observable<LocalDate> getInvalidDateAsync() {
+        return getInvalidDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+            @Override
+            public LocalDate call(ServiceResponse<LocalDate> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid date value.
+     *
+     * @return the observable to the LocalDate object
+     */
+    public Observable<ServiceResponse<LocalDate>> getInvalidDateAsyncWithServiceResponse() {
         return service.getInvalidDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -192,8 +220,8 @@ public final class DatesImpl implements Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<LocalDate> getOverflowDate() throws ErrorException, IOException {
-        return getOverflowDateAsync().toBlocking().single();
+    public LocalDate getOverflowDate() throws ErrorException, IOException {
+        return getOverflowDateAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -203,7 +231,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getOverflowDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getOverflowDateAsync(), serviceCallback);
+        return ServiceCall.create(getOverflowDateAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -211,7 +239,21 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getOverflowDateAsync() {
+    public Observable<LocalDate> getOverflowDateAsync() {
+        return getOverflowDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+            @Override
+            public LocalDate call(ServiceResponse<LocalDate> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get overflow date value.
+     *
+     * @return the observable to the LocalDate object
+     */
+    public Observable<ServiceResponse<LocalDate>> getOverflowDateAsyncWithServiceResponse() {
         return service.getOverflowDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -240,8 +282,8 @@ public final class DatesImpl implements Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<LocalDate> getUnderflowDate() throws ErrorException, IOException {
-        return getUnderflowDateAsync().toBlocking().single();
+    public LocalDate getUnderflowDate() throws ErrorException, IOException {
+        return getUnderflowDateAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -251,7 +293,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getUnderflowDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getUnderflowDateAsync(), serviceCallback);
+        return ServiceCall.create(getUnderflowDateAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -259,7 +301,21 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getUnderflowDateAsync() {
+    public Observable<LocalDate> getUnderflowDateAsync() {
+        return getUnderflowDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+            @Override
+            public LocalDate call(ServiceResponse<LocalDate> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get underflow date value.
+     *
+     * @return the observable to the LocalDate object
+     */
+    public Observable<ServiceResponse<LocalDate>> getUnderflowDateAsyncWithServiceResponse() {
         return service.getUnderflowDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -290,8 +346,8 @@ public final class DatesImpl implements Dates {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putMaxDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putMaxDateAsync(dateBody).toBlocking().single();
+    public void putMaxDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException {
+        putMaxDateAsyncWithServiceResponse(dateBody).toBlocking().single().getBody();
     }
 
     /**
@@ -302,7 +358,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMaxDateAsync(LocalDate dateBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMaxDateAsync(dateBody), serviceCallback);
+        return ServiceCall.create(putMaxDateAsyncWithServiceResponse(dateBody), serviceCallback);
     }
 
     /**
@@ -311,7 +367,22 @@ public final class DatesImpl implements Dates {
      * @param dateBody the LocalDate value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMaxDateAsync(LocalDate dateBody) {
+    public Observable<Void> putMaxDateAsync(LocalDate dateBody) {
+        return putMaxDateAsyncWithServiceResponse(dateBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put max date value 9999-12-31.
+     *
+     * @param dateBody the LocalDate value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putMaxDateAsyncWithServiceResponse(LocalDate dateBody) {
         if (dateBody == null) {
             throw new IllegalArgumentException("Parameter dateBody is required and cannot be null.");
         }
@@ -343,8 +414,8 @@ public final class DatesImpl implements Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<LocalDate> getMaxDate() throws ErrorException, IOException {
-        return getMaxDateAsync().toBlocking().single();
+    public LocalDate getMaxDate() throws ErrorException, IOException {
+        return getMaxDateAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -354,7 +425,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getMaxDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getMaxDateAsync(), serviceCallback);
+        return ServiceCall.create(getMaxDateAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -362,7 +433,21 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getMaxDateAsync() {
+    public Observable<LocalDate> getMaxDateAsync() {
+        return getMaxDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+            @Override
+            public LocalDate call(ServiceResponse<LocalDate> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max date value 9999-12-31.
+     *
+     * @return the observable to the LocalDate object
+     */
+    public Observable<ServiceResponse<LocalDate>> getMaxDateAsyncWithServiceResponse() {
         return service.getMaxDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override
@@ -393,8 +478,8 @@ public final class DatesImpl implements Dates {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putMinDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putMinDateAsync(dateBody).toBlocking().single();
+    public void putMinDate(LocalDate dateBody) throws ErrorException, IOException, IllegalArgumentException {
+        putMinDateAsyncWithServiceResponse(dateBody).toBlocking().single().getBody();
     }
 
     /**
@@ -405,7 +490,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMinDateAsync(LocalDate dateBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMinDateAsync(dateBody), serviceCallback);
+        return ServiceCall.create(putMinDateAsyncWithServiceResponse(dateBody), serviceCallback);
     }
 
     /**
@@ -414,7 +499,22 @@ public final class DatesImpl implements Dates {
      * @param dateBody the LocalDate value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMinDateAsync(LocalDate dateBody) {
+    public Observable<Void> putMinDateAsync(LocalDate dateBody) {
+        return putMinDateAsyncWithServiceResponse(dateBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put min date value 0000-01-01.
+     *
+     * @param dateBody the LocalDate value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putMinDateAsyncWithServiceResponse(LocalDate dateBody) {
         if (dateBody == null) {
             throw new IllegalArgumentException("Parameter dateBody is required and cannot be null.");
         }
@@ -446,8 +546,8 @@ public final class DatesImpl implements Dates {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the LocalDate object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<LocalDate> getMinDate() throws ErrorException, IOException {
-        return getMinDateAsync().toBlocking().single();
+    public LocalDate getMinDate() throws ErrorException, IOException {
+        return getMinDateAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -457,7 +557,7 @@ public final class DatesImpl implements Dates {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<LocalDate> getMinDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
-        return ServiceCall.create(getMinDateAsync(), serviceCallback);
+        return ServiceCall.create(getMinDateAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -465,7 +565,21 @@ public final class DatesImpl implements Dates {
      *
      * @return the observable to the LocalDate object
      */
-    public Observable<ServiceResponse<LocalDate>> getMinDateAsync() {
+    public Observable<LocalDate> getMinDateAsync() {
+        return getMinDateAsyncWithServiceResponse().map(new Func1<ServiceResponse<LocalDate>, LocalDate>() {
+            @Override
+            public LocalDate call(ServiceResponse<LocalDate> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get min date value 0000-01-01.
+     *
+     * @return the observable to the LocalDate object
+     */
+    public Observable<ServiceResponse<LocalDate>> getMinDateAsyncWithServiceResponse() {
         return service.getMinDate()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<LocalDate>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetime/Datetimes.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetime/Datetimes.java
@@ -28,7 +28,7 @@ public interface Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getNull() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getNullWithServiceResponseAsync();
 
     /**
      * Get invalid datetime value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getInvalid() throws ErrorException, IOException;
 
@@ -83,14 +83,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getInvalidWithServiceResponseAsync();
 
     /**
      * Get overflow datetime value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getOverflow() throws ErrorException, IOException;
 
@@ -114,14 +114,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getOverflowAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getOverflowWithServiceResponseAsync();
 
     /**
      * Get underflow datetime value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUnderflow() throws ErrorException, IOException;
 
@@ -145,7 +145,7 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUnderflowAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUnderflowWithServiceResponseAsync();
 
     /**
      * Put max datetime value 9999-12-31T23:59:59.9999999Z.
@@ -154,7 +154,6 @@ public interface Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -181,14 +180,14 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
+    Observable<ServiceResponse<Void>> putUtcMaxDateTimeWithServiceResponseAsync(DateTime datetimeBody);
 
     /**
      * Get max datetime value 9999-12-31t23:59:59.9999999z.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUtcLowercaseMaxDateTime() throws ErrorException, IOException;
 
@@ -212,14 +211,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeWithServiceResponseAsync();
 
     /**
      * Get max datetime value 9999-12-31T23:59:59.9999999Z.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUtcUppercaseMaxDateTime() throws ErrorException, IOException;
 
@@ -243,7 +242,7 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeWithServiceResponseAsync();
 
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00.
@@ -252,7 +251,6 @@ public interface Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putLocalPositiveOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -279,14 +277,14 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
+    Observable<ServiceResponse<Void>> putLocalPositiveOffsetMaxDateTimeWithServiceResponseAsync(DateTime datetimeBody);
 
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getLocalPositiveOffsetLowercaseMaxDateTime() throws ErrorException, IOException;
 
@@ -310,14 +308,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeWithServiceResponseAsync();
 
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getLocalPositiveOffsetUppercaseMaxDateTime() throws ErrorException, IOException;
 
@@ -341,7 +339,7 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeWithServiceResponseAsync();
 
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00.
@@ -350,7 +348,6 @@ public interface Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putLocalNegativeOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -377,14 +374,14 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
+    Observable<ServiceResponse<Void>> putLocalNegativeOffsetMaxDateTimeWithServiceResponseAsync(DateTime datetimeBody);
 
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getLocalNegativeOffsetUppercaseMaxDateTime() throws ErrorException, IOException;
 
@@ -408,14 +405,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeWithServiceResponseAsync();
 
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getLocalNegativeOffsetLowercaseMaxDateTime() throws ErrorException, IOException;
 
@@ -439,7 +436,7 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeWithServiceResponseAsync();
 
     /**
      * Put min datetime value 0001-01-01T00:00:00Z.
@@ -448,7 +445,6 @@ public interface Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -475,14 +471,14 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUtcMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
+    Observable<ServiceResponse<Void>> putUtcMinDateTimeWithServiceResponseAsync(DateTime datetimeBody);
 
     /**
      * Get min datetime value 0001-01-01T00:00:00Z.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUtcMinDateTime() throws ErrorException, IOException;
 
@@ -506,7 +502,7 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUtcMinDateTimeWithServiceResponseAsync();
 
     /**
      * Put min datetime value 0001-01-01T00:00:00+14:00.
@@ -515,7 +511,6 @@ public interface Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putLocalPositiveOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -542,14 +537,14 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
+    Observable<ServiceResponse<Void>> putLocalPositiveOffsetMinDateTimeWithServiceResponseAsync(DateTime datetimeBody);
 
     /**
      * Get min datetime value 0001-01-01T00:00:00+14:00.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getLocalPositiveOffsetMinDateTime() throws ErrorException, IOException;
 
@@ -573,7 +568,7 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetMinDateTimeWithServiceResponseAsync();
 
     /**
      * Put min datetime value 0001-01-01T00:00:00-14:00.
@@ -582,7 +577,6 @@ public interface Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putLocalNegativeOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -609,14 +603,14 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
+    Observable<ServiceResponse<Void>> putLocalNegativeOffsetMinDateTimeWithServiceResponseAsync(DateTime datetimeBody);
 
     /**
      * Get min datetime value 0001-01-01T00:00:00-14:00.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getLocalNegativeOffsetMinDateTime() throws ErrorException, IOException;
 
@@ -640,6 +634,6 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetMinDateTimeWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetime/Datetimes.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetime/Datetimes.java
@@ -30,7 +30,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getNull() throws ErrorException, IOException;
+    DateTime getNull() throws ErrorException, IOException;
 
     /**
      * Get null datetime value.
@@ -45,7 +45,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getNullAsync();
+    Observable<DateTime> getNullAsync();
+
+    /**
+     * Get null datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getNullAsyncWithServiceResponse();
 
     /**
      * Get invalid datetime value.
@@ -54,7 +61,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getInvalid() throws ErrorException, IOException;
+    DateTime getInvalid() throws ErrorException, IOException;
 
     /**
      * Get invalid datetime value.
@@ -69,7 +76,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getInvalidAsync();
+    Observable<DateTime> getInvalidAsync();
+
+    /**
+     * Get invalid datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getInvalidAsyncWithServiceResponse();
 
     /**
      * Get overflow datetime value.
@@ -78,7 +92,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getOverflow() throws ErrorException, IOException;
+    DateTime getOverflow() throws ErrorException, IOException;
 
     /**
      * Get overflow datetime value.
@@ -93,7 +107,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getOverflowAsync();
+    Observable<DateTime> getOverflowAsync();
+
+    /**
+     * Get overflow datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getOverflowAsyncWithServiceResponse();
 
     /**
      * Get underflow datetime value.
@@ -102,7 +123,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUnderflow() throws ErrorException, IOException;
+    DateTime getUnderflow() throws ErrorException, IOException;
 
     /**
      * Get underflow datetime value.
@@ -117,7 +138,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUnderflowAsync();
+    Observable<DateTime> getUnderflowAsync();
+
+    /**
+     * Get underflow datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUnderflowAsyncWithServiceResponse();
 
     /**
      * Put max datetime value 9999-12-31T23:59:59.9999999Z.
@@ -128,7 +156,7 @@ public interface Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put max datetime value 9999-12-31T23:59:59.9999999Z.
@@ -145,7 +173,15 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsync(DateTime datetimeBody);
+    Observable<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody);
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
 
     /**
      * Get max datetime value 9999-12-31t23:59:59.9999999z.
@@ -154,7 +190,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUtcLowercaseMaxDateTime() throws ErrorException, IOException;
+    DateTime getUtcLowercaseMaxDateTime() throws ErrorException, IOException;
 
     /**
      * Get max datetime value 9999-12-31t23:59:59.9999999z.
@@ -169,7 +205,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsync();
+    Observable<DateTime> getUtcLowercaseMaxDateTimeAsync();
+
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.9999999z.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsyncWithServiceResponse();
 
     /**
      * Get max datetime value 9999-12-31T23:59:59.9999999Z.
@@ -178,7 +221,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUtcUppercaseMaxDateTime() throws ErrorException, IOException;
+    DateTime getUtcUppercaseMaxDateTime() throws ErrorException, IOException;
 
     /**
      * Get max datetime value 9999-12-31T23:59:59.9999999Z.
@@ -193,7 +236,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsync();
+    Observable<DateTime> getUtcUppercaseMaxDateTimeAsync();
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsyncWithServiceResponse();
 
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00.
@@ -204,7 +254,7 @@ public interface Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putLocalPositiveOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putLocalPositiveOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00.
@@ -221,7 +271,15 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody);
+    Observable<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody);
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
 
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00.
@@ -230,7 +288,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getLocalPositiveOffsetLowercaseMaxDateTime() throws ErrorException, IOException;
+    DateTime getLocalPositiveOffsetLowercaseMaxDateTime() throws ErrorException, IOException;
 
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00.
@@ -245,7 +303,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeAsync();
+    Observable<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync();
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse();
 
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00.
@@ -254,7 +319,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getLocalPositiveOffsetUppercaseMaxDateTime() throws ErrorException, IOException;
+    DateTime getLocalPositiveOffsetUppercaseMaxDateTime() throws ErrorException, IOException;
 
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00.
@@ -269,7 +334,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeAsync();
+    Observable<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync();
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse();
 
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00.
@@ -280,7 +352,7 @@ public interface Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putLocalNegativeOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putLocalNegativeOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00.
@@ -297,7 +369,15 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody);
+    Observable<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody);
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
 
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00.
@@ -306,7 +386,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getLocalNegativeOffsetUppercaseMaxDateTime() throws ErrorException, IOException;
+    DateTime getLocalNegativeOffsetUppercaseMaxDateTime() throws ErrorException, IOException;
 
     /**
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00.
@@ -321,7 +401,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeAsync();
+    Observable<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync();
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse();
 
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00.
@@ -330,7 +417,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getLocalNegativeOffsetLowercaseMaxDateTime() throws ErrorException, IOException;
+    DateTime getLocalNegativeOffsetLowercaseMaxDateTime() throws ErrorException, IOException;
 
     /**
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00.
@@ -345,7 +432,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeAsync();
+    Observable<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync();
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse();
 
     /**
      * Put min datetime value 0001-01-01T00:00:00Z.
@@ -356,7 +450,7 @@ public interface Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put min datetime value 0001-01-01T00:00:00Z.
@@ -373,7 +467,15 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUtcMinDateTimeAsync(DateTime datetimeBody);
+    Observable<Void> putUtcMinDateTimeAsync(DateTime datetimeBody);
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putUtcMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
 
     /**
      * Get min datetime value 0001-01-01T00:00:00Z.
@@ -382,7 +484,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUtcMinDateTime() throws ErrorException, IOException;
+    DateTime getUtcMinDateTime() throws ErrorException, IOException;
 
     /**
      * Get min datetime value 0001-01-01T00:00:00Z.
@@ -397,7 +499,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsync();
+    Observable<DateTime> getUtcMinDateTimeAsync();
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsyncWithServiceResponse();
 
     /**
      * Put min datetime value 0001-01-01T00:00:00+14:00.
@@ -408,7 +517,7 @@ public interface Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putLocalPositiveOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putLocalPositiveOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put min datetime value 0001-01-01T00:00:00+14:00.
@@ -425,7 +534,15 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody);
+    Observable<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody);
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
 
     /**
      * Get min datetime value 0001-01-01T00:00:00+14:00.
@@ -434,7 +551,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getLocalPositiveOffsetMinDateTime() throws ErrorException, IOException;
+    DateTime getLocalPositiveOffsetMinDateTime() throws ErrorException, IOException;
 
     /**
      * Get min datetime value 0001-01-01T00:00:00+14:00.
@@ -449,7 +566,14 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetMinDateTimeAsync();
+    Observable<DateTime> getLocalPositiveOffsetMinDateTimeAsync();
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse();
 
     /**
      * Put min datetime value 0001-01-01T00:00:00-14:00.
@@ -460,7 +584,7 @@ public interface Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putLocalNegativeOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putLocalNegativeOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put min datetime value 0001-01-01T00:00:00-14:00.
@@ -477,7 +601,15 @@ public interface Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody);
+    Observable<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody);
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
 
     /**
      * Get min datetime value 0001-01-01T00:00:00-14:00.
@@ -486,7 +618,7 @@ public interface Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getLocalNegativeOffsetMinDateTime() throws ErrorException, IOException;
+    DateTime getLocalNegativeOffsetMinDateTime() throws ErrorException, IOException;
 
     /**
      * Get min datetime value 0001-01-01T00:00:00-14:00.
@@ -501,6 +633,13 @@ public interface Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetMinDateTimeAsync();
+    Observable<DateTime> getLocalNegativeOffsetMinDateTimeAsync();
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetime/implementation/DatetimesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetime/implementation/DatetimesImpl.java
@@ -140,8 +140,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public DateTime getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -151,7 +151,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getNullAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -159,7 +159,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getNullAsync() {
+    public Observable<DateTime> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -188,8 +202,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public DateTime getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -199,7 +213,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getInvalidAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -207,7 +221,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getInvalidAsync() {
+    public Observable<DateTime> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -236,8 +264,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getOverflow() throws ErrorException, IOException {
-        return getOverflowAsync().toBlocking().single();
+    public DateTime getOverflow() throws ErrorException, IOException {
+        return getOverflowAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -247,7 +275,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getOverflowAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getOverflowAsync(), serviceCallback);
+        return ServiceCall.create(getOverflowAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -255,7 +283,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getOverflowAsync() {
+    public Observable<DateTime> getOverflowAsync() {
+        return getOverflowAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get overflow datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getOverflowAsyncWithServiceResponse() {
         return service.getOverflow()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -284,8 +326,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUnderflow() throws ErrorException, IOException {
-        return getUnderflowAsync().toBlocking().single();
+    public DateTime getUnderflow() throws ErrorException, IOException {
+        return getUnderflowAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -295,7 +337,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUnderflowAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUnderflowAsync(), serviceCallback);
+        return ServiceCall.create(getUnderflowAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -303,7 +345,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUnderflowAsync() {
+    public Observable<DateTime> getUnderflowAsync() {
+        return getUnderflowAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get underflow datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUnderflowAsyncWithServiceResponse() {
         return service.getUnderflow()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -334,8 +390,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putUtcMaxDateTimeAsync(datetimeBody).toBlocking().single();
+    public void putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
+        putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -346,7 +402,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUtcMaxDateTimeAsync(datetimeBody), serviceCallback);
+        return ServiceCall.create(putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
     }
 
     /**
@@ -355,7 +411,22 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
+    public Observable<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
+        return putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -387,8 +458,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUtcLowercaseMaxDateTime() throws ErrorException, IOException {
-        return getUtcLowercaseMaxDateTimeAsync().toBlocking().single();
+    public DateTime getUtcLowercaseMaxDateTime() throws ErrorException, IOException {
+        return getUtcLowercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -398,7 +469,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcLowercaseMaxDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getUtcLowercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -406,7 +477,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsync() {
+    public Observable<DateTime> getUtcLowercaseMaxDateTimeAsync() {
+        return getUtcLowercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.9999999z.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsyncWithServiceResponse() {
         return service.getUtcLowercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -435,8 +520,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUtcUppercaseMaxDateTime() throws ErrorException, IOException {
-        return getUtcUppercaseMaxDateTimeAsync().toBlocking().single();
+    public DateTime getUtcUppercaseMaxDateTime() throws ErrorException, IOException {
+        return getUtcUppercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -446,7 +531,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcUppercaseMaxDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getUtcUppercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -454,7 +539,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsync() {
+    public Observable<DateTime> getUtcUppercaseMaxDateTimeAsync() {
+        return getUtcUppercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsyncWithServiceResponse() {
         return service.getUtcUppercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -485,8 +584,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putLocalPositiveOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putLocalPositiveOffsetMaxDateTimeAsync(datetimeBody).toBlocking().single();
+    public void putLocalPositiveOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
+        putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -497,7 +596,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLocalPositiveOffsetMaxDateTimeAsync(datetimeBody), serviceCallback);
+        return ServiceCall.create(putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
     }
 
     /**
@@ -506,7 +605,22 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody) {
+    public Observable<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody) {
+        return putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -538,8 +652,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getLocalPositiveOffsetLowercaseMaxDateTime() throws ErrorException, IOException {
-        return getLocalPositiveOffsetLowercaseMaxDateTimeAsync().toBlocking().single();
+    public DateTime getLocalPositiveOffsetLowercaseMaxDateTime() throws ErrorException, IOException {
+        return getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -549,7 +663,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalPositiveOffsetLowercaseMaxDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -557,7 +671,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeAsync() {
+    public Observable<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync() {
+        return getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse() {
         return service.getLocalPositiveOffsetLowercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -586,8 +714,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getLocalPositiveOffsetUppercaseMaxDateTime() throws ErrorException, IOException {
-        return getLocalPositiveOffsetUppercaseMaxDateTimeAsync().toBlocking().single();
+    public DateTime getLocalPositiveOffsetUppercaseMaxDateTime() throws ErrorException, IOException {
+        return getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -597,7 +725,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalPositiveOffsetUppercaseMaxDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -605,7 +733,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeAsync() {
+    public Observable<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync() {
+        return getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse() {
         return service.getLocalPositiveOffsetUppercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -636,8 +778,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putLocalNegativeOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putLocalNegativeOffsetMaxDateTimeAsync(datetimeBody).toBlocking().single();
+    public void putLocalNegativeOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
+        putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -648,7 +790,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLocalNegativeOffsetMaxDateTimeAsync(datetimeBody), serviceCallback);
+        return ServiceCall.create(putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
     }
 
     /**
@@ -657,7 +799,22 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody) {
+    public Observable<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody) {
+        return putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -689,8 +846,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getLocalNegativeOffsetUppercaseMaxDateTime() throws ErrorException, IOException {
-        return getLocalNegativeOffsetUppercaseMaxDateTimeAsync().toBlocking().single();
+    public DateTime getLocalNegativeOffsetUppercaseMaxDateTime() throws ErrorException, IOException {
+        return getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -700,7 +857,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalNegativeOffsetUppercaseMaxDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -708,7 +865,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeAsync() {
+    public Observable<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync() {
+        return getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse() {
         return service.getLocalNegativeOffsetUppercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -737,8 +908,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getLocalNegativeOffsetLowercaseMaxDateTime() throws ErrorException, IOException {
-        return getLocalNegativeOffsetLowercaseMaxDateTimeAsync().toBlocking().single();
+    public DateTime getLocalNegativeOffsetLowercaseMaxDateTime() throws ErrorException, IOException {
+        return getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -748,7 +919,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalNegativeOffsetLowercaseMaxDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -756,7 +927,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeAsync() {
+    public Observable<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync() {
+        return getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse() {
         return service.getLocalNegativeOffsetLowercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -787,8 +972,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putUtcMinDateTimeAsync(datetimeBody).toBlocking().single();
+    public void putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
+        putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -799,7 +984,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUtcMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUtcMinDateTimeAsync(datetimeBody), serviceCallback);
+        return ServiceCall.create(putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
     }
 
     /**
@@ -808,7 +993,22 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUtcMinDateTimeAsync(DateTime datetimeBody) {
+    public Observable<Void> putUtcMinDateTimeAsync(DateTime datetimeBody) {
+        return putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putUtcMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -840,8 +1040,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUtcMinDateTime() throws ErrorException, IOException {
-        return getUtcMinDateTimeAsync().toBlocking().single();
+    public DateTime getUtcMinDateTime() throws ErrorException, IOException {
+        return getUtcMinDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -851,7 +1051,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcMinDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getUtcMinDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -859,7 +1059,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsync() {
+    public Observable<DateTime> getUtcMinDateTimeAsync() {
+        return getUtcMinDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsyncWithServiceResponse() {
         return service.getUtcMinDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -890,8 +1104,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putLocalPositiveOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putLocalPositiveOffsetMinDateTimeAsync(datetimeBody).toBlocking().single();
+    public void putLocalPositiveOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
+        putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -902,7 +1116,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLocalPositiveOffsetMinDateTimeAsync(datetimeBody), serviceCallback);
+        return ServiceCall.create(putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
     }
 
     /**
@@ -911,7 +1125,22 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody) {
+    public Observable<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody) {
+        return putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -943,8 +1172,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getLocalPositiveOffsetMinDateTime() throws ErrorException, IOException {
-        return getLocalPositiveOffsetMinDateTimeAsync().toBlocking().single();
+    public DateTime getLocalPositiveOffsetMinDateTime() throws ErrorException, IOException {
+        return getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -954,7 +1183,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalPositiveOffsetMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalPositiveOffsetMinDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -962,7 +1191,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetMinDateTimeAsync() {
+    public Observable<DateTime> getLocalPositiveOffsetMinDateTimeAsync() {
+        return getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse() {
         return service.getLocalPositiveOffsetMinDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -993,8 +1236,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putLocalNegativeOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putLocalNegativeOffsetMinDateTimeAsync(datetimeBody).toBlocking().single();
+    public void putLocalNegativeOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
+        putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1005,7 +1248,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLocalNegativeOffsetMinDateTimeAsync(datetimeBody), serviceCallback);
+        return ServiceCall.create(putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
     }
 
     /**
@@ -1014,7 +1257,22 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody) {
+    public Observable<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody) {
+        return putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -1046,8 +1304,8 @@ public final class DatetimesImpl implements Datetimes {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getLocalNegativeOffsetMinDateTime() throws ErrorException, IOException {
-        return getLocalNegativeOffsetMinDateTimeAsync().toBlocking().single();
+    public DateTime getLocalNegativeOffsetMinDateTime() throws ErrorException, IOException {
+        return getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1057,7 +1315,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalNegativeOffsetMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalNegativeOffsetMinDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1065,7 +1323,21 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetMinDateTimeAsync() {
+    public Observable<DateTime> getLocalNegativeOffsetMinDateTimeAsync() {
+        return getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse() {
         return service.getLocalNegativeOffsetMinDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetime/implementation/DatetimesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetime/implementation/DatetimesImpl.java
@@ -138,10 +138,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -151,7 +151,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getNullAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -160,12 +160,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -173,7 +173,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -200,10 +200,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -213,7 +213,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getInvalidAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -222,12 +222,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -235,7 +235,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -262,10 +262,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getOverflow() throws ErrorException, IOException {
-        return getOverflowAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getOverflowWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -275,7 +275,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getOverflowAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getOverflowAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getOverflowWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -284,12 +284,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getOverflowAsync() {
-        return getOverflowAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getOverflowWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -297,7 +297,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getOverflowAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getOverflowWithServiceResponseAsync() {
         return service.getOverflow()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -324,10 +324,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUnderflow() throws ErrorException, IOException {
-        return getUnderflowAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUnderflowWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -337,7 +337,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUnderflowAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUnderflowAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUnderflowWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -346,12 +346,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUnderflowAsync() {
-        return getUnderflowAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUnderflowWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -359,7 +359,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUnderflowAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUnderflowWithServiceResponseAsync() {
         return service.getUnderflow()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -388,10 +388,9 @@ public final class DatetimesImpl implements Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
+        putUtcMaxDateTimeWithServiceResponseAsync(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -402,7 +401,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
+        return ServiceCall.create(putUtcMaxDateTimeWithServiceResponseAsync(datetimeBody), serviceCallback);
     }
 
     /**
@@ -412,12 +411,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
-        return putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putUtcMaxDateTimeWithServiceResponseAsync(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -426,7 +425,7 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
+    public Observable<ServiceResponse<Void>> putUtcMaxDateTimeWithServiceResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -456,10 +455,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUtcLowercaseMaxDateTime() throws ErrorException, IOException {
-        return getUtcLowercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUtcLowercaseMaxDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -469,7 +468,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcLowercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUtcLowercaseMaxDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -478,12 +477,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUtcLowercaseMaxDateTimeAsync() {
-        return getUtcLowercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUtcLowercaseMaxDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -491,7 +490,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeWithServiceResponseAsync() {
         return service.getUtcLowercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -518,10 +517,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUtcUppercaseMaxDateTime() throws ErrorException, IOException {
-        return getUtcUppercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUtcUppercaseMaxDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -531,7 +530,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcUppercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUtcUppercaseMaxDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -540,12 +539,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUtcUppercaseMaxDateTimeAsync() {
-        return getUtcUppercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUtcUppercaseMaxDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -553,7 +552,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeWithServiceResponseAsync() {
         return service.getUtcUppercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -582,10 +581,9 @@ public final class DatetimesImpl implements Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putLocalPositiveOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
+        putLocalPositiveOffsetMaxDateTimeWithServiceResponseAsync(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -596,7 +594,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
+        return ServiceCall.create(putLocalPositiveOffsetMaxDateTimeWithServiceResponseAsync(datetimeBody), serviceCallback);
     }
 
     /**
@@ -606,12 +604,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody) {
-        return putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putLocalPositiveOffsetMaxDateTimeWithServiceResponseAsync(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -620,7 +618,7 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLocalPositiveOffsetMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
+    public Observable<ServiceResponse<Void>> putLocalPositiveOffsetMaxDateTimeWithServiceResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -650,10 +648,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getLocalPositiveOffsetLowercaseMaxDateTime() throws ErrorException, IOException {
-        return getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLocalPositiveOffsetLowercaseMaxDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -663,7 +661,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLocalPositiveOffsetLowercaseMaxDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -672,12 +670,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync() {
-        return getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getLocalPositiveOffsetLowercaseMaxDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -685,7 +683,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeWithServiceResponseAsync() {
         return service.getLocalPositiveOffsetLowercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -712,10 +710,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getLocalPositiveOffsetUppercaseMaxDateTime() throws ErrorException, IOException {
-        return getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLocalPositiveOffsetUppercaseMaxDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -725,7 +723,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLocalPositiveOffsetUppercaseMaxDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -734,12 +732,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync() {
-        return getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getLocalPositiveOffsetUppercaseMaxDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -747,7 +745,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeWithServiceResponseAsync() {
         return service.getLocalPositiveOffsetUppercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -776,10 +774,9 @@ public final class DatetimesImpl implements Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putLocalNegativeOffsetMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
+        putLocalNegativeOffsetMaxDateTimeWithServiceResponseAsync(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -790,7 +787,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
+        return ServiceCall.create(putLocalNegativeOffsetMaxDateTimeWithServiceResponseAsync(datetimeBody), serviceCallback);
     }
 
     /**
@@ -800,12 +797,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody) {
-        return putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putLocalNegativeOffsetMaxDateTimeWithServiceResponseAsync(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -814,7 +811,7 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLocalNegativeOffsetMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
+    public Observable<ServiceResponse<Void>> putLocalNegativeOffsetMaxDateTimeWithServiceResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -844,10 +841,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getLocalNegativeOffsetUppercaseMaxDateTime() throws ErrorException, IOException {
-        return getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLocalNegativeOffsetUppercaseMaxDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -857,7 +854,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLocalNegativeOffsetUppercaseMaxDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -866,12 +863,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync() {
-        return getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getLocalNegativeOffsetUppercaseMaxDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -879,7 +876,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeWithServiceResponseAsync() {
         return service.getLocalNegativeOffsetUppercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -906,10 +903,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getLocalNegativeOffsetLowercaseMaxDateTime() throws ErrorException, IOException {
-        return getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLocalNegativeOffsetLowercaseMaxDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -919,7 +916,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLocalNegativeOffsetLowercaseMaxDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -928,12 +925,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync() {
-        return getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getLocalNegativeOffsetLowercaseMaxDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -941,7 +938,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeWithServiceResponseAsync() {
         return service.getLocalNegativeOffsetLowercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -970,10 +967,9 @@ public final class DatetimesImpl implements Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
+        putUtcMinDateTimeWithServiceResponseAsync(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -984,7 +980,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUtcMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
+        return ServiceCall.create(putUtcMinDateTimeWithServiceResponseAsync(datetimeBody), serviceCallback);
     }
 
     /**
@@ -994,12 +990,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putUtcMinDateTimeAsync(DateTime datetimeBody) {
-        return putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putUtcMinDateTimeWithServiceResponseAsync(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1008,7 +1004,7 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUtcMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
+    public Observable<ServiceResponse<Void>> putUtcMinDateTimeWithServiceResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -1038,10 +1034,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUtcMinDateTime() throws ErrorException, IOException {
-        return getUtcMinDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUtcMinDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1051,7 +1047,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcMinDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUtcMinDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1060,12 +1056,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUtcMinDateTimeAsync() {
-        return getUtcMinDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUtcMinDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1073,7 +1069,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUtcMinDateTimeWithServiceResponseAsync() {
         return service.getUtcMinDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -1102,10 +1098,9 @@ public final class DatetimesImpl implements Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putLocalPositiveOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
+        putLocalPositiveOffsetMinDateTimeWithServiceResponseAsync(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1116,7 +1111,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
+        return ServiceCall.create(putLocalPositiveOffsetMinDateTimeWithServiceResponseAsync(datetimeBody), serviceCallback);
     }
 
     /**
@@ -1126,12 +1121,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody) {
-        return putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putLocalPositiveOffsetMinDateTimeWithServiceResponseAsync(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1140,7 +1135,7 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
+    public Observable<ServiceResponse<Void>> putLocalPositiveOffsetMinDateTimeWithServiceResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -1170,10 +1165,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getLocalPositiveOffsetMinDateTime() throws ErrorException, IOException {
-        return getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLocalPositiveOffsetMinDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1183,7 +1178,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalPositiveOffsetMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLocalPositiveOffsetMinDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1192,12 +1187,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getLocalPositiveOffsetMinDateTimeAsync() {
-        return getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getLocalPositiveOffsetMinDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1205,7 +1200,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetMinDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getLocalPositiveOffsetMinDateTimeWithServiceResponseAsync() {
         return service.getLocalPositiveOffsetMinDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -1234,10 +1229,9 @@ public final class DatetimesImpl implements Datetimes {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putLocalNegativeOffsetMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
+        putLocalNegativeOffsetMinDateTimeWithServiceResponseAsync(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1248,7 +1242,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
+        return ServiceCall.create(putLocalNegativeOffsetMinDateTimeWithServiceResponseAsync(datetimeBody), serviceCallback);
     }
 
     /**
@@ -1258,12 +1252,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody) {
-        return putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putLocalNegativeOffsetMinDateTimeWithServiceResponseAsync(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1272,7 +1266,7 @@ public final class DatetimesImpl implements Datetimes {
      * @param datetimeBody the DateTime value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
+    public Observable<ServiceResponse<Void>> putLocalNegativeOffsetMinDateTimeWithServiceResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -1302,10 +1296,10 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getLocalNegativeOffsetMinDateTime() throws ErrorException, IOException {
-        return getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLocalNegativeOffsetMinDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1315,7 +1309,7 @@ public final class DatetimesImpl implements Datetimes {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getLocalNegativeOffsetMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLocalNegativeOffsetMinDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1324,12 +1318,12 @@ public final class DatetimesImpl implements Datetimes {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getLocalNegativeOffsetMinDateTimeAsync() {
-        return getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getLocalNegativeOffsetMinDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1337,7 +1331,7 @@ public final class DatetimesImpl implements Datetimes {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetMinDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getLocalNegativeOffsetMinDateTimeWithServiceResponseAsync() {
         return service.getLocalNegativeOffsetMinDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
@@ -28,7 +28,7 @@ public interface Datetimerfc1123s {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getNull() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getNullWithServiceResponseAsync();
 
     /**
      * Get invalid datetime value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getInvalid() throws ErrorException, IOException;
 
@@ -83,14 +83,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getInvalidWithServiceResponseAsync();
 
     /**
      * Get overflow datetime value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getOverflow() throws ErrorException, IOException;
 
@@ -114,14 +114,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getOverflowAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getOverflowWithServiceResponseAsync();
 
     /**
      * Get underflow datetime value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUnderflow() throws ErrorException, IOException;
 
@@ -145,7 +145,7 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUnderflowAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUnderflowWithServiceResponseAsync();
 
     /**
      * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
@@ -154,7 +154,6 @@ public interface Datetimerfc1123s {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -181,14 +180,14 @@ public interface Datetimerfc1123s {
      * @param datetimeBody the DateTimeRfc1123 value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
+    Observable<ServiceResponse<Void>> putUtcMaxDateTimeWithServiceResponseAsync(DateTime datetimeBody);
 
     /**
      * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUtcLowercaseMaxDateTime() throws ErrorException, IOException;
 
@@ -212,14 +211,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeWithServiceResponseAsync();
 
     /**
      * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUtcUppercaseMaxDateTime() throws ErrorException, IOException;
 
@@ -243,7 +242,7 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeWithServiceResponseAsync();
 
     /**
      * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
@@ -252,7 +251,6 @@ public interface Datetimerfc1123s {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -279,14 +277,14 @@ public interface Datetimerfc1123s {
      * @param datetimeBody the DateTimeRfc1123 value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUtcMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
+    Observable<ServiceResponse<Void>> putUtcMinDateTimeWithServiceResponseAsync(DateTime datetimeBody);
 
     /**
      * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUtcMinDateTime() throws ErrorException, IOException;
 
@@ -310,6 +308,6 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUtcMinDateTimeWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
@@ -30,7 +30,7 @@ public interface Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getNull() throws ErrorException, IOException;
+    DateTime getNull() throws ErrorException, IOException;
 
     /**
      * Get null datetime value.
@@ -45,7 +45,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getNullAsync();
+    Observable<DateTime> getNullAsync();
+
+    /**
+     * Get null datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getNullAsyncWithServiceResponse();
 
     /**
      * Get invalid datetime value.
@@ -54,7 +61,7 @@ public interface Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getInvalid() throws ErrorException, IOException;
+    DateTime getInvalid() throws ErrorException, IOException;
 
     /**
      * Get invalid datetime value.
@@ -69,7 +76,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getInvalidAsync();
+    Observable<DateTime> getInvalidAsync();
+
+    /**
+     * Get invalid datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getInvalidAsyncWithServiceResponse();
 
     /**
      * Get overflow datetime value.
@@ -78,7 +92,7 @@ public interface Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getOverflow() throws ErrorException, IOException;
+    DateTime getOverflow() throws ErrorException, IOException;
 
     /**
      * Get overflow datetime value.
@@ -93,7 +107,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getOverflowAsync();
+    Observable<DateTime> getOverflowAsync();
+
+    /**
+     * Get overflow datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getOverflowAsyncWithServiceResponse();
 
     /**
      * Get underflow datetime value.
@@ -102,7 +123,7 @@ public interface Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUnderflow() throws ErrorException, IOException;
+    DateTime getUnderflow() throws ErrorException, IOException;
 
     /**
      * Get underflow datetime value.
@@ -117,7 +138,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUnderflowAsync();
+    Observable<DateTime> getUnderflowAsync();
+
+    /**
+     * Get underflow datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUnderflowAsyncWithServiceResponse();
 
     /**
      * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
@@ -128,7 +156,7 @@ public interface Datetimerfc1123s {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
@@ -145,7 +173,15 @@ public interface Datetimerfc1123s {
      * @param datetimeBody the DateTimeRfc1123 value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsync(DateTime datetimeBody);
+    Observable<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody);
+
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     *
+     * @param datetimeBody the DateTimeRfc1123 value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
 
     /**
      * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
@@ -154,7 +190,7 @@ public interface Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUtcLowercaseMaxDateTime() throws ErrorException, IOException;
+    DateTime getUtcLowercaseMaxDateTime() throws ErrorException, IOException;
 
     /**
      * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
@@ -169,7 +205,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsync();
+    Observable<DateTime> getUtcLowercaseMaxDateTimeAsync();
+
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsyncWithServiceResponse();
 
     /**
      * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
@@ -178,7 +221,7 @@ public interface Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUtcUppercaseMaxDateTime() throws ErrorException, IOException;
+    DateTime getUtcUppercaseMaxDateTime() throws ErrorException, IOException;
 
     /**
      * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
@@ -193,7 +236,14 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsync();
+    Observable<DateTime> getUtcUppercaseMaxDateTimeAsync();
+
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsyncWithServiceResponse();
 
     /**
      * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
@@ -204,7 +254,7 @@ public interface Datetimerfc1123s {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
@@ -221,7 +271,15 @@ public interface Datetimerfc1123s {
      * @param datetimeBody the DateTimeRfc1123 value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUtcMinDateTimeAsync(DateTime datetimeBody);
+    Observable<Void> putUtcMinDateTimeAsync(DateTime datetimeBody);
+
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @param datetimeBody the DateTimeRfc1123 value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putUtcMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody);
 
     /**
      * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
@@ -230,7 +288,7 @@ public interface Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUtcMinDateTime() throws ErrorException, IOException;
+    DateTime getUtcMinDateTime() throws ErrorException, IOException;
 
     /**
      * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
@@ -245,6 +303,13 @@ public interface Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsync();
+    Observable<DateTime> getUtcMinDateTimeAsync();
+
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/implementation/Datetimerfc1123sImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/implementation/Datetimerfc1123sImpl.java
@@ -99,10 +99,10 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -112,7 +112,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getNullAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -121,12 +121,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -134,7 +134,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -166,10 +166,10 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -179,7 +179,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getInvalidAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -188,12 +188,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -201,7 +201,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -233,10 +233,10 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getOverflow() throws ErrorException, IOException {
-        return getOverflowAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getOverflowWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -246,7 +246,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getOverflowAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getOverflowAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getOverflowWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -255,12 +255,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getOverflowAsync() {
-        return getOverflowAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getOverflowWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -268,7 +268,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getOverflowAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getOverflowWithServiceResponseAsync() {
         return service.getOverflow()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -300,10 +300,10 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUnderflow() throws ErrorException, IOException {
-        return getUnderflowAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUnderflowWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -313,7 +313,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUnderflowAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUnderflowAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUnderflowWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -322,12 +322,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUnderflowAsync() {
-        return getUnderflowAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUnderflowWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -335,7 +335,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUnderflowAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUnderflowWithServiceResponseAsync() {
         return service.getUnderflow()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -369,10 +369,9 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
+        putUtcMaxDateTimeWithServiceResponseAsync(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -383,7 +382,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
+        return ServiceCall.create(putUtcMaxDateTimeWithServiceResponseAsync(datetimeBody), serviceCallback);
     }
 
     /**
@@ -393,12 +392,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
-        return putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putUtcMaxDateTimeWithServiceResponseAsync(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -407,7 +406,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @param datetimeBody the DateTimeRfc1123 value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
+    public Observable<ServiceResponse<Void>> putUtcMaxDateTimeWithServiceResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -438,10 +437,10 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUtcLowercaseMaxDateTime() throws ErrorException, IOException {
-        return getUtcLowercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUtcLowercaseMaxDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -451,7 +450,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcLowercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUtcLowercaseMaxDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -460,12 +459,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUtcLowercaseMaxDateTimeAsync() {
-        return getUtcLowercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUtcLowercaseMaxDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -473,7 +472,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeWithServiceResponseAsync() {
         return service.getUtcLowercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -505,10 +504,10 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUtcUppercaseMaxDateTime() throws ErrorException, IOException {
-        return getUtcUppercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUtcUppercaseMaxDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -518,7 +517,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcUppercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUtcUppercaseMaxDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -527,12 +526,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUtcUppercaseMaxDateTimeAsync() {
-        return getUtcUppercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUtcUppercaseMaxDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -540,7 +539,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeWithServiceResponseAsync() {
         return service.getUtcUppercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -574,10 +573,9 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
+        putUtcMinDateTimeWithServiceResponseAsync(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -588,7 +586,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUtcMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
+        return ServiceCall.create(putUtcMinDateTimeWithServiceResponseAsync(datetimeBody), serviceCallback);
     }
 
     /**
@@ -598,12 +596,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putUtcMinDateTimeAsync(DateTime datetimeBody) {
-        return putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putUtcMinDateTimeWithServiceResponseAsync(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -612,7 +610,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @param datetimeBody the DateTimeRfc1123 value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUtcMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
+    public Observable<ServiceResponse<Void>> putUtcMinDateTimeWithServiceResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -643,10 +641,10 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUtcMinDateTime() throws ErrorException, IOException {
-        return getUtcMinDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUtcMinDateTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -656,7 +654,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcMinDateTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUtcMinDateTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -665,12 +663,12 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUtcMinDateTimeAsync() {
-        return getUtcMinDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUtcMinDateTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -678,7 +676,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUtcMinDateTimeWithServiceResponseAsync() {
         return service.getUtcMinDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/implementation/Datetimerfc1123sImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydatetimerfc1123/implementation/Datetimerfc1123sImpl.java
@@ -101,8 +101,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public DateTime getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -112,7 +112,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getNullAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -120,7 +120,21 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getNullAsync() {
+    public Observable<DateTime> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -154,8 +168,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public DateTime getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -165,7 +179,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getInvalidAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -173,7 +187,21 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getInvalidAsync() {
+    public Observable<DateTime> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -207,8 +235,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getOverflow() throws ErrorException, IOException {
-        return getOverflowAsync().toBlocking().single();
+    public DateTime getOverflow() throws ErrorException, IOException {
+        return getOverflowAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -218,7 +246,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getOverflowAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getOverflowAsync(), serviceCallback);
+        return ServiceCall.create(getOverflowAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -226,7 +254,21 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getOverflowAsync() {
+    public Observable<DateTime> getOverflowAsync() {
+        return getOverflowAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get overflow datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getOverflowAsyncWithServiceResponse() {
         return service.getOverflow()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -260,8 +302,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUnderflow() throws ErrorException, IOException {
-        return getUnderflowAsync().toBlocking().single();
+    public DateTime getUnderflow() throws ErrorException, IOException {
+        return getUnderflowAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -271,7 +313,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUnderflowAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUnderflowAsync(), serviceCallback);
+        return ServiceCall.create(getUnderflowAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -279,7 +321,21 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUnderflowAsync() {
+    public Observable<DateTime> getUnderflowAsync() {
+        return getUnderflowAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get underflow datetime value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUnderflowAsyncWithServiceResponse() {
         return service.getUnderflow()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -315,8 +371,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putUtcMaxDateTimeAsync(datetimeBody).toBlocking().single();
+    public void putUtcMaxDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
+        putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -327,7 +383,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUtcMaxDateTimeAsync(datetimeBody), serviceCallback);
+        return ServiceCall.create(putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
     }
 
     /**
@@ -336,7 +392,22 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @param datetimeBody the DateTimeRfc1123 value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
+    public Observable<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
+        return putUtcMaxDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     *
+     * @param datetimeBody the DateTimeRfc1123 value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putUtcMaxDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -369,8 +440,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUtcLowercaseMaxDateTime() throws ErrorException, IOException {
-        return getUtcLowercaseMaxDateTimeAsync().toBlocking().single();
+    public DateTime getUtcLowercaseMaxDateTime() throws ErrorException, IOException {
+        return getUtcLowercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -380,7 +451,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcLowercaseMaxDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getUtcLowercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -388,7 +459,21 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsync() {
+    public Observable<DateTime> getUtcLowercaseMaxDateTimeAsync() {
+        return getUtcLowercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUtcLowercaseMaxDateTimeAsyncWithServiceResponse() {
         return service.getUtcLowercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -422,8 +507,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUtcUppercaseMaxDateTime() throws ErrorException, IOException {
-        return getUtcUppercaseMaxDateTimeAsync().toBlocking().single();
+    public DateTime getUtcUppercaseMaxDateTime() throws ErrorException, IOException {
+        return getUtcUppercaseMaxDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -433,7 +518,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcUppercaseMaxDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getUtcUppercaseMaxDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -441,7 +526,21 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsync() {
+    public Observable<DateTime> getUtcUppercaseMaxDateTimeAsync() {
+        return getUtcUppercaseMaxDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUtcUppercaseMaxDateTimeAsyncWithServiceResponse() {
         return service.getUtcUppercaseMaxDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -477,8 +576,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putUtcMinDateTimeAsync(datetimeBody).toBlocking().single();
+    public void putUtcMinDateTime(DateTime datetimeBody) throws ErrorException, IOException, IllegalArgumentException {
+        putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody).toBlocking().single().getBody();
     }
 
     /**
@@ -489,7 +588,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUtcMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUtcMinDateTimeAsync(datetimeBody), serviceCallback);
+        return ServiceCall.create(putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody), serviceCallback);
     }
 
     /**
@@ -498,7 +597,22 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @param datetimeBody the DateTimeRfc1123 value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUtcMinDateTimeAsync(DateTime datetimeBody) {
+    public Observable<Void> putUtcMinDateTimeAsync(DateTime datetimeBody) {
+        return putUtcMinDateTimeAsyncWithServiceResponse(datetimeBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @param datetimeBody the DateTimeRfc1123 value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putUtcMinDateTimeAsyncWithServiceResponse(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
@@ -531,8 +645,8 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUtcMinDateTime() throws ErrorException, IOException {
-        return getUtcMinDateTimeAsync().toBlocking().single();
+    public DateTime getUtcMinDateTime() throws ErrorException, IOException {
+        return getUtcMinDateTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -542,7 +656,7 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUtcMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUtcMinDateTimeAsync(), serviceCallback);
+        return ServiceCall.create(getUtcMinDateTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -550,7 +664,21 @@ public final class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsync() {
+    public Observable<DateTime> getUtcMinDateTimeAsync() {
+        return getUtcMinDateTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUtcMinDateTimeAsyncWithServiceResponse() {
         return service.getUtcMinDateTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydictionary/Dictionarys.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydictionary/Dictionarys.java
@@ -33,7 +33,7 @@ public interface Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     Map<String, Integer> getNull() throws ErrorException, IOException;
 
@@ -57,14 +57,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Integer>>> getNullWithServiceResponseAsync();
 
     /**
      * Get empty dictionary value {}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     Map<String, Integer> getEmpty() throws ErrorException, IOException;
 
@@ -88,7 +88,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Integer>>> getEmptyWithServiceResponseAsync();
 
     /**
      * Set dictionary value empty {}.
@@ -97,7 +97,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putEmpty(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -124,14 +123,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(Map<String, String> arrayBody);
+    Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(Map<String, String> arrayBody);
 
     /**
      * Get Dictionary with null value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     Map<String, String> getNullValue() throws ErrorException, IOException;
 
@@ -155,14 +154,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getNullValueAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, String>>> getNullValueWithServiceResponseAsync();
 
     /**
      * Get Dictionary with null key.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     Map<String, String> getNullKey() throws ErrorException, IOException;
 
@@ -186,14 +185,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getNullKeyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, String>>> getNullKeyWithServiceResponseAsync();
 
     /**
      * Get Dictionary with key as empty string.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     Map<String, String> getEmptyStringKey() throws ErrorException, IOException;
 
@@ -217,14 +216,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getEmptyStringKeyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, String>>> getEmptyStringKeyWithServiceResponseAsync();
 
     /**
      * Get invalid Dictionary value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     Map<String, String> getInvalid() throws ErrorException, IOException;
 
@@ -248,14 +247,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, String>>> getInvalidWithServiceResponseAsync();
 
     /**
      * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Boolean&gt; object if successful.
      */
     Map<String, Boolean> getBooleanTfft() throws ErrorException, IOException;
 
@@ -279,7 +278,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanTfftAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanTfftWithServiceResponseAsync();
 
     /**
      * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
@@ -288,7 +287,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBooleanTfft(Map<String, Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -315,14 +313,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Boolean&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBooleanTfftAsyncWithServiceResponse(Map<String, Boolean> arrayBody);
+    Observable<ServiceResponse<Void>> putBooleanTfftWithServiceResponseAsync(Map<String, Boolean> arrayBody);
 
     /**
      * Get boolean dictionary value {"0": true, "1": null, "2": false }.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Boolean&gt; object if successful.
      */
     Map<String, Boolean> getBooleanInvalidNull() throws ErrorException, IOException;
 
@@ -346,14 +344,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidNullWithServiceResponseAsync();
 
     /**
      * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Boolean&gt; object if successful.
      */
     Map<String, Boolean> getBooleanInvalidString() throws ErrorException, IOException;
 
@@ -377,14 +375,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidStringWithServiceResponseAsync();
 
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     Map<String, Integer> getIntegerValid() throws ErrorException, IOException;
 
@@ -408,7 +406,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getIntegerValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Integer>>> getIntegerValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -417,7 +415,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putIntegerValid(Map<String, Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -444,14 +441,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Integer&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putIntegerValidAsyncWithServiceResponse(Map<String, Integer> arrayBody);
+    Observable<ServiceResponse<Void>> putIntegerValidWithServiceResponseAsync(Map<String, Integer> arrayBody);
 
     /**
      * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     Map<String, Integer> getIntInvalidNull() throws ErrorException, IOException;
 
@@ -475,14 +472,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidNullWithServiceResponseAsync();
 
     /**
      * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     Map<String, Integer> getIntInvalidString() throws ErrorException, IOException;
 
@@ -506,14 +503,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidStringWithServiceResponseAsync();
 
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Long&gt; object if successful.
      */
     Map<String, Long> getLongValid() throws ErrorException, IOException;
 
@@ -537,7 +534,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    Observable<ServiceResponse<Map<String, Long>>> getLongValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Long>>> getLongValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -546,7 +543,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putLongValid(Map<String, Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -573,14 +569,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Long&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLongValidAsyncWithServiceResponse(Map<String, Long> arrayBody);
+    Observable<ServiceResponse<Void>> putLongValidWithServiceResponseAsync(Map<String, Long> arrayBody);
 
     /**
      * Get long dictionary value {"0": 1, "1": null, "2": 0}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Long&gt; object if successful.
      */
     Map<String, Long> getLongInvalidNull() throws ErrorException, IOException;
 
@@ -604,14 +600,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    Observable<ServiceResponse<Map<String, Long>>> getLongInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Long>>> getLongInvalidNullWithServiceResponseAsync();
 
     /**
      * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Long&gt; object if successful.
      */
     Map<String, Long> getLongInvalidString() throws ErrorException, IOException;
 
@@ -635,14 +631,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    Observable<ServiceResponse<Map<String, Long>>> getLongInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Long>>> getLongInvalidStringWithServiceResponseAsync();
 
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     Map<String, Double> getFloatValid() throws ErrorException, IOException;
 
@@ -666,7 +662,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getFloatValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Double>>> getFloatValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -675,7 +671,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putFloatValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -702,14 +697,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putFloatValidAsyncWithServiceResponse(Map<String, Double> arrayBody);
+    Observable<ServiceResponse<Void>> putFloatValidWithServiceResponseAsync(Map<String, Double> arrayBody);
 
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     Map<String, Double> getFloatInvalidNull() throws ErrorException, IOException;
 
@@ -733,14 +728,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidNullWithServiceResponseAsync();
 
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     Map<String, Double> getFloatInvalidString() throws ErrorException, IOException;
 
@@ -764,14 +759,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidStringWithServiceResponseAsync();
 
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     Map<String, Double> getDoubleValid() throws ErrorException, IOException;
 
@@ -795,7 +790,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getDoubleValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Double>>> getDoubleValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -804,7 +799,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDoubleValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -831,14 +825,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDoubleValidAsyncWithServiceResponse(Map<String, Double> arrayBody);
+    Observable<ServiceResponse<Void>> putDoubleValidWithServiceResponseAsync(Map<String, Double> arrayBody);
 
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     Map<String, Double> getDoubleInvalidNull() throws ErrorException, IOException;
 
@@ -862,14 +856,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidNullWithServiceResponseAsync();
 
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     Map<String, Double> getDoubleInvalidString() throws ErrorException, IOException;
 
@@ -893,14 +887,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidStringAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidStringWithServiceResponseAsync();
 
     /**
      * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     Map<String, String> getStringValid() throws ErrorException, IOException;
 
@@ -924,7 +918,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getStringValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, String>>> getStringValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
@@ -933,7 +927,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putStringValid(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -960,14 +953,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putStringValidAsyncWithServiceResponse(Map<String, String> arrayBody);
+    Observable<ServiceResponse<Void>> putStringValidWithServiceResponseAsync(Map<String, String> arrayBody);
 
     /**
      * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     Map<String, String> getStringWithNull() throws ErrorException, IOException;
 
@@ -991,14 +984,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getStringWithNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, String>>> getStringWithNullWithServiceResponseAsync();
 
     /**
      * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     Map<String, String> getStringWithInvalid() throws ErrorException, IOException;
 
@@ -1022,14 +1015,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getStringWithInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, String>>> getStringWithInvalidWithServiceResponseAsync();
 
     /**
      * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, LocalDate&gt; object if successful.
      */
     Map<String, LocalDate> getDateValid() throws ErrorException, IOException;
 
@@ -1053,7 +1046,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    Observable<ServiceResponse<Map<String, LocalDate>>> getDateValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, LocalDate>>> getDateValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
@@ -1062,7 +1055,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDateValid(Map<String, LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1089,14 +1081,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, LocalDate&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateValidAsyncWithServiceResponse(Map<String, LocalDate> arrayBody);
+    Observable<ServiceResponse<Void>> putDateValidWithServiceResponseAsync(Map<String, LocalDate> arrayBody);
 
     /**
      * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, LocalDate&gt; object if successful.
      */
     Map<String, LocalDate> getDateInvalidNull() throws ErrorException, IOException;
 
@@ -1120,14 +1112,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidNullWithServiceResponseAsync();
 
     /**
      * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, LocalDate&gt; object if successful.
      */
     Map<String, LocalDate> getDateInvalidChars() throws ErrorException, IOException;
 
@@ -1151,14 +1143,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidCharsAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidCharsWithServiceResponseAsync();
 
     /**
      * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, DateTime&gt; object if successful.
      */
     Map<String, DateTime> getDateTimeValid() throws ErrorException, IOException;
 
@@ -1182,7 +1174,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
@@ -1191,7 +1183,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDateTimeValid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1218,14 +1209,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, DateTime&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeValidAsyncWithServiceResponse(Map<String, DateTime> arrayBody);
+    Observable<ServiceResponse<Void>> putDateTimeValidWithServiceResponseAsync(Map<String, DateTime> arrayBody);
 
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, DateTime&gt; object if successful.
      */
     Map<String, DateTime> getDateTimeInvalidNull() throws ErrorException, IOException;
 
@@ -1249,14 +1240,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidNullWithServiceResponseAsync();
 
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, DateTime&gt; object if successful.
      */
     Map<String, DateTime> getDateTimeInvalidChars() throws ErrorException, IOException;
 
@@ -1280,14 +1271,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidCharsAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidCharsWithServiceResponseAsync();
 
     /**
      * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, DateTime&gt; object if successful.
      */
     Map<String, DateTime> getDateTimeRfc1123Valid() throws ErrorException, IOException;
 
@@ -1311,7 +1302,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeRfc1123ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeRfc1123ValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
@@ -1320,7 +1311,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDateTimeRfc1123Valid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1347,14 +1337,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsyncWithServiceResponse(Map<String, DateTime> arrayBody);
+    Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidWithServiceResponseAsync(Map<String, DateTime> arrayBody);
 
     /**
      * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Period&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Period&gt; object if successful.
      */
     Map<String, Period> getDurationValid() throws ErrorException, IOException;
 
@@ -1378,7 +1368,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Period&gt; object
      */
-    Observable<ServiceResponse<Map<String, Period>>> getDurationValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Period>>> getDurationValidWithServiceResponseAsync();
 
     /**
      * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
@@ -1387,7 +1377,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDurationValid(Map<String, Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1414,14 +1403,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Period&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDurationValidAsyncWithServiceResponse(Map<String, Period> arrayBody);
+    Observable<ServiceResponse<Void>> putDurationValidWithServiceResponseAsync(Map<String, Period> arrayBody);
 
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, byte[]&gt; object if successful.
      */
     Map<String, byte[]> getByteValid() throws ErrorException, IOException;
 
@@ -1445,7 +1434,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    Observable<ServiceResponse<Map<String, byte[]>>> getByteValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, byte[]>>> getByteValidWithServiceResponseAsync();
 
     /**
      * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
@@ -1454,7 +1443,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putByteValid(Map<String, byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1481,14 +1469,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, byte[]&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putByteValidAsyncWithServiceResponse(Map<String, byte[]> arrayBody);
+    Observable<ServiceResponse<Void>> putByteValidWithServiceResponseAsync(Map<String, byte[]> arrayBody);
 
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, byte[]&gt; object if successful.
      */
     Map<String, byte[]> getByteInvalidNull() throws ErrorException, IOException;
 
@@ -1512,14 +1500,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    Observable<ServiceResponse<Map<String, byte[]>>> getByteInvalidNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, byte[]>>> getByteInvalidNullWithServiceResponseAsync();
 
     /**
      * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, byte[]&gt; object if successful.
      */
     Map<String, byte[]> getBase64Url() throws ErrorException, IOException;
 
@@ -1543,14 +1531,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    Observable<ServiceResponse<Map<String, byte[]>>> getBase64UrlAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, byte[]>>> getBase64UrlWithServiceResponseAsync();
 
     /**
      * Get dictionary of complex type null value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     Map<String, Widget> getComplexNull() throws ErrorException, IOException;
 
@@ -1574,14 +1562,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexNullWithServiceResponseAsync();
 
     /**
      * Get empty dictionary of complex type {}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     Map<String, Widget> getComplexEmpty() throws ErrorException, IOException;
 
@@ -1605,14 +1593,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexEmptyWithServiceResponseAsync();
 
     /**
      * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     Map<String, Widget> getComplexItemNull() throws ErrorException, IOException;
 
@@ -1636,14 +1624,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexItemNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexItemNullWithServiceResponseAsync();
 
     /**
      * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     Map<String, Widget> getComplexItemEmpty() throws ErrorException, IOException;
 
@@ -1667,14 +1655,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexItemEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexItemEmptyWithServiceResponseAsync();
 
     /**
      * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     Map<String, Widget> getComplexValid() throws ErrorException, IOException;
 
@@ -1698,7 +1686,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexValidWithServiceResponseAsync();
 
     /**
      * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
@@ -1707,7 +1695,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putComplexValid(Map<String, Widget> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1734,14 +1721,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Widget&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putComplexValidAsyncWithServiceResponse(Map<String, Widget> arrayBody);
+    Observable<ServiceResponse<Void>> putComplexValidWithServiceResponseAsync(Map<String, Widget> arrayBody);
 
     /**
      * Get a null array.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     Map<String, List<String>> getArrayNull() throws ErrorException, IOException;
 
@@ -1765,14 +1752,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayNullWithServiceResponseAsync();
 
     /**
      * Get an empty dictionary {}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     Map<String, List<String>> getArrayEmpty() throws ErrorException, IOException;
 
@@ -1796,14 +1783,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayEmptyWithServiceResponseAsync();
 
     /**
      * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     Map<String, List<String>> getArrayItemNull() throws ErrorException, IOException;
 
@@ -1827,14 +1814,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemNullWithServiceResponseAsync();
 
     /**
      * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     Map<String, List<String>> getArrayItemEmpty() throws ErrorException, IOException;
 
@@ -1858,14 +1845,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemEmptyWithServiceResponseAsync();
 
     /**
      * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     Map<String, List<String>> getArrayValid() throws ErrorException, IOException;
 
@@ -1889,7 +1876,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayValidWithServiceResponseAsync();
 
     /**
      * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
@@ -1898,7 +1885,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putArrayValid(Map<String, List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1925,14 +1911,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayValidAsyncWithServiceResponse(Map<String, List<String>> arrayBody);
+    Observable<ServiceResponse<Void>> putArrayValidWithServiceResponseAsync(Map<String, List<String>> arrayBody);
 
     /**
      * Get an dictionaries of dictionaries with value null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     Map<String, Map<String, String>> getDictionaryNull() throws ErrorException, IOException;
 
@@ -1956,14 +1942,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryNullWithServiceResponseAsync();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     Map<String, Map<String, String>> getDictionaryEmpty() throws ErrorException, IOException;
 
@@ -1987,14 +1973,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryEmptyWithServiceResponseAsync();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     Map<String, Map<String, String>> getDictionaryItemNull() throws ErrorException, IOException;
 
@@ -2018,14 +2004,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemNullWithServiceResponseAsync();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     Map<String, Map<String, String>> getDictionaryItemEmpty() throws ErrorException, IOException;
 
@@ -2049,14 +2035,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemEmptyWithServiceResponseAsync();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     Map<String, Map<String, String>> getDictionaryValid() throws ErrorException, IOException;
 
@@ -2080,7 +2066,7 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryValidWithServiceResponseAsync();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -2089,7 +2075,6 @@ public interface Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDictionaryValid(Map<String, Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -2116,6 +2101,6 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryValidAsyncWithServiceResponse(Map<String, Map<String, String>> arrayBody);
+    Observable<ServiceResponse<Void>> putDictionaryValidWithServiceResponseAsync(Map<String, Map<String, String>> arrayBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydictionary/Dictionarys.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydictionary/Dictionarys.java
@@ -35,7 +35,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Integer>> getNull() throws ErrorException, IOException;
+    Map<String, Integer> getNull() throws ErrorException, IOException;
 
     /**
      * Get null dictionary value.
@@ -50,7 +50,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getNullAsync();
+    Observable<Map<String, Integer>> getNullAsync();
+
+    /**
+     * Get null dictionary value.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Integer>>> getNullAsyncWithServiceResponse();
 
     /**
      * Get empty dictionary value {}.
@@ -59,7 +66,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Integer>> getEmpty() throws ErrorException, IOException;
+    Map<String, Integer> getEmpty() throws ErrorException, IOException;
 
     /**
      * Get empty dictionary value {}.
@@ -74,7 +81,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getEmptyAsync();
+    Observable<Map<String, Integer>> getEmptyAsync();
+
+    /**
+     * Get empty dictionary value {}.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Integer>>> getEmptyAsyncWithServiceResponse();
 
     /**
      * Set dictionary value empty {}.
@@ -85,7 +99,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putEmpty(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putEmpty(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value empty {}.
@@ -102,7 +116,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsync(Map<String, String> arrayBody);
+    Observable<Void> putEmptyAsync(Map<String, String> arrayBody);
+
+    /**
+     * Set dictionary value empty {}.
+     *
+     * @param arrayBody the Map&lt;String, String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(Map<String, String> arrayBody);
 
     /**
      * Get Dictionary with null value.
@@ -111,7 +133,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, String>> getNullValue() throws ErrorException, IOException;
+    Map<String, String> getNullValue() throws ErrorException, IOException;
 
     /**
      * Get Dictionary with null value.
@@ -126,7 +148,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getNullValueAsync();
+    Observable<Map<String, String>> getNullValueAsync();
+
+    /**
+     * Get Dictionary with null value.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Observable<ServiceResponse<Map<String, String>>> getNullValueAsyncWithServiceResponse();
 
     /**
      * Get Dictionary with null key.
@@ -135,7 +164,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, String>> getNullKey() throws ErrorException, IOException;
+    Map<String, String> getNullKey() throws ErrorException, IOException;
 
     /**
      * Get Dictionary with null key.
@@ -150,7 +179,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getNullKeyAsync();
+    Observable<Map<String, String>> getNullKeyAsync();
+
+    /**
+     * Get Dictionary with null key.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Observable<ServiceResponse<Map<String, String>>> getNullKeyAsyncWithServiceResponse();
 
     /**
      * Get Dictionary with key as empty string.
@@ -159,7 +195,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, String>> getEmptyStringKey() throws ErrorException, IOException;
+    Map<String, String> getEmptyStringKey() throws ErrorException, IOException;
 
     /**
      * Get Dictionary with key as empty string.
@@ -174,7 +210,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getEmptyStringKeyAsync();
+    Observable<Map<String, String>> getEmptyStringKeyAsync();
+
+    /**
+     * Get Dictionary with key as empty string.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Observable<ServiceResponse<Map<String, String>>> getEmptyStringKeyAsyncWithServiceResponse();
 
     /**
      * Get invalid Dictionary value.
@@ -183,7 +226,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, String>> getInvalid() throws ErrorException, IOException;
+    Map<String, String> getInvalid() throws ErrorException, IOException;
 
     /**
      * Get invalid Dictionary value.
@@ -198,7 +241,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getInvalidAsync();
+    Observable<Map<String, String>> getInvalidAsync();
+
+    /**
+     * Get invalid Dictionary value.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Observable<ServiceResponse<Map<String, String>>> getInvalidAsyncWithServiceResponse();
 
     /**
      * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
@@ -207,7 +257,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Boolean>> getBooleanTfft() throws ErrorException, IOException;
+    Map<String, Boolean> getBooleanTfft() throws ErrorException, IOException;
 
     /**
      * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
@@ -222,7 +272,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanTfftAsync();
+    Observable<Map<String, Boolean>> getBooleanTfftAsync();
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanTfftAsyncWithServiceResponse();
 
     /**
      * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
@@ -233,7 +290,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBooleanTfft(Map<String, Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putBooleanTfft(Map<String, Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
@@ -250,7 +307,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Boolean&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBooleanTfftAsync(Map<String, Boolean> arrayBody);
+    Observable<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody);
+
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @param arrayBody the Map&lt;String, Boolean&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBooleanTfftAsyncWithServiceResponse(Map<String, Boolean> arrayBody);
 
     /**
      * Get boolean dictionary value {"0": true, "1": null, "2": false }.
@@ -259,7 +324,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Boolean>> getBooleanInvalidNull() throws ErrorException, IOException;
+    Map<String, Boolean> getBooleanInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get boolean dictionary value {"0": true, "1": null, "2": false }.
@@ -274,7 +339,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidNullAsync();
+    Observable<Map<String, Boolean>> getBooleanInvalidNullAsync();
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     *
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
@@ -283,7 +355,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Boolean>> getBooleanInvalidString() throws ErrorException, IOException;
+    Map<String, Boolean> getBooleanInvalidString() throws ErrorException, IOException;
 
     /**
      * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
@@ -298,7 +370,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidStringAsync();
+    Observable<Map<String, Boolean>> getBooleanInvalidStringAsync();
+
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     *
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -307,7 +386,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Integer>> getIntegerValid() throws ErrorException, IOException;
+    Map<String, Integer> getIntegerValid() throws ErrorException, IOException;
 
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -322,7 +401,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getIntegerValidAsync();
+    Observable<Map<String, Integer>> getIntegerValidAsync();
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Integer>>> getIntegerValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -333,7 +419,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putIntegerValid(Map<String, Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putIntegerValid(Map<String, Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -350,7 +436,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Integer&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putIntegerValidAsync(Map<String, Integer> arrayBody);
+    Observable<Void> putIntegerValidAsync(Map<String, Integer> arrayBody);
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody the Map&lt;String, Integer&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putIntegerValidAsyncWithServiceResponse(Map<String, Integer> arrayBody);
 
     /**
      * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
@@ -359,7 +453,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Integer>> getIntInvalidNull() throws ErrorException, IOException;
+    Map<String, Integer> getIntInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
@@ -374,7 +468,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidNullAsync();
+    Observable<Map<String, Integer>> getIntInvalidNullAsync();
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
@@ -383,7 +484,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Integer>> getIntInvalidString() throws ErrorException, IOException;
+    Map<String, Integer> getIntInvalidString() throws ErrorException, IOException;
 
     /**
      * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
@@ -398,7 +499,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidStringAsync();
+    Observable<Map<String, Integer>> getIntInvalidStringAsync();
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -407,7 +515,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Long>> getLongValid() throws ErrorException, IOException;
+    Map<String, Long> getLongValid() throws ErrorException, IOException;
 
     /**
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -422,7 +530,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    Observable<ServiceResponse<Map<String, Long>>> getLongValidAsync();
+    Observable<Map<String, Long>> getLongValidAsync();
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Long>>> getLongValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -433,7 +548,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putLongValid(Map<String, Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putLongValid(Map<String, Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
@@ -450,7 +565,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Long&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putLongValidAsync(Map<String, Long> arrayBody);
+    Observable<Void> putLongValidAsync(Map<String, Long> arrayBody);
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody the Map&lt;String, Long&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putLongValidAsyncWithServiceResponse(Map<String, Long> arrayBody);
 
     /**
      * Get long dictionary value {"0": 1, "1": null, "2": 0}.
@@ -459,7 +582,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Long>> getLongInvalidNull() throws ErrorException, IOException;
+    Map<String, Long> getLongInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get long dictionary value {"0": 1, "1": null, "2": 0}.
@@ -474,7 +597,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    Observable<ServiceResponse<Map<String, Long>>> getLongInvalidNullAsync();
+    Observable<Map<String, Long>> getLongInvalidNullAsync();
+
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Long>>> getLongInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
@@ -483,7 +613,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Long>> getLongInvalidString() throws ErrorException, IOException;
+    Map<String, Long> getLongInvalidString() throws ErrorException, IOException;
 
     /**
      * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
@@ -498,7 +628,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    Observable<ServiceResponse<Map<String, Long>>> getLongInvalidStringAsync();
+    Observable<Map<String, Long>> getLongInvalidStringAsync();
+
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Long>>> getLongInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -507,7 +644,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Double>> getFloatValid() throws ErrorException, IOException;
+    Map<String, Double> getFloatValid() throws ErrorException, IOException;
 
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -522,7 +659,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getFloatValidAsync();
+    Observable<Map<String, Double>> getFloatValidAsync();
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Double>>> getFloatValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -533,7 +677,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putFloatValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putFloatValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -550,7 +694,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putFloatValidAsync(Map<String, Double> arrayBody);
+    Observable<Void> putFloatValidAsync(Map<String, Double> arrayBody);
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody the Map&lt;String, Double&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putFloatValidAsyncWithServiceResponse(Map<String, Double> arrayBody);
 
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
@@ -559,7 +711,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Double>> getFloatInvalidNull() throws ErrorException, IOException;
+    Map<String, Double> getFloatInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
@@ -574,7 +726,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidNullAsync();
+    Observable<Map<String, Double>> getFloatInvalidNullAsync();
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
@@ -583,7 +742,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Double>> getFloatInvalidString() throws ErrorException, IOException;
+    Map<String, Double> getFloatInvalidString() throws ErrorException, IOException;
 
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
@@ -598,7 +757,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidStringAsync();
+    Observable<Map<String, Double>> getFloatInvalidStringAsync();
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -607,7 +773,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Double>> getDoubleValid() throws ErrorException, IOException;
+    Map<String, Double> getDoubleValid() throws ErrorException, IOException;
 
     /**
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -622,7 +788,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getDoubleValidAsync();
+    Observable<Map<String, Double>> getDoubleValidAsync();
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Double>>> getDoubleValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -633,7 +806,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDoubleValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDoubleValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
@@ -650,7 +823,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDoubleValidAsync(Map<String, Double> arrayBody);
+    Observable<Void> putDoubleValidAsync(Map<String, Double> arrayBody);
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody the Map&lt;String, Double&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDoubleValidAsyncWithServiceResponse(Map<String, Double> arrayBody);
 
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
@@ -659,7 +840,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Double>> getDoubleInvalidNull() throws ErrorException, IOException;
+    Map<String, Double> getDoubleInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
@@ -674,7 +855,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidNullAsync();
+    Observable<Map<String, Double>> getDoubleInvalidNullAsync();
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
@@ -683,7 +871,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Double>> getDoubleInvalidString() throws ErrorException, IOException;
+    Map<String, Double> getDoubleInvalidString() throws ErrorException, IOException;
 
     /**
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
@@ -698,7 +886,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidStringAsync();
+    Observable<Map<String, Double>> getDoubleInvalidStringAsync();
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidStringAsyncWithServiceResponse();
 
     /**
      * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
@@ -707,7 +902,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, String>> getStringValid() throws ErrorException, IOException;
+    Map<String, String> getStringValid() throws ErrorException, IOException;
 
     /**
      * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
@@ -722,7 +917,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getStringValidAsync();
+    Observable<Map<String, String>> getStringValidAsync();
+
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Observable<ServiceResponse<Map<String, String>>> getStringValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
@@ -733,7 +935,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putStringValid(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putStringValid(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
@@ -750,7 +952,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putStringValidAsync(Map<String, String> arrayBody);
+    Observable<Void> putStringValidAsync(Map<String, String> arrayBody);
+
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @param arrayBody the Map&lt;String, String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putStringValidAsyncWithServiceResponse(Map<String, String> arrayBody);
 
     /**
      * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
@@ -759,7 +969,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, String>> getStringWithNull() throws ErrorException, IOException;
+    Map<String, String> getStringWithNull() throws ErrorException, IOException;
 
     /**
      * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
@@ -774,7 +984,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getStringWithNullAsync();
+    Observable<Map<String, String>> getStringWithNullAsync();
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Observable<ServiceResponse<Map<String, String>>> getStringWithNullAsyncWithServiceResponse();
 
     /**
      * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
@@ -783,7 +1000,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, String>> getStringWithInvalid() throws ErrorException, IOException;
+    Map<String, String> getStringWithInvalid() throws ErrorException, IOException;
 
     /**
      * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
@@ -798,7 +1015,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    Observable<ServiceResponse<Map<String, String>>> getStringWithInvalidAsync();
+    Observable<Map<String, String>> getStringWithInvalidAsync();
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Observable<ServiceResponse<Map<String, String>>> getStringWithInvalidAsyncWithServiceResponse();
 
     /**
      * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
@@ -807,7 +1031,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, LocalDate>> getDateValid() throws ErrorException, IOException;
+    Map<String, LocalDate> getDateValid() throws ErrorException, IOException;
 
     /**
      * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
@@ -822,7 +1046,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    Observable<ServiceResponse<Map<String, LocalDate>>> getDateValidAsync();
+    Observable<Map<String, LocalDate>> getDateValidAsync();
+
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    Observable<ServiceResponse<Map<String, LocalDate>>> getDateValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
@@ -833,7 +1064,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDateValid(Map<String, LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDateValid(Map<String, LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
@@ -850,7 +1081,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, LocalDate&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateValidAsync(Map<String, LocalDate> arrayBody);
+    Observable<Void> putDateValidAsync(Map<String, LocalDate> arrayBody);
+
+    /**
+     * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @param arrayBody the Map&lt;String, LocalDate&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateValidAsyncWithServiceResponse(Map<String, LocalDate> arrayBody);
 
     /**
      * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
@@ -859,7 +1098,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, LocalDate>> getDateInvalidNull() throws ErrorException, IOException;
+    Map<String, LocalDate> getDateInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
@@ -874,7 +1113,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidNullAsync();
+    Observable<Map<String, LocalDate>> getDateInvalidNullAsync();
+
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     *
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
@@ -883,7 +1129,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, LocalDate>> getDateInvalidChars() throws ErrorException, IOException;
+    Map<String, LocalDate> getDateInvalidChars() throws ErrorException, IOException;
 
     /**
      * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
@@ -898,7 +1144,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidCharsAsync();
+    Observable<Map<String, LocalDate>> getDateInvalidCharsAsync();
+
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     *
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidCharsAsyncWithServiceResponse();
 
     /**
      * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
@@ -907,7 +1160,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, DateTime>> getDateTimeValid() throws ErrorException, IOException;
+    Map<String, DateTime> getDateTimeValid() throws ErrorException, IOException;
 
     /**
      * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
@@ -922,7 +1175,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeValidAsync();
+    Observable<Map<String, DateTime>> getDateTimeValidAsync();
+
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     *
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
@@ -933,7 +1193,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDateTimeValid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDateTimeValid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
@@ -950,7 +1210,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, DateTime&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeValidAsync(Map<String, DateTime> arrayBody);
+    Observable<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody);
+
+    /**
+     * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     *
+     * @param arrayBody the Map&lt;String, DateTime&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateTimeValidAsyncWithServiceResponse(Map<String, DateTime> arrayBody);
 
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
@@ -959,7 +1227,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, DateTime>> getDateTimeInvalidNull() throws ErrorException, IOException;
+    Map<String, DateTime> getDateTimeInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
@@ -974,7 +1242,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidNullAsync();
+    Observable<Map<String, DateTime>> getDateTimeInvalidNullAsync();
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     *
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
@@ -983,7 +1258,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, DateTime>> getDateTimeInvalidChars() throws ErrorException, IOException;
+    Map<String, DateTime> getDateTimeInvalidChars() throws ErrorException, IOException;
 
     /**
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
@@ -998,7 +1273,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidCharsAsync();
+    Observable<Map<String, DateTime>> getDateTimeInvalidCharsAsync();
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     *
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidCharsAsyncWithServiceResponse();
 
     /**
      * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
@@ -1007,7 +1289,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, DateTime>> getDateTimeRfc1123Valid() throws ErrorException, IOException;
+    Map<String, DateTime> getDateTimeRfc1123Valid() throws ErrorException, IOException;
 
     /**
      * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
@@ -1022,7 +1304,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeRfc1123ValidAsync();
+    Observable<Map<String, DateTime>> getDateTimeRfc1123ValidAsync();
+
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeRfc1123ValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
@@ -1033,7 +1322,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDateTimeRfc1123Valid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDateTimeRfc1123Valid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
@@ -1050,7 +1339,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody);
+    Observable<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody);
+
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsyncWithServiceResponse(Map<String, DateTime> arrayBody);
 
     /**
      * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
@@ -1059,7 +1356,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Period&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Period>> getDurationValid() throws ErrorException, IOException;
+    Map<String, Period> getDurationValid() throws ErrorException, IOException;
 
     /**
      * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
@@ -1074,7 +1371,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Period&gt; object
      */
-    Observable<ServiceResponse<Map<String, Period>>> getDurationValidAsync();
+    Observable<Map<String, Period>> getDurationValidAsync();
+
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @return the observable to the Map&lt;String, Period&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Period>>> getDurationValidAsyncWithServiceResponse();
 
     /**
      * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
@@ -1085,7 +1389,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDurationValid(Map<String, Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDurationValid(Map<String, Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
@@ -1102,7 +1406,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Period&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDurationValidAsync(Map<String, Period> arrayBody);
+    Observable<Void> putDurationValidAsync(Map<String, Period> arrayBody);
+
+    /**
+     * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @param arrayBody the Map&lt;String, Period&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDurationValidAsyncWithServiceResponse(Map<String, Period> arrayBody);
 
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
@@ -1111,7 +1423,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, byte[]>> getByteValid() throws ErrorException, IOException;
+    Map<String, byte[]> getByteValid() throws ErrorException, IOException;
 
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
@@ -1126,7 +1438,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    Observable<ServiceResponse<Map<String, byte[]>>> getByteValidAsync();
+    Observable<Map<String, byte[]>> getByteValidAsync();
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
+     *
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    Observable<ServiceResponse<Map<String, byte[]>>> getByteValidAsyncWithServiceResponse();
 
     /**
      * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
@@ -1137,7 +1456,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putByteValid(Map<String, byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putByteValid(Map<String, byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
@@ -1154,7 +1473,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, byte[]&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putByteValidAsync(Map<String, byte[]> arrayBody);
+    Observable<Void> putByteValidAsync(Map<String, byte[]> arrayBody);
+
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     *
+     * @param arrayBody the Map&lt;String, byte[]&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putByteValidAsyncWithServiceResponse(Map<String, byte[]> arrayBody);
 
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
@@ -1163,7 +1490,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, byte[]>> getByteInvalidNull() throws ErrorException, IOException;
+    Map<String, byte[]> getByteInvalidNull() throws ErrorException, IOException;
 
     /**
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
@@ -1178,7 +1505,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    Observable<ServiceResponse<Map<String, byte[]>>> getByteInvalidNullAsync();
+    Observable<Map<String, byte[]>> getByteInvalidNullAsync();
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     *
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    Observable<ServiceResponse<Map<String, byte[]>>> getByteInvalidNullAsyncWithServiceResponse();
 
     /**
      * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
@@ -1187,7 +1521,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, byte[]>> getBase64Url() throws ErrorException, IOException;
+    Map<String, byte[]> getBase64Url() throws ErrorException, IOException;
 
     /**
      * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
@@ -1202,7 +1536,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    Observable<ServiceResponse<Map<String, byte[]>>> getBase64UrlAsync();
+    Observable<Map<String, byte[]>> getBase64UrlAsync();
+
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
+     *
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    Observable<ServiceResponse<Map<String, byte[]>>> getBase64UrlAsyncWithServiceResponse();
 
     /**
      * Get dictionary of complex type null value.
@@ -1211,7 +1552,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Widget>> getComplexNull() throws ErrorException, IOException;
+    Map<String, Widget> getComplexNull() throws ErrorException, IOException;
 
     /**
      * Get dictionary of complex type null value.
@@ -1226,7 +1567,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexNullAsync();
+    Observable<Map<String, Widget>> getComplexNullAsync();
+
+    /**
+     * Get dictionary of complex type null value.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexNullAsyncWithServiceResponse();
 
     /**
      * Get empty dictionary of complex type {}.
@@ -1235,7 +1583,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Widget>> getComplexEmpty() throws ErrorException, IOException;
+    Map<String, Widget> getComplexEmpty() throws ErrorException, IOException;
 
     /**
      * Get empty dictionary of complex type {}.
@@ -1250,7 +1598,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexEmptyAsync();
+    Observable<Map<String, Widget>> getComplexEmptyAsync();
+
+    /**
+     * Get empty dictionary of complex type {}.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexEmptyAsyncWithServiceResponse();
 
     /**
      * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
@@ -1259,7 +1614,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Widget>> getComplexItemNull() throws ErrorException, IOException;
+    Map<String, Widget> getComplexItemNull() throws ErrorException, IOException;
 
     /**
      * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
@@ -1274,7 +1629,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexItemNullAsync();
+    Observable<Map<String, Widget>> getComplexItemNullAsync();
+
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexItemNullAsyncWithServiceResponse();
 
     /**
      * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
@@ -1283,7 +1645,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Widget>> getComplexItemEmpty() throws ErrorException, IOException;
+    Map<String, Widget> getComplexItemEmpty() throws ErrorException, IOException;
 
     /**
      * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
@@ -1298,7 +1660,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexItemEmptyAsync();
+    Observable<Map<String, Widget>> getComplexItemEmptyAsync();
+
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexItemEmptyAsyncWithServiceResponse();
 
     /**
      * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
@@ -1307,7 +1676,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Widget>> getComplexValid() throws ErrorException, IOException;
+    Map<String, Widget> getComplexValid() throws ErrorException, IOException;
 
     /**
      * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
@@ -1322,7 +1691,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    Observable<ServiceResponse<Map<String, Widget>>> getComplexValidAsync();
+    Observable<Map<String, Widget>> getComplexValidAsync();
+
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Widget>>> getComplexValidAsyncWithServiceResponse();
 
     /**
      * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
@@ -1333,7 +1709,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putComplexValid(Map<String, Widget> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putComplexValid(Map<String, Widget> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
@@ -1350,7 +1726,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Widget&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putComplexValidAsync(Map<String, Widget> arrayBody);
+    Observable<Void> putComplexValidAsync(Map<String, Widget> arrayBody);
+
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @param arrayBody the Map&lt;String, Widget&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putComplexValidAsyncWithServiceResponse(Map<String, Widget> arrayBody);
 
     /**
      * Get a null array.
@@ -1359,7 +1743,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, List<String>>> getArrayNull() throws ErrorException, IOException;
+    Map<String, List<String>> getArrayNull() throws ErrorException, IOException;
 
     /**
      * Get a null array.
@@ -1374,7 +1758,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayNullAsync();
+    Observable<Map<String, List<String>>> getArrayNullAsync();
+
+    /**
+     * Get a null array.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayNullAsyncWithServiceResponse();
 
     /**
      * Get an empty dictionary {}.
@@ -1383,7 +1774,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, List<String>>> getArrayEmpty() throws ErrorException, IOException;
+    Map<String, List<String>> getArrayEmpty() throws ErrorException, IOException;
 
     /**
      * Get an empty dictionary {}.
@@ -1398,7 +1789,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayEmptyAsync();
+    Observable<Map<String, List<String>>> getArrayEmptyAsync();
+
+    /**
+     * Get an empty dictionary {}.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayEmptyAsyncWithServiceResponse();
 
     /**
      * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
@@ -1407,7 +1805,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, List<String>>> getArrayItemNull() throws ErrorException, IOException;
+    Map<String, List<String>> getArrayItemNull() throws ErrorException, IOException;
 
     /**
      * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
@@ -1422,7 +1820,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemNullAsync();
+    Observable<Map<String, List<String>>> getArrayItemNullAsync();
+
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemNullAsyncWithServiceResponse();
 
     /**
      * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
@@ -1431,7 +1836,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, List<String>>> getArrayItemEmpty() throws ErrorException, IOException;
+    Map<String, List<String>> getArrayItemEmpty() throws ErrorException, IOException;
 
     /**
      * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
@@ -1446,7 +1851,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemEmptyAsync();
+    Observable<Map<String, List<String>>> getArrayItemEmptyAsync();
+
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemEmptyAsyncWithServiceResponse();
 
     /**
      * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
@@ -1455,7 +1867,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, List<String>>> getArrayValid() throws ErrorException, IOException;
+    Map<String, List<String>> getArrayValid() throws ErrorException, IOException;
 
     /**
      * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
@@ -1470,7 +1882,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, List<String>>>> getArrayValidAsync();
+    Observable<Map<String, List<String>>> getArrayValidAsync();
+
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, List<String>>>> getArrayValidAsyncWithServiceResponse();
 
     /**
      * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
@@ -1481,7 +1900,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putArrayValid(Map<String, List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putArrayValid(Map<String, List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
@@ -1498,7 +1917,15 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayValidAsync(Map<String, List<String>> arrayBody);
+    Observable<Void> putArrayValidAsync(Map<String, List<String>> arrayBody);
+
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putArrayValidAsyncWithServiceResponse(Map<String, List<String>> arrayBody);
 
     /**
      * Get an dictionaries of dictionaries with value null.
@@ -1507,7 +1934,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Map<String, String>>> getDictionaryNull() throws ErrorException, IOException;
+    Map<String, Map<String, String>> getDictionaryNull() throws ErrorException, IOException;
 
     /**
      * Get an dictionaries of dictionaries with value null.
@@ -1522,7 +1949,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryNullAsync();
+    Observable<Map<String, Map<String, String>>> getDictionaryNullAsync();
+
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryNullAsyncWithServiceResponse();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
@@ -1531,7 +1965,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Map<String, String>>> getDictionaryEmpty() throws ErrorException, IOException;
+    Map<String, Map<String, String>> getDictionaryEmpty() throws ErrorException, IOException;
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
@@ -1546,7 +1980,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryEmptyAsync();
+    Observable<Map<String, Map<String, String>>> getDictionaryEmptyAsync();
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryEmptyAsyncWithServiceResponse();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -1555,7 +1996,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Map<String, String>>> getDictionaryItemNull() throws ErrorException, IOException;
+    Map<String, Map<String, String>> getDictionaryItemNull() throws ErrorException, IOException;
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -1570,7 +2011,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemNullAsync();
+    Observable<Map<String, Map<String, String>>> getDictionaryItemNullAsync();
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemNullAsyncWithServiceResponse();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -1579,7 +2027,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Map<String, String>>> getDictionaryItemEmpty() throws ErrorException, IOException;
+    Map<String, Map<String, String>> getDictionaryItemEmpty() throws ErrorException, IOException;
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -1594,7 +2042,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemEmptyAsync();
+    Observable<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync();
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemEmptyAsyncWithServiceResponse();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -1603,7 +2058,7 @@ public interface Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Map<String, String>>> getDictionaryValid() throws ErrorException, IOException;
+    Map<String, Map<String, String>> getDictionaryValid() throws ErrorException, IOException;
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -1618,7 +2073,14 @@ public interface Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryValidAsync();
+    Observable<Map<String, Map<String, String>>> getDictionaryValidAsync();
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryValidAsyncWithServiceResponse();
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -1629,7 +2091,7 @@ public interface Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDictionaryValid(Map<String, Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putDictionaryValid(Map<String, Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
@@ -1646,6 +2108,14 @@ public interface Dictionarys {
      * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody);
+    Observable<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody);
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDictionaryValidAsyncWithServiceResponse(Map<String, Map<String, String>> arrayBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
@@ -333,8 +333,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Integer>> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public Map<String, Integer> getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -344,7 +344,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getNullAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -352,7 +352,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getNullAsync() {
+    public Observable<Map<String, Integer>> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null dictionary value.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Integer>>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -381,8 +395,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Integer>> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsync().toBlocking().single();
+    public Map<String, Integer> getEmpty() throws ErrorException, IOException {
+        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -392,7 +406,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getEmptyAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -400,7 +414,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getEmptyAsync() {
+    public Observable<Map<String, Integer>> getEmptyAsync() {
+        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty dictionary value {}.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Integer>>> getEmptyAsyncWithServiceResponse() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -431,8 +459,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putEmpty(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putEmptyAsync(arrayBody).toBlocking().single();
+    public void putEmpty(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putEmptyAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -443,7 +471,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(Map<String, String> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putEmptyAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -452,7 +480,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsync(Map<String, String> arrayBody) {
+    public Observable<Void> putEmptyAsync(Map<String, String> arrayBody) {
+        return putEmptyAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value empty {}.
+     *
+     * @param arrayBody the Map&lt;String, String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(Map<String, String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -485,8 +528,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, String>> getNullValue() throws ErrorException, IOException {
-        return getNullValueAsync().toBlocking().single();
+    public Map<String, String> getNullValue() throws ErrorException, IOException {
+        return getNullValueAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -496,7 +539,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getNullValueAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getNullValueAsync(), serviceCallback);
+        return ServiceCall.create(getNullValueAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -504,7 +547,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getNullValueAsync() {
+    public Observable<Map<String, String>> getNullValueAsync() {
+        return getNullValueAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+            @Override
+            public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get Dictionary with null value.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, String>>> getNullValueAsyncWithServiceResponse() {
         return service.getNullValue()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -533,8 +590,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, String>> getNullKey() throws ErrorException, IOException {
-        return getNullKeyAsync().toBlocking().single();
+    public Map<String, String> getNullKey() throws ErrorException, IOException {
+        return getNullKeyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -544,7 +601,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getNullKeyAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getNullKeyAsync(), serviceCallback);
+        return ServiceCall.create(getNullKeyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -552,7 +609,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getNullKeyAsync() {
+    public Observable<Map<String, String>> getNullKeyAsync() {
+        return getNullKeyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+            @Override
+            public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get Dictionary with null key.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, String>>> getNullKeyAsyncWithServiceResponse() {
         return service.getNullKey()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -581,8 +652,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, String>> getEmptyStringKey() throws ErrorException, IOException {
-        return getEmptyStringKeyAsync().toBlocking().single();
+    public Map<String, String> getEmptyStringKey() throws ErrorException, IOException {
+        return getEmptyStringKeyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -592,7 +663,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getEmptyStringKeyAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getEmptyStringKeyAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyStringKeyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -600,7 +671,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getEmptyStringKeyAsync() {
+    public Observable<Map<String, String>> getEmptyStringKeyAsync() {
+        return getEmptyStringKeyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+            @Override
+            public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get Dictionary with key as empty string.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, String>>> getEmptyStringKeyAsyncWithServiceResponse() {
         return service.getEmptyStringKey()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -629,8 +714,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, String>> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public Map<String, String> getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -640,7 +725,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getInvalidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -648,7 +733,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getInvalidAsync() {
+    public Observable<Map<String, String>> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+            @Override
+            public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid Dictionary value.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, String>>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -677,8 +776,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Boolean>> getBooleanTfft() throws ErrorException, IOException {
-        return getBooleanTfftAsync().toBlocking().single();
+    public Map<String, Boolean> getBooleanTfft() throws ErrorException, IOException {
+        return getBooleanTfftAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -688,7 +787,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Boolean>> getBooleanTfftAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanTfftAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanTfftAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -696,7 +795,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanTfftAsync() {
+    public Observable<Map<String, Boolean>> getBooleanTfftAsync() {
+        return getBooleanTfftAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
+            @Override
+            public Map<String, Boolean> call(ServiceResponse<Map<String, Boolean>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanTfftAsyncWithServiceResponse() {
         return service.getBooleanTfft()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Boolean>>>>() {
                 @Override
@@ -727,8 +840,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBooleanTfft(Map<String, Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putBooleanTfftAsync(arrayBody).toBlocking().single();
+    public void putBooleanTfft(Map<String, Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putBooleanTfftAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -739,7 +852,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBooleanTfftAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putBooleanTfftAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -748,7 +861,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Boolean&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBooleanTfftAsync(Map<String, Boolean> arrayBody) {
+    public Observable<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody) {
+        return putBooleanTfftAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @param arrayBody the Map&lt;String, Boolean&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBooleanTfftAsyncWithServiceResponse(Map<String, Boolean> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -781,8 +909,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Boolean>> getBooleanInvalidNull() throws ErrorException, IOException {
-        return getBooleanInvalidNullAsync().toBlocking().single();
+    public Map<String, Boolean> getBooleanInvalidNull() throws ErrorException, IOException {
+        return getBooleanInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -792,7 +920,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Boolean>> getBooleanInvalidNullAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -800,7 +928,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidNullAsync() {
+    public Observable<Map<String, Boolean>> getBooleanInvalidNullAsync() {
+        return getBooleanInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
+            @Override
+            public Map<String, Boolean> call(ServiceResponse<Map<String, Boolean>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     *
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidNullAsyncWithServiceResponse() {
         return service.getBooleanInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Boolean>>>>() {
                 @Override
@@ -829,8 +971,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Boolean>> getBooleanInvalidString() throws ErrorException, IOException {
-        return getBooleanInvalidStringAsync().toBlocking().single();
+    public Map<String, Boolean> getBooleanInvalidString() throws ErrorException, IOException {
+        return getBooleanInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -840,7 +982,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Boolean>> getBooleanInvalidStringAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -848,7 +990,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidStringAsync() {
+    public Observable<Map<String, Boolean>> getBooleanInvalidStringAsync() {
+        return getBooleanInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
+            @Override
+            public Map<String, Boolean> call(ServiceResponse<Map<String, Boolean>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     *
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidStringAsyncWithServiceResponse() {
         return service.getBooleanInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Boolean>>>>() {
                 @Override
@@ -877,8 +1033,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Integer>> getIntegerValid() throws ErrorException, IOException {
-        return getIntegerValidAsync().toBlocking().single();
+    public Map<String, Integer> getIntegerValid() throws ErrorException, IOException {
+        return getIntegerValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -888,7 +1044,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getIntegerValidAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getIntegerValidAsync(), serviceCallback);
+        return ServiceCall.create(getIntegerValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -896,7 +1052,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getIntegerValidAsync() {
+    public Observable<Map<String, Integer>> getIntegerValidAsync() {
+        return getIntegerValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Integer>>> getIntegerValidAsyncWithServiceResponse() {
         return service.getIntegerValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -927,8 +1097,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putIntegerValid(Map<String, Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putIntegerValidAsync(arrayBody).toBlocking().single();
+    public void putIntegerValid(Map<String, Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putIntegerValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -939,7 +1109,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putIntegerValidAsync(Map<String, Integer> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putIntegerValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putIntegerValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -948,7 +1118,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Integer&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putIntegerValidAsync(Map<String, Integer> arrayBody) {
+    public Observable<Void> putIntegerValidAsync(Map<String, Integer> arrayBody) {
+        return putIntegerValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody the Map&lt;String, Integer&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putIntegerValidAsyncWithServiceResponse(Map<String, Integer> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -981,8 +1166,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Integer>> getIntInvalidNull() throws ErrorException, IOException {
-        return getIntInvalidNullAsync().toBlocking().single();
+    public Map<String, Integer> getIntInvalidNull() throws ErrorException, IOException {
+        return getIntInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -992,7 +1177,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getIntInvalidNullAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getIntInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getIntInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1000,7 +1185,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidNullAsync() {
+    public Observable<Map<String, Integer>> getIntInvalidNullAsync() {
+        return getIntInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidNullAsyncWithServiceResponse() {
         return service.getIntInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -1029,8 +1228,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Integer>> getIntInvalidString() throws ErrorException, IOException {
-        return getIntInvalidStringAsync().toBlocking().single();
+    public Map<String, Integer> getIntInvalidString() throws ErrorException, IOException {
+        return getIntInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1040,7 +1239,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getIntInvalidStringAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getIntInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getIntInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1048,7 +1247,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidStringAsync() {
+    public Observable<Map<String, Integer>> getIntInvalidStringAsync() {
+        return getIntInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidStringAsyncWithServiceResponse() {
         return service.getIntInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -1077,8 +1290,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Long>> getLongValid() throws ErrorException, IOException {
-        return getLongValidAsync().toBlocking().single();
+    public Map<String, Long> getLongValid() throws ErrorException, IOException {
+        return getLongValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1088,7 +1301,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Long>> getLongValidAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
-        return ServiceCall.create(getLongValidAsync(), serviceCallback);
+        return ServiceCall.create(getLongValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1096,7 +1309,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Long>>> getLongValidAsync() {
+    public Observable<Map<String, Long>> getLongValidAsync() {
+        return getLongValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
+            @Override
+            public Map<String, Long> call(ServiceResponse<Map<String, Long>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Long>>> getLongValidAsyncWithServiceResponse() {
         return service.getLongValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Long>>>>() {
                 @Override
@@ -1127,8 +1354,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putLongValid(Map<String, Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putLongValidAsync(arrayBody).toBlocking().single();
+    public void putLongValid(Map<String, Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putLongValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1139,7 +1366,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLongValidAsync(Map<String, Long> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLongValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putLongValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1148,7 +1375,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Long&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLongValidAsync(Map<String, Long> arrayBody) {
+    public Observable<Void> putLongValidAsync(Map<String, Long> arrayBody) {
+        return putLongValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody the Map&lt;String, Long&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putLongValidAsyncWithServiceResponse(Map<String, Long> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1181,8 +1423,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Long>> getLongInvalidNull() throws ErrorException, IOException {
-        return getLongInvalidNullAsync().toBlocking().single();
+    public Map<String, Long> getLongInvalidNull() throws ErrorException, IOException {
+        return getLongInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1192,7 +1434,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Long>> getLongInvalidNullAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
-        return ServiceCall.create(getLongInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getLongInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1200,7 +1442,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Long>>> getLongInvalidNullAsync() {
+    public Observable<Map<String, Long>> getLongInvalidNullAsync() {
+        return getLongInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
+            @Override
+            public Map<String, Long> call(ServiceResponse<Map<String, Long>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Long>>> getLongInvalidNullAsyncWithServiceResponse() {
         return service.getLongInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Long>>>>() {
                 @Override
@@ -1229,8 +1485,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Long>> getLongInvalidString() throws ErrorException, IOException {
-        return getLongInvalidStringAsync().toBlocking().single();
+    public Map<String, Long> getLongInvalidString() throws ErrorException, IOException {
+        return getLongInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1240,7 +1496,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Long>> getLongInvalidStringAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
-        return ServiceCall.create(getLongInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getLongInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1248,7 +1504,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Long>>> getLongInvalidStringAsync() {
+    public Observable<Map<String, Long>> getLongInvalidStringAsync() {
+        return getLongInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
+            @Override
+            public Map<String, Long> call(ServiceResponse<Map<String, Long>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Long>>> getLongInvalidStringAsyncWithServiceResponse() {
         return service.getLongInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Long>>>>() {
                 @Override
@@ -1277,8 +1547,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Double>> getFloatValid() throws ErrorException, IOException {
-        return getFloatValidAsync().toBlocking().single();
+    public Map<String, Double> getFloatValid() throws ErrorException, IOException {
+        return getFloatValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1288,7 +1558,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getFloatValidAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getFloatValidAsync(), serviceCallback);
+        return ServiceCall.create(getFloatValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1296,7 +1566,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getFloatValidAsync() {
+    public Observable<Map<String, Double>> getFloatValidAsync() {
+        return getFloatValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+            @Override
+            public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Double>>> getFloatValidAsyncWithServiceResponse() {
         return service.getFloatValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1327,8 +1611,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putFloatValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putFloatValidAsync(arrayBody).toBlocking().single();
+    public void putFloatValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putFloatValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1339,7 +1623,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putFloatValidAsync(Map<String, Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putFloatValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putFloatValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1348,7 +1632,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putFloatValidAsync(Map<String, Double> arrayBody) {
+    public Observable<Void> putFloatValidAsync(Map<String, Double> arrayBody) {
+        return putFloatValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody the Map&lt;String, Double&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putFloatValidAsyncWithServiceResponse(Map<String, Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1381,8 +1680,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Double>> getFloatInvalidNull() throws ErrorException, IOException {
-        return getFloatInvalidNullAsync().toBlocking().single();
+    public Map<String, Double> getFloatInvalidNull() throws ErrorException, IOException {
+        return getFloatInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1392,7 +1691,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getFloatInvalidNullAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getFloatInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getFloatInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1400,7 +1699,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidNullAsync() {
+    public Observable<Map<String, Double>> getFloatInvalidNullAsync() {
+        return getFloatInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+            @Override
+            public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidNullAsyncWithServiceResponse() {
         return service.getFloatInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1429,8 +1742,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Double>> getFloatInvalidString() throws ErrorException, IOException {
-        return getFloatInvalidStringAsync().toBlocking().single();
+    public Map<String, Double> getFloatInvalidString() throws ErrorException, IOException {
+        return getFloatInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1440,7 +1753,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getFloatInvalidStringAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getFloatInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getFloatInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1448,7 +1761,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidStringAsync() {
+    public Observable<Map<String, Double>> getFloatInvalidStringAsync() {
+        return getFloatInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+            @Override
+            public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidStringAsyncWithServiceResponse() {
         return service.getFloatInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1477,8 +1804,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Double>> getDoubleValid() throws ErrorException, IOException {
-        return getDoubleValidAsync().toBlocking().single();
+    public Map<String, Double> getDoubleValid() throws ErrorException, IOException {
+        return getDoubleValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1488,7 +1815,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getDoubleValidAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleValidAsync(), serviceCallback);
+        return ServiceCall.create(getDoubleValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1496,7 +1823,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getDoubleValidAsync() {
+    public Observable<Map<String, Double>> getDoubleValidAsync() {
+        return getDoubleValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+            @Override
+            public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Double>>> getDoubleValidAsyncWithServiceResponse() {
         return service.getDoubleValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1527,8 +1868,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDoubleValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDoubleValidAsync(arrayBody).toBlocking().single();
+    public void putDoubleValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDoubleValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1539,7 +1880,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDoubleValidAsync(Map<String, Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDoubleValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDoubleValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1548,7 +1889,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDoubleValidAsync(Map<String, Double> arrayBody) {
+    public Observable<Void> putDoubleValidAsync(Map<String, Double> arrayBody) {
+        return putDoubleValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody the Map&lt;String, Double&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDoubleValidAsyncWithServiceResponse(Map<String, Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1581,8 +1937,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Double>> getDoubleInvalidNull() throws ErrorException, IOException {
-        return getDoubleInvalidNullAsync().toBlocking().single();
+    public Map<String, Double> getDoubleInvalidNull() throws ErrorException, IOException {
+        return getDoubleInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1592,7 +1948,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getDoubleInvalidNullAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getDoubleInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1600,7 +1956,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidNullAsync() {
+    public Observable<Map<String, Double>> getDoubleInvalidNullAsync() {
+        return getDoubleInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+            @Override
+            public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidNullAsyncWithServiceResponse() {
         return service.getDoubleInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1629,8 +1999,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Double>> getDoubleInvalidString() throws ErrorException, IOException {
-        return getDoubleInvalidStringAsync().toBlocking().single();
+    public Map<String, Double> getDoubleInvalidString() throws ErrorException, IOException {
+        return getDoubleInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1640,7 +2010,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getDoubleInvalidStringAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleInvalidStringAsync(), serviceCallback);
+        return ServiceCall.create(getDoubleInvalidStringAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1648,7 +2018,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidStringAsync() {
+    public Observable<Map<String, Double>> getDoubleInvalidStringAsync() {
+        return getDoubleInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+            @Override
+            public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidStringAsyncWithServiceResponse() {
         return service.getDoubleInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1677,8 +2061,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, String>> getStringValid() throws ErrorException, IOException {
-        return getStringValidAsync().toBlocking().single();
+    public Map<String, String> getStringValid() throws ErrorException, IOException {
+        return getStringValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1688,7 +2072,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getStringValidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getStringValidAsync(), serviceCallback);
+        return ServiceCall.create(getStringValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1696,7 +2080,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getStringValidAsync() {
+    public Observable<Map<String, String>> getStringValidAsync() {
+        return getStringValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+            @Override
+            public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, String>>> getStringValidAsyncWithServiceResponse() {
         return service.getStringValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -1727,8 +2125,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putStringValid(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putStringValidAsync(arrayBody).toBlocking().single();
+    public void putStringValid(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putStringValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1739,7 +2137,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putStringValidAsync(Map<String, String> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putStringValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putStringValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1748,7 +2146,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putStringValidAsync(Map<String, String> arrayBody) {
+    public Observable<Void> putStringValidAsync(Map<String, String> arrayBody) {
+        return putStringValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @param arrayBody the Map&lt;String, String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putStringValidAsyncWithServiceResponse(Map<String, String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1781,8 +2194,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, String>> getStringWithNull() throws ErrorException, IOException {
-        return getStringWithNullAsync().toBlocking().single();
+    public Map<String, String> getStringWithNull() throws ErrorException, IOException {
+        return getStringWithNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1792,7 +2205,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getStringWithNullAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getStringWithNullAsync(), serviceCallback);
+        return ServiceCall.create(getStringWithNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1800,7 +2213,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getStringWithNullAsync() {
+    public Observable<Map<String, String>> getStringWithNullAsync() {
+        return getStringWithNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+            @Override
+            public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, String>>> getStringWithNullAsyncWithServiceResponse() {
         return service.getStringWithNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -1829,8 +2256,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, String>> getStringWithInvalid() throws ErrorException, IOException {
-        return getStringWithInvalidAsync().toBlocking().single();
+    public Map<String, String> getStringWithInvalid() throws ErrorException, IOException {
+        return getStringWithInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1840,7 +2267,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getStringWithInvalidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getStringWithInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getStringWithInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1848,7 +2275,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getStringWithInvalidAsync() {
+    public Observable<Map<String, String>> getStringWithInvalidAsync() {
+        return getStringWithInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+            @Override
+            public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     *
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, String>>> getStringWithInvalidAsyncWithServiceResponse() {
         return service.getStringWithInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -1877,8 +2318,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, LocalDate>> getDateValid() throws ErrorException, IOException {
-        return getDateValidAsync().toBlocking().single();
+    public Map<String, LocalDate> getDateValid() throws ErrorException, IOException {
+        return getDateValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1888,7 +2329,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, LocalDate>> getDateValidAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateValidAsync(), serviceCallback);
+        return ServiceCall.create(getDateValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1896,7 +2337,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateValidAsync() {
+    public Observable<Map<String, LocalDate>> getDateValidAsync() {
+        return getDateValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
+            @Override
+            public Map<String, LocalDate> call(ServiceResponse<Map<String, LocalDate>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateValidAsyncWithServiceResponse() {
         return service.getDateValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, LocalDate>>>>() {
                 @Override
@@ -1927,8 +2382,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDateValid(Map<String, LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateValidAsync(arrayBody).toBlocking().single();
+    public void putDateValid(Map<String, LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1939,7 +2394,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateValidAsync(Map<String, LocalDate> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -1948,7 +2403,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, LocalDate&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateValidAsync(Map<String, LocalDate> arrayBody) {
+    public Observable<Void> putDateValidAsync(Map<String, LocalDate> arrayBody) {
+        return putDateValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @param arrayBody the Map&lt;String, LocalDate&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateValidAsyncWithServiceResponse(Map<String, LocalDate> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1981,8 +2451,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, LocalDate>> getDateInvalidNull() throws ErrorException, IOException {
-        return getDateInvalidNullAsync().toBlocking().single();
+    public Map<String, LocalDate> getDateInvalidNull() throws ErrorException, IOException {
+        return getDateInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1992,7 +2462,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, LocalDate>> getDateInvalidNullAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getDateInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2000,7 +2470,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidNullAsync() {
+    public Observable<Map<String, LocalDate>> getDateInvalidNullAsync() {
+        return getDateInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
+            @Override
+            public Map<String, LocalDate> call(ServiceResponse<Map<String, LocalDate>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     *
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidNullAsyncWithServiceResponse() {
         return service.getDateInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, LocalDate>>>>() {
                 @Override
@@ -2029,8 +2513,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, LocalDate>> getDateInvalidChars() throws ErrorException, IOException {
-        return getDateInvalidCharsAsync().toBlocking().single();
+    public Map<String, LocalDate> getDateInvalidChars() throws ErrorException, IOException {
+        return getDateInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2040,7 +2524,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, LocalDate>> getDateInvalidCharsAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateInvalidCharsAsync(), serviceCallback);
+        return ServiceCall.create(getDateInvalidCharsAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2048,7 +2532,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidCharsAsync() {
+    public Observable<Map<String, LocalDate>> getDateInvalidCharsAsync() {
+        return getDateInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
+            @Override
+            public Map<String, LocalDate> call(ServiceResponse<Map<String, LocalDate>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     *
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidCharsAsyncWithServiceResponse() {
         return service.getDateInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, LocalDate>>>>() {
                 @Override
@@ -2077,8 +2575,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, DateTime>> getDateTimeValid() throws ErrorException, IOException {
-        return getDateTimeValidAsync().toBlocking().single();
+    public Map<String, DateTime> getDateTimeValid() throws ErrorException, IOException {
+        return getDateTimeValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2088,7 +2586,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, DateTime>> getDateTimeValidAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeValidAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2096,7 +2594,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeValidAsync() {
+    public Observable<Map<String, DateTime>> getDateTimeValidAsync() {
+        return getDateTimeValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
+            @Override
+            public Map<String, DateTime> call(ServiceResponse<Map<String, DateTime>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     *
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeValidAsyncWithServiceResponse() {
         return service.getDateTimeValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, DateTime>>>>() {
                 @Override
@@ -2127,8 +2639,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDateTimeValid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateTimeValidAsync(arrayBody).toBlocking().single();
+    public void putDateTimeValid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateTimeValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2139,7 +2651,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateTimeValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2148,7 +2660,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, DateTime&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeValidAsync(Map<String, DateTime> arrayBody) {
+    public Observable<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody) {
+        return putDateTimeValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     *
+     * @param arrayBody the Map&lt;String, DateTime&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateTimeValidAsyncWithServiceResponse(Map<String, DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2181,8 +2708,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, DateTime>> getDateTimeInvalidNull() throws ErrorException, IOException {
-        return getDateTimeInvalidNullAsync().toBlocking().single();
+    public Map<String, DateTime> getDateTimeInvalidNull() throws ErrorException, IOException {
+        return getDateTimeInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2192,7 +2719,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, DateTime>> getDateTimeInvalidNullAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2200,7 +2727,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidNullAsync() {
+    public Observable<Map<String, DateTime>> getDateTimeInvalidNullAsync() {
+        return getDateTimeInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
+            @Override
+            public Map<String, DateTime> call(ServiceResponse<Map<String, DateTime>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     *
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidNullAsyncWithServiceResponse() {
         return service.getDateTimeInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, DateTime>>>>() {
                 @Override
@@ -2229,8 +2770,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, DateTime>> getDateTimeInvalidChars() throws ErrorException, IOException {
-        return getDateTimeInvalidCharsAsync().toBlocking().single();
+    public Map<String, DateTime> getDateTimeInvalidChars() throws ErrorException, IOException {
+        return getDateTimeInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2240,7 +2781,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, DateTime>> getDateTimeInvalidCharsAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeInvalidCharsAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeInvalidCharsAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2248,7 +2789,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidCharsAsync() {
+    public Observable<Map<String, DateTime>> getDateTimeInvalidCharsAsync() {
+        return getDateTimeInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
+            @Override
+            public Map<String, DateTime> call(ServiceResponse<Map<String, DateTime>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     *
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidCharsAsyncWithServiceResponse() {
         return service.getDateTimeInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, DateTime>>>>() {
                 @Override
@@ -2277,8 +2832,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, DateTime>> getDateTimeRfc1123Valid() throws ErrorException, IOException {
-        return getDateTimeRfc1123ValidAsync().toBlocking().single();
+    public Map<String, DateTime> getDateTimeRfc1123Valid() throws ErrorException, IOException {
+        return getDateTimeRfc1123ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2288,7 +2843,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, DateTime>> getDateTimeRfc1123ValidAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeRfc1123ValidAsync(), serviceCallback);
+        return ServiceCall.create(getDateTimeRfc1123ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2296,7 +2851,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeRfc1123ValidAsync() {
+    public Observable<Map<String, DateTime>> getDateTimeRfc1123ValidAsync() {
+        return getDateTimeRfc1123ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
+            @Override
+            public Map<String, DateTime> call(ServiceResponse<Map<String, DateTime>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeRfc1123ValidAsyncWithServiceResponse() {
         return service.getDateTimeRfc1123Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, DateTime>>>>() {
                 @Override
@@ -2337,8 +2906,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDateTimeRfc1123Valid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDateTimeRfc1123ValidAsync(arrayBody).toBlocking().single();
+    public void putDateTimeRfc1123Valid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2349,7 +2918,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeRfc1123ValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2358,7 +2927,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody) {
+    public Observable<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody) {
+        return putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsyncWithServiceResponse(Map<String, DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2396,8 +2980,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Period&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Period>> getDurationValid() throws ErrorException, IOException {
-        return getDurationValidAsync().toBlocking().single();
+    public Map<String, Period> getDurationValid() throws ErrorException, IOException {
+        return getDurationValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2407,7 +2991,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Period>> getDurationValidAsync(final ServiceCallback<Map<String, Period>> serviceCallback) {
-        return ServiceCall.create(getDurationValidAsync(), serviceCallback);
+        return ServiceCall.create(getDurationValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2415,7 +2999,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Period&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Period>>> getDurationValidAsync() {
+    public Observable<Map<String, Period>> getDurationValidAsync() {
+        return getDurationValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Period>>, Map<String, Period>>() {
+            @Override
+            public Map<String, Period> call(ServiceResponse<Map<String, Period>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @return the observable to the Map&lt;String, Period&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Period>>> getDurationValidAsyncWithServiceResponse() {
         return service.getDurationValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Period>>>>() {
                 @Override
@@ -2446,8 +3044,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDurationValid(Map<String, Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDurationValidAsync(arrayBody).toBlocking().single();
+    public void putDurationValid(Map<String, Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDurationValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2458,7 +3056,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDurationValidAsync(Map<String, Period> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDurationValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDurationValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2467,7 +3065,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Period&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDurationValidAsync(Map<String, Period> arrayBody) {
+    public Observable<Void> putDurationValidAsync(Map<String, Period> arrayBody) {
+        return putDurationValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @param arrayBody the Map&lt;String, Period&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDurationValidAsyncWithServiceResponse(Map<String, Period> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2500,8 +3113,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, byte[]>> getByteValid() throws ErrorException, IOException {
-        return getByteValidAsync().toBlocking().single();
+    public Map<String, byte[]> getByteValid() throws ErrorException, IOException {
+        return getByteValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2511,7 +3124,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, byte[]>> getByteValidAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
-        return ServiceCall.create(getByteValidAsync(), serviceCallback);
+        return ServiceCall.create(getByteValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2519,7 +3132,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    public Observable<ServiceResponse<Map<String, byte[]>>> getByteValidAsync() {
+    public Observable<Map<String, byte[]>> getByteValidAsync() {
+        return getByteValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
+            @Override
+            public Map<String, byte[]> call(ServiceResponse<Map<String, byte[]>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
+     *
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, byte[]>>> getByteValidAsyncWithServiceResponse() {
         return service.getByteValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, byte[]>>>>() {
                 @Override
@@ -2550,8 +3177,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putByteValid(Map<String, byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putByteValidAsync(arrayBody).toBlocking().single();
+    public void putByteValid(Map<String, byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putByteValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2562,7 +3189,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putByteValidAsync(Map<String, byte[]> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putByteValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putByteValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2571,7 +3198,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, byte[]&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putByteValidAsync(Map<String, byte[]> arrayBody) {
+    public Observable<Void> putByteValidAsync(Map<String, byte[]> arrayBody) {
+        return putByteValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     *
+     * @param arrayBody the Map&lt;String, byte[]&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putByteValidAsyncWithServiceResponse(Map<String, byte[]> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2604,8 +3246,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, byte[]>> getByteInvalidNull() throws ErrorException, IOException {
-        return getByteInvalidNullAsync().toBlocking().single();
+    public Map<String, byte[]> getByteInvalidNull() throws ErrorException, IOException {
+        return getByteInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2615,7 +3257,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, byte[]>> getByteInvalidNullAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
-        return ServiceCall.create(getByteInvalidNullAsync(), serviceCallback);
+        return ServiceCall.create(getByteInvalidNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2623,7 +3265,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    public Observable<ServiceResponse<Map<String, byte[]>>> getByteInvalidNullAsync() {
+    public Observable<Map<String, byte[]>> getByteInvalidNullAsync() {
+        return getByteInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
+            @Override
+            public Map<String, byte[]> call(ServiceResponse<Map<String, byte[]>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     *
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, byte[]>>> getByteInvalidNullAsyncWithServiceResponse() {
         return service.getByteInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, byte[]>>>>() {
                 @Override
@@ -2652,8 +3308,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, byte[]>> getBase64Url() throws ErrorException, IOException {
-        return getBase64UrlAsync().toBlocking().single();
+    public Map<String, byte[]> getBase64Url() throws ErrorException, IOException {
+        return getBase64UrlAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2663,7 +3319,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, byte[]>> getBase64UrlAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
-        return ServiceCall.create(getBase64UrlAsync(), serviceCallback);
+        return ServiceCall.create(getBase64UrlAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2671,7 +3327,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    public Observable<ServiceResponse<Map<String, byte[]>>> getBase64UrlAsync() {
+    public Observable<Map<String, byte[]>> getBase64UrlAsync() {
+        return getBase64UrlAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
+            @Override
+            public Map<String, byte[]> call(ServiceResponse<Map<String, byte[]>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
+     *
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, byte[]>>> getBase64UrlAsyncWithServiceResponse() {
         return service.getBase64Url()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, byte[]>>>>() {
                 @Override
@@ -2710,8 +3380,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Widget>> getComplexNull() throws ErrorException, IOException {
-        return getComplexNullAsync().toBlocking().single();
+    public Map<String, Widget> getComplexNull() throws ErrorException, IOException {
+        return getComplexNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2721,7 +3391,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexNullAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexNullAsync(), serviceCallback);
+        return ServiceCall.create(getComplexNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2729,7 +3399,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexNullAsync() {
+    public Observable<Map<String, Widget>> getComplexNullAsync() {
+        return getComplexNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+            @Override
+            public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get dictionary of complex type null value.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexNullAsyncWithServiceResponse() {
         return service.getComplexNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -2758,8 +3442,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Widget>> getComplexEmpty() throws ErrorException, IOException {
-        return getComplexEmptyAsync().toBlocking().single();
+    public Map<String, Widget> getComplexEmpty() throws ErrorException, IOException {
+        return getComplexEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2769,7 +3453,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexEmptyAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getComplexEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2777,7 +3461,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexEmptyAsync() {
+    public Observable<Map<String, Widget>> getComplexEmptyAsync() {
+        return getComplexEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+            @Override
+            public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty dictionary of complex type {}.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexEmptyAsyncWithServiceResponse() {
         return service.getComplexEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -2806,8 +3504,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Widget>> getComplexItemNull() throws ErrorException, IOException {
-        return getComplexItemNullAsync().toBlocking().single();
+    public Map<String, Widget> getComplexItemNull() throws ErrorException, IOException {
+        return getComplexItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2817,7 +3515,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexItemNullAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexItemNullAsync(), serviceCallback);
+        return ServiceCall.create(getComplexItemNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2825,7 +3523,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexItemNullAsync() {
+    public Observable<Map<String, Widget>> getComplexItemNullAsync() {
+        return getComplexItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+            @Override
+            public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexItemNullAsyncWithServiceResponse() {
         return service.getComplexItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -2854,8 +3566,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Widget>> getComplexItemEmpty() throws ErrorException, IOException {
-        return getComplexItemEmptyAsync().toBlocking().single();
+    public Map<String, Widget> getComplexItemEmpty() throws ErrorException, IOException {
+        return getComplexItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2865,7 +3577,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexItemEmptyAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexItemEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getComplexItemEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2873,7 +3585,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexItemEmptyAsync() {
+    public Observable<Map<String, Widget>> getComplexItemEmptyAsync() {
+        return getComplexItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+            @Override
+            public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexItemEmptyAsyncWithServiceResponse() {
         return service.getComplexItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -2902,8 +3628,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Widget>> getComplexValid() throws ErrorException, IOException {
-        return getComplexValidAsync().toBlocking().single();
+    public Map<String, Widget> getComplexValid() throws ErrorException, IOException {
+        return getComplexValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2913,7 +3639,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexValidAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexValidAsync(), serviceCallback);
+        return ServiceCall.create(getComplexValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2921,7 +3647,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexValidAsync() {
+    public Observable<Map<String, Widget>> getComplexValidAsync() {
+        return getComplexValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+            @Override
+            public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexValidAsyncWithServiceResponse() {
         return service.getComplexValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -2952,8 +3692,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putComplexValid(Map<String, Widget> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putComplexValidAsync(arrayBody).toBlocking().single();
+    public void putComplexValid(Map<String, Widget> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putComplexValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2964,7 +3704,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putComplexValidAsync(Map<String, Widget> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putComplexValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putComplexValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -2973,7 +3713,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Widget&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putComplexValidAsync(Map<String, Widget> arrayBody) {
+    public Observable<Void> putComplexValidAsync(Map<String, Widget> arrayBody) {
+        return putComplexValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @param arrayBody the Map&lt;String, Widget&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putComplexValidAsyncWithServiceResponse(Map<String, Widget> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3006,8 +3761,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, List<String>>> getArrayNull() throws ErrorException, IOException {
-        return getArrayNullAsync().toBlocking().single();
+    public Map<String, List<String>> getArrayNull() throws ErrorException, IOException {
+        return getArrayNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3017,7 +3772,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayNullAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayNullAsync(), serviceCallback);
+        return ServiceCall.create(getArrayNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3025,7 +3780,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayNullAsync() {
+    public Observable<Map<String, List<String>>> getArrayNullAsync() {
+        return getArrayNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+            @Override
+            public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a null array.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayNullAsyncWithServiceResponse() {
         return service.getArrayNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -3054,8 +3823,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, List<String>>> getArrayEmpty() throws ErrorException, IOException {
-        return getArrayEmptyAsync().toBlocking().single();
+    public Map<String, List<String>> getArrayEmpty() throws ErrorException, IOException {
+        return getArrayEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3065,7 +3834,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayEmptyAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getArrayEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3073,7 +3842,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayEmptyAsync() {
+    public Observable<Map<String, List<String>>> getArrayEmptyAsync() {
+        return getArrayEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+            @Override
+            public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an empty dictionary {}.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayEmptyAsyncWithServiceResponse() {
         return service.getArrayEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -3102,8 +3885,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, List<String>>> getArrayItemNull() throws ErrorException, IOException {
-        return getArrayItemNullAsync().toBlocking().single();
+    public Map<String, List<String>> getArrayItemNull() throws ErrorException, IOException {
+        return getArrayItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3113,7 +3896,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayItemNullAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayItemNullAsync(), serviceCallback);
+        return ServiceCall.create(getArrayItemNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3121,7 +3904,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemNullAsync() {
+    public Observable<Map<String, List<String>>> getArrayItemNullAsync() {
+        return getArrayItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+            @Override
+            public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemNullAsyncWithServiceResponse() {
         return service.getArrayItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -3150,8 +3947,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, List<String>>> getArrayItemEmpty() throws ErrorException, IOException {
-        return getArrayItemEmptyAsync().toBlocking().single();
+    public Map<String, List<String>> getArrayItemEmpty() throws ErrorException, IOException {
+        return getArrayItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3161,7 +3958,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayItemEmptyAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayItemEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getArrayItemEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3169,7 +3966,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemEmptyAsync() {
+    public Observable<Map<String, List<String>>> getArrayItemEmptyAsync() {
+        return getArrayItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+            @Override
+            public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemEmptyAsyncWithServiceResponse() {
         return service.getArrayItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -3198,8 +4009,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, List<String>>> getArrayValid() throws ErrorException, IOException {
-        return getArrayValidAsync().toBlocking().single();
+    public Map<String, List<String>> getArrayValid() throws ErrorException, IOException {
+        return getArrayValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3209,7 +4020,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayValidAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayValidAsync(), serviceCallback);
+        return ServiceCall.create(getArrayValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3217,7 +4028,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayValidAsync() {
+    public Observable<Map<String, List<String>>> getArrayValidAsync() {
+        return getArrayValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+            @Override
+            public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayValidAsyncWithServiceResponse() {
         return service.getArrayValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -3248,8 +4073,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putArrayValid(Map<String, List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putArrayValidAsync(arrayBody).toBlocking().single();
+    public void putArrayValid(Map<String, List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putArrayValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3260,7 +4085,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayValidAsync(Map<String, List<String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putArrayValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -3269,7 +4094,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayValidAsync(Map<String, List<String>> arrayBody) {
+    public Observable<Void> putArrayValidAsync(Map<String, List<String>> arrayBody) {
+        return putArrayValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putArrayValidAsyncWithServiceResponse(Map<String, List<String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3302,8 +4142,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Map<String, String>>> getDictionaryNull() throws ErrorException, IOException {
-        return getDictionaryNullAsync().toBlocking().single();
+    public Map<String, Map<String, String>> getDictionaryNull() throws ErrorException, IOException {
+        return getDictionaryNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3313,7 +4153,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryNullAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryNullAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3321,7 +4161,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryNullAsync() {
+    public Observable<Map<String, Map<String, String>>> getDictionaryNullAsync() {
+        return getDictionaryNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+            @Override
+            public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryNullAsyncWithServiceResponse() {
         return service.getDictionaryNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -3350,8 +4204,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Map<String, String>>> getDictionaryEmpty() throws ErrorException, IOException {
-        return getDictionaryEmptyAsync().toBlocking().single();
+    public Map<String, Map<String, String>> getDictionaryEmpty() throws ErrorException, IOException {
+        return getDictionaryEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3361,7 +4215,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryEmptyAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3369,7 +4223,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryEmptyAsync() {
+    public Observable<Map<String, Map<String, String>>> getDictionaryEmptyAsync() {
+        return getDictionaryEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+            @Override
+            public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryEmptyAsyncWithServiceResponse() {
         return service.getDictionaryEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -3398,8 +4266,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Map<String, String>>> getDictionaryItemNull() throws ErrorException, IOException {
-        return getDictionaryItemNullAsync().toBlocking().single();
+    public Map<String, Map<String, String>> getDictionaryItemNull() throws ErrorException, IOException {
+        return getDictionaryItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3409,7 +4277,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryItemNullAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryItemNullAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryItemNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3417,7 +4285,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemNullAsync() {
+    public Observable<Map<String, Map<String, String>>> getDictionaryItemNullAsync() {
+        return getDictionaryItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+            @Override
+            public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemNullAsyncWithServiceResponse() {
         return service.getDictionaryItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -3446,8 +4328,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Map<String, String>>> getDictionaryItemEmpty() throws ErrorException, IOException {
-        return getDictionaryItemEmptyAsync().toBlocking().single();
+    public Map<String, Map<String, String>> getDictionaryItemEmpty() throws ErrorException, IOException {
+        return getDictionaryItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3457,7 +4339,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryItemEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryItemEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3465,7 +4347,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemEmptyAsync() {
+    public Observable<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync() {
+        return getDictionaryItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+            @Override
+            public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemEmptyAsyncWithServiceResponse() {
         return service.getDictionaryItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -3494,8 +4390,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Map<String, String>>> getDictionaryValid() throws ErrorException, IOException {
-        return getDictionaryValidAsync().toBlocking().single();
+    public Map<String, Map<String, String>> getDictionaryValid() throws ErrorException, IOException {
+        return getDictionaryValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -3505,7 +4401,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryValidAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryValidAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -3513,7 +4409,21 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryValidAsync() {
+    public Observable<Map<String, Map<String, String>>> getDictionaryValidAsync() {
+        return getDictionaryValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+            @Override
+            public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryValidAsyncWithServiceResponse() {
         return service.getDictionaryValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -3544,8 +4454,8 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDictionaryValid(Map<String, Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putDictionaryValidAsync(arrayBody).toBlocking().single();
+    public void putDictionaryValid(Map<String, Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
+        putDictionaryValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3556,7 +4466,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryValidAsync(arrayBody), serviceCallback);
+        return ServiceCall.create(putDictionaryValidAsyncWithServiceResponse(arrayBody), serviceCallback);
     }
 
     /**
@@ -3565,7 +4475,22 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody) {
+    public Observable<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody) {
+        return putDictionaryValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDictionaryValidAsyncWithServiceResponse(Map<String, Map<String, String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
@@ -331,10 +331,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     public Map<String, Integer> getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -344,7 +344,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getNullAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -353,12 +353,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     public Observable<Map<String, Integer>> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
             @Override
             public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -366,7 +366,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Integer>>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -393,10 +393,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     public Map<String, Integer> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -406,7 +406,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getEmptyAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -415,12 +415,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     public Observable<Map<String, Integer>> getEmptyAsync() {
-        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+        return getEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
             @Override
             public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -428,7 +428,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Integer>>> getEmptyWithServiceResponseAsync() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -457,10 +457,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putEmpty(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putEmptyAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putEmptyWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -471,7 +470,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(Map<String, String> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putEmptyWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -481,12 +480,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putEmptyAsync(Map<String, String> arrayBody) {
-        return putEmptyAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putEmptyWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -495,7 +494,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(Map<String, String> arrayBody) {
+    public Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(Map<String, String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -526,10 +525,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     public Map<String, String> getNullValue() throws ErrorException, IOException {
-        return getNullValueAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullValueWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -539,7 +538,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getNullValueAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getNullValueAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullValueWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -548,12 +547,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     public Observable<Map<String, String>> getNullValueAsync() {
-        return getNullValueAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+        return getNullValueWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
             @Override
             public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -561,7 +560,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getNullValueAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, String>>> getNullValueWithServiceResponseAsync() {
         return service.getNullValue()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -588,10 +587,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     public Map<String, String> getNullKey() throws ErrorException, IOException {
-        return getNullKeyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullKeyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -601,7 +600,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getNullKeyAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getNullKeyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullKeyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -610,12 +609,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     public Observable<Map<String, String>> getNullKeyAsync() {
-        return getNullKeyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+        return getNullKeyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
             @Override
             public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -623,7 +622,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getNullKeyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, String>>> getNullKeyWithServiceResponseAsync() {
         return service.getNullKey()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -650,10 +649,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     public Map<String, String> getEmptyStringKey() throws ErrorException, IOException {
-        return getEmptyStringKeyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyStringKeyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -663,7 +662,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getEmptyStringKeyAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getEmptyStringKeyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyStringKeyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -672,12 +671,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     public Observable<Map<String, String>> getEmptyStringKeyAsync() {
-        return getEmptyStringKeyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+        return getEmptyStringKeyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
             @Override
             public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -685,7 +684,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getEmptyStringKeyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, String>>> getEmptyStringKeyWithServiceResponseAsync() {
         return service.getEmptyStringKey()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -712,10 +711,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     public Map<String, String> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -725,7 +724,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getInvalidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -734,12 +733,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     public Observable<Map<String, String>> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
             @Override
             public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -747,7 +746,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, String>>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -774,10 +773,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Boolean&gt; object if successful.
      */
     public Map<String, Boolean> getBooleanTfft() throws ErrorException, IOException {
-        return getBooleanTfftAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBooleanTfftWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -787,7 +786,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Boolean>> getBooleanTfftAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanTfftAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanTfftWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -796,12 +795,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
     public Observable<Map<String, Boolean>> getBooleanTfftAsync() {
-        return getBooleanTfftAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
+        return getBooleanTfftWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
             @Override
             public Map<String, Boolean> call(ServiceResponse<Map<String, Boolean>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -809,7 +808,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanTfftAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanTfftWithServiceResponseAsync() {
         return service.getBooleanTfft()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Boolean>>>>() {
                 @Override
@@ -838,10 +837,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBooleanTfft(Map<String, Boolean> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putBooleanTfftAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putBooleanTfftWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -852,7 +850,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBooleanTfftAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putBooleanTfftWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -862,12 +860,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody) {
-        return putBooleanTfftAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBooleanTfftWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -876,7 +874,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Boolean&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBooleanTfftAsyncWithServiceResponse(Map<String, Boolean> arrayBody) {
+    public Observable<ServiceResponse<Void>> putBooleanTfftWithServiceResponseAsync(Map<String, Boolean> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -907,10 +905,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Boolean&gt; object if successful.
      */
     public Map<String, Boolean> getBooleanInvalidNull() throws ErrorException, IOException {
-        return getBooleanInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBooleanInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -920,7 +918,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Boolean>> getBooleanInvalidNullAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -929,12 +927,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
     public Observable<Map<String, Boolean>> getBooleanInvalidNullAsync() {
-        return getBooleanInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
+        return getBooleanInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
             @Override
             public Map<String, Boolean> call(ServiceResponse<Map<String, Boolean>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -942,7 +940,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidNullWithServiceResponseAsync() {
         return service.getBooleanInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Boolean>>>>() {
                 @Override
@@ -969,10 +967,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Boolean&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Boolean&gt; object if successful.
      */
     public Map<String, Boolean> getBooleanInvalidString() throws ErrorException, IOException {
-        return getBooleanInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBooleanInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -982,7 +980,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Boolean>> getBooleanInvalidStringAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
-        return ServiceCall.create(getBooleanInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -991,12 +989,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
     public Observable<Map<String, Boolean>> getBooleanInvalidStringAsync() {
-        return getBooleanInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
+        return getBooleanInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Boolean>>, Map<String, Boolean>>() {
             @Override
             public Map<String, Boolean> call(ServiceResponse<Map<String, Boolean>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1004,7 +1002,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Boolean>>> getBooleanInvalidStringWithServiceResponseAsync() {
         return service.getBooleanInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Boolean>>>>() {
                 @Override
@@ -1031,10 +1029,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     public Map<String, Integer> getIntegerValid() throws ErrorException, IOException {
-        return getIntegerValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getIntegerValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1044,7 +1042,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getIntegerValidAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getIntegerValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntegerValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1053,12 +1051,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     public Observable<Map<String, Integer>> getIntegerValidAsync() {
-        return getIntegerValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+        return getIntegerValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
             @Override
             public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1066,7 +1064,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getIntegerValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Integer>>> getIntegerValidWithServiceResponseAsync() {
         return service.getIntegerValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -1095,10 +1093,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putIntegerValid(Map<String, Integer> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putIntegerValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putIntegerValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1109,7 +1106,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putIntegerValidAsync(Map<String, Integer> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putIntegerValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putIntegerValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -1119,12 +1116,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putIntegerValidAsync(Map<String, Integer> arrayBody) {
-        return putIntegerValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putIntegerValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1133,7 +1130,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Integer&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putIntegerValidAsyncWithServiceResponse(Map<String, Integer> arrayBody) {
+    public Observable<ServiceResponse<Void>> putIntegerValidWithServiceResponseAsync(Map<String, Integer> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1164,10 +1161,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     public Map<String, Integer> getIntInvalidNull() throws ErrorException, IOException {
-        return getIntInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getIntInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1177,7 +1174,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getIntInvalidNullAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getIntInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1186,12 +1183,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     public Observable<Map<String, Integer>> getIntInvalidNullAsync() {
-        return getIntInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+        return getIntInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
             @Override
             public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1199,7 +1196,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidNullWithServiceResponseAsync() {
         return service.getIntInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -1226,10 +1223,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     public Map<String, Integer> getIntInvalidString() throws ErrorException, IOException {
-        return getIntInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getIntInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1239,7 +1236,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getIntInvalidStringAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getIntInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1248,12 +1245,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     public Observable<Map<String, Integer>> getIntInvalidStringAsync() {
-        return getIntInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+        return getIntInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
             @Override
             public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1261,7 +1258,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Integer>>> getIntInvalidStringWithServiceResponseAsync() {
         return service.getIntInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override
@@ -1288,10 +1285,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Long&gt; object if successful.
      */
     public Map<String, Long> getLongValid() throws ErrorException, IOException {
-        return getLongValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLongValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1301,7 +1298,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Long>> getLongValidAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
-        return ServiceCall.create(getLongValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLongValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1310,12 +1307,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Long&gt; object
      */
     public Observable<Map<String, Long>> getLongValidAsync() {
-        return getLongValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
+        return getLongValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
             @Override
             public Map<String, Long> call(ServiceResponse<Map<String, Long>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1323,7 +1320,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Long>>> getLongValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Long>>> getLongValidWithServiceResponseAsync() {
         return service.getLongValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Long>>>>() {
                 @Override
@@ -1352,10 +1349,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putLongValid(Map<String, Long> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putLongValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putLongValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1366,7 +1362,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putLongValidAsync(Map<String, Long> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putLongValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putLongValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -1376,12 +1372,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putLongValidAsync(Map<String, Long> arrayBody) {
-        return putLongValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putLongValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1390,7 +1386,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Long&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putLongValidAsyncWithServiceResponse(Map<String, Long> arrayBody) {
+    public Observable<ServiceResponse<Void>> putLongValidWithServiceResponseAsync(Map<String, Long> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1421,10 +1417,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Long&gt; object if successful.
      */
     public Map<String, Long> getLongInvalidNull() throws ErrorException, IOException {
-        return getLongInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLongInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1434,7 +1430,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Long>> getLongInvalidNullAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
-        return ServiceCall.create(getLongInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLongInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1443,12 +1439,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Long&gt; object
      */
     public Observable<Map<String, Long>> getLongInvalidNullAsync() {
-        return getLongInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
+        return getLongInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
             @Override
             public Map<String, Long> call(ServiceResponse<Map<String, Long>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1456,7 +1452,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Long>>> getLongInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Long>>> getLongInvalidNullWithServiceResponseAsync() {
         return service.getLongInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Long>>>>() {
                 @Override
@@ -1483,10 +1479,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Long&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Long&gt; object if successful.
      */
     public Map<String, Long> getLongInvalidString() throws ErrorException, IOException {
-        return getLongInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getLongInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1496,7 +1492,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Long>> getLongInvalidStringAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
-        return ServiceCall.create(getLongInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLongInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1505,12 +1501,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Long&gt; object
      */
     public Observable<Map<String, Long>> getLongInvalidStringAsync() {
-        return getLongInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
+        return getLongInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Long>>, Map<String, Long>>() {
             @Override
             public Map<String, Long> call(ServiceResponse<Map<String, Long>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1518,7 +1514,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Long&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Long>>> getLongInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Long>>> getLongInvalidStringWithServiceResponseAsync() {
         return service.getLongInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Long>>>>() {
                 @Override
@@ -1545,10 +1541,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     public Map<String, Double> getFloatValid() throws ErrorException, IOException {
-        return getFloatValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFloatValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1558,7 +1554,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getFloatValidAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getFloatValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFloatValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1567,12 +1563,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     public Observable<Map<String, Double>> getFloatValidAsync() {
-        return getFloatValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+        return getFloatValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
             @Override
             public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1580,7 +1576,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getFloatValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Double>>> getFloatValidWithServiceResponseAsync() {
         return service.getFloatValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1609,10 +1605,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putFloatValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putFloatValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putFloatValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1623,7 +1618,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putFloatValidAsync(Map<String, Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putFloatValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putFloatValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -1633,12 +1628,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putFloatValidAsync(Map<String, Double> arrayBody) {
-        return putFloatValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putFloatValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1647,7 +1642,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putFloatValidAsyncWithServiceResponse(Map<String, Double> arrayBody) {
+    public Observable<ServiceResponse<Void>> putFloatValidWithServiceResponseAsync(Map<String, Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1678,10 +1673,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     public Map<String, Double> getFloatInvalidNull() throws ErrorException, IOException {
-        return getFloatInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFloatInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1691,7 +1686,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getFloatInvalidNullAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getFloatInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFloatInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1700,12 +1695,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     public Observable<Map<String, Double>> getFloatInvalidNullAsync() {
-        return getFloatInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+        return getFloatInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
             @Override
             public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1713,7 +1708,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidNullWithServiceResponseAsync() {
         return service.getFloatInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1740,10 +1735,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     public Map<String, Double> getFloatInvalidString() throws ErrorException, IOException {
-        return getFloatInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFloatInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1753,7 +1748,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getFloatInvalidStringAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getFloatInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFloatInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1762,12 +1757,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     public Observable<Map<String, Double>> getFloatInvalidStringAsync() {
-        return getFloatInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+        return getFloatInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
             @Override
             public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1775,7 +1770,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Double>>> getFloatInvalidStringWithServiceResponseAsync() {
         return service.getFloatInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1802,10 +1797,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     public Map<String, Double> getDoubleValid() throws ErrorException, IOException {
-        return getDoubleValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDoubleValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1815,7 +1810,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getDoubleValidAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDoubleValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1824,12 +1819,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     public Observable<Map<String, Double>> getDoubleValidAsync() {
-        return getDoubleValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+        return getDoubleValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
             @Override
             public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1837,7 +1832,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getDoubleValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Double>>> getDoubleValidWithServiceResponseAsync() {
         return service.getDoubleValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1866,10 +1861,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDoubleValid(Map<String, Double> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDoubleValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDoubleValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1880,7 +1874,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDoubleValidAsync(Map<String, Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDoubleValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDoubleValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -1890,12 +1884,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDoubleValidAsync(Map<String, Double> arrayBody) {
-        return putDoubleValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDoubleValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1904,7 +1898,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDoubleValidAsyncWithServiceResponse(Map<String, Double> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDoubleValidWithServiceResponseAsync(Map<String, Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -1935,10 +1929,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     public Map<String, Double> getDoubleInvalidNull() throws ErrorException, IOException {
-        return getDoubleInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDoubleInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1948,7 +1942,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getDoubleInvalidNullAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDoubleInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1957,12 +1951,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     public Observable<Map<String, Double>> getDoubleInvalidNullAsync() {
-        return getDoubleInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+        return getDoubleInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
             @Override
             public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1970,7 +1964,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidNullWithServiceResponseAsync() {
         return service.getDoubleInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -1997,10 +1991,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Double&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Double&gt; object if successful.
      */
     public Map<String, Double> getDoubleInvalidString() throws ErrorException, IOException {
-        return getDoubleInvalidStringAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDoubleInvalidStringWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2010,7 +2004,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Double>> getDoubleInvalidStringAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
-        return ServiceCall.create(getDoubleInvalidStringAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDoubleInvalidStringWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2019,12 +2013,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     public Observable<Map<String, Double>> getDoubleInvalidStringAsync() {
-        return getDoubleInvalidStringAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
+        return getDoubleInvalidStringWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Double>>, Map<String, Double>>() {
             @Override
             public Map<String, Double> call(ServiceResponse<Map<String, Double>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2032,7 +2026,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Double&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidStringAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Double>>> getDoubleInvalidStringWithServiceResponseAsync() {
         return service.getDoubleInvalidString()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Double>>>>() {
                 @Override
@@ -2059,10 +2053,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     public Map<String, String> getStringValid() throws ErrorException, IOException {
-        return getStringValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getStringValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2072,7 +2066,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getStringValidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getStringValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getStringValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2081,12 +2075,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     public Observable<Map<String, String>> getStringValidAsync() {
-        return getStringValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+        return getStringValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
             @Override
             public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2094,7 +2088,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getStringValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, String>>> getStringValidWithServiceResponseAsync() {
         return service.getStringValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -2123,10 +2117,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putStringValid(Map<String, String> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putStringValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putStringValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2137,7 +2130,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putStringValidAsync(Map<String, String> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putStringValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putStringValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -2147,12 +2140,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putStringValidAsync(Map<String, String> arrayBody) {
-        return putStringValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putStringValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2161,7 +2154,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putStringValidAsyncWithServiceResponse(Map<String, String> arrayBody) {
+    public Observable<ServiceResponse<Void>> putStringValidWithServiceResponseAsync(Map<String, String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2192,10 +2185,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     public Map<String, String> getStringWithNull() throws ErrorException, IOException {
-        return getStringWithNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getStringWithNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2205,7 +2198,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getStringWithNullAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getStringWithNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getStringWithNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2214,12 +2207,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     public Observable<Map<String, String>> getStringWithNullAsync() {
-        return getStringWithNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+        return getStringWithNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
             @Override
             public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2227,7 +2220,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getStringWithNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, String>>> getStringWithNullWithServiceResponseAsync() {
         return service.getStringWithNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -2254,10 +2247,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, String&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, String&gt; object if successful.
      */
     public Map<String, String> getStringWithInvalid() throws ErrorException, IOException {
-        return getStringWithInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getStringWithInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2267,7 +2260,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, String>> getStringWithInvalidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
-        return ServiceCall.create(getStringWithInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getStringWithInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2276,12 +2269,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     public Observable<Map<String, String>> getStringWithInvalidAsync() {
-        return getStringWithInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
+        return getStringWithInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, String>>, Map<String, String>>() {
             @Override
             public Map<String, String> call(ServiceResponse<Map<String, String>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2289,7 +2282,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, String&gt; object
      */
-    public Observable<ServiceResponse<Map<String, String>>> getStringWithInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, String>>> getStringWithInvalidWithServiceResponseAsync() {
         return service.getStringWithInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, String>>>>() {
                 @Override
@@ -2316,10 +2309,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, LocalDate&gt; object if successful.
      */
     public Map<String, LocalDate> getDateValid() throws ErrorException, IOException {
-        return getDateValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2329,7 +2322,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, LocalDate>> getDateValidAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2338,12 +2331,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
     public Observable<Map<String, LocalDate>> getDateValidAsync() {
-        return getDateValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
+        return getDateValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
             @Override
             public Map<String, LocalDate> call(ServiceResponse<Map<String, LocalDate>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2351,7 +2344,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateValidWithServiceResponseAsync() {
         return service.getDateValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, LocalDate>>>>() {
                 @Override
@@ -2380,10 +2373,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDateValid(Map<String, LocalDate> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDateValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2394,7 +2386,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateValidAsync(Map<String, LocalDate> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -2404,12 +2396,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateValidAsync(Map<String, LocalDate> arrayBody) {
-        return putDateValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2418,7 +2410,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, LocalDate&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateValidAsyncWithServiceResponse(Map<String, LocalDate> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDateValidWithServiceResponseAsync(Map<String, LocalDate> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2449,10 +2441,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, LocalDate&gt; object if successful.
      */
     public Map<String, LocalDate> getDateInvalidNull() throws ErrorException, IOException {
-        return getDateInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2462,7 +2454,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, LocalDate>> getDateInvalidNullAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2471,12 +2463,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
     public Observable<Map<String, LocalDate>> getDateInvalidNullAsync() {
-        return getDateInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
+        return getDateInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
             @Override
             public Map<String, LocalDate> call(ServiceResponse<Map<String, LocalDate>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2484,7 +2476,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidNullWithServiceResponseAsync() {
         return service.getDateInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, LocalDate>>>>() {
                 @Override
@@ -2511,10 +2503,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, LocalDate&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, LocalDate&gt; object if successful.
      */
     public Map<String, LocalDate> getDateInvalidChars() throws ErrorException, IOException {
-        return getDateInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateInvalidCharsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2524,7 +2516,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, LocalDate>> getDateInvalidCharsAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
-        return ServiceCall.create(getDateInvalidCharsAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateInvalidCharsWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2533,12 +2525,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
     public Observable<Map<String, LocalDate>> getDateInvalidCharsAsync() {
-        return getDateInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
+        return getDateInvalidCharsWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, LocalDate>>, Map<String, LocalDate>>() {
             @Override
             public Map<String, LocalDate> call(ServiceResponse<Map<String, LocalDate>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2546,7 +2538,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
-    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidCharsAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, LocalDate>>> getDateInvalidCharsWithServiceResponseAsync() {
         return service.getDateInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, LocalDate>>>>() {
                 @Override
@@ -2573,10 +2565,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, DateTime&gt; object if successful.
      */
     public Map<String, DateTime> getDateTimeValid() throws ErrorException, IOException {
-        return getDateTimeValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2586,7 +2578,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, DateTime>> getDateTimeValidAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2595,12 +2587,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
     public Observable<Map<String, DateTime>> getDateTimeValidAsync() {
-        return getDateTimeValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
+        return getDateTimeValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
             @Override
             public Map<String, DateTime> call(ServiceResponse<Map<String, DateTime>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2608,7 +2600,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeValidWithServiceResponseAsync() {
         return service.getDateTimeValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, DateTime>>>>() {
                 @Override
@@ -2637,10 +2629,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDateTimeValid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateTimeValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDateTimeValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2651,7 +2642,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateTimeValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -2661,12 +2652,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody) {
-        return putDateTimeValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateTimeValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2675,7 +2666,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, DateTime&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeValidAsyncWithServiceResponse(Map<String, DateTime> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDateTimeValidWithServiceResponseAsync(Map<String, DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2706,10 +2697,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, DateTime&gt; object if successful.
      */
     public Map<String, DateTime> getDateTimeInvalidNull() throws ErrorException, IOException {
-        return getDateTimeInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2719,7 +2710,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, DateTime>> getDateTimeInvalidNullAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2728,12 +2719,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
     public Observable<Map<String, DateTime>> getDateTimeInvalidNullAsync() {
-        return getDateTimeInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
+        return getDateTimeInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
             @Override
             public Map<String, DateTime> call(ServiceResponse<Map<String, DateTime>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2741,7 +2732,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidNullWithServiceResponseAsync() {
         return service.getDateTimeInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, DateTime>>>>() {
                 @Override
@@ -2768,10 +2759,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, DateTime&gt; object if successful.
      */
     public Map<String, DateTime> getDateTimeInvalidChars() throws ErrorException, IOException {
-        return getDateTimeInvalidCharsAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeInvalidCharsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2781,7 +2772,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, DateTime>> getDateTimeInvalidCharsAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeInvalidCharsAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeInvalidCharsWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2790,12 +2781,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
     public Observable<Map<String, DateTime>> getDateTimeInvalidCharsAsync() {
-        return getDateTimeInvalidCharsAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
+        return getDateTimeInvalidCharsWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
             @Override
             public Map<String, DateTime> call(ServiceResponse<Map<String, DateTime>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2803,7 +2794,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidCharsAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeInvalidCharsWithServiceResponseAsync() {
         return service.getDateTimeInvalidChars()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, DateTime>>>>() {
                 @Override
@@ -2830,10 +2821,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, DateTime&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, DateTime&gt; object if successful.
      */
     public Map<String, DateTime> getDateTimeRfc1123Valid() throws ErrorException, IOException {
-        return getDateTimeRfc1123ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDateTimeRfc1123ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2843,7 +2834,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, DateTime>> getDateTimeRfc1123ValidAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
-        return ServiceCall.create(getDateTimeRfc1123ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDateTimeRfc1123ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2852,12 +2843,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
     public Observable<Map<String, DateTime>> getDateTimeRfc1123ValidAsync() {
-        return getDateTimeRfc1123ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
+        return getDateTimeRfc1123ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, DateTime>>, Map<String, DateTime>>() {
             @Override
             public Map<String, DateTime> call(ServiceResponse<Map<String, DateTime>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2865,7 +2856,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
-    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeRfc1123ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, DateTime>>> getDateTimeRfc1123ValidWithServiceResponseAsync() {
         return service.getDateTimeRfc1123Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, DateTime>>>>() {
                 @Override
@@ -2904,10 +2895,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDateTimeRfc1123Valid(Map<String, DateTime> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDateTimeRfc1123ValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -2918,7 +2908,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDateTimeRfc1123ValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -2928,12 +2918,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody) {
-        return putDateTimeRfc1123ValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDateTimeRfc1123ValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2942,7 +2932,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidAsyncWithServiceResponse(Map<String, DateTime> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDateTimeRfc1123ValidWithServiceResponseAsync(Map<String, DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -2978,10 +2968,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Period&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Period&gt; object if successful.
      */
     public Map<String, Period> getDurationValid() throws ErrorException, IOException {
-        return getDurationValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDurationValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2991,7 +2981,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Period>> getDurationValidAsync(final ServiceCallback<Map<String, Period>> serviceCallback) {
-        return ServiceCall.create(getDurationValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDurationValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3000,12 +2990,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Period&gt; object
      */
     public Observable<Map<String, Period>> getDurationValidAsync() {
-        return getDurationValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Period>>, Map<String, Period>>() {
+        return getDurationValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Period>>, Map<String, Period>>() {
             @Override
             public Map<String, Period> call(ServiceResponse<Map<String, Period>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3013,7 +3003,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Period&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Period>>> getDurationValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Period>>> getDurationValidWithServiceResponseAsync() {
         return service.getDurationValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Period>>>>() {
                 @Override
@@ -3042,10 +3032,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDurationValid(Map<String, Period> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDurationValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDurationValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3056,7 +3045,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDurationValidAsync(Map<String, Period> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDurationValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDurationValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -3066,12 +3055,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDurationValidAsync(Map<String, Period> arrayBody) {
-        return putDurationValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDurationValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3080,7 +3069,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Period&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDurationValidAsyncWithServiceResponse(Map<String, Period> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDurationValidWithServiceResponseAsync(Map<String, Period> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3111,10 +3100,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, byte[]&gt; object if successful.
      */
     public Map<String, byte[]> getByteValid() throws ErrorException, IOException {
-        return getByteValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getByteValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3124,7 +3113,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, byte[]>> getByteValidAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
-        return ServiceCall.create(getByteValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getByteValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3133,12 +3122,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
     public Observable<Map<String, byte[]>> getByteValidAsync() {
-        return getByteValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
+        return getByteValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
             @Override
             public Map<String, byte[]> call(ServiceResponse<Map<String, byte[]>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3146,7 +3135,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    public Observable<ServiceResponse<Map<String, byte[]>>> getByteValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, byte[]>>> getByteValidWithServiceResponseAsync() {
         return service.getByteValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, byte[]>>>>() {
                 @Override
@@ -3175,10 +3164,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putByteValid(Map<String, byte[]> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putByteValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putByteValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3189,7 +3177,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putByteValidAsync(Map<String, byte[]> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putByteValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putByteValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -3199,12 +3187,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putByteValidAsync(Map<String, byte[]> arrayBody) {
-        return putByteValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putByteValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3213,7 +3201,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, byte[]&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putByteValidAsyncWithServiceResponse(Map<String, byte[]> arrayBody) {
+    public Observable<ServiceResponse<Void>> putByteValidWithServiceResponseAsync(Map<String, byte[]> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3244,10 +3232,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, byte[]&gt; object if successful.
      */
     public Map<String, byte[]> getByteInvalidNull() throws ErrorException, IOException {
-        return getByteInvalidNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getByteInvalidNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3257,7 +3245,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, byte[]>> getByteInvalidNullAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
-        return ServiceCall.create(getByteInvalidNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getByteInvalidNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3266,12 +3254,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
     public Observable<Map<String, byte[]>> getByteInvalidNullAsync() {
-        return getByteInvalidNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
+        return getByteInvalidNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
             @Override
             public Map<String, byte[]> call(ServiceResponse<Map<String, byte[]>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3279,7 +3267,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    public Observable<ServiceResponse<Map<String, byte[]>>> getByteInvalidNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, byte[]>>> getByteInvalidNullWithServiceResponseAsync() {
         return service.getByteInvalidNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, byte[]>>>>() {
                 @Override
@@ -3306,10 +3294,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, byte[]&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, byte[]&gt; object if successful.
      */
     public Map<String, byte[]> getBase64Url() throws ErrorException, IOException {
-        return getBase64UrlAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBase64UrlWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3319,7 +3307,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, byte[]>> getBase64UrlAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
-        return ServiceCall.create(getBase64UrlAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBase64UrlWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3328,12 +3316,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
     public Observable<Map<String, byte[]>> getBase64UrlAsync() {
-        return getBase64UrlAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
+        return getBase64UrlWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, byte[]>>, Map<String, byte[]>>() {
             @Override
             public Map<String, byte[]> call(ServiceResponse<Map<String, byte[]>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3341,7 +3329,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
-    public Observable<ServiceResponse<Map<String, byte[]>>> getBase64UrlAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, byte[]>>> getBase64UrlWithServiceResponseAsync() {
         return service.getBase64Url()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, byte[]>>>>() {
                 @Override
@@ -3378,10 +3366,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     public Map<String, Widget> getComplexNull() throws ErrorException, IOException {
-        return getComplexNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3391,7 +3379,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexNullAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3400,12 +3388,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     public Observable<Map<String, Widget>> getComplexNullAsync() {
-        return getComplexNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+        return getComplexNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
             @Override
             public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3413,7 +3401,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexNullWithServiceResponseAsync() {
         return service.getComplexNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -3440,10 +3428,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     public Map<String, Widget> getComplexEmpty() throws ErrorException, IOException {
-        return getComplexEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3453,7 +3441,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexEmptyAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3462,12 +3450,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     public Observable<Map<String, Widget>> getComplexEmptyAsync() {
-        return getComplexEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+        return getComplexEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
             @Override
             public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3475,7 +3463,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexEmptyWithServiceResponseAsync() {
         return service.getComplexEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -3502,10 +3490,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     public Map<String, Widget> getComplexItemNull() throws ErrorException, IOException {
-        return getComplexItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexItemNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3515,7 +3503,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexItemNullAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexItemNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexItemNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3524,12 +3512,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     public Observable<Map<String, Widget>> getComplexItemNullAsync() {
-        return getComplexItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+        return getComplexItemNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
             @Override
             public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3537,7 +3525,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexItemNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexItemNullWithServiceResponseAsync() {
         return service.getComplexItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -3564,10 +3552,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     public Map<String, Widget> getComplexItemEmpty() throws ErrorException, IOException {
-        return getComplexItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexItemEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3577,7 +3565,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexItemEmptyAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexItemEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexItemEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3586,12 +3574,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     public Observable<Map<String, Widget>> getComplexItemEmptyAsync() {
-        return getComplexItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+        return getComplexItemEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
             @Override
             public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3599,7 +3587,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexItemEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexItemEmptyWithServiceResponseAsync() {
         return service.getComplexItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -3626,10 +3614,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Widget&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Widget&gt; object if successful.
      */
     public Map<String, Widget> getComplexValid() throws ErrorException, IOException {
-        return getComplexValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getComplexValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3639,7 +3627,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Widget>> getComplexValidAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
-        return ServiceCall.create(getComplexValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getComplexValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3648,12 +3636,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     public Observable<Map<String, Widget>> getComplexValidAsync() {
-        return getComplexValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
+        return getComplexValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Widget>>, Map<String, Widget>>() {
             @Override
             public Map<String, Widget> call(ServiceResponse<Map<String, Widget>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3661,7 +3649,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Widget>>> getComplexValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Widget>>> getComplexValidWithServiceResponseAsync() {
         return service.getComplexValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Widget>>>>() {
                 @Override
@@ -3690,10 +3678,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putComplexValid(Map<String, Widget> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putComplexValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putComplexValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -3704,7 +3691,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putComplexValidAsync(Map<String, Widget> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putComplexValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putComplexValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -3714,12 +3701,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putComplexValidAsync(Map<String, Widget> arrayBody) {
-        return putComplexValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putComplexValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3728,7 +3715,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Widget&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putComplexValidAsyncWithServiceResponse(Map<String, Widget> arrayBody) {
+    public Observable<ServiceResponse<Void>> putComplexValidWithServiceResponseAsync(Map<String, Widget> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -3759,10 +3746,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     public Map<String, List<String>> getArrayNull() throws ErrorException, IOException {
-        return getArrayNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3772,7 +3759,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayNullAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3781,12 +3768,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     public Observable<Map<String, List<String>>> getArrayNullAsync() {
-        return getArrayNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+        return getArrayNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
             @Override
             public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3794,7 +3781,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayNullWithServiceResponseAsync() {
         return service.getArrayNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -3821,10 +3808,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     public Map<String, List<String>> getArrayEmpty() throws ErrorException, IOException {
-        return getArrayEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3834,7 +3821,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayEmptyAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3843,12 +3830,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     public Observable<Map<String, List<String>>> getArrayEmptyAsync() {
-        return getArrayEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+        return getArrayEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
             @Override
             public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3856,7 +3843,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayEmptyWithServiceResponseAsync() {
         return service.getArrayEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -3883,10 +3870,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     public Map<String, List<String>> getArrayItemNull() throws ErrorException, IOException {
-        return getArrayItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayItemNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3896,7 +3883,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayItemNullAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayItemNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayItemNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3905,12 +3892,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     public Observable<Map<String, List<String>>> getArrayItemNullAsync() {
-        return getArrayItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+        return getArrayItemNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
             @Override
             public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3918,7 +3905,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemNullWithServiceResponseAsync() {
         return service.getArrayItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -3945,10 +3932,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     public Map<String, List<String>> getArrayItemEmpty() throws ErrorException, IOException {
-        return getArrayItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayItemEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3958,7 +3945,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayItemEmptyAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayItemEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayItemEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3967,12 +3954,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     public Observable<Map<String, List<String>>> getArrayItemEmptyAsync() {
-        return getArrayItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+        return getArrayItemEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
             @Override
             public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3980,7 +3967,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayItemEmptyWithServiceResponseAsync() {
         return service.getArrayItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -4007,10 +3994,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, List&lt;String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, List&lt;String&gt;&gt; object if successful.
      */
     public Map<String, List<String>> getArrayValid() throws ErrorException, IOException {
-        return getArrayValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4020,7 +4007,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, List<String>>> getArrayValidAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
-        return ServiceCall.create(getArrayValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4029,12 +4016,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     public Observable<Map<String, List<String>>> getArrayValidAsync() {
-        return getArrayValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
+        return getArrayValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, List<String>>>, Map<String, List<String>>>() {
             @Override
             public Map<String, List<String>> call(ServiceResponse<Map<String, List<String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4042,7 +4029,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, List<String>>>> getArrayValidWithServiceResponseAsync() {
         return service.getArrayValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, List<String>>>>>() {
                 @Override
@@ -4071,10 +4058,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putArrayValid(Map<String, List<String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putArrayValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putArrayValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -4085,7 +4071,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayValidAsync(Map<String, List<String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putArrayValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -4095,12 +4081,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putArrayValidAsync(Map<String, List<String>> arrayBody) {
-        return putArrayValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putArrayValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4109,7 +4095,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayValidAsyncWithServiceResponse(Map<String, List<String>> arrayBody) {
+    public Observable<ServiceResponse<Void>> putArrayValidWithServiceResponseAsync(Map<String, List<String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
@@ -4140,10 +4126,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     public Map<String, Map<String, String>> getDictionaryNull() throws ErrorException, IOException {
-        return getDictionaryNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4153,7 +4139,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryNullAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4162,12 +4148,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     public Observable<Map<String, Map<String, String>>> getDictionaryNullAsync() {
-        return getDictionaryNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+        return getDictionaryNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
             @Override
             public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4175,7 +4161,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryNullWithServiceResponseAsync() {
         return service.getDictionaryNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -4202,10 +4188,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     public Map<String, Map<String, String>> getDictionaryEmpty() throws ErrorException, IOException {
-        return getDictionaryEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4215,7 +4201,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryEmptyAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4224,12 +4210,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     public Observable<Map<String, Map<String, String>>> getDictionaryEmptyAsync() {
-        return getDictionaryEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+        return getDictionaryEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
             @Override
             public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4237,7 +4223,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryEmptyWithServiceResponseAsync() {
         return service.getDictionaryEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -4264,10 +4250,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     public Map<String, Map<String, String>> getDictionaryItemNull() throws ErrorException, IOException {
-        return getDictionaryItemNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryItemNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4277,7 +4263,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryItemNullAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryItemNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryItemNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4286,12 +4272,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     public Observable<Map<String, Map<String, String>>> getDictionaryItemNullAsync() {
-        return getDictionaryItemNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+        return getDictionaryItemNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
             @Override
             public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4299,7 +4285,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemNullWithServiceResponseAsync() {
         return service.getDictionaryItemNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -4326,10 +4312,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     public Map<String, Map<String, String>> getDictionaryItemEmpty() throws ErrorException, IOException {
-        return getDictionaryItemEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryItemEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4339,7 +4325,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryItemEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryItemEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4348,12 +4334,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     public Observable<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync() {
-        return getDictionaryItemEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+        return getDictionaryItemEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
             @Override
             public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4361,7 +4347,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryItemEmptyWithServiceResponseAsync() {
         return service.getDictionaryItemEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -4388,10 +4374,10 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Map&lt;String, String&gt;&gt; object if successful.
      */
     public Map<String, Map<String, String>> getDictionaryValid() throws ErrorException, IOException {
-        return getDictionaryValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -4401,7 +4387,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Map<String, String>>> getDictionaryValidAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
-        return ServiceCall.create(getDictionaryValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -4410,12 +4396,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     public Observable<Map<String, Map<String, String>>> getDictionaryValidAsync() {
-        return getDictionaryValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
+        return getDictionaryValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() {
             @Override
             public Map<String, Map<String, String>> call(ServiceResponse<Map<String, Map<String, String>>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4423,7 +4409,7 @@ public final class DictionarysImpl implements Dictionarys {
      *
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Map<String, String>>>> getDictionaryValidWithServiceResponseAsync() {
         return service.getDictionaryValid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Map<String, String>>>>>() {
                 @Override
@@ -4452,10 +4438,9 @@ public final class DictionarysImpl implements Dictionarys {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDictionaryValid(Map<String, Map<String, String>> arrayBody) throws ErrorException, IOException, IllegalArgumentException {
-        putDictionaryValidAsyncWithServiceResponse(arrayBody).toBlocking().single().getBody();
+        putDictionaryValidWithServiceResponseAsync(arrayBody).toBlocking().single().getBody();
     }
 
     /**
@@ -4466,7 +4451,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryValidAsyncWithServiceResponse(arrayBody), serviceCallback);
+        return ServiceCall.create(putDictionaryValidWithServiceResponseAsync(arrayBody), serviceCallback);
     }
 
     /**
@@ -4476,12 +4461,12 @@ public final class DictionarysImpl implements Dictionarys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody) {
-        return putDictionaryValidAsyncWithServiceResponse(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDictionaryValidWithServiceResponseAsync(arrayBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -4490,7 +4475,7 @@ public final class DictionarysImpl implements Dictionarys {
      * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryValidAsyncWithServiceResponse(Map<String, Map<String, String>> arrayBody) {
+    public Observable<ServiceResponse<Void>> putDictionaryValidWithServiceResponseAsync(Map<String, Map<String, String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyduration/Durations.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyduration/Durations.java
@@ -28,7 +28,7 @@ public interface Durations {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Period object wrapped in {@link ServiceResponse} if successful.
+     * @return the Period object if successful.
      */
     Period getNull() throws ErrorException, IOException;
 
@@ -52,7 +52,7 @@ public interface Durations {
      *
      * @return the observable to the Period object
      */
-    Observable<ServiceResponse<Period>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Period>> getNullWithServiceResponseAsync();
 
     /**
      * Put a positive duration value.
@@ -61,7 +61,6 @@ public interface Durations {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putPositiveDuration(Period durationBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -88,14 +87,14 @@ public interface Durations {
      * @param durationBody the Period value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putPositiveDurationAsyncWithServiceResponse(Period durationBody);
+    Observable<ServiceResponse<Void>> putPositiveDurationWithServiceResponseAsync(Period durationBody);
 
     /**
      * Get a positive duration value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Period object wrapped in {@link ServiceResponse} if successful.
+     * @return the Period object if successful.
      */
     Period getPositiveDuration() throws ErrorException, IOException;
 
@@ -119,14 +118,14 @@ public interface Durations {
      *
      * @return the observable to the Period object
      */
-    Observable<ServiceResponse<Period>> getPositiveDurationAsyncWithServiceResponse();
+    Observable<ServiceResponse<Period>> getPositiveDurationWithServiceResponseAsync();
 
     /**
      * Get an invalid duration value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Period object wrapped in {@link ServiceResponse} if successful.
+     * @return the Period object if successful.
      */
     Period getInvalid() throws ErrorException, IOException;
 
@@ -150,6 +149,6 @@ public interface Durations {
      *
      * @return the observable to the Period object
      */
-    Observable<ServiceResponse<Period>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Period>> getInvalidWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyduration/Durations.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyduration/Durations.java
@@ -30,7 +30,7 @@ public interface Durations {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Period object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Period> getNull() throws ErrorException, IOException;
+    Period getNull() throws ErrorException, IOException;
 
     /**
      * Get null duration value.
@@ -45,7 +45,14 @@ public interface Durations {
      *
      * @return the observable to the Period object
      */
-    Observable<ServiceResponse<Period>> getNullAsync();
+    Observable<Period> getNullAsync();
+
+    /**
+     * Get null duration value.
+     *
+     * @return the observable to the Period object
+     */
+    Observable<ServiceResponse<Period>> getNullAsyncWithServiceResponse();
 
     /**
      * Put a positive duration value.
@@ -56,7 +63,7 @@ public interface Durations {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putPositiveDuration(Period durationBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putPositiveDuration(Period durationBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put a positive duration value.
@@ -73,7 +80,15 @@ public interface Durations {
      * @param durationBody the Period value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putPositiveDurationAsync(Period durationBody);
+    Observable<Void> putPositiveDurationAsync(Period durationBody);
+
+    /**
+     * Put a positive duration value.
+     *
+     * @param durationBody the Period value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putPositiveDurationAsyncWithServiceResponse(Period durationBody);
 
     /**
      * Get a positive duration value.
@@ -82,7 +97,7 @@ public interface Durations {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Period object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Period> getPositiveDuration() throws ErrorException, IOException;
+    Period getPositiveDuration() throws ErrorException, IOException;
 
     /**
      * Get a positive duration value.
@@ -97,7 +112,14 @@ public interface Durations {
      *
      * @return the observable to the Period object
      */
-    Observable<ServiceResponse<Period>> getPositiveDurationAsync();
+    Observable<Period> getPositiveDurationAsync();
+
+    /**
+     * Get a positive duration value.
+     *
+     * @return the observable to the Period object
+     */
+    Observable<ServiceResponse<Period>> getPositiveDurationAsyncWithServiceResponse();
 
     /**
      * Get an invalid duration value.
@@ -106,7 +128,7 @@ public interface Durations {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Period object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Period> getInvalid() throws ErrorException, IOException;
+    Period getInvalid() throws ErrorException, IOException;
 
     /**
      * Get an invalid duration value.
@@ -121,6 +143,13 @@ public interface Durations {
      *
      * @return the observable to the Period object
      */
-    Observable<ServiceResponse<Period>> getInvalidAsync();
+    Observable<Period> getInvalidAsync();
+
+    /**
+     * Get an invalid duration value.
+     *
+     * @return the observable to the Period object
+     */
+    Observable<ServiceResponse<Period>> getInvalidAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyduration/implementation/DurationsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyduration/implementation/DurationsImpl.java
@@ -80,8 +80,8 @@ public final class DurationsImpl implements Durations {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Period object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Period> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public Period getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -91,7 +91,7 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Period> getNullAsync(final ServiceCallback<Period> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -99,7 +99,21 @@ public final class DurationsImpl implements Durations {
      *
      * @return the observable to the Period object
      */
-    public Observable<ServiceResponse<Period>> getNullAsync() {
+    public Observable<Period> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Period>, Period>() {
+            @Override
+            public Period call(ServiceResponse<Period> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null duration value.
+     *
+     * @return the observable to the Period object
+     */
+    public Observable<ServiceResponse<Period>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Period>>>() {
                 @Override
@@ -130,8 +144,8 @@ public final class DurationsImpl implements Durations {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putPositiveDuration(Period durationBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putPositiveDurationAsync(durationBody).toBlocking().single();
+    public void putPositiveDuration(Period durationBody) throws ErrorException, IOException, IllegalArgumentException {
+        putPositiveDurationAsyncWithServiceResponse(durationBody).toBlocking().single().getBody();
     }
 
     /**
@@ -142,7 +156,7 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putPositiveDurationAsync(Period durationBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putPositiveDurationAsync(durationBody), serviceCallback);
+        return ServiceCall.create(putPositiveDurationAsyncWithServiceResponse(durationBody), serviceCallback);
     }
 
     /**
@@ -151,7 +165,22 @@ public final class DurationsImpl implements Durations {
      * @param durationBody the Period value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putPositiveDurationAsync(Period durationBody) {
+    public Observable<Void> putPositiveDurationAsync(Period durationBody) {
+        return putPositiveDurationAsyncWithServiceResponse(durationBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put a positive duration value.
+     *
+     * @param durationBody the Period value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putPositiveDurationAsyncWithServiceResponse(Period durationBody) {
         if (durationBody == null) {
             throw new IllegalArgumentException("Parameter durationBody is required and cannot be null.");
         }
@@ -183,8 +212,8 @@ public final class DurationsImpl implements Durations {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Period object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Period> getPositiveDuration() throws ErrorException, IOException {
-        return getPositiveDurationAsync().toBlocking().single();
+    public Period getPositiveDuration() throws ErrorException, IOException {
+        return getPositiveDurationAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -194,7 +223,7 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Period> getPositiveDurationAsync(final ServiceCallback<Period> serviceCallback) {
-        return ServiceCall.create(getPositiveDurationAsync(), serviceCallback);
+        return ServiceCall.create(getPositiveDurationAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -202,7 +231,21 @@ public final class DurationsImpl implements Durations {
      *
      * @return the observable to the Period object
      */
-    public Observable<ServiceResponse<Period>> getPositiveDurationAsync() {
+    public Observable<Period> getPositiveDurationAsync() {
+        return getPositiveDurationAsyncWithServiceResponse().map(new Func1<ServiceResponse<Period>, Period>() {
+            @Override
+            public Period call(ServiceResponse<Period> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a positive duration value.
+     *
+     * @return the observable to the Period object
+     */
+    public Observable<ServiceResponse<Period>> getPositiveDurationAsyncWithServiceResponse() {
         return service.getPositiveDuration()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Period>>>() {
                 @Override
@@ -231,8 +274,8 @@ public final class DurationsImpl implements Durations {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Period object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Period> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public Period getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -242,7 +285,7 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Period> getInvalidAsync(final ServiceCallback<Period> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -250,7 +293,21 @@ public final class DurationsImpl implements Durations {
      *
      * @return the observable to the Period object
      */
-    public Observable<ServiceResponse<Period>> getInvalidAsync() {
+    public Observable<Period> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Period>, Period>() {
+            @Override
+            public Period call(ServiceResponse<Period> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an invalid duration value.
+     *
+     * @return the observable to the Period object
+     */
+    public Observable<ServiceResponse<Period>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Period>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyduration/implementation/DurationsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyduration/implementation/DurationsImpl.java
@@ -78,10 +78,10 @@ public final class DurationsImpl implements Durations {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Period object wrapped in {@link ServiceResponse} if successful.
+     * @return the Period object if successful.
      */
     public Period getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -91,7 +91,7 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Period> getNullAsync(final ServiceCallback<Period> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -100,12 +100,12 @@ public final class DurationsImpl implements Durations {
      * @return the observable to the Period object
      */
     public Observable<Period> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Period>, Period>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Period>, Period>() {
             @Override
             public Period call(ServiceResponse<Period> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -113,7 +113,7 @@ public final class DurationsImpl implements Durations {
      *
      * @return the observable to the Period object
      */
-    public Observable<ServiceResponse<Period>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Period>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Period>>>() {
                 @Override
@@ -142,10 +142,9 @@ public final class DurationsImpl implements Durations {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putPositiveDuration(Period durationBody) throws ErrorException, IOException, IllegalArgumentException {
-        putPositiveDurationAsyncWithServiceResponse(durationBody).toBlocking().single().getBody();
+        putPositiveDurationWithServiceResponseAsync(durationBody).toBlocking().single().getBody();
     }
 
     /**
@@ -156,7 +155,7 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putPositiveDurationAsync(Period durationBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putPositiveDurationAsyncWithServiceResponse(durationBody), serviceCallback);
+        return ServiceCall.create(putPositiveDurationWithServiceResponseAsync(durationBody), serviceCallback);
     }
 
     /**
@@ -166,12 +165,12 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putPositiveDurationAsync(Period durationBody) {
-        return putPositiveDurationAsyncWithServiceResponse(durationBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putPositiveDurationWithServiceResponseAsync(durationBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -180,7 +179,7 @@ public final class DurationsImpl implements Durations {
      * @param durationBody the Period value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putPositiveDurationAsyncWithServiceResponse(Period durationBody) {
+    public Observable<ServiceResponse<Void>> putPositiveDurationWithServiceResponseAsync(Period durationBody) {
         if (durationBody == null) {
             throw new IllegalArgumentException("Parameter durationBody is required and cannot be null.");
         }
@@ -210,10 +209,10 @@ public final class DurationsImpl implements Durations {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Period object wrapped in {@link ServiceResponse} if successful.
+     * @return the Period object if successful.
      */
     public Period getPositiveDuration() throws ErrorException, IOException {
-        return getPositiveDurationAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getPositiveDurationWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -223,7 +222,7 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Period> getPositiveDurationAsync(final ServiceCallback<Period> serviceCallback) {
-        return ServiceCall.create(getPositiveDurationAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getPositiveDurationWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -232,12 +231,12 @@ public final class DurationsImpl implements Durations {
      * @return the observable to the Period object
      */
     public Observable<Period> getPositiveDurationAsync() {
-        return getPositiveDurationAsyncWithServiceResponse().map(new Func1<ServiceResponse<Period>, Period>() {
+        return getPositiveDurationWithServiceResponseAsync().map(new Func1<ServiceResponse<Period>, Period>() {
             @Override
             public Period call(ServiceResponse<Period> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -245,7 +244,7 @@ public final class DurationsImpl implements Durations {
      *
      * @return the observable to the Period object
      */
-    public Observable<ServiceResponse<Period>> getPositiveDurationAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Period>> getPositiveDurationWithServiceResponseAsync() {
         return service.getPositiveDuration()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Period>>>() {
                 @Override
@@ -272,10 +271,10 @@ public final class DurationsImpl implements Durations {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Period object wrapped in {@link ServiceResponse} if successful.
+     * @return the Period object if successful.
      */
     public Period getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -285,7 +284,7 @@ public final class DurationsImpl implements Durations {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Period> getInvalidAsync(final ServiceCallback<Period> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -294,12 +293,12 @@ public final class DurationsImpl implements Durations {
      * @return the observable to the Period object
      */
     public Observable<Period> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Period>, Period>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Period>, Period>() {
             @Override
             public Period call(ServiceResponse<Period> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -307,7 +306,7 @@ public final class DurationsImpl implements Durations {
      *
      * @return the observable to the Period object
      */
-    public Observable<ServiceResponse<Period>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Period>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Period>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyfile/Files.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyfile/Files.java
@@ -28,7 +28,7 @@ public interface Files {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     InputStream getFile() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface Files {
      *
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> getFileAsyncWithServiceResponse();
+    Observable<ServiceResponse<InputStream>> getFileWithServiceResponseAsync();
 
     /**
      * Get a large file.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     InputStream getFileLarge() throws ErrorException, IOException;
 
@@ -83,14 +83,14 @@ public interface Files {
      *
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> getFileLargeAsyncWithServiceResponse();
+    Observable<ServiceResponse<InputStream>> getFileLargeWithServiceResponseAsync();
 
     /**
      * Get empty file.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     InputStream getEmptyFile() throws ErrorException, IOException;
 
@@ -114,6 +114,6 @@ public interface Files {
      *
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> getEmptyFileAsyncWithServiceResponse();
+    Observable<ServiceResponse<InputStream>> getEmptyFileWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyfile/Files.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyfile/Files.java
@@ -30,7 +30,7 @@ public interface Files {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> getFile() throws ErrorException, IOException;
+    InputStream getFile() throws ErrorException, IOException;
 
     /**
      * Get file.
@@ -45,7 +45,14 @@ public interface Files {
      *
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> getFileAsync();
+    Observable<InputStream> getFileAsync();
+
+    /**
+     * Get file.
+     *
+     * @return the observable to the InputStream object
+     */
+    Observable<ServiceResponse<InputStream>> getFileAsyncWithServiceResponse();
 
     /**
      * Get a large file.
@@ -54,7 +61,7 @@ public interface Files {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> getFileLarge() throws ErrorException, IOException;
+    InputStream getFileLarge() throws ErrorException, IOException;
 
     /**
      * Get a large file.
@@ -69,7 +76,14 @@ public interface Files {
      *
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> getFileLargeAsync();
+    Observable<InputStream> getFileLargeAsync();
+
+    /**
+     * Get a large file.
+     *
+     * @return the observable to the InputStream object
+     */
+    Observable<ServiceResponse<InputStream>> getFileLargeAsyncWithServiceResponse();
 
     /**
      * Get empty file.
@@ -78,7 +92,7 @@ public interface Files {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> getEmptyFile() throws ErrorException, IOException;
+    InputStream getEmptyFile() throws ErrorException, IOException;
 
     /**
      * Get empty file.
@@ -93,6 +107,13 @@ public interface Files {
      *
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> getEmptyFileAsync();
+    Observable<InputStream> getEmptyFileAsync();
+
+    /**
+     * Get empty file.
+     *
+     * @return the observable to the InputStream object
+     */
+    Observable<ServiceResponse<InputStream>> getEmptyFileAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyfile/implementation/FilesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyfile/implementation/FilesImpl.java
@@ -76,10 +76,10 @@ public final class FilesImpl implements Files {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     public InputStream getFile() throws ErrorException, IOException {
-        return getFileAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFileWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -89,7 +89,7 @@ public final class FilesImpl implements Files {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> getFileAsync(final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(getFileAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFileWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -98,12 +98,12 @@ public final class FilesImpl implements Files {
      * @return the observable to the InputStream object
      */
     public Observable<InputStream> getFileAsync() {
-        return getFileAsyncWithServiceResponse().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+        return getFileWithServiceResponseAsync().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
             @Override
             public InputStream call(ServiceResponse<InputStream> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -111,7 +111,7 @@ public final class FilesImpl implements Files {
      *
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> getFileAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<InputStream>> getFileWithServiceResponseAsync() {
         return service.getFile()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<InputStream>>>() {
                 @Override
@@ -138,10 +138,10 @@ public final class FilesImpl implements Files {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     public InputStream getFileLarge() throws ErrorException, IOException {
-        return getFileLargeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getFileLargeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -151,7 +151,7 @@ public final class FilesImpl implements Files {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> getFileLargeAsync(final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(getFileLargeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getFileLargeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -160,12 +160,12 @@ public final class FilesImpl implements Files {
      * @return the observable to the InputStream object
      */
     public Observable<InputStream> getFileLargeAsync() {
-        return getFileLargeAsyncWithServiceResponse().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+        return getFileLargeWithServiceResponseAsync().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
             @Override
             public InputStream call(ServiceResponse<InputStream> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -173,7 +173,7 @@ public final class FilesImpl implements Files {
      *
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> getFileLargeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<InputStream>> getFileLargeWithServiceResponseAsync() {
         return service.getFileLarge()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<InputStream>>>() {
                 @Override
@@ -200,10 +200,10 @@ public final class FilesImpl implements Files {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     public InputStream getEmptyFile() throws ErrorException, IOException {
-        return getEmptyFileAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyFileWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -213,7 +213,7 @@ public final class FilesImpl implements Files {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> getEmptyFileAsync(final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(getEmptyFileAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyFileWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -222,12 +222,12 @@ public final class FilesImpl implements Files {
      * @return the observable to the InputStream object
      */
     public Observable<InputStream> getEmptyFileAsync() {
-        return getEmptyFileAsyncWithServiceResponse().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+        return getEmptyFileWithServiceResponseAsync().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
             @Override
             public InputStream call(ServiceResponse<InputStream> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -235,7 +235,7 @@ public final class FilesImpl implements Files {
      *
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> getEmptyFileAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<InputStream>> getEmptyFileWithServiceResponseAsync() {
         return service.getEmptyFile()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<InputStream>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyfile/implementation/FilesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyfile/implementation/FilesImpl.java
@@ -78,8 +78,8 @@ public final class FilesImpl implements Files {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> getFile() throws ErrorException, IOException {
-        return getFileAsync().toBlocking().single();
+    public InputStream getFile() throws ErrorException, IOException {
+        return getFileAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -89,7 +89,7 @@ public final class FilesImpl implements Files {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> getFileAsync(final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(getFileAsync(), serviceCallback);
+        return ServiceCall.create(getFileAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -97,7 +97,21 @@ public final class FilesImpl implements Files {
      *
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> getFileAsync() {
+    public Observable<InputStream> getFileAsync() {
+        return getFileAsyncWithServiceResponse().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+            @Override
+            public InputStream call(ServiceResponse<InputStream> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get file.
+     *
+     * @return the observable to the InputStream object
+     */
+    public Observable<ServiceResponse<InputStream>> getFileAsyncWithServiceResponse() {
         return service.getFile()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<InputStream>>>() {
                 @Override
@@ -126,8 +140,8 @@ public final class FilesImpl implements Files {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> getFileLarge() throws ErrorException, IOException {
-        return getFileLargeAsync().toBlocking().single();
+    public InputStream getFileLarge() throws ErrorException, IOException {
+        return getFileLargeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -137,7 +151,7 @@ public final class FilesImpl implements Files {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> getFileLargeAsync(final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(getFileLargeAsync(), serviceCallback);
+        return ServiceCall.create(getFileLargeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -145,7 +159,21 @@ public final class FilesImpl implements Files {
      *
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> getFileLargeAsync() {
+    public Observable<InputStream> getFileLargeAsync() {
+        return getFileLargeAsyncWithServiceResponse().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+            @Override
+            public InputStream call(ServiceResponse<InputStream> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a large file.
+     *
+     * @return the observable to the InputStream object
+     */
+    public Observable<ServiceResponse<InputStream>> getFileLargeAsyncWithServiceResponse() {
         return service.getFileLarge()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<InputStream>>>() {
                 @Override
@@ -174,8 +202,8 @@ public final class FilesImpl implements Files {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> getEmptyFile() throws ErrorException, IOException {
-        return getEmptyFileAsync().toBlocking().single();
+    public InputStream getEmptyFile() throws ErrorException, IOException {
+        return getEmptyFileAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -185,7 +213,7 @@ public final class FilesImpl implements Files {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> getEmptyFileAsync(final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(getEmptyFileAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyFileAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -193,7 +221,21 @@ public final class FilesImpl implements Files {
      *
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> getEmptyFileAsync() {
+    public Observable<InputStream> getEmptyFileAsync() {
+        return getEmptyFileAsyncWithServiceResponse().map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+            @Override
+            public InputStream call(ServiceResponse<InputStream> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty file.
+     *
+     * @return the observable to the InputStream object
+     */
+    public Observable<ServiceResponse<InputStream>> getEmptyFileAsyncWithServiceResponse() {
         return service.getEmptyFile()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<InputStream>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyformdata/Formdatas.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyformdata/Formdatas.java
@@ -33,7 +33,7 @@ public interface Formdatas {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException;
+    InputStream uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Upload file.
@@ -52,7 +52,16 @@ public interface Formdatas {
      * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> uploadFileAsync(byte[] fileContent, String fileName);
+    Observable<InputStream> uploadFileAsync(byte[] fileContent, String fileName);
+
+    /**
+     * Upload file.
+     *
+     * @param fileContent File to upload.
+     * @param fileName File name to upload. Name has to be spelled exactly as written here.
+     * @return the observable to the InputStream object
+     */
+    Observable<ServiceResponse<InputStream>> uploadFileAsyncWithServiceResponse(byte[] fileContent, String fileName);
 
     /**
      * Upload file.
@@ -63,7 +72,7 @@ public interface Formdatas {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<InputStream> uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException;
+    InputStream uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Upload file.
@@ -80,6 +89,14 @@ public interface Formdatas {
      * @param fileContent File to upload.
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> uploadFileViaBodyAsync(byte[] fileContent);
+    Observable<InputStream> uploadFileViaBodyAsync(byte[] fileContent);
+
+    /**
+     * Upload file.
+     *
+     * @param fileContent File to upload.
+     * @return the observable to the InputStream object
+     */
+    Observable<ServiceResponse<InputStream>> uploadFileViaBodyAsyncWithServiceResponse(byte[] fileContent);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyformdata/Formdatas.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyformdata/Formdatas.java
@@ -31,7 +31,7 @@ public interface Formdatas {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     InputStream uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -61,7 +61,7 @@ public interface Formdatas {
      * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> uploadFileAsyncWithServiceResponse(byte[] fileContent, String fileName);
+    Observable<ServiceResponse<InputStream>> uploadFileWithServiceResponseAsync(byte[] fileContent, String fileName);
 
     /**
      * Upload file.
@@ -70,7 +70,7 @@ public interface Formdatas {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     InputStream uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -97,6 +97,6 @@ public interface Formdatas {
      * @param fileContent File to upload.
      * @return the observable to the InputStream object
      */
-    Observable<ServiceResponse<InputStream>> uploadFileViaBodyAsyncWithServiceResponse(byte[] fileContent);
+    Observable<ServiceResponse<InputStream>> uploadFileViaBodyWithServiceResponseAsync(byte[] fileContent);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyformdata/implementation/FormdatasImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyformdata/implementation/FormdatasImpl.java
@@ -80,10 +80,10 @@ public final class FormdatasImpl implements Formdatas {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     public InputStream uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException {
-        return uploadFileAsyncWithServiceResponse(fileContent, fileName).toBlocking().single().getBody();
+        return uploadFileWithServiceResponseAsync(fileContent, fileName).toBlocking().single().getBody();
     }
 
     /**
@@ -95,7 +95,7 @@ public final class FormdatasImpl implements Formdatas {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> uploadFileAsync(byte[] fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(uploadFileAsyncWithServiceResponse(fileContent, fileName), serviceCallback);
+        return ServiceCall.create(uploadFileWithServiceResponseAsync(fileContent, fileName), serviceCallback);
     }
 
     /**
@@ -106,12 +106,12 @@ public final class FormdatasImpl implements Formdatas {
      * @return the observable to the InputStream object
      */
     public Observable<InputStream> uploadFileAsync(byte[] fileContent, String fileName) {
-        return uploadFileAsyncWithServiceResponse(fileContent, fileName).map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+        return uploadFileWithServiceResponseAsync(fileContent, fileName).map(new Func1<ServiceResponse<InputStream>, InputStream>() {
             @Override
             public InputStream call(ServiceResponse<InputStream> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -121,7 +121,7 @@ public final class FormdatasImpl implements Formdatas {
      * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> uploadFileAsyncWithServiceResponse(byte[] fileContent, String fileName) {
+    public Observable<ServiceResponse<InputStream>> uploadFileWithServiceResponseAsync(byte[] fileContent, String fileName) {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
@@ -157,10 +157,10 @@ public final class FormdatasImpl implements Formdatas {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
+     * @return the InputStream object if successful.
      */
     public InputStream uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException {
-        return uploadFileViaBodyAsyncWithServiceResponse(fileContent).toBlocking().single().getBody();
+        return uploadFileViaBodyWithServiceResponseAsync(fileContent).toBlocking().single().getBody();
     }
 
     /**
@@ -171,7 +171,7 @@ public final class FormdatasImpl implements Formdatas {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> uploadFileViaBodyAsync(byte[] fileContent, final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(uploadFileViaBodyAsyncWithServiceResponse(fileContent), serviceCallback);
+        return ServiceCall.create(uploadFileViaBodyWithServiceResponseAsync(fileContent), serviceCallback);
     }
 
     /**
@@ -181,12 +181,12 @@ public final class FormdatasImpl implements Formdatas {
      * @return the observable to the InputStream object
      */
     public Observable<InputStream> uploadFileViaBodyAsync(byte[] fileContent) {
-        return uploadFileViaBodyAsyncWithServiceResponse(fileContent).map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+        return uploadFileViaBodyWithServiceResponseAsync(fileContent).map(new Func1<ServiceResponse<InputStream>, InputStream>() {
             @Override
             public InputStream call(ServiceResponse<InputStream> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -195,7 +195,7 @@ public final class FormdatasImpl implements Formdatas {
      * @param fileContent File to upload.
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> uploadFileViaBodyAsyncWithServiceResponse(byte[] fileContent) {
+    public Observable<ServiceResponse<InputStream>> uploadFileViaBodyWithServiceResponseAsync(byte[] fileContent) {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyformdata/implementation/FormdatasImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyformdata/implementation/FormdatasImpl.java
@@ -82,8 +82,8 @@ public final class FormdatasImpl implements Formdatas {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException {
-        return uploadFileAsync(fileContent, fileName).toBlocking().single();
+    public InputStream uploadFile(byte[] fileContent, String fileName) throws ErrorException, IOException, IllegalArgumentException {
+        return uploadFileAsyncWithServiceResponse(fileContent, fileName).toBlocking().single().getBody();
     }
 
     /**
@@ -95,7 +95,7 @@ public final class FormdatasImpl implements Formdatas {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> uploadFileAsync(byte[] fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(uploadFileAsync(fileContent, fileName), serviceCallback);
+        return ServiceCall.create(uploadFileAsyncWithServiceResponse(fileContent, fileName), serviceCallback);
     }
 
     /**
@@ -105,7 +105,23 @@ public final class FormdatasImpl implements Formdatas {
      * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> uploadFileAsync(byte[] fileContent, String fileName) {
+    public Observable<InputStream> uploadFileAsync(byte[] fileContent, String fileName) {
+        return uploadFileAsyncWithServiceResponse(fileContent, fileName).map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+            @Override
+            public InputStream call(ServiceResponse<InputStream> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Upload file.
+     *
+     * @param fileContent File to upload.
+     * @param fileName File name to upload. Name has to be spelled exactly as written here.
+     * @return the observable to the InputStream object
+     */
+    public Observable<ServiceResponse<InputStream>> uploadFileAsyncWithServiceResponse(byte[] fileContent, String fileName) {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
@@ -143,8 +159,8 @@ public final class FormdatasImpl implements Formdatas {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the InputStream object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<InputStream> uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException {
-        return uploadFileViaBodyAsync(fileContent).toBlocking().single();
+    public InputStream uploadFileViaBody(byte[] fileContent) throws ErrorException, IOException, IllegalArgumentException {
+        return uploadFileViaBodyAsyncWithServiceResponse(fileContent).toBlocking().single().getBody();
     }
 
     /**
@@ -155,7 +171,7 @@ public final class FormdatasImpl implements Formdatas {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<InputStream> uploadFileViaBodyAsync(byte[] fileContent, final ServiceCallback<InputStream> serviceCallback) {
-        return ServiceCall.create(uploadFileViaBodyAsync(fileContent), serviceCallback);
+        return ServiceCall.create(uploadFileViaBodyAsyncWithServiceResponse(fileContent), serviceCallback);
     }
 
     /**
@@ -164,7 +180,22 @@ public final class FormdatasImpl implements Formdatas {
      * @param fileContent File to upload.
      * @return the observable to the InputStream object
      */
-    public Observable<ServiceResponse<InputStream>> uploadFileViaBodyAsync(byte[] fileContent) {
+    public Observable<InputStream> uploadFileViaBodyAsync(byte[] fileContent) {
+        return uploadFileViaBodyAsyncWithServiceResponse(fileContent).map(new Func1<ServiceResponse<InputStream>, InputStream>() {
+            @Override
+            public InputStream call(ServiceResponse<InputStream> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Upload file.
+     *
+     * @param fileContent File to upload.
+     * @return the observable to the InputStream object
+     */
+    public Observable<ServiceResponse<InputStream>> uploadFileViaBodyAsyncWithServiceResponse(byte[] fileContent) {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyinteger/Ints.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyinteger/Ints.java
@@ -30,7 +30,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the int object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Integer> getNull() throws ErrorException, IOException;
+    int getNull() throws ErrorException, IOException;
 
     /**
      * Get null Int value.
@@ -45,7 +45,14 @@ public interface Ints {
      *
      * @return the observable to the int object
      */
-    Observable<ServiceResponse<Integer>> getNullAsync();
+    Observable<Integer> getNullAsync();
+
+    /**
+     * Get null Int value.
+     *
+     * @return the observable to the int object
+     */
+    Observable<ServiceResponse<Integer>> getNullAsyncWithServiceResponse();
 
     /**
      * Get invalid Int value.
@@ -54,7 +61,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the int object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Integer> getInvalid() throws ErrorException, IOException;
+    int getInvalid() throws ErrorException, IOException;
 
     /**
      * Get invalid Int value.
@@ -69,7 +76,14 @@ public interface Ints {
      *
      * @return the observable to the int object
      */
-    Observable<ServiceResponse<Integer>> getInvalidAsync();
+    Observable<Integer> getInvalidAsync();
+
+    /**
+     * Get invalid Int value.
+     *
+     * @return the observable to the int object
+     */
+    Observable<ServiceResponse<Integer>> getInvalidAsyncWithServiceResponse();
 
     /**
      * Get overflow Int32 value.
@@ -78,7 +92,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the int object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Integer> getOverflowInt32() throws ErrorException, IOException;
+    int getOverflowInt32() throws ErrorException, IOException;
 
     /**
      * Get overflow Int32 value.
@@ -93,7 +107,14 @@ public interface Ints {
      *
      * @return the observable to the int object
      */
-    Observable<ServiceResponse<Integer>> getOverflowInt32Async();
+    Observable<Integer> getOverflowInt32Async();
+
+    /**
+     * Get overflow Int32 value.
+     *
+     * @return the observable to the int object
+     */
+    Observable<ServiceResponse<Integer>> getOverflowInt32AsyncWithServiceResponse();
 
     /**
      * Get underflow Int32 value.
@@ -102,7 +123,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the int object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Integer> getUnderflowInt32() throws ErrorException, IOException;
+    int getUnderflowInt32() throws ErrorException, IOException;
 
     /**
      * Get underflow Int32 value.
@@ -117,7 +138,14 @@ public interface Ints {
      *
      * @return the observable to the int object
      */
-    Observable<ServiceResponse<Integer>> getUnderflowInt32Async();
+    Observable<Integer> getUnderflowInt32Async();
+
+    /**
+     * Get underflow Int32 value.
+     *
+     * @return the observable to the int object
+     */
+    Observable<ServiceResponse<Integer>> getUnderflowInt32AsyncWithServiceResponse();
 
     /**
      * Get overflow Int64 value.
@@ -126,7 +154,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the long object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Long> getOverflowInt64() throws ErrorException, IOException;
+    long getOverflowInt64() throws ErrorException, IOException;
 
     /**
      * Get overflow Int64 value.
@@ -141,7 +169,14 @@ public interface Ints {
      *
      * @return the observable to the long object
      */
-    Observable<ServiceResponse<Long>> getOverflowInt64Async();
+    Observable<Long> getOverflowInt64Async();
+
+    /**
+     * Get overflow Int64 value.
+     *
+     * @return the observable to the long object
+     */
+    Observable<ServiceResponse<Long>> getOverflowInt64AsyncWithServiceResponse();
 
     /**
      * Get underflow Int64 value.
@@ -150,7 +185,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the long object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Long> getUnderflowInt64() throws ErrorException, IOException;
+    long getUnderflowInt64() throws ErrorException, IOException;
 
     /**
      * Get underflow Int64 value.
@@ -165,7 +200,14 @@ public interface Ints {
      *
      * @return the observable to the long object
      */
-    Observable<ServiceResponse<Long>> getUnderflowInt64Async();
+    Observable<Long> getUnderflowInt64Async();
+
+    /**
+     * Get underflow Int64 value.
+     *
+     * @return the observable to the long object
+     */
+    Observable<ServiceResponse<Long>> getUnderflowInt64AsyncWithServiceResponse();
 
     /**
      * Put max int32 value.
@@ -175,7 +217,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putMax32(int intBody) throws ErrorException, IOException;
+    void putMax32(int intBody) throws ErrorException, IOException;
 
     /**
      * Put max int32 value.
@@ -192,7 +234,15 @@ public interface Ints {
      * @param intBody the int value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMax32Async(int intBody);
+    Observable<Void> putMax32Async(int intBody);
+
+    /**
+     * Put max int32 value.
+     *
+     * @param intBody the int value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putMax32AsyncWithServiceResponse(int intBody);
 
     /**
      * Put max int64 value.
@@ -202,7 +252,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putMax64(long intBody) throws ErrorException, IOException;
+    void putMax64(long intBody) throws ErrorException, IOException;
 
     /**
      * Put max int64 value.
@@ -219,7 +269,15 @@ public interface Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMax64Async(long intBody);
+    Observable<Void> putMax64Async(long intBody);
+
+    /**
+     * Put max int64 value.
+     *
+     * @param intBody the long value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putMax64AsyncWithServiceResponse(long intBody);
 
     /**
      * Put min int32 value.
@@ -229,7 +287,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putMin32(int intBody) throws ErrorException, IOException;
+    void putMin32(int intBody) throws ErrorException, IOException;
 
     /**
      * Put min int32 value.
@@ -246,7 +304,15 @@ public interface Ints {
      * @param intBody the int value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMin32Async(int intBody);
+    Observable<Void> putMin32Async(int intBody);
+
+    /**
+     * Put min int32 value.
+     *
+     * @param intBody the int value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putMin32AsyncWithServiceResponse(int intBody);
 
     /**
      * Put min int64 value.
@@ -256,7 +322,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putMin64(long intBody) throws ErrorException, IOException;
+    void putMin64(long intBody) throws ErrorException, IOException;
 
     /**
      * Put min int64 value.
@@ -273,7 +339,15 @@ public interface Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMin64Async(long intBody);
+    Observable<Void> putMin64Async(long intBody);
+
+    /**
+     * Put min int64 value.
+     *
+     * @param intBody the long value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putMin64AsyncWithServiceResponse(long intBody);
 
     /**
      * Get datetime encoded as Unix time value.
@@ -282,7 +356,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getUnixTime() throws ErrorException, IOException;
+    DateTime getUnixTime() throws ErrorException, IOException;
 
     /**
      * Get datetime encoded as Unix time value.
@@ -297,7 +371,14 @@ public interface Ints {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUnixTimeAsync();
+    Observable<DateTime> getUnixTimeAsync();
+
+    /**
+     * Get datetime encoded as Unix time value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getUnixTimeAsyncWithServiceResponse();
 
     /**
      * Put datetime encoded as Unix time.
@@ -307,7 +388,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putUnixTimeDate(DateTime intBody) throws ErrorException, IOException;
+    void putUnixTimeDate(DateTime intBody) throws ErrorException, IOException;
 
     /**
      * Put datetime encoded as Unix time.
@@ -324,7 +405,15 @@ public interface Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUnixTimeDateAsync(DateTime intBody);
+    Observable<Void> putUnixTimeDateAsync(DateTime intBody);
+
+    /**
+     * Put datetime encoded as Unix time.
+     *
+     * @param intBody the long value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putUnixTimeDateAsyncWithServiceResponse(DateTime intBody);
 
     /**
      * Get invalid Unix time value.
@@ -333,7 +422,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getInvalidUnixTime() throws ErrorException, IOException;
+    DateTime getInvalidUnixTime() throws ErrorException, IOException;
 
     /**
      * Get invalid Unix time value.
@@ -348,7 +437,14 @@ public interface Ints {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getInvalidUnixTimeAsync();
+    Observable<DateTime> getInvalidUnixTimeAsync();
+
+    /**
+     * Get invalid Unix time value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getInvalidUnixTimeAsyncWithServiceResponse();
 
     /**
      * Get null Unix time value.
@@ -357,7 +453,7 @@ public interface Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<DateTime> getNullUnixTime() throws ErrorException, IOException;
+    DateTime getNullUnixTime() throws ErrorException, IOException;
 
     /**
      * Get null Unix time value.
@@ -372,6 +468,13 @@ public interface Ints {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getNullUnixTimeAsync();
+    Observable<DateTime> getNullUnixTimeAsync();
+
+    /**
+     * Get null Unix time value.
+     *
+     * @return the observable to the DateTime object
+     */
+    Observable<ServiceResponse<DateTime>> getNullUnixTimeAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyinteger/Ints.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyinteger/Ints.java
@@ -28,7 +28,7 @@ public interface Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the int object wrapped in {@link ServiceResponse} if successful.
+     * @return the int object if successful.
      */
     int getNull() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface Ints {
      *
      * @return the observable to the int object
      */
-    Observable<ServiceResponse<Integer>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Integer>> getNullWithServiceResponseAsync();
 
     /**
      * Get invalid Int value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the int object wrapped in {@link ServiceResponse} if successful.
+     * @return the int object if successful.
      */
     int getInvalid() throws ErrorException, IOException;
 
@@ -83,14 +83,14 @@ public interface Ints {
      *
      * @return the observable to the int object
      */
-    Observable<ServiceResponse<Integer>> getInvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Integer>> getInvalidWithServiceResponseAsync();
 
     /**
      * Get overflow Int32 value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the int object wrapped in {@link ServiceResponse} if successful.
+     * @return the int object if successful.
      */
     int getOverflowInt32() throws ErrorException, IOException;
 
@@ -114,14 +114,14 @@ public interface Ints {
      *
      * @return the observable to the int object
      */
-    Observable<ServiceResponse<Integer>> getOverflowInt32AsyncWithServiceResponse();
+    Observable<ServiceResponse<Integer>> getOverflowInt32WithServiceResponseAsync();
 
     /**
      * Get underflow Int32 value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the int object wrapped in {@link ServiceResponse} if successful.
+     * @return the int object if successful.
      */
     int getUnderflowInt32() throws ErrorException, IOException;
 
@@ -145,14 +145,14 @@ public interface Ints {
      *
      * @return the observable to the int object
      */
-    Observable<ServiceResponse<Integer>> getUnderflowInt32AsyncWithServiceResponse();
+    Observable<ServiceResponse<Integer>> getUnderflowInt32WithServiceResponseAsync();
 
     /**
      * Get overflow Int64 value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the long object wrapped in {@link ServiceResponse} if successful.
+     * @return the long object if successful.
      */
     long getOverflowInt64() throws ErrorException, IOException;
 
@@ -176,14 +176,14 @@ public interface Ints {
      *
      * @return the observable to the long object
      */
-    Observable<ServiceResponse<Long>> getOverflowInt64AsyncWithServiceResponse();
+    Observable<ServiceResponse<Long>> getOverflowInt64WithServiceResponseAsync();
 
     /**
      * Get underflow Int64 value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the long object wrapped in {@link ServiceResponse} if successful.
+     * @return the long object if successful.
      */
     long getUnderflowInt64() throws ErrorException, IOException;
 
@@ -207,7 +207,7 @@ public interface Ints {
      *
      * @return the observable to the long object
      */
-    Observable<ServiceResponse<Long>> getUnderflowInt64AsyncWithServiceResponse();
+    Observable<ServiceResponse<Long>> getUnderflowInt64WithServiceResponseAsync();
 
     /**
      * Put max int32 value.
@@ -215,7 +215,6 @@ public interface Ints {
      * @param intBody the int value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putMax32(int intBody) throws ErrorException, IOException;
 
@@ -242,7 +241,7 @@ public interface Ints {
      * @param intBody the int value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMax32AsyncWithServiceResponse(int intBody);
+    Observable<ServiceResponse<Void>> putMax32WithServiceResponseAsync(int intBody);
 
     /**
      * Put max int64 value.
@@ -250,7 +249,6 @@ public interface Ints {
      * @param intBody the long value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putMax64(long intBody) throws ErrorException, IOException;
 
@@ -277,7 +275,7 @@ public interface Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMax64AsyncWithServiceResponse(long intBody);
+    Observable<ServiceResponse<Void>> putMax64WithServiceResponseAsync(long intBody);
 
     /**
      * Put min int32 value.
@@ -285,7 +283,6 @@ public interface Ints {
      * @param intBody the int value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putMin32(int intBody) throws ErrorException, IOException;
 
@@ -312,7 +309,7 @@ public interface Ints {
      * @param intBody the int value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMin32AsyncWithServiceResponse(int intBody);
+    Observable<ServiceResponse<Void>> putMin32WithServiceResponseAsync(int intBody);
 
     /**
      * Put min int64 value.
@@ -320,7 +317,6 @@ public interface Ints {
      * @param intBody the long value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putMin64(long intBody) throws ErrorException, IOException;
 
@@ -347,14 +343,14 @@ public interface Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMin64AsyncWithServiceResponse(long intBody);
+    Observable<ServiceResponse<Void>> putMin64WithServiceResponseAsync(long intBody);
 
     /**
      * Get datetime encoded as Unix time value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getUnixTime() throws ErrorException, IOException;
 
@@ -378,7 +374,7 @@ public interface Ints {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getUnixTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getUnixTimeWithServiceResponseAsync();
 
     /**
      * Put datetime encoded as Unix time.
@@ -386,7 +382,6 @@ public interface Ints {
      * @param intBody the long value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putUnixTimeDate(DateTime intBody) throws ErrorException, IOException;
 
@@ -413,14 +408,14 @@ public interface Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putUnixTimeDateAsyncWithServiceResponse(DateTime intBody);
+    Observable<ServiceResponse<Void>> putUnixTimeDateWithServiceResponseAsync(DateTime intBody);
 
     /**
      * Get invalid Unix time value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getInvalidUnixTime() throws ErrorException, IOException;
 
@@ -444,14 +439,14 @@ public interface Ints {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getInvalidUnixTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getInvalidUnixTimeWithServiceResponseAsync();
 
     /**
      * Get null Unix time value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     DateTime getNullUnixTime() throws ErrorException, IOException;
 
@@ -475,6 +470,6 @@ public interface Ints {
      *
      * @return the observable to the DateTime object
      */
-    Observable<ServiceResponse<DateTime>> getNullUnixTimeAsyncWithServiceResponse();
+    Observable<ServiceResponse<DateTime>> getNullUnixTimeWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyinteger/implementation/IntsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyinteger/implementation/IntsImpl.java
@@ -121,8 +121,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the int object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Integer> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public int getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -132,7 +132,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Integer> getNullAsync(final ServiceCallback<Integer> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -140,7 +140,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the int object
      */
-    public Observable<ServiceResponse<Integer>> getNullAsync() {
+    public Observable<Integer> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Integer>, Integer>() {
+            @Override
+            public Integer call(ServiceResponse<Integer> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null Int value.
+     *
+     * @return the observable to the int object
+     */
+    public Observable<ServiceResponse<Integer>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Integer>>>() {
                 @Override
@@ -169,8 +183,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the int object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Integer> getInvalid() throws ErrorException, IOException {
-        return getInvalidAsync().toBlocking().single();
+    public int getInvalid() throws ErrorException, IOException {
+        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -180,7 +194,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Integer> getInvalidAsync(final ServiceCallback<Integer> serviceCallback) {
-        return ServiceCall.create(getInvalidAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -188,7 +202,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the int object
      */
-    public Observable<ServiceResponse<Integer>> getInvalidAsync() {
+    public Observable<Integer> getInvalidAsync() {
+        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Integer>, Integer>() {
+            @Override
+            public Integer call(ServiceResponse<Integer> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid Int value.
+     *
+     * @return the observable to the int object
+     */
+    public Observable<ServiceResponse<Integer>> getInvalidAsyncWithServiceResponse() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Integer>>>() {
                 @Override
@@ -217,8 +245,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the int object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Integer> getOverflowInt32() throws ErrorException, IOException {
-        return getOverflowInt32Async().toBlocking().single();
+    public int getOverflowInt32() throws ErrorException, IOException {
+        return getOverflowInt32AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -228,7 +256,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Integer> getOverflowInt32Async(final ServiceCallback<Integer> serviceCallback) {
-        return ServiceCall.create(getOverflowInt32Async(), serviceCallback);
+        return ServiceCall.create(getOverflowInt32AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -236,7 +264,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the int object
      */
-    public Observable<ServiceResponse<Integer>> getOverflowInt32Async() {
+    public Observable<Integer> getOverflowInt32Async() {
+        return getOverflowInt32AsyncWithServiceResponse().map(new Func1<ServiceResponse<Integer>, Integer>() {
+            @Override
+            public Integer call(ServiceResponse<Integer> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get overflow Int32 value.
+     *
+     * @return the observable to the int object
+     */
+    public Observable<ServiceResponse<Integer>> getOverflowInt32AsyncWithServiceResponse() {
         return service.getOverflowInt32()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Integer>>>() {
                 @Override
@@ -265,8 +307,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the int object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Integer> getUnderflowInt32() throws ErrorException, IOException {
-        return getUnderflowInt32Async().toBlocking().single();
+    public int getUnderflowInt32() throws ErrorException, IOException {
+        return getUnderflowInt32AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -276,7 +318,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Integer> getUnderflowInt32Async(final ServiceCallback<Integer> serviceCallback) {
-        return ServiceCall.create(getUnderflowInt32Async(), serviceCallback);
+        return ServiceCall.create(getUnderflowInt32AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -284,7 +326,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the int object
      */
-    public Observable<ServiceResponse<Integer>> getUnderflowInt32Async() {
+    public Observable<Integer> getUnderflowInt32Async() {
+        return getUnderflowInt32AsyncWithServiceResponse().map(new Func1<ServiceResponse<Integer>, Integer>() {
+            @Override
+            public Integer call(ServiceResponse<Integer> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get underflow Int32 value.
+     *
+     * @return the observable to the int object
+     */
+    public Observable<ServiceResponse<Integer>> getUnderflowInt32AsyncWithServiceResponse() {
         return service.getUnderflowInt32()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Integer>>>() {
                 @Override
@@ -313,8 +369,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the long object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Long> getOverflowInt64() throws ErrorException, IOException {
-        return getOverflowInt64Async().toBlocking().single();
+    public long getOverflowInt64() throws ErrorException, IOException {
+        return getOverflowInt64AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -324,7 +380,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Long> getOverflowInt64Async(final ServiceCallback<Long> serviceCallback) {
-        return ServiceCall.create(getOverflowInt64Async(), serviceCallback);
+        return ServiceCall.create(getOverflowInt64AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -332,7 +388,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the long object
      */
-    public Observable<ServiceResponse<Long>> getOverflowInt64Async() {
+    public Observable<Long> getOverflowInt64Async() {
+        return getOverflowInt64AsyncWithServiceResponse().map(new Func1<ServiceResponse<Long>, Long>() {
+            @Override
+            public Long call(ServiceResponse<Long> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get overflow Int64 value.
+     *
+     * @return the observable to the long object
+     */
+    public Observable<ServiceResponse<Long>> getOverflowInt64AsyncWithServiceResponse() {
         return service.getOverflowInt64()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Long>>>() {
                 @Override
@@ -361,8 +431,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the long object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Long> getUnderflowInt64() throws ErrorException, IOException {
-        return getUnderflowInt64Async().toBlocking().single();
+    public long getUnderflowInt64() throws ErrorException, IOException {
+        return getUnderflowInt64AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -372,7 +442,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Long> getUnderflowInt64Async(final ServiceCallback<Long> serviceCallback) {
-        return ServiceCall.create(getUnderflowInt64Async(), serviceCallback);
+        return ServiceCall.create(getUnderflowInt64AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -380,7 +450,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the long object
      */
-    public Observable<ServiceResponse<Long>> getUnderflowInt64Async() {
+    public Observable<Long> getUnderflowInt64Async() {
+        return getUnderflowInt64AsyncWithServiceResponse().map(new Func1<ServiceResponse<Long>, Long>() {
+            @Override
+            public Long call(ServiceResponse<Long> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get underflow Int64 value.
+     *
+     * @return the observable to the long object
+     */
+    public Observable<ServiceResponse<Long>> getUnderflowInt64AsyncWithServiceResponse() {
         return service.getUnderflowInt64()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Long>>>() {
                 @Override
@@ -410,8 +494,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putMax32(int intBody) throws ErrorException, IOException {
-        return putMax32Async(intBody).toBlocking().single();
+    public void putMax32(int intBody) throws ErrorException, IOException {
+        putMax32AsyncWithServiceResponse(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -422,7 +506,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMax32Async(int intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMax32Async(intBody), serviceCallback);
+        return ServiceCall.create(putMax32AsyncWithServiceResponse(intBody), serviceCallback);
     }
 
     /**
@@ -431,7 +515,22 @@ public final class IntsImpl implements Ints {
      * @param intBody the int value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMax32Async(int intBody) {
+    public Observable<Void> putMax32Async(int intBody) {
+        return putMax32AsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put max int32 value.
+     *
+     * @param intBody the int value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putMax32AsyncWithServiceResponse(int intBody) {
         return service.putMax32(intBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -461,8 +560,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putMax64(long intBody) throws ErrorException, IOException {
-        return putMax64Async(intBody).toBlocking().single();
+    public void putMax64(long intBody) throws ErrorException, IOException {
+        putMax64AsyncWithServiceResponse(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -473,7 +572,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMax64Async(long intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMax64Async(intBody), serviceCallback);
+        return ServiceCall.create(putMax64AsyncWithServiceResponse(intBody), serviceCallback);
     }
 
     /**
@@ -482,7 +581,22 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMax64Async(long intBody) {
+    public Observable<Void> putMax64Async(long intBody) {
+        return putMax64AsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put max int64 value.
+     *
+     * @param intBody the long value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putMax64AsyncWithServiceResponse(long intBody) {
         return service.putMax64(intBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -512,8 +626,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putMin32(int intBody) throws ErrorException, IOException {
-        return putMin32Async(intBody).toBlocking().single();
+    public void putMin32(int intBody) throws ErrorException, IOException {
+        putMin32AsyncWithServiceResponse(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -524,7 +638,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMin32Async(int intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMin32Async(intBody), serviceCallback);
+        return ServiceCall.create(putMin32AsyncWithServiceResponse(intBody), serviceCallback);
     }
 
     /**
@@ -533,7 +647,22 @@ public final class IntsImpl implements Ints {
      * @param intBody the int value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMin32Async(int intBody) {
+    public Observable<Void> putMin32Async(int intBody) {
+        return putMin32AsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put min int32 value.
+     *
+     * @param intBody the int value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putMin32AsyncWithServiceResponse(int intBody) {
         return service.putMin32(intBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -563,8 +692,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putMin64(long intBody) throws ErrorException, IOException {
-        return putMin64Async(intBody).toBlocking().single();
+    public void putMin64(long intBody) throws ErrorException, IOException {
+        putMin64AsyncWithServiceResponse(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -575,7 +704,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMin64Async(long intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMin64Async(intBody), serviceCallback);
+        return ServiceCall.create(putMin64AsyncWithServiceResponse(intBody), serviceCallback);
     }
 
     /**
@@ -584,7 +713,22 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMin64Async(long intBody) {
+    public Observable<Void> putMin64Async(long intBody) {
+        return putMin64AsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put min int64 value.
+     *
+     * @param intBody the long value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putMin64AsyncWithServiceResponse(long intBody) {
         return service.putMin64(intBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -613,8 +757,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getUnixTime() throws ErrorException, IOException {
-        return getUnixTimeAsync().toBlocking().single();
+    public DateTime getUnixTime() throws ErrorException, IOException {
+        return getUnixTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -624,7 +768,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUnixTimeAsync(), serviceCallback);
+        return ServiceCall.create(getUnixTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -632,7 +776,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUnixTimeAsync() {
+    public Observable<DateTime> getUnixTimeAsync() {
+        return getUnixTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get datetime encoded as Unix time value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getUnixTimeAsyncWithServiceResponse() {
         return service.getUnixTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -667,8 +825,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putUnixTimeDate(DateTime intBody) throws ErrorException, IOException {
-        return putUnixTimeDateAsync(intBody).toBlocking().single();
+    public void putUnixTimeDate(DateTime intBody) throws ErrorException, IOException {
+        putUnixTimeDateAsyncWithServiceResponse(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -679,7 +837,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUnixTimeDateAsync(DateTime intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUnixTimeDateAsync(intBody), serviceCallback);
+        return ServiceCall.create(putUnixTimeDateAsyncWithServiceResponse(intBody), serviceCallback);
     }
 
     /**
@@ -688,7 +846,22 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUnixTimeDateAsync(DateTime intBody) {
+    public Observable<Void> putUnixTimeDateAsync(DateTime intBody) {
+        return putUnixTimeDateAsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put datetime encoded as Unix time.
+     *
+     * @param intBody the long value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putUnixTimeDateAsyncWithServiceResponse(DateTime intBody) {
         Long intBodyConverted = intBody.toDateTime(DateTimeZone.UTC).getMillis() / 1000;
         return service.putUnixTimeDate(intBodyConverted)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -718,8 +891,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getInvalidUnixTime() throws ErrorException, IOException {
-        return getInvalidUnixTimeAsync().toBlocking().single();
+    public DateTime getInvalidUnixTime() throws ErrorException, IOException {
+        return getInvalidUnixTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -729,7 +902,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getInvalidUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getInvalidUnixTimeAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidUnixTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -737,7 +910,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getInvalidUnixTimeAsync() {
+    public Observable<DateTime> getInvalidUnixTimeAsync() {
+        return getInvalidUnixTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid Unix time value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getInvalidUnixTimeAsyncWithServiceResponse() {
         return service.getInvalidUnixTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -771,8 +958,8 @@ public final class IntsImpl implements Ints {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<DateTime> getNullUnixTime() throws ErrorException, IOException {
-        return getNullUnixTimeAsync().toBlocking().single();
+    public DateTime getNullUnixTime() throws ErrorException, IOException {
+        return getNullUnixTimeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -782,7 +969,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getNullUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getNullUnixTimeAsync(), serviceCallback);
+        return ServiceCall.create(getNullUnixTimeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -790,7 +977,21 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getNullUnixTimeAsync() {
+    public Observable<DateTime> getNullUnixTimeAsync() {
+        return getNullUnixTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+            @Override
+            public DateTime call(ServiceResponse<DateTime> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null Unix time value.
+     *
+     * @return the observable to the DateTime object
+     */
+    public Observable<ServiceResponse<DateTime>> getNullUnixTimeAsyncWithServiceResponse() {
         return service.getNullUnixTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyinteger/implementation/IntsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodyinteger/implementation/IntsImpl.java
@@ -119,10 +119,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the int object wrapped in {@link ServiceResponse} if successful.
+     * @return the int object if successful.
      */
     public int getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -132,7 +132,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Integer> getNullAsync(final ServiceCallback<Integer> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -141,12 +141,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the int object
      */
     public Observable<Integer> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Integer>, Integer>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Integer>, Integer>() {
             @Override
             public Integer call(ServiceResponse<Integer> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -154,7 +154,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the int object
      */
-    public Observable<ServiceResponse<Integer>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Integer>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Integer>>>() {
                 @Override
@@ -181,10 +181,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the int object wrapped in {@link ServiceResponse} if successful.
+     * @return the int object if successful.
      */
     public int getInvalid() throws ErrorException, IOException {
-        return getInvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -194,7 +194,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Integer> getInvalidAsync(final ServiceCallback<Integer> serviceCallback) {
-        return ServiceCall.create(getInvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -203,12 +203,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the int object
      */
     public Observable<Integer> getInvalidAsync() {
-        return getInvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Integer>, Integer>() {
+        return getInvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Integer>, Integer>() {
             @Override
             public Integer call(ServiceResponse<Integer> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -216,7 +216,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the int object
      */
-    public Observable<ServiceResponse<Integer>> getInvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Integer>> getInvalidWithServiceResponseAsync() {
         return service.getInvalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Integer>>>() {
                 @Override
@@ -243,10 +243,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the int object wrapped in {@link ServiceResponse} if successful.
+     * @return the int object if successful.
      */
     public int getOverflowInt32() throws ErrorException, IOException {
-        return getOverflowInt32AsyncWithServiceResponse().toBlocking().single().getBody();
+        return getOverflowInt32WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -256,7 +256,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Integer> getOverflowInt32Async(final ServiceCallback<Integer> serviceCallback) {
-        return ServiceCall.create(getOverflowInt32AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getOverflowInt32WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -265,12 +265,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the int object
      */
     public Observable<Integer> getOverflowInt32Async() {
-        return getOverflowInt32AsyncWithServiceResponse().map(new Func1<ServiceResponse<Integer>, Integer>() {
+        return getOverflowInt32WithServiceResponseAsync().map(new Func1<ServiceResponse<Integer>, Integer>() {
             @Override
             public Integer call(ServiceResponse<Integer> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -278,7 +278,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the int object
      */
-    public Observable<ServiceResponse<Integer>> getOverflowInt32AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Integer>> getOverflowInt32WithServiceResponseAsync() {
         return service.getOverflowInt32()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Integer>>>() {
                 @Override
@@ -305,10 +305,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the int object wrapped in {@link ServiceResponse} if successful.
+     * @return the int object if successful.
      */
     public int getUnderflowInt32() throws ErrorException, IOException {
-        return getUnderflowInt32AsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUnderflowInt32WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -318,7 +318,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Integer> getUnderflowInt32Async(final ServiceCallback<Integer> serviceCallback) {
-        return ServiceCall.create(getUnderflowInt32AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUnderflowInt32WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -327,12 +327,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the int object
      */
     public Observable<Integer> getUnderflowInt32Async() {
-        return getUnderflowInt32AsyncWithServiceResponse().map(new Func1<ServiceResponse<Integer>, Integer>() {
+        return getUnderflowInt32WithServiceResponseAsync().map(new Func1<ServiceResponse<Integer>, Integer>() {
             @Override
             public Integer call(ServiceResponse<Integer> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -340,7 +340,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the int object
      */
-    public Observable<ServiceResponse<Integer>> getUnderflowInt32AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Integer>> getUnderflowInt32WithServiceResponseAsync() {
         return service.getUnderflowInt32()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Integer>>>() {
                 @Override
@@ -367,10 +367,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the long object wrapped in {@link ServiceResponse} if successful.
+     * @return the long object if successful.
      */
     public long getOverflowInt64() throws ErrorException, IOException {
-        return getOverflowInt64AsyncWithServiceResponse().toBlocking().single().getBody();
+        return getOverflowInt64WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -380,7 +380,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Long> getOverflowInt64Async(final ServiceCallback<Long> serviceCallback) {
-        return ServiceCall.create(getOverflowInt64AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getOverflowInt64WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -389,12 +389,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the long object
      */
     public Observable<Long> getOverflowInt64Async() {
-        return getOverflowInt64AsyncWithServiceResponse().map(new Func1<ServiceResponse<Long>, Long>() {
+        return getOverflowInt64WithServiceResponseAsync().map(new Func1<ServiceResponse<Long>, Long>() {
             @Override
             public Long call(ServiceResponse<Long> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -402,7 +402,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the long object
      */
-    public Observable<ServiceResponse<Long>> getOverflowInt64AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Long>> getOverflowInt64WithServiceResponseAsync() {
         return service.getOverflowInt64()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Long>>>() {
                 @Override
@@ -429,10 +429,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the long object wrapped in {@link ServiceResponse} if successful.
+     * @return the long object if successful.
      */
     public long getUnderflowInt64() throws ErrorException, IOException {
-        return getUnderflowInt64AsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUnderflowInt64WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -442,7 +442,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Long> getUnderflowInt64Async(final ServiceCallback<Long> serviceCallback) {
-        return ServiceCall.create(getUnderflowInt64AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUnderflowInt64WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -451,12 +451,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the long object
      */
     public Observable<Long> getUnderflowInt64Async() {
-        return getUnderflowInt64AsyncWithServiceResponse().map(new Func1<ServiceResponse<Long>, Long>() {
+        return getUnderflowInt64WithServiceResponseAsync().map(new Func1<ServiceResponse<Long>, Long>() {
             @Override
             public Long call(ServiceResponse<Long> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -464,7 +464,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the long object
      */
-    public Observable<ServiceResponse<Long>> getUnderflowInt64AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Long>> getUnderflowInt64WithServiceResponseAsync() {
         return service.getUnderflowInt64()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Long>>>() {
                 @Override
@@ -492,10 +492,9 @@ public final class IntsImpl implements Ints {
      * @param intBody the int value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putMax32(int intBody) throws ErrorException, IOException {
-        putMax32AsyncWithServiceResponse(intBody).toBlocking().single().getBody();
+        putMax32WithServiceResponseAsync(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -506,7 +505,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMax32Async(int intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMax32AsyncWithServiceResponse(intBody), serviceCallback);
+        return ServiceCall.create(putMax32WithServiceResponseAsync(intBody), serviceCallback);
     }
 
     /**
@@ -516,12 +515,12 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putMax32Async(int intBody) {
-        return putMax32AsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putMax32WithServiceResponseAsync(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -530,7 +529,7 @@ public final class IntsImpl implements Ints {
      * @param intBody the int value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMax32AsyncWithServiceResponse(int intBody) {
+    public Observable<ServiceResponse<Void>> putMax32WithServiceResponseAsync(int intBody) {
         return service.putMax32(intBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -558,10 +557,9 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putMax64(long intBody) throws ErrorException, IOException {
-        putMax64AsyncWithServiceResponse(intBody).toBlocking().single().getBody();
+        putMax64WithServiceResponseAsync(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -572,7 +570,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMax64Async(long intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMax64AsyncWithServiceResponse(intBody), serviceCallback);
+        return ServiceCall.create(putMax64WithServiceResponseAsync(intBody), serviceCallback);
     }
 
     /**
@@ -582,12 +580,12 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putMax64Async(long intBody) {
-        return putMax64AsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putMax64WithServiceResponseAsync(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -596,7 +594,7 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMax64AsyncWithServiceResponse(long intBody) {
+    public Observable<ServiceResponse<Void>> putMax64WithServiceResponseAsync(long intBody) {
         return service.putMax64(intBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -624,10 +622,9 @@ public final class IntsImpl implements Ints {
      * @param intBody the int value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putMin32(int intBody) throws ErrorException, IOException {
-        putMin32AsyncWithServiceResponse(intBody).toBlocking().single().getBody();
+        putMin32WithServiceResponseAsync(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -638,7 +635,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMin32Async(int intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMin32AsyncWithServiceResponse(intBody), serviceCallback);
+        return ServiceCall.create(putMin32WithServiceResponseAsync(intBody), serviceCallback);
     }
 
     /**
@@ -648,12 +645,12 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putMin32Async(int intBody) {
-        return putMin32AsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putMin32WithServiceResponseAsync(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -662,7 +659,7 @@ public final class IntsImpl implements Ints {
      * @param intBody the int value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMin32AsyncWithServiceResponse(int intBody) {
+    public Observable<ServiceResponse<Void>> putMin32WithServiceResponseAsync(int intBody) {
         return service.putMin32(intBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -690,10 +687,9 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putMin64(long intBody) throws ErrorException, IOException {
-        putMin64AsyncWithServiceResponse(intBody).toBlocking().single().getBody();
+        putMin64WithServiceResponseAsync(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -704,7 +700,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMin64Async(long intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMin64AsyncWithServiceResponse(intBody), serviceCallback);
+        return ServiceCall.create(putMin64WithServiceResponseAsync(intBody), serviceCallback);
     }
 
     /**
@@ -714,12 +710,12 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putMin64Async(long intBody) {
-        return putMin64AsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putMin64WithServiceResponseAsync(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -728,7 +724,7 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMin64AsyncWithServiceResponse(long intBody) {
+    public Observable<ServiceResponse<Void>> putMin64WithServiceResponseAsync(long intBody) {
         return service.putMin64(intBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -755,10 +751,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getUnixTime() throws ErrorException, IOException {
-        return getUnixTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getUnixTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -768,7 +764,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getUnixTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getUnixTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -777,12 +773,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getUnixTimeAsync() {
-        return getUnixTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getUnixTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -790,7 +786,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getUnixTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getUnixTimeWithServiceResponseAsync() {
         return service.getUnixTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -823,10 +819,9 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putUnixTimeDate(DateTime intBody) throws ErrorException, IOException {
-        putUnixTimeDateAsyncWithServiceResponse(intBody).toBlocking().single().getBody();
+        putUnixTimeDateWithServiceResponseAsync(intBody).toBlocking().single().getBody();
     }
 
     /**
@@ -837,7 +832,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putUnixTimeDateAsync(DateTime intBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putUnixTimeDateAsyncWithServiceResponse(intBody), serviceCallback);
+        return ServiceCall.create(putUnixTimeDateWithServiceResponseAsync(intBody), serviceCallback);
     }
 
     /**
@@ -847,12 +842,12 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putUnixTimeDateAsync(DateTime intBody) {
-        return putUnixTimeDateAsyncWithServiceResponse(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putUnixTimeDateWithServiceResponseAsync(intBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -861,7 +856,7 @@ public final class IntsImpl implements Ints {
      * @param intBody the long value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putUnixTimeDateAsyncWithServiceResponse(DateTime intBody) {
+    public Observable<ServiceResponse<Void>> putUnixTimeDateWithServiceResponseAsync(DateTime intBody) {
         Long intBodyConverted = intBody.toDateTime(DateTimeZone.UTC).getMillis() / 1000;
         return service.putUnixTimeDate(intBodyConverted)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -889,10 +884,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getInvalidUnixTime() throws ErrorException, IOException {
-        return getInvalidUnixTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidUnixTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -902,7 +897,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getInvalidUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getInvalidUnixTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidUnixTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -911,12 +906,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getInvalidUnixTimeAsync() {
-        return getInvalidUnixTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getInvalidUnixTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -924,7 +919,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getInvalidUnixTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getInvalidUnixTimeWithServiceResponseAsync() {
         return service.getInvalidUnixTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override
@@ -956,10 +951,10 @@ public final class IntsImpl implements Ints {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the DateTime object wrapped in {@link ServiceResponse} if successful.
+     * @return the DateTime object if successful.
      */
     public DateTime getNullUnixTime() throws ErrorException, IOException {
-        return getNullUnixTimeAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullUnixTimeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -969,7 +964,7 @@ public final class IntsImpl implements Ints {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<DateTime> getNullUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
-        return ServiceCall.create(getNullUnixTimeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullUnixTimeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -978,12 +973,12 @@ public final class IntsImpl implements Ints {
      * @return the observable to the DateTime object
      */
     public Observable<DateTime> getNullUnixTimeAsync() {
-        return getNullUnixTimeAsyncWithServiceResponse().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
+        return getNullUnixTimeWithServiceResponseAsync().map(new Func1<ServiceResponse<DateTime>, DateTime>() {
             @Override
             public DateTime call(ServiceResponse<DateTime> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -991,7 +986,7 @@ public final class IntsImpl implements Ints {
      *
      * @return the observable to the DateTime object
      */
-    public Observable<ServiceResponse<DateTime>> getNullUnixTimeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<DateTime>> getNullUnixTimeWithServiceResponseAsync() {
         return service.getNullUnixTime()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<DateTime>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodynumber/Numbers.java
@@ -28,7 +28,7 @@ public interface Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getNull() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getNullWithServiceResponseAsync();
 
     /**
      * Get invalid float Number value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getInvalidFloat() throws ErrorException, IOException;
 
@@ -83,14 +83,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getInvalidFloatAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getInvalidFloatWithServiceResponseAsync();
 
     /**
      * Get invalid double Number value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getInvalidDouble() throws ErrorException, IOException;
 
@@ -114,14 +114,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getInvalidDoubleAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getInvalidDoubleWithServiceResponseAsync();
 
     /**
      * Get invalid decimal Number value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     BigDecimal getInvalidDecimal() throws ErrorException, IOException;
 
@@ -145,7 +145,7 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getInvalidDecimalAsyncWithServiceResponse();
+    Observable<ServiceResponse<BigDecimal>> getInvalidDecimalWithServiceResponseAsync();
 
     /**
      * Put big float value 3.402823e+20.
@@ -153,7 +153,6 @@ public interface Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBigFloat(double numberBody) throws ErrorException, IOException;
 
@@ -180,14 +179,14 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigFloatAsyncWithServiceResponse(double numberBody);
+    Observable<ServiceResponse<Void>> putBigFloatWithServiceResponseAsync(double numberBody);
 
     /**
      * Get big float value 3.402823e+20.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getBigFloat() throws ErrorException, IOException;
 
@@ -211,7 +210,7 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getBigFloatAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getBigFloatWithServiceResponseAsync();
 
     /**
      * Put big double value 2.5976931e+101.
@@ -219,7 +218,6 @@ public interface Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBigDouble(double numberBody) throws ErrorException, IOException;
 
@@ -246,14 +244,14 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDoubleAsyncWithServiceResponse(double numberBody);
+    Observable<ServiceResponse<Void>> putBigDoubleWithServiceResponseAsync(double numberBody);
 
     /**
      * Get big double value 2.5976931e+101.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getBigDouble() throws ErrorException, IOException;
 
@@ -277,7 +275,7 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getBigDoubleAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getBigDoubleWithServiceResponseAsync();
 
     /**
      * Put big double value 99999999.99.
@@ -285,7 +283,6 @@ public interface Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBigDoublePositiveDecimal(double numberBody) throws ErrorException, IOException;
 
@@ -312,14 +309,14 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDoublePositiveDecimalAsyncWithServiceResponse(double numberBody);
+    Observable<ServiceResponse<Void>> putBigDoublePositiveDecimalWithServiceResponseAsync(double numberBody);
 
     /**
      * Get big double value 99999999.99.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getBigDoublePositiveDecimal() throws ErrorException, IOException;
 
@@ -343,7 +340,7 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getBigDoublePositiveDecimalAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getBigDoublePositiveDecimalWithServiceResponseAsync();
 
     /**
      * Put big double value -99999999.99.
@@ -351,7 +348,6 @@ public interface Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBigDoubleNegativeDecimal(double numberBody) throws ErrorException, IOException;
 
@@ -378,14 +374,14 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDoubleNegativeDecimalAsyncWithServiceResponse(double numberBody);
+    Observable<ServiceResponse<Void>> putBigDoubleNegativeDecimalWithServiceResponseAsync(double numberBody);
 
     /**
      * Get big double value -99999999.99.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getBigDoubleNegativeDecimal() throws ErrorException, IOException;
 
@@ -409,7 +405,7 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getBigDoubleNegativeDecimalAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getBigDoubleNegativeDecimalWithServiceResponseAsync();
 
     /**
      * Put big decimal value 2.5976931e+101.
@@ -418,7 +414,6 @@ public interface Numbers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBigDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -445,14 +440,14 @@ public interface Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDecimalAsyncWithServiceResponse(BigDecimal numberBody);
+    Observable<ServiceResponse<Void>> putBigDecimalWithServiceResponseAsync(BigDecimal numberBody);
 
     /**
      * Get big decimal value 2.5976931e+101.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     BigDecimal getBigDecimal() throws ErrorException, IOException;
 
@@ -476,7 +471,7 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getBigDecimalAsyncWithServiceResponse();
+    Observable<ServiceResponse<BigDecimal>> getBigDecimalWithServiceResponseAsync();
 
     /**
      * Put big decimal value 99999999.99.
@@ -485,7 +480,6 @@ public interface Numbers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBigDecimalPositiveDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -512,14 +506,14 @@ public interface Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDecimalPositiveDecimalAsyncWithServiceResponse(BigDecimal numberBody);
+    Observable<ServiceResponse<Void>> putBigDecimalPositiveDecimalWithServiceResponseAsync(BigDecimal numberBody);
 
     /**
      * Get big decimal value 99999999.99.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     BigDecimal getBigDecimalPositiveDecimal() throws ErrorException, IOException;
 
@@ -543,7 +537,7 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getBigDecimalPositiveDecimalAsyncWithServiceResponse();
+    Observable<ServiceResponse<BigDecimal>> getBigDecimalPositiveDecimalWithServiceResponseAsync();
 
     /**
      * Put big decimal value -99999999.99.
@@ -552,7 +546,6 @@ public interface Numbers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBigDecimalNegativeDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -579,14 +572,14 @@ public interface Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDecimalNegativeDecimalAsyncWithServiceResponse(BigDecimal numberBody);
+    Observable<ServiceResponse<Void>> putBigDecimalNegativeDecimalWithServiceResponseAsync(BigDecimal numberBody);
 
     /**
      * Get big decimal value -99999999.99.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     BigDecimal getBigDecimalNegativeDecimal() throws ErrorException, IOException;
 
@@ -610,7 +603,7 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getBigDecimalNegativeDecimalAsyncWithServiceResponse();
+    Observable<ServiceResponse<BigDecimal>> getBigDecimalNegativeDecimalWithServiceResponseAsync();
 
     /**
      * Put small float value 3.402823e-20.
@@ -618,7 +611,6 @@ public interface Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putSmallFloat(double numberBody) throws ErrorException, IOException;
 
@@ -645,14 +637,14 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putSmallFloatAsyncWithServiceResponse(double numberBody);
+    Observable<ServiceResponse<Void>> putSmallFloatWithServiceResponseAsync(double numberBody);
 
     /**
      * Get big double value 3.402823e-20.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getSmallFloat() throws ErrorException, IOException;
 
@@ -676,7 +668,7 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getSmallFloatAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getSmallFloatWithServiceResponseAsync();
 
     /**
      * Put small double value 2.5976931e-101.
@@ -684,7 +676,6 @@ public interface Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putSmallDouble(double numberBody) throws ErrorException, IOException;
 
@@ -711,14 +702,14 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putSmallDoubleAsyncWithServiceResponse(double numberBody);
+    Observable<ServiceResponse<Void>> putSmallDoubleWithServiceResponseAsync(double numberBody);
 
     /**
      * Get big double value 2.5976931e-101.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     double getSmallDouble() throws ErrorException, IOException;
 
@@ -742,7 +733,7 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getSmallDoubleAsyncWithServiceResponse();
+    Observable<ServiceResponse<Double>> getSmallDoubleWithServiceResponseAsync();
 
     /**
      * Put small decimal value 2.5976931e-101.
@@ -751,7 +742,6 @@ public interface Numbers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putSmallDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -778,14 +768,14 @@ public interface Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putSmallDecimalAsyncWithServiceResponse(BigDecimal numberBody);
+    Observable<ServiceResponse<Void>> putSmallDecimalWithServiceResponseAsync(BigDecimal numberBody);
 
     /**
      * Get small decimal value 2.5976931e-101.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     BigDecimal getSmallDecimal() throws ErrorException, IOException;
 
@@ -809,6 +799,6 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getSmallDecimalAsyncWithServiceResponse();
+    Observable<ServiceResponse<BigDecimal>> getSmallDecimalWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodynumber/Numbers.java
@@ -30,7 +30,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getNull() throws ErrorException, IOException;
+    double getNull() throws ErrorException, IOException;
 
     /**
      * Get null Number value.
@@ -45,7 +45,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getNullAsync();
+    Observable<Double> getNullAsync();
+
+    /**
+     * Get null Number value.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getNullAsyncWithServiceResponse();
 
     /**
      * Get invalid float Number value.
@@ -54,7 +61,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getInvalidFloat() throws ErrorException, IOException;
+    double getInvalidFloat() throws ErrorException, IOException;
 
     /**
      * Get invalid float Number value.
@@ -69,7 +76,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getInvalidFloatAsync();
+    Observable<Double> getInvalidFloatAsync();
+
+    /**
+     * Get invalid float Number value.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getInvalidFloatAsyncWithServiceResponse();
 
     /**
      * Get invalid double Number value.
@@ -78,7 +92,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getInvalidDouble() throws ErrorException, IOException;
+    double getInvalidDouble() throws ErrorException, IOException;
 
     /**
      * Get invalid double Number value.
@@ -93,7 +107,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getInvalidDoubleAsync();
+    Observable<Double> getInvalidDoubleAsync();
+
+    /**
+     * Get invalid double Number value.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getInvalidDoubleAsyncWithServiceResponse();
 
     /**
      * Get invalid decimal Number value.
@@ -102,7 +123,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<BigDecimal> getInvalidDecimal() throws ErrorException, IOException;
+    BigDecimal getInvalidDecimal() throws ErrorException, IOException;
 
     /**
      * Get invalid decimal Number value.
@@ -117,7 +138,14 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getInvalidDecimalAsync();
+    Observable<BigDecimal> getInvalidDecimalAsync();
+
+    /**
+     * Get invalid decimal Number value.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    Observable<ServiceResponse<BigDecimal>> getInvalidDecimalAsyncWithServiceResponse();
 
     /**
      * Put big float value 3.402823e+20.
@@ -127,7 +155,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBigFloat(double numberBody) throws ErrorException, IOException;
+    void putBigFloat(double numberBody) throws ErrorException, IOException;
 
     /**
      * Put big float value 3.402823e+20.
@@ -144,7 +172,15 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigFloatAsync(double numberBody);
+    Observable<Void> putBigFloatAsync(double numberBody);
+
+    /**
+     * Put big float value 3.402823e+20.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBigFloatAsyncWithServiceResponse(double numberBody);
 
     /**
      * Get big float value 3.402823e+20.
@@ -153,7 +189,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getBigFloat() throws ErrorException, IOException;
+    double getBigFloat() throws ErrorException, IOException;
 
     /**
      * Get big float value 3.402823e+20.
@@ -168,7 +204,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getBigFloatAsync();
+    Observable<Double> getBigFloatAsync();
+
+    /**
+     * Get big float value 3.402823e+20.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getBigFloatAsyncWithServiceResponse();
 
     /**
      * Put big double value 2.5976931e+101.
@@ -178,7 +221,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBigDouble(double numberBody) throws ErrorException, IOException;
+    void putBigDouble(double numberBody) throws ErrorException, IOException;
 
     /**
      * Put big double value 2.5976931e+101.
@@ -195,7 +238,15 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDoubleAsync(double numberBody);
+    Observable<Void> putBigDoubleAsync(double numberBody);
+
+    /**
+     * Put big double value 2.5976931e+101.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBigDoubleAsyncWithServiceResponse(double numberBody);
 
     /**
      * Get big double value 2.5976931e+101.
@@ -204,7 +255,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getBigDouble() throws ErrorException, IOException;
+    double getBigDouble() throws ErrorException, IOException;
 
     /**
      * Get big double value 2.5976931e+101.
@@ -219,7 +270,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getBigDoubleAsync();
+    Observable<Double> getBigDoubleAsync();
+
+    /**
+     * Get big double value 2.5976931e+101.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getBigDoubleAsyncWithServiceResponse();
 
     /**
      * Put big double value 99999999.99.
@@ -229,7 +287,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBigDoublePositiveDecimal(double numberBody) throws ErrorException, IOException;
+    void putBigDoublePositiveDecimal(double numberBody) throws ErrorException, IOException;
 
     /**
      * Put big double value 99999999.99.
@@ -246,7 +304,15 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDoublePositiveDecimalAsync(double numberBody);
+    Observable<Void> putBigDoublePositiveDecimalAsync(double numberBody);
+
+    /**
+     * Put big double value 99999999.99.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBigDoublePositiveDecimalAsyncWithServiceResponse(double numberBody);
 
     /**
      * Get big double value 99999999.99.
@@ -255,7 +321,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getBigDoublePositiveDecimal() throws ErrorException, IOException;
+    double getBigDoublePositiveDecimal() throws ErrorException, IOException;
 
     /**
      * Get big double value 99999999.99.
@@ -270,7 +336,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getBigDoublePositiveDecimalAsync();
+    Observable<Double> getBigDoublePositiveDecimalAsync();
+
+    /**
+     * Get big double value 99999999.99.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getBigDoublePositiveDecimalAsyncWithServiceResponse();
 
     /**
      * Put big double value -99999999.99.
@@ -280,7 +353,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBigDoubleNegativeDecimal(double numberBody) throws ErrorException, IOException;
+    void putBigDoubleNegativeDecimal(double numberBody) throws ErrorException, IOException;
 
     /**
      * Put big double value -99999999.99.
@@ -297,7 +370,15 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDoubleNegativeDecimalAsync(double numberBody);
+    Observable<Void> putBigDoubleNegativeDecimalAsync(double numberBody);
+
+    /**
+     * Put big double value -99999999.99.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBigDoubleNegativeDecimalAsyncWithServiceResponse(double numberBody);
 
     /**
      * Get big double value -99999999.99.
@@ -306,7 +387,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getBigDoubleNegativeDecimal() throws ErrorException, IOException;
+    double getBigDoubleNegativeDecimal() throws ErrorException, IOException;
 
     /**
      * Get big double value -99999999.99.
@@ -321,7 +402,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getBigDoubleNegativeDecimalAsync();
+    Observable<Double> getBigDoubleNegativeDecimalAsync();
+
+    /**
+     * Get big double value -99999999.99.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getBigDoubleNegativeDecimalAsyncWithServiceResponse();
 
     /**
      * Put big decimal value 2.5976931e+101.
@@ -332,7 +420,7 @@ public interface Numbers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBigDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putBigDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put big decimal value 2.5976931e+101.
@@ -349,7 +437,15 @@ public interface Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDecimalAsync(BigDecimal numberBody);
+    Observable<Void> putBigDecimalAsync(BigDecimal numberBody);
+
+    /**
+     * Put big decimal value 2.5976931e+101.
+     *
+     * @param numberBody the BigDecimal value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBigDecimalAsyncWithServiceResponse(BigDecimal numberBody);
 
     /**
      * Get big decimal value 2.5976931e+101.
@@ -358,7 +454,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<BigDecimal> getBigDecimal() throws ErrorException, IOException;
+    BigDecimal getBigDecimal() throws ErrorException, IOException;
 
     /**
      * Get big decimal value 2.5976931e+101.
@@ -373,7 +469,14 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getBigDecimalAsync();
+    Observable<BigDecimal> getBigDecimalAsync();
+
+    /**
+     * Get big decimal value 2.5976931e+101.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    Observable<ServiceResponse<BigDecimal>> getBigDecimalAsyncWithServiceResponse();
 
     /**
      * Put big decimal value 99999999.99.
@@ -384,7 +487,7 @@ public interface Numbers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBigDecimalPositiveDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putBigDecimalPositiveDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put big decimal value 99999999.99.
@@ -401,7 +504,15 @@ public interface Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody);
+    Observable<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody);
+
+    /**
+     * Put big decimal value 99999999.99.
+     *
+     * @param numberBody the BigDecimal value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBigDecimalPositiveDecimalAsyncWithServiceResponse(BigDecimal numberBody);
 
     /**
      * Get big decimal value 99999999.99.
@@ -410,7 +521,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<BigDecimal> getBigDecimalPositiveDecimal() throws ErrorException, IOException;
+    BigDecimal getBigDecimalPositiveDecimal() throws ErrorException, IOException;
 
     /**
      * Get big decimal value 99999999.99.
@@ -425,7 +536,14 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getBigDecimalPositiveDecimalAsync();
+    Observable<BigDecimal> getBigDecimalPositiveDecimalAsync();
+
+    /**
+     * Get big decimal value 99999999.99.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    Observable<ServiceResponse<BigDecimal>> getBigDecimalPositiveDecimalAsyncWithServiceResponse();
 
     /**
      * Put big decimal value -99999999.99.
@@ -436,7 +554,7 @@ public interface Numbers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBigDecimalNegativeDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putBigDecimalNegativeDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put big decimal value -99999999.99.
@@ -453,7 +571,15 @@ public interface Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody);
+    Observable<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody);
+
+    /**
+     * Put big decimal value -99999999.99.
+     *
+     * @param numberBody the BigDecimal value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBigDecimalNegativeDecimalAsyncWithServiceResponse(BigDecimal numberBody);
 
     /**
      * Get big decimal value -99999999.99.
@@ -462,7 +588,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<BigDecimal> getBigDecimalNegativeDecimal() throws ErrorException, IOException;
+    BigDecimal getBigDecimalNegativeDecimal() throws ErrorException, IOException;
 
     /**
      * Get big decimal value -99999999.99.
@@ -477,7 +603,14 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getBigDecimalNegativeDecimalAsync();
+    Observable<BigDecimal> getBigDecimalNegativeDecimalAsync();
+
+    /**
+     * Get big decimal value -99999999.99.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    Observable<ServiceResponse<BigDecimal>> getBigDecimalNegativeDecimalAsyncWithServiceResponse();
 
     /**
      * Put small float value 3.402823e-20.
@@ -487,7 +620,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putSmallFloat(double numberBody) throws ErrorException, IOException;
+    void putSmallFloat(double numberBody) throws ErrorException, IOException;
 
     /**
      * Put small float value 3.402823e-20.
@@ -504,7 +637,15 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putSmallFloatAsync(double numberBody);
+    Observable<Void> putSmallFloatAsync(double numberBody);
+
+    /**
+     * Put small float value 3.402823e-20.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putSmallFloatAsyncWithServiceResponse(double numberBody);
 
     /**
      * Get big double value 3.402823e-20.
@@ -513,7 +654,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getSmallFloat() throws ErrorException, IOException;
+    double getSmallFloat() throws ErrorException, IOException;
 
     /**
      * Get big double value 3.402823e-20.
@@ -528,7 +669,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getSmallFloatAsync();
+    Observable<Double> getSmallFloatAsync();
+
+    /**
+     * Get big double value 3.402823e-20.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getSmallFloatAsyncWithServiceResponse();
 
     /**
      * Put small double value 2.5976931e-101.
@@ -538,7 +686,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putSmallDouble(double numberBody) throws ErrorException, IOException;
+    void putSmallDouble(double numberBody) throws ErrorException, IOException;
 
     /**
      * Put small double value 2.5976931e-101.
@@ -555,7 +703,15 @@ public interface Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putSmallDoubleAsync(double numberBody);
+    Observable<Void> putSmallDoubleAsync(double numberBody);
+
+    /**
+     * Put small double value 2.5976931e-101.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putSmallDoubleAsyncWithServiceResponse(double numberBody);
 
     /**
      * Get big double value 2.5976931e-101.
@@ -564,7 +720,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Double> getSmallDouble() throws ErrorException, IOException;
+    double getSmallDouble() throws ErrorException, IOException;
 
     /**
      * Get big double value 2.5976931e-101.
@@ -579,7 +735,14 @@ public interface Numbers {
      *
      * @return the observable to the double object
      */
-    Observable<ServiceResponse<Double>> getSmallDoubleAsync();
+    Observable<Double> getSmallDoubleAsync();
+
+    /**
+     * Get big double value 2.5976931e-101.
+     *
+     * @return the observable to the double object
+     */
+    Observable<ServiceResponse<Double>> getSmallDoubleAsyncWithServiceResponse();
 
     /**
      * Put small decimal value 2.5976931e-101.
@@ -590,7 +753,7 @@ public interface Numbers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putSmallDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putSmallDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put small decimal value 2.5976931e-101.
@@ -607,7 +770,15 @@ public interface Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putSmallDecimalAsync(BigDecimal numberBody);
+    Observable<Void> putSmallDecimalAsync(BigDecimal numberBody);
+
+    /**
+     * Put small decimal value 2.5976931e-101.
+     *
+     * @param numberBody the BigDecimal value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putSmallDecimalAsyncWithServiceResponse(BigDecimal numberBody);
 
     /**
      * Get small decimal value 2.5976931e-101.
@@ -616,7 +787,7 @@ public interface Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<BigDecimal> getSmallDecimal() throws ErrorException, IOException;
+    BigDecimal getSmallDecimal() throws ErrorException, IOException;
 
     /**
      * Get small decimal value 2.5976931e-101.
@@ -631,6 +802,13 @@ public interface Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    Observable<ServiceResponse<BigDecimal>> getSmallDecimalAsync();
+    Observable<BigDecimal> getSmallDecimalAsync();
+
+    /**
+     * Get small decimal value 2.5976931e-101.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    Observable<ServiceResponse<BigDecimal>> getSmallDecimalAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodynumber/implementation/NumbersImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodynumber/implementation/NumbersImpl.java
@@ -160,8 +160,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public double getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -171,7 +171,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getNullAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -179,7 +179,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getNullAsync() {
+    public Observable<Double> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null Number value.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -208,8 +222,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getInvalidFloat() throws ErrorException, IOException {
-        return getInvalidFloatAsync().toBlocking().single();
+    public double getInvalidFloat() throws ErrorException, IOException {
+        return getInvalidFloatAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -219,7 +233,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getInvalidFloatAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getInvalidFloatAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidFloatAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -227,7 +241,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getInvalidFloatAsync() {
+    public Observable<Double> getInvalidFloatAsync() {
+        return getInvalidFloatAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid float Number value.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getInvalidFloatAsyncWithServiceResponse() {
         return service.getInvalidFloat()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -256,8 +284,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getInvalidDouble() throws ErrorException, IOException {
-        return getInvalidDoubleAsync().toBlocking().single();
+    public double getInvalidDouble() throws ErrorException, IOException {
+        return getInvalidDoubleAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -267,7 +295,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getInvalidDoubleAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getInvalidDoubleAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidDoubleAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -275,7 +303,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getInvalidDoubleAsync() {
+    public Observable<Double> getInvalidDoubleAsync() {
+        return getInvalidDoubleAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid double Number value.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getInvalidDoubleAsyncWithServiceResponse() {
         return service.getInvalidDouble()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -304,8 +346,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<BigDecimal> getInvalidDecimal() throws ErrorException, IOException {
-        return getInvalidDecimalAsync().toBlocking().single();
+    public BigDecimal getInvalidDecimal() throws ErrorException, IOException {
+        return getInvalidDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -315,7 +357,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getInvalidDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getInvalidDecimalAsync(), serviceCallback);
+        return ServiceCall.create(getInvalidDecimalAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -323,7 +365,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getInvalidDecimalAsync() {
+    public Observable<BigDecimal> getInvalidDecimalAsync() {
+        return getInvalidDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+            @Override
+            public BigDecimal call(ServiceResponse<BigDecimal> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get invalid decimal Number value.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    public Observable<ServiceResponse<BigDecimal>> getInvalidDecimalAsyncWithServiceResponse() {
         return service.getInvalidDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override
@@ -353,8 +409,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBigFloat(double numberBody) throws ErrorException, IOException {
-        return putBigFloatAsync(numberBody).toBlocking().single();
+    public void putBigFloat(double numberBody) throws ErrorException, IOException {
+        putBigFloatAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -365,7 +421,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigFloatAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigFloatAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putBigFloatAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -374,7 +430,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigFloatAsync(double numberBody) {
+    public Observable<Void> putBigFloatAsync(double numberBody) {
+        return putBigFloatAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put big float value 3.402823e+20.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBigFloatAsyncWithServiceResponse(double numberBody) {
         return service.putBigFloat(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -403,8 +474,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getBigFloat() throws ErrorException, IOException {
-        return getBigFloatAsync().toBlocking().single();
+    public double getBigFloat() throws ErrorException, IOException {
+        return getBigFloatAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -414,7 +485,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getBigFloatAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getBigFloatAsync(), serviceCallback);
+        return ServiceCall.create(getBigFloatAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -422,7 +493,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getBigFloatAsync() {
+    public Observable<Double> getBigFloatAsync() {
+        return getBigFloatAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big float value 3.402823e+20.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getBigFloatAsyncWithServiceResponse() {
         return service.getBigFloat()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -452,8 +537,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBigDouble(double numberBody) throws ErrorException, IOException {
-        return putBigDoubleAsync(numberBody).toBlocking().single();
+    public void putBigDouble(double numberBody) throws ErrorException, IOException {
+        putBigDoubleAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -464,7 +549,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDoubleAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDoubleAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDoubleAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -473,7 +558,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDoubleAsync(double numberBody) {
+    public Observable<Void> putBigDoubleAsync(double numberBody) {
+        return putBigDoubleAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put big double value 2.5976931e+101.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBigDoubleAsyncWithServiceResponse(double numberBody) {
         return service.putBigDouble(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -502,8 +602,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getBigDouble() throws ErrorException, IOException {
-        return getBigDoubleAsync().toBlocking().single();
+    public double getBigDouble() throws ErrorException, IOException {
+        return getBigDoubleAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -513,7 +613,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getBigDoubleAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getBigDoubleAsync(), serviceCallback);
+        return ServiceCall.create(getBigDoubleAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -521,7 +621,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getBigDoubleAsync() {
+    public Observable<Double> getBigDoubleAsync() {
+        return getBigDoubleAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big double value 2.5976931e+101.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getBigDoubleAsyncWithServiceResponse() {
         return service.getBigDouble()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -551,8 +665,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBigDoublePositiveDecimal(double numberBody) throws ErrorException, IOException {
-        return putBigDoublePositiveDecimalAsync(numberBody).toBlocking().single();
+    public void putBigDoublePositiveDecimal(double numberBody) throws ErrorException, IOException {
+        putBigDoublePositiveDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -563,7 +677,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDoublePositiveDecimalAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDoublePositiveDecimalAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDoublePositiveDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -572,7 +686,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDoublePositiveDecimalAsync(double numberBody) {
+    public Observable<Void> putBigDoublePositiveDecimalAsync(double numberBody) {
+        return putBigDoublePositiveDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put big double value 99999999.99.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBigDoublePositiveDecimalAsyncWithServiceResponse(double numberBody) {
         return service.putBigDoublePositiveDecimal(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -601,8 +730,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getBigDoublePositiveDecimal() throws ErrorException, IOException {
-        return getBigDoublePositiveDecimalAsync().toBlocking().single();
+    public double getBigDoublePositiveDecimal() throws ErrorException, IOException {
+        return getBigDoublePositiveDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -612,7 +741,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getBigDoublePositiveDecimalAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getBigDoublePositiveDecimalAsync(), serviceCallback);
+        return ServiceCall.create(getBigDoublePositiveDecimalAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -620,7 +749,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getBigDoublePositiveDecimalAsync() {
+    public Observable<Double> getBigDoublePositiveDecimalAsync() {
+        return getBigDoublePositiveDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big double value 99999999.99.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getBigDoublePositiveDecimalAsyncWithServiceResponse() {
         return service.getBigDoublePositiveDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -650,8 +793,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBigDoubleNegativeDecimal(double numberBody) throws ErrorException, IOException {
-        return putBigDoubleNegativeDecimalAsync(numberBody).toBlocking().single();
+    public void putBigDoubleNegativeDecimal(double numberBody) throws ErrorException, IOException {
+        putBigDoubleNegativeDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -662,7 +805,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDoubleNegativeDecimalAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDoubleNegativeDecimalAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDoubleNegativeDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -671,7 +814,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDoubleNegativeDecimalAsync(double numberBody) {
+    public Observable<Void> putBigDoubleNegativeDecimalAsync(double numberBody) {
+        return putBigDoubleNegativeDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put big double value -99999999.99.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBigDoubleNegativeDecimalAsyncWithServiceResponse(double numberBody) {
         return service.putBigDoubleNegativeDecimal(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -700,8 +858,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getBigDoubleNegativeDecimal() throws ErrorException, IOException {
-        return getBigDoubleNegativeDecimalAsync().toBlocking().single();
+    public double getBigDoubleNegativeDecimal() throws ErrorException, IOException {
+        return getBigDoubleNegativeDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -711,7 +869,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getBigDoubleNegativeDecimalAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getBigDoubleNegativeDecimalAsync(), serviceCallback);
+        return ServiceCall.create(getBigDoubleNegativeDecimalAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -719,7 +877,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getBigDoubleNegativeDecimalAsync() {
+    public Observable<Double> getBigDoubleNegativeDecimalAsync() {
+        return getBigDoubleNegativeDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big double value -99999999.99.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getBigDoubleNegativeDecimalAsyncWithServiceResponse() {
         return service.getBigDoubleNegativeDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -750,8 +922,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBigDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putBigDecimalAsync(numberBody).toBlocking().single();
+    public void putBigDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
+        putBigDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -762,7 +934,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDecimalAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -771,7 +943,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDecimalAsync(BigDecimal numberBody) {
+    public Observable<Void> putBigDecimalAsync(BigDecimal numberBody) {
+        return putBigDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put big decimal value 2.5976931e+101.
+     *
+     * @param numberBody the BigDecimal value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBigDecimalAsyncWithServiceResponse(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
@@ -803,8 +990,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<BigDecimal> getBigDecimal() throws ErrorException, IOException {
-        return getBigDecimalAsync().toBlocking().single();
+    public BigDecimal getBigDecimal() throws ErrorException, IOException {
+        return getBigDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -814,7 +1001,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getBigDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getBigDecimalAsync(), serviceCallback);
+        return ServiceCall.create(getBigDecimalAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -822,7 +1009,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getBigDecimalAsync() {
+    public Observable<BigDecimal> getBigDecimalAsync() {
+        return getBigDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+            @Override
+            public BigDecimal call(ServiceResponse<BigDecimal> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big decimal value 2.5976931e+101.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    public Observable<ServiceResponse<BigDecimal>> getBigDecimalAsyncWithServiceResponse() {
         return service.getBigDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override
@@ -853,8 +1054,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBigDecimalPositiveDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putBigDecimalPositiveDecimalAsync(numberBody).toBlocking().single();
+    public void putBigDecimalPositiveDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
+        putBigDecimalPositiveDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -865,7 +1066,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDecimalPositiveDecimalAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDecimalPositiveDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -874,7 +1075,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody) {
+    public Observable<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody) {
+        return putBigDecimalPositiveDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put big decimal value 99999999.99.
+     *
+     * @param numberBody the BigDecimal value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBigDecimalPositiveDecimalAsyncWithServiceResponse(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
@@ -906,8 +1122,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<BigDecimal> getBigDecimalPositiveDecimal() throws ErrorException, IOException {
-        return getBigDecimalPositiveDecimalAsync().toBlocking().single();
+    public BigDecimal getBigDecimalPositiveDecimal() throws ErrorException, IOException {
+        return getBigDecimalPositiveDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -917,7 +1133,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getBigDecimalPositiveDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getBigDecimalPositiveDecimalAsync(), serviceCallback);
+        return ServiceCall.create(getBigDecimalPositiveDecimalAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -925,7 +1141,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getBigDecimalPositiveDecimalAsync() {
+    public Observable<BigDecimal> getBigDecimalPositiveDecimalAsync() {
+        return getBigDecimalPositiveDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+            @Override
+            public BigDecimal call(ServiceResponse<BigDecimal> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big decimal value 99999999.99.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    public Observable<ServiceResponse<BigDecimal>> getBigDecimalPositiveDecimalAsyncWithServiceResponse() {
         return service.getBigDecimalPositiveDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override
@@ -956,8 +1186,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBigDecimalNegativeDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putBigDecimalNegativeDecimalAsync(numberBody).toBlocking().single();
+    public void putBigDecimalNegativeDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
+        putBigDecimalNegativeDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -968,7 +1198,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDecimalNegativeDecimalAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDecimalNegativeDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -977,7 +1207,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody) {
+    public Observable<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody) {
+        return putBigDecimalNegativeDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put big decimal value -99999999.99.
+     *
+     * @param numberBody the BigDecimal value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBigDecimalNegativeDecimalAsyncWithServiceResponse(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
@@ -1009,8 +1254,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<BigDecimal> getBigDecimalNegativeDecimal() throws ErrorException, IOException {
-        return getBigDecimalNegativeDecimalAsync().toBlocking().single();
+    public BigDecimal getBigDecimalNegativeDecimal() throws ErrorException, IOException {
+        return getBigDecimalNegativeDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1020,7 +1265,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getBigDecimalNegativeDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getBigDecimalNegativeDecimalAsync(), serviceCallback);
+        return ServiceCall.create(getBigDecimalNegativeDecimalAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1028,7 +1273,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getBigDecimalNegativeDecimalAsync() {
+    public Observable<BigDecimal> getBigDecimalNegativeDecimalAsync() {
+        return getBigDecimalNegativeDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+            @Override
+            public BigDecimal call(ServiceResponse<BigDecimal> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big decimal value -99999999.99.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    public Observable<ServiceResponse<BigDecimal>> getBigDecimalNegativeDecimalAsyncWithServiceResponse() {
         return service.getBigDecimalNegativeDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override
@@ -1058,8 +1317,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putSmallFloat(double numberBody) throws ErrorException, IOException {
-        return putSmallFloatAsync(numberBody).toBlocking().single();
+    public void putSmallFloat(double numberBody) throws ErrorException, IOException {
+        putSmallFloatAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1070,7 +1329,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putSmallFloatAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putSmallFloatAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putSmallFloatAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -1079,7 +1338,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putSmallFloatAsync(double numberBody) {
+    public Observable<Void> putSmallFloatAsync(double numberBody) {
+        return putSmallFloatAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put small float value 3.402823e-20.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putSmallFloatAsyncWithServiceResponse(double numberBody) {
         return service.putSmallFloat(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1108,8 +1382,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getSmallFloat() throws ErrorException, IOException {
-        return getSmallFloatAsync().toBlocking().single();
+    public double getSmallFloat() throws ErrorException, IOException {
+        return getSmallFloatAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1119,7 +1393,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getSmallFloatAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getSmallFloatAsync(), serviceCallback);
+        return ServiceCall.create(getSmallFloatAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1127,7 +1401,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getSmallFloatAsync() {
+    public Observable<Double> getSmallFloatAsync() {
+        return getSmallFloatAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big double value 3.402823e-20.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getSmallFloatAsyncWithServiceResponse() {
         return service.getSmallFloat()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -1157,8 +1445,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putSmallDouble(double numberBody) throws ErrorException, IOException {
-        return putSmallDoubleAsync(numberBody).toBlocking().single();
+    public void putSmallDouble(double numberBody) throws ErrorException, IOException {
+        putSmallDoubleAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1169,7 +1457,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putSmallDoubleAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putSmallDoubleAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putSmallDoubleAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -1178,7 +1466,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putSmallDoubleAsync(double numberBody) {
+    public Observable<Void> putSmallDoubleAsync(double numberBody) {
+        return putSmallDoubleAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put small double value 2.5976931e-101.
+     *
+     * @param numberBody the double value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putSmallDoubleAsyncWithServiceResponse(double numberBody) {
         return service.putSmallDouble(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1207,8 +1510,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the double object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Double> getSmallDouble() throws ErrorException, IOException {
-        return getSmallDoubleAsync().toBlocking().single();
+    public double getSmallDouble() throws ErrorException, IOException {
+        return getSmallDoubleAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1218,7 +1521,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getSmallDoubleAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getSmallDoubleAsync(), serviceCallback);
+        return ServiceCall.create(getSmallDoubleAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1226,7 +1529,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getSmallDoubleAsync() {
+    public Observable<Double> getSmallDoubleAsync() {
+        return getSmallDoubleAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+            @Override
+            public Double call(ServiceResponse<Double> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get big double value 2.5976931e-101.
+     *
+     * @return the observable to the double object
+     */
+    public Observable<ServiceResponse<Double>> getSmallDoubleAsyncWithServiceResponse() {
         return service.getSmallDouble()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -1257,8 +1574,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putSmallDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putSmallDecimalAsync(numberBody).toBlocking().single();
+    public void putSmallDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
+        putSmallDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1269,7 +1586,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putSmallDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putSmallDecimalAsync(numberBody), serviceCallback);
+        return ServiceCall.create(putSmallDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
     }
 
     /**
@@ -1278,7 +1595,22 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putSmallDecimalAsync(BigDecimal numberBody) {
+    public Observable<Void> putSmallDecimalAsync(BigDecimal numberBody) {
+        return putSmallDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put small decimal value 2.5976931e-101.
+     *
+     * @param numberBody the BigDecimal value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putSmallDecimalAsyncWithServiceResponse(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
@@ -1310,8 +1642,8 @@ public final class NumbersImpl implements Numbers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<BigDecimal> getSmallDecimal() throws ErrorException, IOException {
-        return getSmallDecimalAsync().toBlocking().single();
+    public BigDecimal getSmallDecimal() throws ErrorException, IOException {
+        return getSmallDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1321,7 +1653,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getSmallDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getSmallDecimalAsync(), serviceCallback);
+        return ServiceCall.create(getSmallDecimalAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1329,7 +1661,21 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getSmallDecimalAsync() {
+    public Observable<BigDecimal> getSmallDecimalAsync() {
+        return getSmallDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+            @Override
+            public BigDecimal call(ServiceResponse<BigDecimal> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get small decimal value 2.5976931e-101.
+     *
+     * @return the observable to the BigDecimal object
+     */
+    public Observable<ServiceResponse<BigDecimal>> getSmallDecimalAsyncWithServiceResponse() {
         return service.getSmallDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodynumber/implementation/NumbersImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodynumber/implementation/NumbersImpl.java
@@ -158,10 +158,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -171,7 +171,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getNullAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -180,12 +180,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -193,7 +193,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -220,10 +220,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getInvalidFloat() throws ErrorException, IOException {
-        return getInvalidFloatAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidFloatWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -233,7 +233,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getInvalidFloatAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getInvalidFloatAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidFloatWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -242,12 +242,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getInvalidFloatAsync() {
-        return getInvalidFloatAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getInvalidFloatWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -255,7 +255,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getInvalidFloatAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getInvalidFloatWithServiceResponseAsync() {
         return service.getInvalidFloat()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -282,10 +282,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getInvalidDouble() throws ErrorException, IOException {
-        return getInvalidDoubleAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidDoubleWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -295,7 +295,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getInvalidDoubleAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getInvalidDoubleAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidDoubleWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -304,12 +304,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getInvalidDoubleAsync() {
-        return getInvalidDoubleAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getInvalidDoubleWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -317,7 +317,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getInvalidDoubleAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getInvalidDoubleWithServiceResponseAsync() {
         return service.getInvalidDouble()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -344,10 +344,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     public BigDecimal getInvalidDecimal() throws ErrorException, IOException {
-        return getInvalidDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getInvalidDecimalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -357,7 +357,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getInvalidDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getInvalidDecimalAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getInvalidDecimalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -366,12 +366,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the BigDecimal object
      */
     public Observable<BigDecimal> getInvalidDecimalAsync() {
-        return getInvalidDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+        return getInvalidDecimalWithServiceResponseAsync().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
             @Override
             public BigDecimal call(ServiceResponse<BigDecimal> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -379,7 +379,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getInvalidDecimalAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<BigDecimal>> getInvalidDecimalWithServiceResponseAsync() {
         return service.getInvalidDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override
@@ -407,10 +407,9 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBigFloat(double numberBody) throws ErrorException, IOException {
-        putBigFloatAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putBigFloatWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -421,7 +420,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigFloatAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigFloatAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putBigFloatWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -431,12 +430,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBigFloatAsync(double numberBody) {
-        return putBigFloatAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBigFloatWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -445,7 +444,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigFloatAsyncWithServiceResponse(double numberBody) {
+    public Observable<ServiceResponse<Void>> putBigFloatWithServiceResponseAsync(double numberBody) {
         return service.putBigFloat(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -472,10 +471,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getBigFloat() throws ErrorException, IOException {
-        return getBigFloatAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBigFloatWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -485,7 +484,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getBigFloatAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getBigFloatAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBigFloatWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -494,12 +493,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getBigFloatAsync() {
-        return getBigFloatAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getBigFloatWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -507,7 +506,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getBigFloatAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getBigFloatWithServiceResponseAsync() {
         return service.getBigFloat()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -535,10 +534,9 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBigDouble(double numberBody) throws ErrorException, IOException {
-        putBigDoubleAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putBigDoubleWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -549,7 +547,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDoubleAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDoubleAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDoubleWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -559,12 +557,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBigDoubleAsync(double numberBody) {
-        return putBigDoubleAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBigDoubleWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -573,7 +571,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDoubleAsyncWithServiceResponse(double numberBody) {
+    public Observable<ServiceResponse<Void>> putBigDoubleWithServiceResponseAsync(double numberBody) {
         return service.putBigDouble(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -600,10 +598,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getBigDouble() throws ErrorException, IOException {
-        return getBigDoubleAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBigDoubleWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -613,7 +611,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getBigDoubleAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getBigDoubleAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBigDoubleWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -622,12 +620,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getBigDoubleAsync() {
-        return getBigDoubleAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getBigDoubleWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -635,7 +633,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getBigDoubleAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getBigDoubleWithServiceResponseAsync() {
         return service.getBigDouble()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -663,10 +661,9 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBigDoublePositiveDecimal(double numberBody) throws ErrorException, IOException {
-        putBigDoublePositiveDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putBigDoublePositiveDecimalWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -677,7 +674,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDoublePositiveDecimalAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDoublePositiveDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDoublePositiveDecimalWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -687,12 +684,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBigDoublePositiveDecimalAsync(double numberBody) {
-        return putBigDoublePositiveDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBigDoublePositiveDecimalWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -701,7 +698,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDoublePositiveDecimalAsyncWithServiceResponse(double numberBody) {
+    public Observable<ServiceResponse<Void>> putBigDoublePositiveDecimalWithServiceResponseAsync(double numberBody) {
         return service.putBigDoublePositiveDecimal(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -728,10 +725,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getBigDoublePositiveDecimal() throws ErrorException, IOException {
-        return getBigDoublePositiveDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBigDoublePositiveDecimalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -741,7 +738,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getBigDoublePositiveDecimalAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getBigDoublePositiveDecimalAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBigDoublePositiveDecimalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -750,12 +747,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getBigDoublePositiveDecimalAsync() {
-        return getBigDoublePositiveDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getBigDoublePositiveDecimalWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -763,7 +760,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getBigDoublePositiveDecimalAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getBigDoublePositiveDecimalWithServiceResponseAsync() {
         return service.getBigDoublePositiveDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -791,10 +788,9 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBigDoubleNegativeDecimal(double numberBody) throws ErrorException, IOException {
-        putBigDoubleNegativeDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putBigDoubleNegativeDecimalWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -805,7 +801,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDoubleNegativeDecimalAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDoubleNegativeDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDoubleNegativeDecimalWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -815,12 +811,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBigDoubleNegativeDecimalAsync(double numberBody) {
-        return putBigDoubleNegativeDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBigDoubleNegativeDecimalWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -829,7 +825,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDoubleNegativeDecimalAsyncWithServiceResponse(double numberBody) {
+    public Observable<ServiceResponse<Void>> putBigDoubleNegativeDecimalWithServiceResponseAsync(double numberBody) {
         return service.putBigDoubleNegativeDecimal(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -856,10 +852,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getBigDoubleNegativeDecimal() throws ErrorException, IOException {
-        return getBigDoubleNegativeDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBigDoubleNegativeDecimalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -869,7 +865,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getBigDoubleNegativeDecimalAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getBigDoubleNegativeDecimalAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBigDoubleNegativeDecimalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -878,12 +874,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getBigDoubleNegativeDecimalAsync() {
-        return getBigDoubleNegativeDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getBigDoubleNegativeDecimalWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -891,7 +887,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getBigDoubleNegativeDecimalAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getBigDoubleNegativeDecimalWithServiceResponseAsync() {
         return service.getBigDoubleNegativeDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -920,10 +916,9 @@ public final class NumbersImpl implements Numbers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBigDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
-        putBigDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putBigDecimalWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -934,7 +929,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDecimalWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -944,12 +939,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBigDecimalAsync(BigDecimal numberBody) {
-        return putBigDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBigDecimalWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -958,7 +953,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDecimalAsyncWithServiceResponse(BigDecimal numberBody) {
+    public Observable<ServiceResponse<Void>> putBigDecimalWithServiceResponseAsync(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
@@ -988,10 +983,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     public BigDecimal getBigDecimal() throws ErrorException, IOException {
-        return getBigDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBigDecimalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1001,7 +996,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getBigDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getBigDecimalAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBigDecimalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1010,12 +1005,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the BigDecimal object
      */
     public Observable<BigDecimal> getBigDecimalAsync() {
-        return getBigDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+        return getBigDecimalWithServiceResponseAsync().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
             @Override
             public BigDecimal call(ServiceResponse<BigDecimal> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1023,7 +1018,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getBigDecimalAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<BigDecimal>> getBigDecimalWithServiceResponseAsync() {
         return service.getBigDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override
@@ -1052,10 +1047,9 @@ public final class NumbersImpl implements Numbers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBigDecimalPositiveDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
-        putBigDecimalPositiveDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putBigDecimalPositiveDecimalWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1066,7 +1060,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDecimalPositiveDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDecimalPositiveDecimalWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -1076,12 +1070,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody) {
-        return putBigDecimalPositiveDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBigDecimalPositiveDecimalWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1090,7 +1084,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDecimalPositiveDecimalAsyncWithServiceResponse(BigDecimal numberBody) {
+    public Observable<ServiceResponse<Void>> putBigDecimalPositiveDecimalWithServiceResponseAsync(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
@@ -1120,10 +1114,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     public BigDecimal getBigDecimalPositiveDecimal() throws ErrorException, IOException {
-        return getBigDecimalPositiveDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBigDecimalPositiveDecimalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1133,7 +1127,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getBigDecimalPositiveDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getBigDecimalPositiveDecimalAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBigDecimalPositiveDecimalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1142,12 +1136,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the BigDecimal object
      */
     public Observable<BigDecimal> getBigDecimalPositiveDecimalAsync() {
-        return getBigDecimalPositiveDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+        return getBigDecimalPositiveDecimalWithServiceResponseAsync().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
             @Override
             public BigDecimal call(ServiceResponse<BigDecimal> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1155,7 +1149,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getBigDecimalPositiveDecimalAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<BigDecimal>> getBigDecimalPositiveDecimalWithServiceResponseAsync() {
         return service.getBigDecimalPositiveDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override
@@ -1184,10 +1178,9 @@ public final class NumbersImpl implements Numbers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBigDecimalNegativeDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
-        putBigDecimalNegativeDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putBigDecimalNegativeDecimalWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1198,7 +1191,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBigDecimalNegativeDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putBigDecimalNegativeDecimalWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -1208,12 +1201,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody) {
-        return putBigDecimalNegativeDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBigDecimalNegativeDecimalWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1222,7 +1215,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBigDecimalNegativeDecimalAsyncWithServiceResponse(BigDecimal numberBody) {
+    public Observable<ServiceResponse<Void>> putBigDecimalNegativeDecimalWithServiceResponseAsync(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
@@ -1252,10 +1245,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     public BigDecimal getBigDecimalNegativeDecimal() throws ErrorException, IOException {
-        return getBigDecimalNegativeDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBigDecimalNegativeDecimalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1265,7 +1258,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getBigDecimalNegativeDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getBigDecimalNegativeDecimalAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBigDecimalNegativeDecimalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1274,12 +1267,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the BigDecimal object
      */
     public Observable<BigDecimal> getBigDecimalNegativeDecimalAsync() {
-        return getBigDecimalNegativeDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+        return getBigDecimalNegativeDecimalWithServiceResponseAsync().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
             @Override
             public BigDecimal call(ServiceResponse<BigDecimal> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1287,7 +1280,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getBigDecimalNegativeDecimalAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<BigDecimal>> getBigDecimalNegativeDecimalWithServiceResponseAsync() {
         return service.getBigDecimalNegativeDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override
@@ -1315,10 +1308,9 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putSmallFloat(double numberBody) throws ErrorException, IOException {
-        putSmallFloatAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putSmallFloatWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1329,7 +1321,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putSmallFloatAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putSmallFloatAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putSmallFloatWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -1339,12 +1331,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putSmallFloatAsync(double numberBody) {
-        return putSmallFloatAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putSmallFloatWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1353,7 +1345,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putSmallFloatAsyncWithServiceResponse(double numberBody) {
+    public Observable<ServiceResponse<Void>> putSmallFloatWithServiceResponseAsync(double numberBody) {
         return service.putSmallFloat(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1380,10 +1372,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getSmallFloat() throws ErrorException, IOException {
-        return getSmallFloatAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getSmallFloatWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1393,7 +1385,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getSmallFloatAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getSmallFloatAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getSmallFloatWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1402,12 +1394,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getSmallFloatAsync() {
-        return getSmallFloatAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getSmallFloatWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1415,7 +1407,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getSmallFloatAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getSmallFloatWithServiceResponseAsync() {
         return service.getSmallFloat()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -1443,10 +1435,9 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putSmallDouble(double numberBody) throws ErrorException, IOException {
-        putSmallDoubleAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putSmallDoubleWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1457,7 +1448,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putSmallDoubleAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putSmallDoubleAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putSmallDoubleWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -1467,12 +1458,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putSmallDoubleAsync(double numberBody) {
-        return putSmallDoubleAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putSmallDoubleWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1481,7 +1472,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the double value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putSmallDoubleAsyncWithServiceResponse(double numberBody) {
+    public Observable<ServiceResponse<Void>> putSmallDoubleWithServiceResponseAsync(double numberBody) {
         return service.putSmallDouble(numberBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1508,10 +1499,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the double object wrapped in {@link ServiceResponse} if successful.
+     * @return the double object if successful.
      */
     public double getSmallDouble() throws ErrorException, IOException {
-        return getSmallDoubleAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getSmallDoubleWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1521,7 +1512,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Double> getSmallDoubleAsync(final ServiceCallback<Double> serviceCallback) {
-        return ServiceCall.create(getSmallDoubleAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getSmallDoubleWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1530,12 +1521,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the double object
      */
     public Observable<Double> getSmallDoubleAsync() {
-        return getSmallDoubleAsyncWithServiceResponse().map(new Func1<ServiceResponse<Double>, Double>() {
+        return getSmallDoubleWithServiceResponseAsync().map(new Func1<ServiceResponse<Double>, Double>() {
             @Override
             public Double call(ServiceResponse<Double> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1543,7 +1534,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the double object
      */
-    public Observable<ServiceResponse<Double>> getSmallDoubleAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Double>> getSmallDoubleWithServiceResponseAsync() {
         return service.getSmallDouble()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Double>>>() {
                 @Override
@@ -1572,10 +1563,9 @@ public final class NumbersImpl implements Numbers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putSmallDecimal(BigDecimal numberBody) throws ErrorException, IOException, IllegalArgumentException {
-        putSmallDecimalAsyncWithServiceResponse(numberBody).toBlocking().single().getBody();
+        putSmallDecimalWithServiceResponseAsync(numberBody).toBlocking().single().getBody();
     }
 
     /**
@@ -1586,7 +1576,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putSmallDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putSmallDecimalAsyncWithServiceResponse(numberBody), serviceCallback);
+        return ServiceCall.create(putSmallDecimalWithServiceResponseAsync(numberBody), serviceCallback);
     }
 
     /**
@@ -1596,12 +1586,12 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putSmallDecimalAsync(BigDecimal numberBody) {
-        return putSmallDecimalAsyncWithServiceResponse(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putSmallDecimalWithServiceResponseAsync(numberBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1610,7 +1600,7 @@ public final class NumbersImpl implements Numbers {
      * @param numberBody the BigDecimal value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putSmallDecimalAsyncWithServiceResponse(BigDecimal numberBody) {
+    public Observable<ServiceResponse<Void>> putSmallDecimalWithServiceResponseAsync(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
@@ -1640,10 +1630,10 @@ public final class NumbersImpl implements Numbers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the BigDecimal object wrapped in {@link ServiceResponse} if successful.
+     * @return the BigDecimal object if successful.
      */
     public BigDecimal getSmallDecimal() throws ErrorException, IOException {
-        return getSmallDecimalAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getSmallDecimalWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1653,7 +1643,7 @@ public final class NumbersImpl implements Numbers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<BigDecimal> getSmallDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
-        return ServiceCall.create(getSmallDecimalAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getSmallDecimalWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1662,12 +1652,12 @@ public final class NumbersImpl implements Numbers {
      * @return the observable to the BigDecimal object
      */
     public Observable<BigDecimal> getSmallDecimalAsync() {
-        return getSmallDecimalAsyncWithServiceResponse().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
+        return getSmallDecimalWithServiceResponseAsync().map(new Func1<ServiceResponse<BigDecimal>, BigDecimal>() {
             @Override
             public BigDecimal call(ServiceResponse<BigDecimal> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1675,7 +1665,7 @@ public final class NumbersImpl implements Numbers {
      *
      * @return the observable to the BigDecimal object
      */
-    public Observable<ServiceResponse<BigDecimal>> getSmallDecimalAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<BigDecimal>> getSmallDecimalWithServiceResponseAsync() {
         return service.getSmallDecimal()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<BigDecimal>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/Enums.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/Enums.java
@@ -31,7 +31,7 @@ public interface Enums {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Colors object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Colors> getNotExpandable() throws ErrorException, IOException;
+    Colors getNotExpandable() throws ErrorException, IOException;
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -46,7 +46,14 @@ public interface Enums {
      *
      * @return the observable to the Colors object
      */
-    Observable<ServiceResponse<Colors>> getNotExpandableAsync();
+    Observable<Colors> getNotExpandableAsync();
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @return the observable to the Colors object
+     */
+    Observable<ServiceResponse<Colors>> getNotExpandableAsyncWithServiceResponse();
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -57,7 +64,7 @@ public interface Enums {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putNotExpandable(Colors stringBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putNotExpandable(Colors stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -74,7 +81,15 @@ public interface Enums {
      * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putNotExpandableAsync(Colors stringBody);
+    Observable<Void> putNotExpandableAsync(Colors stringBody);
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putNotExpandableAsyncWithServiceResponse(Colors stringBody);
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -83,7 +98,7 @@ public interface Enums {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Colors object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Colors> getReferenced() throws ErrorException, IOException;
+    Colors getReferenced() throws ErrorException, IOException;
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -98,7 +113,14 @@ public interface Enums {
      *
      * @return the observable to the Colors object
      */
-    Observable<ServiceResponse<Colors>> getReferencedAsync();
+    Observable<Colors> getReferencedAsync();
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @return the observable to the Colors object
+     */
+    Observable<ServiceResponse<Colors>> getReferencedAsyncWithServiceResponse();
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -109,7 +131,7 @@ public interface Enums {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putReferenced(Colors enumStringBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putReferenced(Colors enumStringBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -126,7 +148,15 @@ public interface Enums {
      * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putReferencedAsync(Colors enumStringBody);
+    Observable<Void> putReferencedAsync(Colors enumStringBody);
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putReferencedAsyncWithServiceResponse(Colors enumStringBody);
 
     /**
      * Get value 'green-color' from the constant.
@@ -135,7 +165,7 @@ public interface Enums {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the RefColorConstant object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<RefColorConstant> getReferencedConstant() throws ErrorException, IOException;
+    RefColorConstant getReferencedConstant() throws ErrorException, IOException;
 
     /**
      * Get value 'green-color' from the constant.
@@ -150,7 +180,14 @@ public interface Enums {
      *
      * @return the observable to the RefColorConstant object
      */
-    Observable<ServiceResponse<RefColorConstant>> getReferencedConstantAsync();
+    Observable<RefColorConstant> getReferencedConstantAsync();
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @return the observable to the RefColorConstant object
+     */
+    Observable<ServiceResponse<RefColorConstant>> getReferencedConstantAsyncWithServiceResponse();
 
     /**
      * Sends value 'green-color' from a constant.
@@ -161,7 +198,7 @@ public interface Enums {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putReferencedConstant(RefColorConstant enumStringBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putReferencedConstant(RefColorConstant enumStringBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Sends value 'green-color' from a constant.
@@ -178,6 +215,14 @@ public interface Enums {
      * @param enumStringBody the RefColorConstant value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putReferencedConstantAsync(RefColorConstant enumStringBody);
+    Observable<Void> putReferencedConstantAsync(RefColorConstant enumStringBody);
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody the RefColorConstant value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putReferencedConstantAsyncWithServiceResponse(RefColorConstant enumStringBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/Enums.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/Enums.java
@@ -29,7 +29,7 @@ public interface Enums {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Colors object wrapped in {@link ServiceResponse} if successful.
+     * @return the Colors object if successful.
      */
     Colors getNotExpandable() throws ErrorException, IOException;
 
@@ -53,7 +53,7 @@ public interface Enums {
      *
      * @return the observable to the Colors object
      */
-    Observable<ServiceResponse<Colors>> getNotExpandableAsyncWithServiceResponse();
+    Observable<ServiceResponse<Colors>> getNotExpandableWithServiceResponseAsync();
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -62,7 +62,6 @@ public interface Enums {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putNotExpandable(Colors stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -89,14 +88,14 @@ public interface Enums {
      * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putNotExpandableAsyncWithServiceResponse(Colors stringBody);
+    Observable<ServiceResponse<Void>> putNotExpandableWithServiceResponseAsync(Colors stringBody);
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Colors object wrapped in {@link ServiceResponse} if successful.
+     * @return the Colors object if successful.
      */
     Colors getReferenced() throws ErrorException, IOException;
 
@@ -120,7 +119,7 @@ public interface Enums {
      *
      * @return the observable to the Colors object
      */
-    Observable<ServiceResponse<Colors>> getReferencedAsyncWithServiceResponse();
+    Observable<ServiceResponse<Colors>> getReferencedWithServiceResponseAsync();
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -129,7 +128,6 @@ public interface Enums {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putReferenced(Colors enumStringBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -156,14 +154,14 @@ public interface Enums {
      * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putReferencedAsyncWithServiceResponse(Colors enumStringBody);
+    Observable<ServiceResponse<Void>> putReferencedWithServiceResponseAsync(Colors enumStringBody);
 
     /**
      * Get value 'green-color' from the constant.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the RefColorConstant object wrapped in {@link ServiceResponse} if successful.
+     * @return the RefColorConstant object if successful.
      */
     RefColorConstant getReferencedConstant() throws ErrorException, IOException;
 
@@ -187,7 +185,7 @@ public interface Enums {
      *
      * @return the observable to the RefColorConstant object
      */
-    Observable<ServiceResponse<RefColorConstant>> getReferencedConstantAsyncWithServiceResponse();
+    Observable<ServiceResponse<RefColorConstant>> getReferencedConstantWithServiceResponseAsync();
 
     /**
      * Sends value 'green-color' from a constant.
@@ -196,7 +194,6 @@ public interface Enums {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putReferencedConstant(RefColorConstant enumStringBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -223,6 +220,6 @@ public interface Enums {
      * @param enumStringBody the RefColorConstant value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putReferencedConstantAsyncWithServiceResponse(RefColorConstant enumStringBody);
+    Observable<ServiceResponse<Void>> putReferencedConstantWithServiceResponseAsync(RefColorConstant enumStringBody);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/Strings.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/Strings.java
@@ -27,7 +27,7 @@ public interface Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     String getNull() throws ErrorException, IOException;
 
@@ -51,14 +51,13 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<String>> getNullWithServiceResponseAsync();
 
     /**
      * Set string value null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putNull() throws ErrorException, IOException;
 
@@ -73,7 +72,6 @@ public interface Strings {
     /**
      * Set string value null.
      *
-     * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putNullAsync();
@@ -81,17 +79,15 @@ public interface Strings {
     /**
      * Set string value null.
      *
-     * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putNullWithServiceResponseAsync();
     /**
      * Set string value null.
      *
      * @param stringBody Possible values include: ''
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putNull(String stringBody) throws ErrorException, IOException;
 
@@ -118,14 +114,14 @@ public interface Strings {
      * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putNullAsyncWithServiceResponse(String stringBody);
+    Observable<ServiceResponse<Void>> putNullWithServiceResponseAsync(String stringBody);
 
     /**
      * Get empty string value value ''.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     String getEmpty() throws ErrorException, IOException;
 
@@ -149,7 +145,7 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<String>> getEmptyWithServiceResponseAsync();
 
     /**
      * Set string value empty ''.
@@ -158,7 +154,6 @@ public interface Strings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putEmpty(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -185,14 +180,14 @@ public interface Strings {
      * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(String stringBody);
+    Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(String stringBody);
 
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     String getMbcs() throws ErrorException, IOException;
 
@@ -216,7 +211,7 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getMbcsAsyncWithServiceResponse();
+    Observable<ServiceResponse<String>> getMbcsWithServiceResponseAsync();
 
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
@@ -225,7 +220,6 @@ public interface Strings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putMbcs(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -252,14 +246,14 @@ public interface Strings {
      * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMbcsAsyncWithServiceResponse(String stringBody);
+    Observable<ServiceResponse<Void>> putMbcsWithServiceResponseAsync(String stringBody);
 
     /**
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     String getWhitespace() throws ErrorException, IOException;
 
@@ -283,7 +277,7 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getWhitespaceAsyncWithServiceResponse();
+    Observable<ServiceResponse<String>> getWhitespaceWithServiceResponseAsync();
 
     /**
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
@@ -292,7 +286,6 @@ public interface Strings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putWhitespace(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -319,14 +312,14 @@ public interface Strings {
      * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putWhitespaceAsyncWithServiceResponse(String stringBody);
+    Observable<ServiceResponse<Void>> putWhitespaceWithServiceResponseAsync(String stringBody);
 
     /**
      * Get String value when no string value is sent in response payload.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     String getNotProvided() throws ErrorException, IOException;
 
@@ -350,14 +343,14 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getNotProvidedAsyncWithServiceResponse();
+    Observable<ServiceResponse<String>> getNotProvidedWithServiceResponseAsync();
 
     /**
      * Get value that is base64 encoded.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     byte[] getBase64Encoded() throws ErrorException, IOException;
 
@@ -381,14 +374,14 @@ public interface Strings {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getBase64EncodedAsyncWithServiceResponse();
+    Observable<ServiceResponse<byte[]>> getBase64EncodedWithServiceResponseAsync();
 
     /**
      * Get value that is base64url encoded.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     byte[] getBase64UrlEncoded() throws ErrorException, IOException;
 
@@ -412,7 +405,7 @@ public interface Strings {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getBase64UrlEncodedAsyncWithServiceResponse();
+    Observable<ServiceResponse<byte[]>> getBase64UrlEncodedWithServiceResponseAsync();
 
     /**
      * Put value that is base64url encoded.
@@ -421,7 +414,6 @@ public interface Strings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putBase64UrlEncoded(byte[] stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -448,14 +440,14 @@ public interface Strings {
      * @param stringBody the Base64Url value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBase64UrlEncodedAsyncWithServiceResponse(byte[] stringBody);
+    Observable<ServiceResponse<Void>> putBase64UrlEncodedWithServiceResponseAsync(byte[] stringBody);
 
     /**
      * Get null value that is expected to be base64url encoded.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     byte[] getNullBase64UrlEncoded() throws ErrorException, IOException;
 
@@ -479,6 +471,6 @@ public interface Strings {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getNullBase64UrlEncodedAsyncWithServiceResponse();
+    Observable<ServiceResponse<byte[]>> getNullBase64UrlEncodedWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/Strings.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/Strings.java
@@ -29,7 +29,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<String> getNull() throws ErrorException, IOException;
+    String getNull() throws ErrorException, IOException;
 
     /**
      * Get null string value value.
@@ -44,7 +44,14 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getNullAsync();
+    Observable<String> getNullAsync();
+
+    /**
+     * Get null string value value.
+     *
+     * @return the observable to the String object
+     */
+    Observable<ServiceResponse<String>> getNullAsyncWithServiceResponse();
 
     /**
      * Set string value null.
@@ -53,7 +60,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putNull() throws ErrorException, IOException;
+    void putNull() throws ErrorException, IOException;
 
     /**
      * Set string value null.
@@ -62,6 +69,22 @@ public interface Strings {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody Possible values include: ''
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putNullAsync();
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody Possible values include: ''
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putNullAsyncWithServiceResponse();
     /**
      * Set string value null.
      *
@@ -70,7 +93,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putNull(String stringBody) throws ErrorException, IOException;
+    void putNull(String stringBody) throws ErrorException, IOException;
 
     /**
      * Set string value null.
@@ -87,7 +110,15 @@ public interface Strings {
      * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putNullAsync(String stringBody);
+    Observable<Void> putNullAsync(String stringBody);
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody Possible values include: ''
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putNullAsyncWithServiceResponse(String stringBody);
 
     /**
      * Get empty string value value ''.
@@ -96,7 +127,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<String> getEmpty() throws ErrorException, IOException;
+    String getEmpty() throws ErrorException, IOException;
 
     /**
      * Get empty string value value ''.
@@ -111,7 +142,14 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getEmptyAsync();
+    Observable<String> getEmptyAsync();
+
+    /**
+     * Get empty string value value ''.
+     *
+     * @return the observable to the String object
+     */
+    Observable<ServiceResponse<String>> getEmptyAsyncWithServiceResponse();
 
     /**
      * Set string value empty ''.
@@ -122,7 +160,7 @@ public interface Strings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putEmpty(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putEmpty(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set string value empty ''.
@@ -139,7 +177,15 @@ public interface Strings {
      * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putEmptyAsync(String stringBody);
+    Observable<Void> putEmptyAsync(String stringBody);
+
+    /**
+     * Set string value empty ''.
+     *
+     * @param stringBody Possible values include: ''
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(String stringBody);
 
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
@@ -148,7 +194,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<String> getMbcs() throws ErrorException, IOException;
+    String getMbcs() throws ErrorException, IOException;
 
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
@@ -163,7 +209,14 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getMbcsAsync();
+    Observable<String> getMbcsAsync();
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
+     *
+     * @return the observable to the String object
+     */
+    Observable<ServiceResponse<String>> getMbcsAsyncWithServiceResponse();
 
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
@@ -174,7 +227,7 @@ public interface Strings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putMbcs(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putMbcs(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
@@ -191,7 +244,15 @@ public interface Strings {
      * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putMbcsAsync(String stringBody);
+    Observable<Void> putMbcsAsync(String stringBody);
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
+     *
+     * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putMbcsAsyncWithServiceResponse(String stringBody);
 
     /**
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
@@ -200,7 +261,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<String> getWhitespace() throws ErrorException, IOException;
+    String getWhitespace() throws ErrorException, IOException;
 
     /**
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
@@ -215,7 +276,14 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getWhitespaceAsync();
+    Observable<String> getWhitespaceAsync();
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @return the observable to the String object
+     */
+    Observable<ServiceResponse<String>> getWhitespaceAsyncWithServiceResponse();
 
     /**
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
@@ -226,7 +294,7 @@ public interface Strings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putWhitespace(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putWhitespace(String stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
@@ -243,7 +311,15 @@ public interface Strings {
      * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putWhitespaceAsync(String stringBody);
+    Observable<Void> putWhitespaceAsync(String stringBody);
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putWhitespaceAsyncWithServiceResponse(String stringBody);
 
     /**
      * Get String value when no string value is sent in response payload.
@@ -252,7 +328,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<String> getNotProvided() throws ErrorException, IOException;
+    String getNotProvided() throws ErrorException, IOException;
 
     /**
      * Get String value when no string value is sent in response payload.
@@ -267,7 +343,14 @@ public interface Strings {
      *
      * @return the observable to the String object
      */
-    Observable<ServiceResponse<String>> getNotProvidedAsync();
+    Observable<String> getNotProvidedAsync();
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @return the observable to the String object
+     */
+    Observable<ServiceResponse<String>> getNotProvidedAsyncWithServiceResponse();
 
     /**
      * Get value that is base64 encoded.
@@ -276,7 +359,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<byte[]> getBase64Encoded() throws ErrorException, IOException;
+    byte[] getBase64Encoded() throws ErrorException, IOException;
 
     /**
      * Get value that is base64 encoded.
@@ -291,7 +374,14 @@ public interface Strings {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getBase64EncodedAsync();
+    Observable<byte[]> getBase64EncodedAsync();
+
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @return the observable to the byte[] object
+     */
+    Observable<ServiceResponse<byte[]>> getBase64EncodedAsyncWithServiceResponse();
 
     /**
      * Get value that is base64url encoded.
@@ -300,7 +390,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<byte[]> getBase64UrlEncoded() throws ErrorException, IOException;
+    byte[] getBase64UrlEncoded() throws ErrorException, IOException;
 
     /**
      * Get value that is base64url encoded.
@@ -315,7 +405,14 @@ public interface Strings {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getBase64UrlEncodedAsync();
+    Observable<byte[]> getBase64UrlEncodedAsync();
+
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @return the observable to the byte[] object
+     */
+    Observable<ServiceResponse<byte[]>> getBase64UrlEncodedAsyncWithServiceResponse();
 
     /**
      * Put value that is base64url encoded.
@@ -326,7 +423,7 @@ public interface Strings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putBase64UrlEncoded(byte[] stringBody) throws ErrorException, IOException, IllegalArgumentException;
+    void putBase64UrlEncoded(byte[] stringBody) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put value that is base64url encoded.
@@ -343,7 +440,15 @@ public interface Strings {
      * @param stringBody the Base64Url value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putBase64UrlEncodedAsync(byte[] stringBody);
+    Observable<Void> putBase64UrlEncodedAsync(byte[] stringBody);
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody the Base64Url value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putBase64UrlEncodedAsyncWithServiceResponse(byte[] stringBody);
 
     /**
      * Get null value that is expected to be base64url encoded.
@@ -352,7 +457,7 @@ public interface Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<byte[]> getNullBase64UrlEncoded() throws ErrorException, IOException;
+    byte[] getNullBase64UrlEncoded() throws ErrorException, IOException;
 
     /**
      * Get null value that is expected to be base64url encoded.
@@ -367,6 +472,13 @@ public interface Strings {
      *
      * @return the observable to the byte[] object
      */
-    Observable<ServiceResponse<byte[]>> getNullBase64UrlEncodedAsync();
+    Observable<byte[]> getNullBase64UrlEncodedAsync();
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @return the observable to the byte[] object
+     */
+    Observable<ServiceResponse<byte[]>> getNullBase64UrlEncodedAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
@@ -90,8 +90,8 @@ public final class EnumsImpl implements Enums {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Colors object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Colors> getNotExpandable() throws ErrorException, IOException {
-        return getNotExpandableAsync().toBlocking().single();
+    public Colors getNotExpandable() throws ErrorException, IOException {
+        return getNotExpandableAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -101,7 +101,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Colors> getNotExpandableAsync(final ServiceCallback<Colors> serviceCallback) {
-        return ServiceCall.create(getNotExpandableAsync(), serviceCallback);
+        return ServiceCall.create(getNotExpandableAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -109,7 +109,21 @@ public final class EnumsImpl implements Enums {
      *
      * @return the observable to the Colors object
      */
-    public Observable<ServiceResponse<Colors>> getNotExpandableAsync() {
+    public Observable<Colors> getNotExpandableAsync() {
+        return getNotExpandableAsyncWithServiceResponse().map(new Func1<ServiceResponse<Colors>, Colors>() {
+            @Override
+            public Colors call(ServiceResponse<Colors> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @return the observable to the Colors object
+     */
+    public Observable<ServiceResponse<Colors>> getNotExpandableAsyncWithServiceResponse() {
         return service.getNotExpandable()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Colors>>>() {
                 @Override
@@ -140,8 +154,8 @@ public final class EnumsImpl implements Enums {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putNotExpandable(Colors stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putNotExpandableAsync(stringBody).toBlocking().single();
+    public void putNotExpandable(Colors stringBody) throws ErrorException, IOException, IllegalArgumentException {
+        putNotExpandableAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -152,7 +166,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putNotExpandableAsync(Colors stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putNotExpandableAsync(stringBody), serviceCallback);
+        return ServiceCall.create(putNotExpandableAsyncWithServiceResponse(stringBody), serviceCallback);
     }
 
     /**
@@ -161,7 +175,22 @@ public final class EnumsImpl implements Enums {
      * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putNotExpandableAsync(Colors stringBody) {
+    public Observable<Void> putNotExpandableAsync(Colors stringBody) {
+        return putNotExpandableAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putNotExpandableAsyncWithServiceResponse(Colors stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -193,8 +222,8 @@ public final class EnumsImpl implements Enums {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Colors object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Colors> getReferenced() throws ErrorException, IOException {
-        return getReferencedAsync().toBlocking().single();
+    public Colors getReferenced() throws ErrorException, IOException {
+        return getReferencedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -204,7 +233,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Colors> getReferencedAsync(final ServiceCallback<Colors> serviceCallback) {
-        return ServiceCall.create(getReferencedAsync(), serviceCallback);
+        return ServiceCall.create(getReferencedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -212,7 +241,21 @@ public final class EnumsImpl implements Enums {
      *
      * @return the observable to the Colors object
      */
-    public Observable<ServiceResponse<Colors>> getReferencedAsync() {
+    public Observable<Colors> getReferencedAsync() {
+        return getReferencedAsyncWithServiceResponse().map(new Func1<ServiceResponse<Colors>, Colors>() {
+            @Override
+            public Colors call(ServiceResponse<Colors> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @return the observable to the Colors object
+     */
+    public Observable<ServiceResponse<Colors>> getReferencedAsyncWithServiceResponse() {
         return service.getReferenced()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Colors>>>() {
                 @Override
@@ -243,8 +286,8 @@ public final class EnumsImpl implements Enums {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putReferenced(Colors enumStringBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putReferencedAsync(enumStringBody).toBlocking().single();
+    public void putReferenced(Colors enumStringBody) throws ErrorException, IOException, IllegalArgumentException {
+        putReferencedAsyncWithServiceResponse(enumStringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -255,7 +298,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putReferencedAsync(Colors enumStringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putReferencedAsync(enumStringBody), serviceCallback);
+        return ServiceCall.create(putReferencedAsyncWithServiceResponse(enumStringBody), serviceCallback);
     }
 
     /**
@@ -264,7 +307,22 @@ public final class EnumsImpl implements Enums {
      * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putReferencedAsync(Colors enumStringBody) {
+    public Observable<Void> putReferencedAsync(Colors enumStringBody) {
+        return putReferencedAsyncWithServiceResponse(enumStringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putReferencedAsyncWithServiceResponse(Colors enumStringBody) {
         if (enumStringBody == null) {
             throw new IllegalArgumentException("Parameter enumStringBody is required and cannot be null.");
         }
@@ -296,8 +354,8 @@ public final class EnumsImpl implements Enums {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the RefColorConstant object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<RefColorConstant> getReferencedConstant() throws ErrorException, IOException {
-        return getReferencedConstantAsync().toBlocking().single();
+    public RefColorConstant getReferencedConstant() throws ErrorException, IOException {
+        return getReferencedConstantAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -307,7 +365,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<RefColorConstant> getReferencedConstantAsync(final ServiceCallback<RefColorConstant> serviceCallback) {
-        return ServiceCall.create(getReferencedConstantAsync(), serviceCallback);
+        return ServiceCall.create(getReferencedConstantAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -315,7 +373,21 @@ public final class EnumsImpl implements Enums {
      *
      * @return the observable to the RefColorConstant object
      */
-    public Observable<ServiceResponse<RefColorConstant>> getReferencedConstantAsync() {
+    public Observable<RefColorConstant> getReferencedConstantAsync() {
+        return getReferencedConstantAsyncWithServiceResponse().map(new Func1<ServiceResponse<RefColorConstant>, RefColorConstant>() {
+            @Override
+            public RefColorConstant call(ServiceResponse<RefColorConstant> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @return the observable to the RefColorConstant object
+     */
+    public Observable<ServiceResponse<RefColorConstant>> getReferencedConstantAsyncWithServiceResponse() {
         return service.getReferencedConstant()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<RefColorConstant>>>() {
                 @Override
@@ -346,8 +418,8 @@ public final class EnumsImpl implements Enums {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putReferencedConstant(RefColorConstant enumStringBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putReferencedConstantAsync(enumStringBody).toBlocking().single();
+    public void putReferencedConstant(RefColorConstant enumStringBody) throws ErrorException, IOException, IllegalArgumentException {
+        putReferencedConstantAsyncWithServiceResponse(enumStringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -358,7 +430,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putReferencedConstantAsync(RefColorConstant enumStringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putReferencedConstantAsync(enumStringBody), serviceCallback);
+        return ServiceCall.create(putReferencedConstantAsyncWithServiceResponse(enumStringBody), serviceCallback);
     }
 
     /**
@@ -367,7 +439,22 @@ public final class EnumsImpl implements Enums {
      * @param enumStringBody the RefColorConstant value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putReferencedConstantAsync(RefColorConstant enumStringBody) {
+    public Observable<Void> putReferencedConstantAsync(RefColorConstant enumStringBody) {
+        return putReferencedConstantAsyncWithServiceResponse(enumStringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody the RefColorConstant value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putReferencedConstantAsyncWithServiceResponse(RefColorConstant enumStringBody) {
         if (enumStringBody == null) {
             throw new IllegalArgumentException("Parameter enumStringBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
@@ -88,10 +88,10 @@ public final class EnumsImpl implements Enums {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Colors object wrapped in {@link ServiceResponse} if successful.
+     * @return the Colors object if successful.
      */
     public Colors getNotExpandable() throws ErrorException, IOException {
-        return getNotExpandableAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNotExpandableWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -101,7 +101,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Colors> getNotExpandableAsync(final ServiceCallback<Colors> serviceCallback) {
-        return ServiceCall.create(getNotExpandableAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNotExpandableWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -110,12 +110,12 @@ public final class EnumsImpl implements Enums {
      * @return the observable to the Colors object
      */
     public Observable<Colors> getNotExpandableAsync() {
-        return getNotExpandableAsyncWithServiceResponse().map(new Func1<ServiceResponse<Colors>, Colors>() {
+        return getNotExpandableWithServiceResponseAsync().map(new Func1<ServiceResponse<Colors>, Colors>() {
             @Override
             public Colors call(ServiceResponse<Colors> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -123,7 +123,7 @@ public final class EnumsImpl implements Enums {
      *
      * @return the observable to the Colors object
      */
-    public Observable<ServiceResponse<Colors>> getNotExpandableAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Colors>> getNotExpandableWithServiceResponseAsync() {
         return service.getNotExpandable()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Colors>>>() {
                 @Override
@@ -152,10 +152,9 @@ public final class EnumsImpl implements Enums {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putNotExpandable(Colors stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        putNotExpandableAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
+        putNotExpandableWithServiceResponseAsync(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -166,7 +165,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putNotExpandableAsync(Colors stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putNotExpandableAsyncWithServiceResponse(stringBody), serviceCallback);
+        return ServiceCall.create(putNotExpandableWithServiceResponseAsync(stringBody), serviceCallback);
     }
 
     /**
@@ -176,12 +175,12 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putNotExpandableAsync(Colors stringBody) {
-        return putNotExpandableAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putNotExpandableWithServiceResponseAsync(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -190,7 +189,7 @@ public final class EnumsImpl implements Enums {
      * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putNotExpandableAsyncWithServiceResponse(Colors stringBody) {
+    public Observable<ServiceResponse<Void>> putNotExpandableWithServiceResponseAsync(Colors stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -220,10 +219,10 @@ public final class EnumsImpl implements Enums {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Colors object wrapped in {@link ServiceResponse} if successful.
+     * @return the Colors object if successful.
      */
     public Colors getReferenced() throws ErrorException, IOException {
-        return getReferencedAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getReferencedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -233,7 +232,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Colors> getReferencedAsync(final ServiceCallback<Colors> serviceCallback) {
-        return ServiceCall.create(getReferencedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getReferencedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -242,12 +241,12 @@ public final class EnumsImpl implements Enums {
      * @return the observable to the Colors object
      */
     public Observable<Colors> getReferencedAsync() {
-        return getReferencedAsyncWithServiceResponse().map(new Func1<ServiceResponse<Colors>, Colors>() {
+        return getReferencedWithServiceResponseAsync().map(new Func1<ServiceResponse<Colors>, Colors>() {
             @Override
             public Colors call(ServiceResponse<Colors> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -255,7 +254,7 @@ public final class EnumsImpl implements Enums {
      *
      * @return the observable to the Colors object
      */
-    public Observable<ServiceResponse<Colors>> getReferencedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Colors>> getReferencedWithServiceResponseAsync() {
         return service.getReferenced()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Colors>>>() {
                 @Override
@@ -284,10 +283,9 @@ public final class EnumsImpl implements Enums {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putReferenced(Colors enumStringBody) throws ErrorException, IOException, IllegalArgumentException {
-        putReferencedAsyncWithServiceResponse(enumStringBody).toBlocking().single().getBody();
+        putReferencedWithServiceResponseAsync(enumStringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -298,7 +296,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putReferencedAsync(Colors enumStringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putReferencedAsyncWithServiceResponse(enumStringBody), serviceCallback);
+        return ServiceCall.create(putReferencedWithServiceResponseAsync(enumStringBody), serviceCallback);
     }
 
     /**
@@ -308,12 +306,12 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putReferencedAsync(Colors enumStringBody) {
-        return putReferencedAsyncWithServiceResponse(enumStringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putReferencedWithServiceResponseAsync(enumStringBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -322,7 +320,7 @@ public final class EnumsImpl implements Enums {
      * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putReferencedAsyncWithServiceResponse(Colors enumStringBody) {
+    public Observable<ServiceResponse<Void>> putReferencedWithServiceResponseAsync(Colors enumStringBody) {
         if (enumStringBody == null) {
             throw new IllegalArgumentException("Parameter enumStringBody is required and cannot be null.");
         }
@@ -352,10 +350,10 @@ public final class EnumsImpl implements Enums {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the RefColorConstant object wrapped in {@link ServiceResponse} if successful.
+     * @return the RefColorConstant object if successful.
      */
     public RefColorConstant getReferencedConstant() throws ErrorException, IOException {
-        return getReferencedConstantAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getReferencedConstantWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -365,7 +363,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<RefColorConstant> getReferencedConstantAsync(final ServiceCallback<RefColorConstant> serviceCallback) {
-        return ServiceCall.create(getReferencedConstantAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getReferencedConstantWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -374,12 +372,12 @@ public final class EnumsImpl implements Enums {
      * @return the observable to the RefColorConstant object
      */
     public Observable<RefColorConstant> getReferencedConstantAsync() {
-        return getReferencedConstantAsyncWithServiceResponse().map(new Func1<ServiceResponse<RefColorConstant>, RefColorConstant>() {
+        return getReferencedConstantWithServiceResponseAsync().map(new Func1<ServiceResponse<RefColorConstant>, RefColorConstant>() {
             @Override
             public RefColorConstant call(ServiceResponse<RefColorConstant> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -387,7 +385,7 @@ public final class EnumsImpl implements Enums {
      *
      * @return the observable to the RefColorConstant object
      */
-    public Observable<ServiceResponse<RefColorConstant>> getReferencedConstantAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<RefColorConstant>> getReferencedConstantWithServiceResponseAsync() {
         return service.getReferencedConstant()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<RefColorConstant>>>() {
                 @Override
@@ -416,10 +414,9 @@ public final class EnumsImpl implements Enums {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putReferencedConstant(RefColorConstant enumStringBody) throws ErrorException, IOException, IllegalArgumentException {
-        putReferencedConstantAsyncWithServiceResponse(enumStringBody).toBlocking().single().getBody();
+        putReferencedConstantWithServiceResponseAsync(enumStringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -430,7 +427,7 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putReferencedConstantAsync(RefColorConstant enumStringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putReferencedConstantAsyncWithServiceResponse(enumStringBody), serviceCallback);
+        return ServiceCall.create(putReferencedConstantWithServiceResponseAsync(enumStringBody), serviceCallback);
     }
 
     /**
@@ -440,12 +437,12 @@ public final class EnumsImpl implements Enums {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putReferencedConstantAsync(RefColorConstant enumStringBody) {
-        return putReferencedConstantAsyncWithServiceResponse(enumStringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putReferencedConstantWithServiceResponseAsync(enumStringBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -454,7 +451,7 @@ public final class EnumsImpl implements Enums {
      * @param enumStringBody the RefColorConstant value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putReferencedConstantAsyncWithServiceResponse(RefColorConstant enumStringBody) {
+    public Observable<ServiceResponse<Void>> putReferencedConstantWithServiceResponseAsync(RefColorConstant enumStringBody) {
         if (enumStringBody == null) {
             throw new IllegalArgumentException("Parameter enumStringBody is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/implementation/StringsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/implementation/StringsImpl.java
@@ -116,8 +116,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<String> getNull() throws ErrorException, IOException {
-        return getNullAsync().toBlocking().single();
+    public String getNull() throws ErrorException, IOException {
+        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -127,7 +127,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getNullAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getNullAsync(), serviceCallback);
+        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -135,7 +135,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getNullAsync() {
+    public Observable<String> getNullAsync() {
+        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+            @Override
+            public String call(ServiceResponse<String> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null string value value.
+     *
+     * @return the observable to the String object
+     */
+    public Observable<ServiceResponse<String>> getNullAsyncWithServiceResponse() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -164,8 +178,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putNull() throws ErrorException, IOException {
-        return putNullAsync().toBlocking().single();
+    public void putNull() throws ErrorException, IOException {
+        putNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -175,7 +189,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putNullAsync(), serviceCallback);
+        return ServiceCall.create(putNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -183,7 +197,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putNullAsync() {
+    public Observable<Void> putNullAsync() {
+        return putNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putNullAsyncWithServiceResponse() {
         final String stringBody = null;
         return service.putNull(stringBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -207,8 +235,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putNull(String stringBody) throws ErrorException, IOException {
-        return putNullAsync(stringBody).toBlocking().single();
+    public void putNull(String stringBody) throws ErrorException, IOException {
+        putNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -219,7 +247,21 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putNullAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putNullAsync(stringBody), serviceCallback);
+        return ServiceCall.create(putNullAsyncWithServiceResponse(stringBody), serviceCallback);
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putNullAsync(String stringBody) {
+        return putNullAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -228,7 +270,7 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putNullAsync(String stringBody) {
+    public Observable<ServiceResponse<Void>> putNullAsyncWithServiceResponse(String stringBody) {
         return service.putNull(stringBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -257,8 +299,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<String> getEmpty() throws ErrorException, IOException {
-        return getEmptyAsync().toBlocking().single();
+    public String getEmpty() throws ErrorException, IOException {
+        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -268,7 +310,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getEmptyAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -276,7 +318,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getEmptyAsync() {
+    public Observable<String> getEmptyAsync() {
+        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+            @Override
+            public String call(ServiceResponse<String> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty string value value ''.
+     *
+     * @return the observable to the String object
+     */
+    public Observable<ServiceResponse<String>> getEmptyAsyncWithServiceResponse() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -307,8 +363,8 @@ public final class StringsImpl implements Strings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putEmpty(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putEmptyAsync(stringBody).toBlocking().single();
+    public void putEmpty(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
+        putEmptyAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -319,7 +375,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsync(stringBody), serviceCallback);
+        return ServiceCall.create(putEmptyAsyncWithServiceResponse(stringBody), serviceCallback);
     }
 
     /**
@@ -328,7 +384,22 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsync(String stringBody) {
+    public Observable<Void> putEmptyAsync(String stringBody) {
+        return putEmptyAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set string value empty ''.
+     *
+     * @param stringBody Possible values include: ''
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -360,8 +431,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<String> getMbcs() throws ErrorException, IOException {
-        return getMbcsAsync().toBlocking().single();
+    public String getMbcs() throws ErrorException, IOException {
+        return getMbcsAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -371,7 +442,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getMbcsAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getMbcsAsync(), serviceCallback);
+        return ServiceCall.create(getMbcsAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -379,7 +450,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getMbcsAsync() {
+    public Observable<String> getMbcsAsync() {
+        return getMbcsAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+            @Override
+            public String call(ServiceResponse<String> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
+     *
+     * @return the observable to the String object
+     */
+    public Observable<ServiceResponse<String>> getMbcsAsyncWithServiceResponse() {
         return service.getMbcs()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -410,8 +495,8 @@ public final class StringsImpl implements Strings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putMbcs(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putMbcsAsync(stringBody).toBlocking().single();
+    public void putMbcs(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
+        putMbcsAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -422,7 +507,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMbcsAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMbcsAsync(stringBody), serviceCallback);
+        return ServiceCall.create(putMbcsAsyncWithServiceResponse(stringBody), serviceCallback);
     }
 
     /**
@@ -431,7 +516,22 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMbcsAsync(String stringBody) {
+    public Observable<Void> putMbcsAsync(String stringBody) {
+        return putMbcsAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
+     *
+     * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putMbcsAsyncWithServiceResponse(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -463,8 +563,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<String> getWhitespace() throws ErrorException, IOException {
-        return getWhitespaceAsync().toBlocking().single();
+    public String getWhitespace() throws ErrorException, IOException {
+        return getWhitespaceAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -474,7 +574,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getWhitespaceAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getWhitespaceAsync(), serviceCallback);
+        return ServiceCall.create(getWhitespaceAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -482,7 +582,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getWhitespaceAsync() {
+    public Observable<String> getWhitespaceAsync() {
+        return getWhitespaceAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+            @Override
+            public String call(ServiceResponse<String> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @return the observable to the String object
+     */
+    public Observable<ServiceResponse<String>> getWhitespaceAsyncWithServiceResponse() {
         return service.getWhitespace()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -513,8 +627,8 @@ public final class StringsImpl implements Strings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putWhitespace(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putWhitespaceAsync(stringBody).toBlocking().single();
+    public void putWhitespace(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
+        putWhitespaceAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -525,7 +639,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putWhitespaceAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putWhitespaceAsync(stringBody), serviceCallback);
+        return ServiceCall.create(putWhitespaceAsyncWithServiceResponse(stringBody), serviceCallback);
     }
 
     /**
@@ -534,7 +648,22 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putWhitespaceAsync(String stringBody) {
+    public Observable<Void> putWhitespaceAsync(String stringBody) {
+        return putWhitespaceAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putWhitespaceAsyncWithServiceResponse(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -566,8 +695,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the String object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<String> getNotProvided() throws ErrorException, IOException {
-        return getNotProvidedAsync().toBlocking().single();
+    public String getNotProvided() throws ErrorException, IOException {
+        return getNotProvidedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -577,7 +706,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getNotProvidedAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getNotProvidedAsync(), serviceCallback);
+        return ServiceCall.create(getNotProvidedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -585,7 +714,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getNotProvidedAsync() {
+    public Observable<String> getNotProvidedAsync() {
+        return getNotProvidedAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+            @Override
+            public String call(ServiceResponse<String> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @return the observable to the String object
+     */
+    public Observable<ServiceResponse<String>> getNotProvidedAsyncWithServiceResponse() {
         return service.getNotProvided()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -614,8 +757,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<byte[]> getBase64Encoded() throws ErrorException, IOException {
-        return getBase64EncodedAsync().toBlocking().single();
+    public byte[] getBase64Encoded() throws ErrorException, IOException {
+        return getBase64EncodedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -625,7 +768,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getBase64EncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getBase64EncodedAsync(), serviceCallback);
+        return ServiceCall.create(getBase64EncodedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -633,7 +776,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getBase64EncodedAsync() {
+    public Observable<byte[]> getBase64EncodedAsync() {
+        return getBase64EncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+            @Override
+            public byte[] call(ServiceResponse<byte[]> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @return the observable to the byte[] object
+     */
+    public Observable<ServiceResponse<byte[]>> getBase64EncodedAsyncWithServiceResponse() {
         return service.getBase64Encoded()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -667,8 +824,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<byte[]> getBase64UrlEncoded() throws ErrorException, IOException {
-        return getBase64UrlEncodedAsync().toBlocking().single();
+    public byte[] getBase64UrlEncoded() throws ErrorException, IOException {
+        return getBase64UrlEncodedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -678,7 +835,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getBase64UrlEncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getBase64UrlEncodedAsync(), serviceCallback);
+        return ServiceCall.create(getBase64UrlEncodedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -686,7 +843,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getBase64UrlEncodedAsync() {
+    public Observable<byte[]> getBase64UrlEncodedAsync() {
+        return getBase64UrlEncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+            @Override
+            public byte[] call(ServiceResponse<byte[]> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @return the observable to the byte[] object
+     */
+    public Observable<ServiceResponse<byte[]>> getBase64UrlEncodedAsyncWithServiceResponse() {
         return service.getBase64UrlEncoded()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -722,8 +893,8 @@ public final class StringsImpl implements Strings {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putBase64UrlEncoded(byte[] stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        return putBase64UrlEncodedAsync(stringBody).toBlocking().single();
+    public void putBase64UrlEncoded(byte[] stringBody) throws ErrorException, IOException, IllegalArgumentException {
+        putBase64UrlEncodedAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -734,7 +905,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBase64UrlEncodedAsync(byte[] stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBase64UrlEncodedAsync(stringBody), serviceCallback);
+        return ServiceCall.create(putBase64UrlEncodedAsyncWithServiceResponse(stringBody), serviceCallback);
     }
 
     /**
@@ -743,7 +914,22 @@ public final class StringsImpl implements Strings {
      * @param stringBody the Base64Url value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBase64UrlEncodedAsync(byte[] stringBody) {
+    public Observable<Void> putBase64UrlEncodedAsync(byte[] stringBody) {
+        return putBase64UrlEncodedAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody the Base64Url value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putBase64UrlEncodedAsyncWithServiceResponse(byte[] stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -776,8 +962,8 @@ public final class StringsImpl implements Strings {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<byte[]> getNullBase64UrlEncoded() throws ErrorException, IOException {
-        return getNullBase64UrlEncodedAsync().toBlocking().single();
+    public byte[] getNullBase64UrlEncoded() throws ErrorException, IOException {
+        return getNullBase64UrlEncodedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -787,7 +973,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getNullBase64UrlEncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getNullBase64UrlEncodedAsync(), serviceCallback);
+        return ServiceCall.create(getNullBase64UrlEncodedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -795,7 +981,21 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getNullBase64UrlEncodedAsync() {
+    public Observable<byte[]> getNullBase64UrlEncodedAsync() {
+        return getNullBase64UrlEncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+            @Override
+            public byte[] call(ServiceResponse<byte[]> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @return the observable to the byte[] object
+     */
+    public Observable<ServiceResponse<byte[]>> getNullBase64UrlEncodedAsyncWithServiceResponse() {
         return service.getNullBase64UrlEncoded()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/implementation/StringsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/bodystring/implementation/StringsImpl.java
@@ -114,10 +114,10 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     public String getNull() throws ErrorException, IOException {
-        return getNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -127,7 +127,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getNullAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -136,12 +136,12 @@ public final class StringsImpl implements Strings {
      * @return the observable to the String object
      */
     public Observable<String> getNullAsync() {
-        return getNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+        return getNullWithServiceResponseAsync().map(new Func1<ServiceResponse<String>, String>() {
             @Override
             public String call(ServiceResponse<String> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -149,7 +149,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<String>> getNullWithServiceResponseAsync() {
         return service.getNull()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -176,10 +176,9 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putNull() throws ErrorException, IOException {
-        putNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        putNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -189,7 +188,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(putNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -198,12 +197,12 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putNullAsync() {
-        return putNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return putNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -211,7 +210,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> putNullWithServiceResponseAsync() {
         final String stringBody = null;
         return service.putNull(stringBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -233,10 +232,9 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: ''
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putNull(String stringBody) throws ErrorException, IOException {
-        putNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        putNullWithServiceResponseAsync(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -247,21 +245,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putNullAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putNullAsyncWithServiceResponse(stringBody), serviceCallback);
-    }
-
-    /**
-     * Set string value null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> putNullAsync(String stringBody) {
-        return putNullAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(putNullWithServiceResponseAsync(stringBody), serviceCallback);
     }
 
     /**
@@ -270,7 +254,22 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putNullAsyncWithServiceResponse(String stringBody) {
+    public Observable<Void> putNullAsync(String stringBody) {
+        return putNullWithServiceResponseAsync(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody Possible values include: ''
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putNullWithServiceResponseAsync(String stringBody) {
         return service.putNull(stringBody)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -297,10 +296,10 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     public String getEmpty() throws ErrorException, IOException {
-        return getEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -310,7 +309,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getEmptyAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -319,12 +318,12 @@ public final class StringsImpl implements Strings {
      * @return the observable to the String object
      */
     public Observable<String> getEmptyAsync() {
-        return getEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+        return getEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<String>, String>() {
             @Override
             public String call(ServiceResponse<String> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -332,7 +331,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<String>> getEmptyWithServiceResponseAsync() {
         return service.getEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -361,10 +360,9 @@ public final class StringsImpl implements Strings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putEmpty(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        putEmptyAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
+        putEmptyWithServiceResponseAsync(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -375,7 +373,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putEmptyAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putEmptyAsyncWithServiceResponse(stringBody), serviceCallback);
+        return ServiceCall.create(putEmptyWithServiceResponseAsync(stringBody), serviceCallback);
     }
 
     /**
@@ -385,12 +383,12 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putEmptyAsync(String stringBody) {
-        return putEmptyAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putEmptyWithServiceResponseAsync(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -399,7 +397,7 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: ''
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putEmptyAsyncWithServiceResponse(String stringBody) {
+    public Observable<ServiceResponse<Void>> putEmptyWithServiceResponseAsync(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -429,10 +427,10 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     public String getMbcs() throws ErrorException, IOException {
-        return getMbcsAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getMbcsWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -442,7 +440,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getMbcsAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getMbcsAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getMbcsWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -451,12 +449,12 @@ public final class StringsImpl implements Strings {
      * @return the observable to the String object
      */
     public Observable<String> getMbcsAsync() {
-        return getMbcsAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+        return getMbcsWithServiceResponseAsync().map(new Func1<ServiceResponse<String>, String>() {
             @Override
             public String call(ServiceResponse<String> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -464,7 +462,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getMbcsAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<String>> getMbcsWithServiceResponseAsync() {
         return service.getMbcs()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -493,10 +491,9 @@ public final class StringsImpl implements Strings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putMbcs(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        putMbcsAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
+        putMbcsWithServiceResponseAsync(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -507,7 +504,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putMbcsAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putMbcsAsyncWithServiceResponse(stringBody), serviceCallback);
+        return ServiceCall.create(putMbcsWithServiceResponseAsync(stringBody), serviceCallback);
     }
 
     /**
@@ -517,12 +514,12 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putMbcsAsync(String stringBody) {
-        return putMbcsAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putMbcsWithServiceResponseAsync(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -531,7 +528,7 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putMbcsAsyncWithServiceResponse(String stringBody) {
+    public Observable<ServiceResponse<Void>> putMbcsWithServiceResponseAsync(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -561,10 +558,10 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     public String getWhitespace() throws ErrorException, IOException {
-        return getWhitespaceAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getWhitespaceWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -574,7 +571,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getWhitespaceAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getWhitespaceAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getWhitespaceWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -583,12 +580,12 @@ public final class StringsImpl implements Strings {
      * @return the observable to the String object
      */
     public Observable<String> getWhitespaceAsync() {
-        return getWhitespaceAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+        return getWhitespaceWithServiceResponseAsync().map(new Func1<ServiceResponse<String>, String>() {
             @Override
             public String call(ServiceResponse<String> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -596,7 +593,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getWhitespaceAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<String>> getWhitespaceWithServiceResponseAsync() {
         return service.getWhitespace()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -625,10 +622,9 @@ public final class StringsImpl implements Strings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putWhitespace(String stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        putWhitespaceAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
+        putWhitespaceWithServiceResponseAsync(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -639,7 +635,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putWhitespaceAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putWhitespaceAsyncWithServiceResponse(stringBody), serviceCallback);
+        return ServiceCall.create(putWhitespaceWithServiceResponseAsync(stringBody), serviceCallback);
     }
 
     /**
@@ -649,12 +645,12 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putWhitespaceAsync(String stringBody) {
-        return putWhitespaceAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putWhitespaceWithServiceResponseAsync(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -663,7 +659,7 @@ public final class StringsImpl implements Strings {
      * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putWhitespaceAsyncWithServiceResponse(String stringBody) {
+    public Observable<ServiceResponse<Void>> putWhitespaceWithServiceResponseAsync(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -693,10 +689,10 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the String object wrapped in {@link ServiceResponse} if successful.
+     * @return the String object if successful.
      */
     public String getNotProvided() throws ErrorException, IOException {
-        return getNotProvidedAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNotProvidedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -706,7 +702,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<String> getNotProvidedAsync(final ServiceCallback<String> serviceCallback) {
-        return ServiceCall.create(getNotProvidedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNotProvidedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -715,12 +711,12 @@ public final class StringsImpl implements Strings {
      * @return the observable to the String object
      */
     public Observable<String> getNotProvidedAsync() {
-        return getNotProvidedAsyncWithServiceResponse().map(new Func1<ServiceResponse<String>, String>() {
+        return getNotProvidedWithServiceResponseAsync().map(new Func1<ServiceResponse<String>, String>() {
             @Override
             public String call(ServiceResponse<String> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -728,7 +724,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the String object
      */
-    public Observable<ServiceResponse<String>> getNotProvidedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<String>> getNotProvidedWithServiceResponseAsync() {
         return service.getNotProvided()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<String>>>() {
                 @Override
@@ -755,10 +751,10 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     public byte[] getBase64Encoded() throws ErrorException, IOException {
-        return getBase64EncodedAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBase64EncodedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -768,7 +764,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getBase64EncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getBase64EncodedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBase64EncodedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -777,12 +773,12 @@ public final class StringsImpl implements Strings {
      * @return the observable to the byte[] object
      */
     public Observable<byte[]> getBase64EncodedAsync() {
-        return getBase64EncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+        return getBase64EncodedWithServiceResponseAsync().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
             @Override
             public byte[] call(ServiceResponse<byte[]> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -790,7 +786,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getBase64EncodedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<byte[]>> getBase64EncodedWithServiceResponseAsync() {
         return service.getBase64Encoded()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -822,10 +818,10 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     public byte[] getBase64UrlEncoded() throws ErrorException, IOException {
-        return getBase64UrlEncodedAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getBase64UrlEncodedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -835,7 +831,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getBase64UrlEncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getBase64UrlEncodedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBase64UrlEncodedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -844,12 +840,12 @@ public final class StringsImpl implements Strings {
      * @return the observable to the byte[] object
      */
     public Observable<byte[]> getBase64UrlEncodedAsync() {
-        return getBase64UrlEncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+        return getBase64UrlEncodedWithServiceResponseAsync().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
             @Override
             public byte[] call(ServiceResponse<byte[]> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -857,7 +853,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getBase64UrlEncodedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<byte[]>> getBase64UrlEncodedWithServiceResponseAsync() {
         return service.getBase64UrlEncoded()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override
@@ -891,10 +887,9 @@ public final class StringsImpl implements Strings {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putBase64UrlEncoded(byte[] stringBody) throws ErrorException, IOException, IllegalArgumentException {
-        putBase64UrlEncodedAsyncWithServiceResponse(stringBody).toBlocking().single().getBody();
+        putBase64UrlEncodedWithServiceResponseAsync(stringBody).toBlocking().single().getBody();
     }
 
     /**
@@ -905,7 +900,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putBase64UrlEncodedAsync(byte[] stringBody, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putBase64UrlEncodedAsyncWithServiceResponse(stringBody), serviceCallback);
+        return ServiceCall.create(putBase64UrlEncodedWithServiceResponseAsync(stringBody), serviceCallback);
     }
 
     /**
@@ -915,12 +910,12 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putBase64UrlEncodedAsync(byte[] stringBody) {
-        return putBase64UrlEncodedAsyncWithServiceResponse(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
+        return putBase64UrlEncodedWithServiceResponseAsync(stringBody).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -929,7 +924,7 @@ public final class StringsImpl implements Strings {
      * @param stringBody the Base64Url value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putBase64UrlEncodedAsyncWithServiceResponse(byte[] stringBody) {
+    public Observable<ServiceResponse<Void>> putBase64UrlEncodedWithServiceResponseAsync(byte[] stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
@@ -960,10 +955,10 @@ public final class StringsImpl implements Strings {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the byte[] object wrapped in {@link ServiceResponse} if successful.
+     * @return the byte[] object if successful.
      */
     public byte[] getNullBase64UrlEncoded() throws ErrorException, IOException {
-        return getNullBase64UrlEncodedAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNullBase64UrlEncodedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -973,7 +968,7 @@ public final class StringsImpl implements Strings {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<byte[]> getNullBase64UrlEncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
-        return ServiceCall.create(getNullBase64UrlEncodedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNullBase64UrlEncodedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -982,12 +977,12 @@ public final class StringsImpl implements Strings {
      * @return the observable to the byte[] object
      */
     public Observable<byte[]> getNullBase64UrlEncodedAsync() {
-        return getNullBase64UrlEncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
+        return getNullBase64UrlEncodedWithServiceResponseAsync().map(new Func1<ServiceResponse<byte[]>, byte[]>() {
             @Override
             public byte[] call(ServiceResponse<byte[]> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -995,7 +990,7 @@ public final class StringsImpl implements Strings {
      *
      * @return the observable to the byte[] object
      */
-    public Observable<ServiceResponse<byte[]>> getNullBase64UrlEncodedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<byte[]>> getNullBase64UrlEncodedWithServiceResponseAsync() {
         return service.getNullBase64UrlEncoded()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<byte[]>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseuri/Paths.java
@@ -29,7 +29,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -56,6 +55,6 @@ public interface Paths {
      * @param accountName Account Name
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String accountName);
+    Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String accountName);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseuri/Paths.java
@@ -31,7 +31,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException;
+    void getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a 200 to test a valid base uri.
@@ -48,6 +48,14 @@ public interface Paths {
      * @param accountName Account Name
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getEmptyAsync(String accountName);
+    Observable<Void> getEmptyAsync(String accountName);
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String accountName);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
@@ -67,10 +67,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException {
-        getEmptyAsyncWithServiceResponse(accountName).toBlocking().single().getBody();
+        getEmptyWithServiceResponseAsync(accountName).toBlocking().single().getBody();
     }
 
     /**
@@ -81,7 +80,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getEmptyAsync(String accountName, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(accountName), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(accountName), serviceCallback);
     }
 
     /**
@@ -91,12 +90,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getEmptyAsync(String accountName) {
-        return getEmptyAsyncWithServiceResponse(accountName).map(new Func1<ServiceResponse<Void>, Void>() {
+        return getEmptyWithServiceResponseAsync(accountName).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -105,7 +104,7 @@ public final class PathsImpl implements Paths {
      * @param accountName Account Name
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String accountName) {
+    public Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String accountName) {
         if (accountName == null) {
             throw new IllegalArgumentException("Parameter accountName is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
@@ -69,8 +69,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException {
-        return getEmptyAsync(accountName).toBlocking().single();
+    public void getEmpty(String accountName) throws ErrorException, IOException, IllegalArgumentException {
+        getEmptyAsyncWithServiceResponse(accountName).toBlocking().single().getBody();
     }
 
     /**
@@ -81,7 +81,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getEmptyAsync(String accountName, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(accountName), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(accountName), serviceCallback);
     }
 
     /**
@@ -90,7 +90,22 @@ public final class PathsImpl implements Paths {
      * @param accountName Account Name
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getEmptyAsync(String accountName) {
+    public Observable<Void> getEmptyAsync(String accountName) {
+        return getEmptyAsyncWithServiceResponse(accountName).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String accountName) {
         if (accountName == null) {
             throw new IllegalArgumentException("Parameter accountName is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/Paths.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/Paths.java
@@ -33,7 +33,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getEmpty(String vault, String secret, String keyName) throws ErrorException, IOException, IllegalArgumentException;
+    void getEmpty(String vault, String secret, String keyName) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a 200 to test a valid base uri.
@@ -45,6 +45,28 @@ public interface Paths {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getEmptyAsync(String vault, String secret, String keyName, final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @param keyVersion The key version. Default value 'v1'.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getEmptyAsync(String vault, String secret, String keyName);
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @param keyVersion The key version. Default value 'v1'.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String vault, String secret, String keyName);
     /**
      * Get a 200 to test a valid base uri.
      *
@@ -57,7 +79,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getEmpty(String vault, String secret, String keyName, String keyVersion) throws ErrorException, IOException, IllegalArgumentException;
+    void getEmpty(String vault, String secret, String keyName, String keyVersion) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a 200 to test a valid base uri.
@@ -80,6 +102,17 @@ public interface Paths {
      * @param keyVersion The key version. Default value 'v1'.
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getEmptyAsync(String vault, String secret, String keyName, String keyVersion);
+    Observable<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion);
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @param keyVersion The key version. Default value 'v1'.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String vault, String secret, String keyName, String keyVersion);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/Paths.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/Paths.java
@@ -31,7 +31,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getEmpty(String vault, String secret, String keyName) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -52,7 +51,6 @@ public interface Paths {
      * @param vault The vault name, e.g. https://myvault
      * @param secret Secret value.
      * @param keyName The key name with value 'key1'.
-     * @param keyVersion The key version. Default value 'v1'.
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getEmptyAsync(String vault, String secret, String keyName);
@@ -63,10 +61,9 @@ public interface Paths {
      * @param vault The vault name, e.g. https://myvault
      * @param secret Secret value.
      * @param keyName The key name with value 'key1'.
-     * @param keyVersion The key version. Default value 'v1'.
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String vault, String secret, String keyName);
+    Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String vault, String secret, String keyName);
     /**
      * Get a 200 to test a valid base uri.
      *
@@ -77,7 +74,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getEmpty(String vault, String secret, String keyName, String keyVersion) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -113,6 +109,6 @@ public interface Paths {
      * @param keyVersion The key version. Default value 'v1'.
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String vault, String secret, String keyName, String keyVersion);
+    Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String vault, String secret, String keyName, String keyVersion);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/implementation/PathsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/implementation/PathsImpl.java
@@ -73,8 +73,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getEmpty(String vault, String secret, String keyName) throws ErrorException, IOException, IllegalArgumentException {
-        return getEmptyAsync(vault, secret, keyName).toBlocking().single();
+    public void getEmpty(String vault, String secret, String keyName) throws ErrorException, IOException, IllegalArgumentException {
+        getEmptyAsyncWithServiceResponse(vault, secret, keyName).toBlocking().single().getBody();
     }
 
     /**
@@ -87,7 +87,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getEmptyAsync(String vault, String secret, String keyName, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(vault, secret, keyName), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(vault, secret, keyName), serviceCallback);
     }
 
     /**
@@ -98,7 +98,24 @@ public final class PathsImpl implements Paths {
      * @param keyName The key name with value 'key1'.
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getEmptyAsync(String vault, String secret, String keyName) {
+    public Observable<Void> getEmptyAsync(String vault, String secret, String keyName) {
+        return getEmptyAsyncWithServiceResponse(vault, secret, keyName).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String vault, String secret, String keyName) {
         if (vault == null) {
             throw new IllegalArgumentException("Parameter vault is required and cannot be null.");
         }
@@ -142,8 +159,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getEmpty(String vault, String secret, String keyName, String keyVersion) throws ErrorException, IOException, IllegalArgumentException {
-        return getEmptyAsync(vault, secret, keyName, keyVersion).toBlocking().single();
+    public void getEmpty(String vault, String secret, String keyName, String keyVersion) throws ErrorException, IOException, IllegalArgumentException {
+        getEmptyAsyncWithServiceResponse(vault, secret, keyName).toBlocking().single().getBody();
     }
 
     /**
@@ -157,7 +174,24 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getEmptyAsync(vault, secret, keyName, keyVersion), serviceCallback);
+        return ServiceCall.create(getEmptyAsyncWithServiceResponse(vault, secret, keyName, keyVersion), serviceCallback);
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion) {
+        return getEmptyAsyncWithServiceResponse(vault, secret, keyName, keyVersion).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -169,7 +203,7 @@ public final class PathsImpl implements Paths {
      * @param keyVersion The key version. Default value 'v1'.
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getEmptyAsync(String vault, String secret, String keyName, String keyVersion) {
+    public Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String vault, String secret, String keyName, String keyVersion) {
         if (vault == null) {
             throw new IllegalArgumentException("Parameter vault is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/implementation/PathsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/custombaseurimoreoptions/implementation/PathsImpl.java
@@ -71,10 +71,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getEmpty(String vault, String secret, String keyName) throws ErrorException, IOException, IllegalArgumentException {
-        getEmptyAsyncWithServiceResponse(vault, secret, keyName).toBlocking().single().getBody();
+        getEmptyWithServiceResponseAsync(vault, secret, keyName).toBlocking().single().getBody();
     }
 
     /**
@@ -87,7 +86,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getEmptyAsync(String vault, String secret, String keyName, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(vault, secret, keyName), serviceCallback);
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(vault, secret, keyName), serviceCallback);
     }
 
     /**
@@ -99,12 +98,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getEmptyAsync(String vault, String secret, String keyName) {
-        return getEmptyAsyncWithServiceResponse(vault, secret, keyName).map(new Func1<ServiceResponse<Void>, Void>() {
+        return getEmptyWithServiceResponseAsync(vault, secret, keyName).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -115,7 +114,7 @@ public final class PathsImpl implements Paths {
      * @param keyName The key name with value 'key1'.
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String vault, String secret, String keyName) {
+    public Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String vault, String secret, String keyName) {
         if (vault == null) {
             throw new IllegalArgumentException("Parameter vault is required and cannot be null.");
         }
@@ -157,10 +156,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getEmpty(String vault, String secret, String keyName, String keyVersion) throws ErrorException, IOException, IllegalArgumentException {
-        getEmptyAsyncWithServiceResponse(vault, secret, keyName).toBlocking().single().getBody();
+        getEmptyWithServiceResponseAsync(vault, secret, keyName, keyVersion).toBlocking().single().getBody();
     }
 
     /**
@@ -174,24 +172,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getEmptyAsyncWithServiceResponse(vault, secret, keyName, keyVersion), serviceCallback);
-    }
-
-    /**
-     * Get a 200 to test a valid base uri.
-     *
-     * @param vault The vault name, e.g. https://myvault
-     * @param secret Secret value.
-     * @param keyName The key name with value 'key1'.
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion) {
-        return getEmptyAsyncWithServiceResponse(vault, secret, keyName, keyVersion).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(getEmptyWithServiceResponseAsync(vault, secret, keyName, keyVersion), serviceCallback);
     }
 
     /**
@@ -203,7 +184,25 @@ public final class PathsImpl implements Paths {
      * @param keyVersion The key version. Default value 'v1'.
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getEmptyAsyncWithServiceResponse(String vault, String secret, String keyName, String keyVersion) {
+    public Observable<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion) {
+        return getEmptyWithServiceResponseAsync(vault, secret, keyName, keyVersion).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @param keyVersion The key version. Default value 'v1'.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getEmptyWithServiceResponseAsync(String vault, String secret, String keyName, String keyVersion) {
         if (vault == null) {
             throw new IllegalArgumentException("Parameter vault is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/header/Headers.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/header/Headers.java
@@ -50,7 +50,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramExistingKey(String userAgent) throws ErrorException, IOException, IllegalArgumentException;
+    void paramExistingKey(String userAgent) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header value "User-Agent": "overwrite".
@@ -67,7 +67,15 @@ public interface Headers {
      * @param userAgent Send a post request with header value "User-Agent": "overwrite"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramExistingKeyAsync(String userAgent);
+    Observable<Void> paramExistingKeyAsync(String userAgent);
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramExistingKeyAsyncWithServiceResponse(String userAgent);
 
     /**
      * Get a response with header value "User-Agent": "overwrite".
@@ -76,7 +84,7 @@ public interface Headers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders> responseExistingKey() throws ErrorException, IOException;
+    void responseExistingKey() throws ErrorException, IOException;
 
     /**
      * Get a response with header value "User-Agent": "overwrite".
@@ -91,7 +99,14 @@ public interface Headers {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>> responseExistingKeyAsync();
+    Observable<Void> responseExistingKeyAsync();
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>> responseExistingKeyAsyncWithServiceResponse();
 
     /**
      * Send a post request with header value "Content-Type": "text/html".
@@ -102,7 +117,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramProtectedKey(String contentType) throws ErrorException, IOException, IllegalArgumentException;
+    void paramProtectedKey(String contentType) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header value "Content-Type": "text/html".
@@ -119,7 +134,15 @@ public interface Headers {
      * @param contentType Send a post request with header value "Content-Type": "text/html"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramProtectedKeyAsync(String contentType);
+    Observable<Void> paramProtectedKeyAsync(String contentType);
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramProtectedKeyAsyncWithServiceResponse(String contentType);
 
     /**
      * Get a response with header value "Content-Type": "text/html".
@@ -128,7 +151,7 @@ public interface Headers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders> responseProtectedKey() throws ErrorException, IOException;
+    void responseProtectedKey() throws ErrorException, IOException;
 
     /**
      * Get a response with header value "Content-Type": "text/html".
@@ -143,7 +166,14 @@ public interface Headers {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>> responseProtectedKeyAsync();
+    Observable<Void> responseProtectedKeyAsync();
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>> responseProtectedKeyAsyncWithServiceResponse();
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
@@ -155,7 +185,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramInteger(String scenario, int value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramInteger(String scenario, int value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
@@ -174,7 +204,16 @@ public interface Headers {
      * @param value Send a post request with header values 1 or -2
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramIntegerAsync(String scenario, int value);
+    Observable<Void> paramIntegerAsync(String scenario, int value);
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 1 or -2
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramIntegerAsyncWithServiceResponse(String scenario, int value);
 
     /**
      * Get a response with header value "value": 1 or -2.
@@ -185,7 +224,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders> responseInteger(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseInteger(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header value "value": 1 or -2.
@@ -202,7 +241,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>> responseIntegerAsync(String scenario);
+    Observable<Void> responseIntegerAsync(String scenario);
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>> responseIntegerAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
@@ -214,7 +261,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramLong(String scenario, long value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramLong(String scenario, long value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
@@ -233,7 +280,16 @@ public interface Headers {
      * @param value Send a post request with header values 105 or -2
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramLongAsync(String scenario, long value);
+    Observable<Void> paramLongAsync(String scenario, long value);
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 105 or -2
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramLongAsyncWithServiceResponse(String scenario, long value);
 
     /**
      * Get a response with header value "value": 105 or -2.
@@ -244,7 +300,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders> responseLong(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseLong(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header value "value": 105 or -2.
@@ -261,7 +317,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>> responseLongAsync(String scenario);
+    Observable<Void> responseLongAsync(String scenario);
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>> responseLongAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
@@ -273,7 +337,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramFloat(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramFloat(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
@@ -292,7 +356,16 @@ public interface Headers {
      * @param value Send a post request with header values 0.07 or -3.0
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramFloatAsync(String scenario, double value);
+    Observable<Void> paramFloatAsync(String scenario, double value);
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 0.07 or -3.0
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramFloatAsyncWithServiceResponse(String scenario, double value);
 
     /**
      * Get a response with header value "value": 0.07 or -3.0.
@@ -303,7 +376,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders> responseFloat(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseFloat(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header value "value": 0.07 or -3.0.
@@ -320,7 +393,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>> responseFloatAsync(String scenario);
+    Observable<Void> responseFloatAsync(String scenario);
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>> responseFloatAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
@@ -332,7 +413,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramDouble(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramDouble(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
@@ -351,7 +432,16 @@ public interface Headers {
      * @param value Send a post request with header values 7e120 or -3.0
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDoubleAsync(String scenario, double value);
+    Observable<Void> paramDoubleAsync(String scenario, double value);
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 7e120 or -3.0
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramDoubleAsyncWithServiceResponse(String scenario, double value);
 
     /**
      * Get a response with header value "value": 7e120 or -3.0.
@@ -362,7 +452,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders> responseDouble(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseDouble(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header value "value": 7e120 or -3.0.
@@ -379,7 +469,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>> responseDoubleAsync(String scenario);
+    Observable<Void> responseDoubleAsync(String scenario);
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>> responseDoubleAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
@@ -391,7 +489,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramBool(String scenario, boolean value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramBool(String scenario, boolean value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
@@ -410,7 +508,16 @@ public interface Headers {
      * @param value Send a post request with header values true or false
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramBoolAsync(String scenario, boolean value);
+    Observable<Void> paramBoolAsync(String scenario, boolean value);
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false"
+     * @param value Send a post request with header values true or false
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramBoolAsyncWithServiceResponse(String scenario, boolean value);
 
     /**
      * Get a response with header value "value": true or false.
@@ -421,7 +528,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders> responseBool(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseBool(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header value "value": true or false.
@@ -438,7 +545,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "true" or "false"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>> responseBoolAsync(String scenario);
+    Observable<Void> responseBoolAsync(String scenario);
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>> responseBoolAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
@@ -449,7 +564,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramString(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void paramString(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
@@ -459,6 +574,24 @@ public interface Headers {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> paramStringAsync(String scenario, final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> paramStringAsync(String scenario);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramStringAsyncWithServiceResponse(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
      *
@@ -469,7 +602,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramString(String scenario, String value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramString(String scenario, String value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
@@ -488,7 +621,16 @@ public interface Headers {
      * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramStringAsync(String scenario, String value);
+    Observable<Void> paramStringAsync(String scenario, String value);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramStringAsyncWithServiceResponse(String scenario, String value);
 
     /**
      * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
@@ -499,7 +641,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> responseString(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseString(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
@@ -516,7 +658,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>> responseStringAsync(String scenario);
+    Observable<Void> responseStringAsync(String scenario);
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>> responseStringAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
@@ -528,7 +678,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramDate(String scenario, LocalDate value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramDate(String scenario, LocalDate value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
@@ -547,7 +697,16 @@ public interface Headers {
      * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDateAsync(String scenario, LocalDate value);
+    Observable<Void> paramDateAsync(String scenario, LocalDate value);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramDateAsyncWithServiceResponse(String scenario, LocalDate value);
 
     /**
      * Get a response with header values "2010-01-01" or "0001-01-01".
@@ -558,7 +717,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders> responseDate(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseDate(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header values "2010-01-01" or "0001-01-01".
@@ -575,7 +734,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>> responseDateAsync(String scenario);
+    Observable<Void> responseDateAsync(String scenario);
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>> responseDateAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
@@ -587,7 +754,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramDatetime(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramDatetime(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
@@ -606,7 +773,16 @@ public interface Headers {
      * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDatetimeAsync(String scenario, DateTime value);
+    Observable<Void> paramDatetimeAsync(String scenario, DateTime value);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramDatetimeAsyncWithServiceResponse(String scenario, DateTime value);
 
     /**
      * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
@@ -617,7 +793,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders> responseDatetime(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseDatetime(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
@@ -634,7 +810,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>> responseDatetimeAsync(String scenario);
+    Observable<Void> responseDatetimeAsync(String scenario);
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>> responseDatetimeAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
@@ -645,7 +829,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void paramDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
@@ -655,6 +839,24 @@ public interface Headers {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> paramDatetimeRfc1123Async(String scenario, final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> paramDatetimeRfc1123Async(String scenario);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramDatetimeRfc1123AsyncWithServiceResponse(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
      *
@@ -665,7 +867,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramDatetimeRfc1123(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramDatetimeRfc1123(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
@@ -684,7 +886,16 @@ public interface Headers {
      * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDatetimeRfc1123Async(String scenario, DateTime value);
+    Observable<Void> paramDatetimeRfc1123Async(String scenario, DateTime value);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramDatetimeRfc1123AsyncWithServiceResponse(String scenario, DateTime value);
 
     /**
      * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
@@ -695,7 +906,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers> responseDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
@@ -712,7 +923,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>> responseDatetimeRfc1123Async(String scenario);
+    Observable<Void> responseDatetimeRfc1123Async(String scenario);
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>> responseDatetimeRfc1123AsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
@@ -724,7 +943,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramDuration(String scenario, Period value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramDuration(String scenario, Period value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
@@ -743,7 +962,16 @@ public interface Headers {
      * @param value Send a post request with header values "P123DT22H14M12.011S"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDurationAsync(String scenario, Period value);
+    Observable<Void> paramDurationAsync(String scenario, Period value);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @param value Send a post request with header values "P123DT22H14M12.011S"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramDurationAsyncWithServiceResponse(String scenario, Period value);
 
     /**
      * Get a response with header values "P123DT22H14M12.011S".
@@ -754,7 +982,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders> responseDuration(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseDuration(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header values "P123DT22H14M12.011S".
@@ -771,7 +999,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>> responseDurationAsync(String scenario);
+    Observable<Void> responseDurationAsync(String scenario);
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>> responseDurationAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
@@ -783,7 +1019,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramByte(String scenario, byte[] value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramByte(String scenario, byte[] value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
@@ -802,7 +1038,16 @@ public interface Headers {
      * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramByteAsync(String scenario, byte[] value);
+    Observable<Void> paramByteAsync(String scenario, byte[] value);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramByteAsyncWithServiceResponse(String scenario, byte[] value);
 
     /**
      * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
@@ -813,7 +1058,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders> responseByte(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseByte(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
@@ -830,7 +1075,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>> responseByteAsync(String scenario);
+    Observable<Void> responseByteAsync(String scenario);
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>> responseByteAsyncWithServiceResponse(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
@@ -841,7 +1094,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void paramEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
@@ -851,6 +1104,24 @@ public interface Headers {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> paramEnumAsync(String scenario, final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> paramEnumAsync(String scenario);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramEnumAsyncWithServiceResponse(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
      *
@@ -861,7 +1132,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> paramEnum(String scenario, GreyscaleColors value) throws ErrorException, IOException, IllegalArgumentException;
+    void paramEnum(String scenario, GreyscaleColors value) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
@@ -880,7 +1151,16 @@ public interface Headers {
      * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramEnumAsync(String scenario, GreyscaleColors value);
+    Observable<Void> paramEnumAsync(String scenario, GreyscaleColors value);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> paramEnumAsyncWithServiceResponse(String scenario, GreyscaleColors value);
 
     /**
      * Get a response with header values "GREY" or null.
@@ -891,7 +1171,7 @@ public interface Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders> responseEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException;
+    void responseEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get a response with header values "GREY" or null.
@@ -908,7 +1188,15 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>> responseEnumAsync(String scenario);
+    Observable<Void> responseEnumAsync(String scenario);
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>> responseEnumAsyncWithServiceResponse(String scenario);
 
     /**
      * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
@@ -917,7 +1205,7 @@ public interface Headers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> customRequestId() throws ErrorException, IOException;
+    void customRequestId() throws ErrorException, IOException;
 
     /**
      * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
@@ -932,6 +1220,13 @@ public interface Headers {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> customRequestIdAsync();
+    Observable<Void> customRequestIdAsync();
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> customRequestIdAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/header/Headers.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/header/Headers.java
@@ -48,7 +48,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramExistingKey(String userAgent) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -75,14 +74,13 @@ public interface Headers {
      * @param userAgent Send a post request with header value "User-Agent": "overwrite"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramExistingKeyAsyncWithServiceResponse(String userAgent);
+    Observable<ServiceResponse<Void>> paramExistingKeyWithServiceResponseAsync(String userAgent);
 
     /**
      * Get a response with header value "User-Agent": "overwrite".
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseExistingKey() throws ErrorException, IOException;
 
@@ -106,7 +104,7 @@ public interface Headers {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>> responseExistingKeyAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>> responseExistingKeyWithServiceResponseAsync();
 
     /**
      * Send a post request with header value "Content-Type": "text/html".
@@ -115,7 +113,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramProtectedKey(String contentType) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -142,14 +139,13 @@ public interface Headers {
      * @param contentType Send a post request with header value "Content-Type": "text/html"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramProtectedKeyAsyncWithServiceResponse(String contentType);
+    Observable<ServiceResponse<Void>> paramProtectedKeyWithServiceResponseAsync(String contentType);
 
     /**
      * Get a response with header value "Content-Type": "text/html".
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseProtectedKey() throws ErrorException, IOException;
 
@@ -173,7 +169,7 @@ public interface Headers {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>> responseProtectedKeyAsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>> responseProtectedKeyWithServiceResponseAsync();
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
@@ -183,7 +179,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramInteger(String scenario, int value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -213,7 +208,7 @@ public interface Headers {
      * @param value Send a post request with header values 1 or -2
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramIntegerAsyncWithServiceResponse(String scenario, int value);
+    Observable<ServiceResponse<Void>> paramIntegerWithServiceResponseAsync(String scenario, int value);
 
     /**
      * Get a response with header value "value": 1 or -2.
@@ -222,7 +217,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseInteger(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -249,7 +243,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>> responseIntegerAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>> responseIntegerWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
@@ -259,7 +253,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramLong(String scenario, long value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -289,7 +282,7 @@ public interface Headers {
      * @param value Send a post request with header values 105 or -2
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramLongAsyncWithServiceResponse(String scenario, long value);
+    Observable<ServiceResponse<Void>> paramLongWithServiceResponseAsync(String scenario, long value);
 
     /**
      * Get a response with header value "value": 105 or -2.
@@ -298,7 +291,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseLong(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -325,7 +317,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>> responseLongAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>> responseLongWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
@@ -335,7 +327,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramFloat(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -365,7 +356,7 @@ public interface Headers {
      * @param value Send a post request with header values 0.07 or -3.0
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramFloatAsyncWithServiceResponse(String scenario, double value);
+    Observable<ServiceResponse<Void>> paramFloatWithServiceResponseAsync(String scenario, double value);
 
     /**
      * Get a response with header value "value": 0.07 or -3.0.
@@ -374,7 +365,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseFloat(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -401,7 +391,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>> responseFloatAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>> responseFloatWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
@@ -411,7 +401,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramDouble(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -441,7 +430,7 @@ public interface Headers {
      * @param value Send a post request with header values 7e120 or -3.0
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDoubleAsyncWithServiceResponse(String scenario, double value);
+    Observable<ServiceResponse<Void>> paramDoubleWithServiceResponseAsync(String scenario, double value);
 
     /**
      * Get a response with header value "value": 7e120 or -3.0.
@@ -450,7 +439,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseDouble(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -477,7 +465,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>> responseDoubleAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>> responseDoubleWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
@@ -487,7 +475,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramBool(String scenario, boolean value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -517,7 +504,7 @@ public interface Headers {
      * @param value Send a post request with header values true or false
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramBoolAsyncWithServiceResponse(String scenario, boolean value);
+    Observable<ServiceResponse<Void>> paramBoolWithServiceResponseAsync(String scenario, boolean value);
 
     /**
      * Get a response with header value "value": true or false.
@@ -526,7 +513,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseBool(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -553,7 +539,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "true" or "false"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>> responseBoolAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>> responseBoolWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
@@ -562,7 +548,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramString(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -579,7 +564,6 @@ public interface Headers {
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
-     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> paramStringAsync(String scenario);
@@ -588,10 +572,9 @@ public interface Headers {
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
-     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramStringAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponse<Void>> paramStringWithServiceResponseAsync(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
      *
@@ -600,7 +583,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramString(String scenario, String value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -630,7 +612,7 @@ public interface Headers {
      * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramStringAsyncWithServiceResponse(String scenario, String value);
+    Observable<ServiceResponse<Void>> paramStringWithServiceResponseAsync(String scenario, String value);
 
     /**
      * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
@@ -639,7 +621,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseString(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -666,7 +647,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>> responseStringAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>> responseStringWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
@@ -676,7 +657,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramDate(String scenario, LocalDate value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -706,7 +686,7 @@ public interface Headers {
      * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDateAsyncWithServiceResponse(String scenario, LocalDate value);
+    Observable<ServiceResponse<Void>> paramDateWithServiceResponseAsync(String scenario, LocalDate value);
 
     /**
      * Get a response with header values "2010-01-01" or "0001-01-01".
@@ -715,7 +695,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseDate(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -742,7 +721,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>> responseDateAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>> responseDateWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
@@ -752,7 +731,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramDatetime(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -782,7 +760,7 @@ public interface Headers {
      * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDatetimeAsyncWithServiceResponse(String scenario, DateTime value);
+    Observable<ServiceResponse<Void>> paramDatetimeWithServiceResponseAsync(String scenario, DateTime value);
 
     /**
      * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
@@ -791,7 +769,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseDatetime(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -818,7 +795,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>> responseDatetimeAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>> responseDatetimeWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
@@ -827,7 +804,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -844,7 +820,6 @@ public interface Headers {
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
-     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> paramDatetimeRfc1123Async(String scenario);
@@ -853,10 +828,9 @@ public interface Headers {
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
-     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDatetimeRfc1123AsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponse<Void>> paramDatetimeRfc1123WithServiceResponseAsync(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
      *
@@ -865,7 +839,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramDatetimeRfc1123(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -895,7 +868,7 @@ public interface Headers {
      * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDatetimeRfc1123AsyncWithServiceResponse(String scenario, DateTime value);
+    Observable<ServiceResponse<Void>> paramDatetimeRfc1123WithServiceResponseAsync(String scenario, DateTime value);
 
     /**
      * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
@@ -904,7 +877,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -931,7 +903,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>> responseDatetimeRfc1123AsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>> responseDatetimeRfc1123WithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
@@ -941,7 +913,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramDuration(String scenario, Period value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -971,7 +942,7 @@ public interface Headers {
      * @param value Send a post request with header values "P123DT22H14M12.011S"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramDurationAsyncWithServiceResponse(String scenario, Period value);
+    Observable<ServiceResponse<Void>> paramDurationWithServiceResponseAsync(String scenario, Period value);
 
     /**
      * Get a response with header values "P123DT22H14M12.011S".
@@ -980,7 +951,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseDuration(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1007,7 +977,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>> responseDurationAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>> responseDurationWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
@@ -1017,7 +987,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramByte(String scenario, byte[] value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1047,7 +1016,7 @@ public interface Headers {
      * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramByteAsyncWithServiceResponse(String scenario, byte[] value);
+    Observable<ServiceResponse<Void>> paramByteWithServiceResponseAsync(String scenario, byte[] value);
 
     /**
      * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
@@ -1056,7 +1025,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseByte(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1083,7 +1051,7 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>> responseByteAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>> responseByteWithServiceResponseAsync(String scenario);
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
@@ -1092,7 +1060,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1109,7 +1076,6 @@ public interface Headers {
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
-     * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> paramEnumAsync(String scenario);
@@ -1118,10 +1084,9 @@ public interface Headers {
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
-     * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramEnumAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponse<Void>> paramEnumWithServiceResponseAsync(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
      *
@@ -1130,7 +1095,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void paramEnum(String scenario, GreyscaleColors value) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1160,7 +1124,7 @@ public interface Headers {
      * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> paramEnumAsyncWithServiceResponse(String scenario, GreyscaleColors value);
+    Observable<ServiceResponse<Void>> paramEnumWithServiceResponseAsync(String scenario, GreyscaleColors value);
 
     /**
      * Get a response with header values "GREY" or null.
@@ -1169,7 +1133,6 @@ public interface Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void responseEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1196,14 +1159,13 @@ public interface Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>> responseEnumAsyncWithServiceResponse(String scenario);
+    Observable<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>> responseEnumWithServiceResponseAsync(String scenario);
 
     /**
      * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void customRequestId() throws ErrorException, IOException;
 
@@ -1227,6 +1189,6 @@ public interface Headers {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> customRequestIdAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> customRequestIdWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/header/implementation/HeadersImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/header/implementation/HeadersImpl.java
@@ -198,10 +198,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramExistingKey(String userAgent) throws ErrorException, IOException, IllegalArgumentException {
-        paramExistingKeyAsyncWithServiceResponse(userAgent).toBlocking().single().getBody();
+        paramExistingKeyWithServiceResponseAsync(userAgent).toBlocking().single().getBody();
     }
 
     /**
@@ -212,7 +211,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramExistingKeyAsync(String userAgent, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramExistingKeyAsyncWithServiceResponse(userAgent), serviceCallback);
+        return ServiceCall.create(paramExistingKeyWithServiceResponseAsync(userAgent), serviceCallback);
     }
 
     /**
@@ -222,12 +221,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramExistingKeyAsync(String userAgent) {
-        return paramExistingKeyAsyncWithServiceResponse(userAgent).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramExistingKeyWithServiceResponseAsync(userAgent).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -236,7 +235,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param userAgent Send a post request with header value "User-Agent": "overwrite"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramExistingKeyAsyncWithServiceResponse(String userAgent) {
+    public Observable<ServiceResponse<Void>> paramExistingKeyWithServiceResponseAsync(String userAgent) {
         if (userAgent == null) {
             throw new IllegalArgumentException("Parameter userAgent is required and cannot be null.");
         }
@@ -266,10 +265,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseExistingKey() throws ErrorException, IOException {
-        responseExistingKeyAsyncWithServiceResponse().toBlocking().single().getBody();
+        responseExistingKeyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -279,7 +277,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseExistingKeyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseExistingKeyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(responseExistingKeyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -288,12 +286,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseExistingKeyAsync() {
-        return responseExistingKeyAsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>, Void>() {
+        return responseExistingKeyWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -301,7 +299,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>> responseExistingKeyAsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>> responseExistingKeyWithServiceResponseAsync() {
         return service.responseExistingKey()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>>>() {
                 @Override
@@ -330,10 +328,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramProtectedKey(String contentType) throws ErrorException, IOException, IllegalArgumentException {
-        paramProtectedKeyAsyncWithServiceResponse(contentType).toBlocking().single().getBody();
+        paramProtectedKeyWithServiceResponseAsync(contentType).toBlocking().single().getBody();
     }
 
     /**
@@ -344,7 +341,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramProtectedKeyAsync(String contentType, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramProtectedKeyAsyncWithServiceResponse(contentType), serviceCallback);
+        return ServiceCall.create(paramProtectedKeyWithServiceResponseAsync(contentType), serviceCallback);
     }
 
     /**
@@ -354,12 +351,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramProtectedKeyAsync(String contentType) {
-        return paramProtectedKeyAsyncWithServiceResponse(contentType).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramProtectedKeyWithServiceResponseAsync(contentType).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -368,7 +365,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param contentType Send a post request with header value "Content-Type": "text/html"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramProtectedKeyAsyncWithServiceResponse(String contentType) {
+    public Observable<ServiceResponse<Void>> paramProtectedKeyWithServiceResponseAsync(String contentType) {
         if (contentType == null) {
             throw new IllegalArgumentException("Parameter contentType is required and cannot be null.");
         }
@@ -398,10 +395,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseProtectedKey() throws ErrorException, IOException {
-        responseProtectedKeyAsyncWithServiceResponse().toBlocking().single().getBody();
+        responseProtectedKeyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -411,7 +407,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseProtectedKeyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseProtectedKeyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(responseProtectedKeyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -420,12 +416,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseProtectedKeyAsync() {
-        return responseProtectedKeyAsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>, Void>() {
+        return responseProtectedKeyWithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -433,7 +429,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>> responseProtectedKeyAsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>> responseProtectedKeyWithServiceResponseAsync() {
         return service.responseProtectedKey()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>>>() {
                 @Override
@@ -463,10 +459,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramInteger(String scenario, int value) throws ErrorException, IOException, IllegalArgumentException {
-        paramIntegerAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramIntegerWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -478,7 +473,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramIntegerAsync(String scenario, int value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramIntegerAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramIntegerWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -489,12 +484,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramIntegerAsync(String scenario, int value) {
-        return paramIntegerAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramIntegerWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -504,7 +499,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 1 or -2
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramIntegerAsyncWithServiceResponse(String scenario, int value) {
+    public Observable<ServiceResponse<Void>> paramIntegerWithServiceResponseAsync(String scenario, int value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -536,10 +531,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseInteger(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseIntegerAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseIntegerWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -550,7 +544,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseIntegerAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseIntegerAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseIntegerWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -560,12 +554,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseIntegerAsync(String scenario) {
-        return responseIntegerAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>, Void>() {
+        return responseIntegerWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -574,7 +568,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>> responseIntegerAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>> responseIntegerWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -607,10 +601,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramLong(String scenario, long value) throws ErrorException, IOException, IllegalArgumentException {
-        paramLongAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramLongWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -622,7 +615,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramLongAsync(String scenario, long value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramLongAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramLongWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -633,12 +626,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramLongAsync(String scenario, long value) {
-        return paramLongAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramLongWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -648,7 +641,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 105 or -2
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramLongAsyncWithServiceResponse(String scenario, long value) {
+    public Observable<ServiceResponse<Void>> paramLongWithServiceResponseAsync(String scenario, long value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -680,10 +673,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseLong(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseLongAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseLongWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -694,7 +686,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseLongAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseLongAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseLongWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -704,12 +696,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseLongAsync(String scenario) {
-        return responseLongAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>, Void>() {
+        return responseLongWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -718,7 +710,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>> responseLongAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>> responseLongWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -751,10 +743,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramFloat(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException {
-        paramFloatAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramFloatWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -766,7 +757,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramFloatAsync(String scenario, double value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramFloatAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramFloatWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -777,12 +768,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramFloatAsync(String scenario, double value) {
-        return paramFloatAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramFloatWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -792,7 +783,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 0.07 or -3.0
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramFloatAsyncWithServiceResponse(String scenario, double value) {
+    public Observable<ServiceResponse<Void>> paramFloatWithServiceResponseAsync(String scenario, double value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -824,10 +815,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseFloat(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseFloatAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseFloatWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -838,7 +828,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseFloatAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseFloatAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseFloatWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -848,12 +838,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseFloatAsync(String scenario) {
-        return responseFloatAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>, Void>() {
+        return responseFloatWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -862,7 +852,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>> responseFloatAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>> responseFloatWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -895,10 +885,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramDouble(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException {
-        paramDoubleAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramDoubleWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -910,7 +899,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDoubleAsync(String scenario, double value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDoubleAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDoubleWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -921,12 +910,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramDoubleAsync(String scenario, double value) {
-        return paramDoubleAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramDoubleWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -936,7 +925,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 7e120 or -3.0
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDoubleAsyncWithServiceResponse(String scenario, double value) {
+    public Observable<ServiceResponse<Void>> paramDoubleWithServiceResponseAsync(String scenario, double value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -968,10 +957,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseDouble(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseDoubleAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseDoubleWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -982,7 +970,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDoubleAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDoubleAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDoubleWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -992,12 +980,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseDoubleAsync(String scenario) {
-        return responseDoubleAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>, Void>() {
+        return responseDoubleWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1006,7 +994,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>> responseDoubleAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>> responseDoubleWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1039,10 +1027,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramBool(String scenario, boolean value) throws ErrorException, IOException, IllegalArgumentException {
-        paramBoolAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramBoolWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1054,7 +1041,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramBoolAsync(String scenario, boolean value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramBoolAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramBoolWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -1065,12 +1052,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramBoolAsync(String scenario, boolean value) {
-        return paramBoolAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramBoolWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1080,7 +1067,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values true or false
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramBoolAsyncWithServiceResponse(String scenario, boolean value) {
+    public Observable<ServiceResponse<Void>> paramBoolWithServiceResponseAsync(String scenario, boolean value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1112,10 +1099,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseBool(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseBoolAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseBoolWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1126,7 +1112,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseBoolAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseBoolAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseBoolWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1136,12 +1122,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseBoolAsync(String scenario) {
-        return responseBoolAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>, Void>() {
+        return responseBoolWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1150,7 +1136,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "true" or "false"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>> responseBoolAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>> responseBoolWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1182,10 +1168,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramString(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        paramStringAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        paramStringWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1196,7 +1181,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramStringAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramStringAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.create(paramStringWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1206,12 +1191,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramStringAsync(String scenario) {
-        return paramStringAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramStringWithServiceResponseAsync(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1220,7 +1205,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramStringAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponse<Void>> paramStringWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1247,10 +1232,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramString(String scenario, String value) throws ErrorException, IOException, IllegalArgumentException {
-        paramStringAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        paramStringWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1262,22 +1246,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramStringAsync(String scenario, String value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramStringAsyncWithServiceResponse(scenario, value), serviceCallback);
-    }
-
-    /**
-     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
-     *
-     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> paramStringAsync(String scenario, String value) {
-        return paramStringAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(paramStringWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -1287,7 +1256,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramStringAsyncWithServiceResponse(String scenario, String value) {
+    public Observable<Void> paramStringAsync(String scenario, String value) {
+        return paramStringWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramStringWithServiceResponseAsync(String scenario, String value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1319,10 +1304,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseString(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseStringAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseStringWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1333,7 +1317,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseStringAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseStringAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseStringWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1343,12 +1327,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseStringAsync(String scenario) {
-        return responseStringAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>, Void>() {
+        return responseStringWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1357,7 +1341,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>> responseStringAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>> responseStringWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1390,10 +1374,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramDate(String scenario, LocalDate value) throws ErrorException, IOException, IllegalArgumentException {
-        paramDateAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramDateWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1405,7 +1388,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDateAsync(String scenario, LocalDate value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDateAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDateWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -1416,12 +1399,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramDateAsync(String scenario, LocalDate value) {
-        return paramDateAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramDateWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1431,7 +1414,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDateAsyncWithServiceResponse(String scenario, LocalDate value) {
+    public Observable<ServiceResponse<Void>> paramDateWithServiceResponseAsync(String scenario, LocalDate value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1466,10 +1449,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseDate(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseDateAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseDateWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1480,7 +1462,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDateAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDateAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDateWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1490,12 +1472,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseDateAsync(String scenario) {
-        return responseDateAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>, Void>() {
+        return responseDateWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1504,7 +1486,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>> responseDateAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>> responseDateWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1537,10 +1519,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramDatetime(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException {
-        paramDatetimeAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramDatetimeWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1552,7 +1533,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDatetimeAsync(String scenario, DateTime value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDatetimeAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDatetimeWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -1563,12 +1544,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramDatetimeAsync(String scenario, DateTime value) {
-        return paramDatetimeAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramDatetimeWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1578,7 +1559,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDatetimeAsyncWithServiceResponse(String scenario, DateTime value) {
+    public Observable<ServiceResponse<Void>> paramDatetimeWithServiceResponseAsync(String scenario, DateTime value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1613,10 +1594,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseDatetime(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseDatetimeAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseDatetimeWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1627,7 +1607,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDatetimeAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDatetimeAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDatetimeWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1637,12 +1617,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseDatetimeAsync(String scenario) {
-        return responseDatetimeAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>, Void>() {
+        return responseDatetimeWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1651,7 +1631,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>> responseDatetimeAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>> responseDatetimeWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1683,10 +1663,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        paramDatetimeRfc1123AsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        paramDatetimeRfc1123WithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1697,7 +1676,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDatetimeRfc1123Async(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDatetimeRfc1123AsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.create(paramDatetimeRfc1123WithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1707,12 +1686,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramDatetimeRfc1123Async(String scenario) {
-        return paramDatetimeRfc1123AsyncWithServiceResponse(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramDatetimeRfc1123WithServiceResponseAsync(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1721,7 +1700,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDatetimeRfc1123AsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponse<Void>> paramDatetimeRfc1123WithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1752,10 +1731,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramDatetimeRfc1123(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException {
-        paramDatetimeRfc1123AsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        paramDatetimeRfc1123WithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1767,22 +1745,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDatetimeRfc1123Async(String scenario, DateTime value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDatetimeRfc1123AsyncWithServiceResponse(scenario, value), serviceCallback);
-    }
-
-    /**
-     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
-     *
-     * @param scenario Send a post request with header values "scenario": "valid" or "min"
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> paramDatetimeRfc1123Async(String scenario, DateTime value) {
-        return paramDatetimeRfc1123AsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(paramDatetimeRfc1123WithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -1792,7 +1755,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDatetimeRfc1123AsyncWithServiceResponse(String scenario, DateTime value) {
+    public Observable<Void> paramDatetimeRfc1123Async(String scenario, DateTime value) {
+        return paramDatetimeRfc1123WithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramDatetimeRfc1123WithServiceResponseAsync(String scenario, DateTime value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1828,10 +1807,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseDatetimeRfc1123AsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseDatetimeRfc1123WithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1842,7 +1820,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDatetimeRfc1123Async(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDatetimeRfc1123AsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDatetimeRfc1123WithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1852,12 +1830,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseDatetimeRfc1123Async(String scenario) {
-        return responseDatetimeRfc1123AsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>, Void>() {
+        return responseDatetimeRfc1123WithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1866,7 +1844,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>> responseDatetimeRfc1123AsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>> responseDatetimeRfc1123WithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1899,10 +1877,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramDuration(String scenario, Period value) throws ErrorException, IOException, IllegalArgumentException {
-        paramDurationAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramDurationWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1914,7 +1891,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDurationAsync(String scenario, Period value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDurationAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDurationWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -1925,12 +1902,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramDurationAsync(String scenario, Period value) {
-        return paramDurationAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramDurationWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1940,7 +1917,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "P123DT22H14M12.011S"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDurationAsyncWithServiceResponse(String scenario, Period value) {
+    public Observable<ServiceResponse<Void>> paramDurationWithServiceResponseAsync(String scenario, Period value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1975,10 +1952,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseDuration(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseDurationAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseDurationWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1989,7 +1965,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDurationAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDurationAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDurationWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1999,12 +1975,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseDurationAsync(String scenario) {
-        return responseDurationAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>, Void>() {
+        return responseDurationWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2013,7 +1989,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>> responseDurationAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>> responseDurationWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -2046,10 +2022,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramByte(String scenario, byte[] value) throws ErrorException, IOException, IllegalArgumentException {
-        paramByteAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
+        paramByteWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -2061,7 +2036,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramByteAsync(String scenario, byte[] value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramByteAsyncWithServiceResponse(scenario, value), serviceCallback);
+        return ServiceCall.create(paramByteWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -2072,12 +2047,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramByteAsync(String scenario, byte[] value) {
-        return paramByteAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramByteWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2087,7 +2062,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramByteAsyncWithServiceResponse(String scenario, byte[] value) {
+    public Observable<ServiceResponse<Void>> paramByteWithServiceResponseAsync(String scenario, byte[] value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -2123,10 +2098,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseByte(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseByteAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseByteWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -2137,7 +2111,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseByteAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseByteAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseByteWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -2147,12 +2121,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseByteAsync(String scenario) {
-        return responseByteAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>, Void>() {
+        return responseByteWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2161,7 +2135,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>> responseByteAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>> responseByteWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -2193,10 +2167,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        paramEnumAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        paramEnumWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -2207,7 +2180,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramEnumAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramEnumAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.create(paramEnumWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -2217,12 +2190,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> paramEnumAsync(String scenario) {
-        return paramEnumAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
+        return paramEnumWithServiceResponseAsync(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2231,7 +2204,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramEnumAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponse<Void>> paramEnumWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -2258,10 +2231,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void paramEnum(String scenario, GreyscaleColors value) throws ErrorException, IOException, IllegalArgumentException {
-        paramEnumAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        paramEnumWithServiceResponseAsync(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -2273,22 +2245,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramEnumAsync(String scenario, GreyscaleColors value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramEnumAsyncWithServiceResponse(scenario, value), serviceCallback);
-    }
-
-    /**
-     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
-     *
-     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> paramEnumAsync(String scenario, GreyscaleColors value) {
-        return paramEnumAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(paramEnumWithServiceResponseAsync(scenario, value), serviceCallback);
     }
 
     /**
@@ -2298,7 +2255,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramEnumAsyncWithServiceResponse(String scenario, GreyscaleColors value) {
+    public Observable<Void> paramEnumAsync(String scenario, GreyscaleColors value) {
+        return paramEnumWithServiceResponseAsync(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramEnumWithServiceResponseAsync(String scenario, GreyscaleColors value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -2330,10 +2303,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void responseEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        responseEnumAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
+        responseEnumWithServiceResponseAsync(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -2344,7 +2316,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseEnumAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseEnumAsyncWithServiceResponse(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseEnumWithServiceResponseAsync(scenario), serviceCallback);
     }
 
     /**
@@ -2354,12 +2326,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> responseEnumAsync(String scenario) {
-        return responseEnumAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>, Void>() {
+        return responseEnumWithServiceResponseAsync(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2368,7 +2340,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>> responseEnumAsyncWithServiceResponse(String scenario) {
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>> responseEnumWithServiceResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -2398,10 +2370,9 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void customRequestId() throws ErrorException, IOException {
-        customRequestIdAsyncWithServiceResponse().toBlocking().single().getBody();
+        customRequestIdWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2411,7 +2382,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> customRequestIdAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(customRequestIdAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(customRequestIdWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2420,12 +2391,12 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> customRequestIdAsync() {
-        return customRequestIdAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return customRequestIdWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2433,7 +2404,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> customRequestIdAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> customRequestIdWithServiceResponseAsync() {
         return service.customRequestId()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/header/implementation/HeadersImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/header/implementation/HeadersImpl.java
@@ -200,8 +200,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramExistingKey(String userAgent) throws ErrorException, IOException, IllegalArgumentException {
-        return paramExistingKeyAsync(userAgent).toBlocking().single();
+    public void paramExistingKey(String userAgent) throws ErrorException, IOException, IllegalArgumentException {
+        paramExistingKeyAsyncWithServiceResponse(userAgent).toBlocking().single().getBody();
     }
 
     /**
@@ -212,7 +212,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramExistingKeyAsync(String userAgent, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramExistingKeyAsync(userAgent), serviceCallback);
+        return ServiceCall.create(paramExistingKeyAsyncWithServiceResponse(userAgent), serviceCallback);
     }
 
     /**
@@ -221,7 +221,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param userAgent Send a post request with header value "User-Agent": "overwrite"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramExistingKeyAsync(String userAgent) {
+    public Observable<Void> paramExistingKeyAsync(String userAgent) {
+        return paramExistingKeyAsyncWithServiceResponse(userAgent).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramExistingKeyAsyncWithServiceResponse(String userAgent) {
         if (userAgent == null) {
             throw new IllegalArgumentException("Parameter userAgent is required and cannot be null.");
         }
@@ -253,8 +268,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders> responseExistingKey() throws ErrorException, IOException {
-        return responseExistingKeyAsync().toBlocking().single();
+    public void responseExistingKey() throws ErrorException, IOException {
+        responseExistingKeyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -264,7 +279,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseExistingKeyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseExistingKeyAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(responseExistingKeyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -272,7 +287,21 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>> responseExistingKeyAsync() {
+    public Observable<Void> responseExistingKeyAsync() {
+        return responseExistingKeyAsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>> responseExistingKeyAsyncWithServiceResponse() {
         return service.responseExistingKey()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>>>() {
                 @Override
@@ -303,8 +332,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramProtectedKey(String contentType) throws ErrorException, IOException, IllegalArgumentException {
-        return paramProtectedKeyAsync(contentType).toBlocking().single();
+    public void paramProtectedKey(String contentType) throws ErrorException, IOException, IllegalArgumentException {
+        paramProtectedKeyAsyncWithServiceResponse(contentType).toBlocking().single().getBody();
     }
 
     /**
@@ -315,7 +344,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramProtectedKeyAsync(String contentType, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramProtectedKeyAsync(contentType), serviceCallback);
+        return ServiceCall.create(paramProtectedKeyAsyncWithServiceResponse(contentType), serviceCallback);
     }
 
     /**
@@ -324,7 +353,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param contentType Send a post request with header value "Content-Type": "text/html"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramProtectedKeyAsync(String contentType) {
+    public Observable<Void> paramProtectedKeyAsync(String contentType) {
+        return paramProtectedKeyAsyncWithServiceResponse(contentType).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramProtectedKeyAsyncWithServiceResponse(String contentType) {
         if (contentType == null) {
             throw new IllegalArgumentException("Parameter contentType is required and cannot be null.");
         }
@@ -356,8 +400,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders> responseProtectedKey() throws ErrorException, IOException {
-        return responseProtectedKeyAsync().toBlocking().single();
+    public void responseProtectedKey() throws ErrorException, IOException {
+        responseProtectedKeyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -367,7 +411,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseProtectedKeyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseProtectedKeyAsync(), serviceCallback);
+        return ServiceCall.createWithHeaders(responseProtectedKeyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -375,7 +419,21 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>> responseProtectedKeyAsync() {
+    public Observable<Void> responseProtectedKeyAsync() {
+        return responseProtectedKeyAsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>> responseProtectedKeyAsyncWithServiceResponse() {
         return service.responseProtectedKey()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>>>() {
                 @Override
@@ -407,8 +465,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramInteger(String scenario, int value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramIntegerAsync(scenario, value).toBlocking().single();
+    public void paramInteger(String scenario, int value) throws ErrorException, IOException, IllegalArgumentException {
+        paramIntegerAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -420,7 +478,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramIntegerAsync(String scenario, int value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramIntegerAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramIntegerAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -430,7 +488,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 1 or -2
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramIntegerAsync(String scenario, int value) {
+    public Observable<Void> paramIntegerAsync(String scenario, int value) {
+        return paramIntegerAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 1 or -2
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramIntegerAsyncWithServiceResponse(String scenario, int value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -464,8 +538,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders> responseInteger(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseIntegerAsync(scenario).toBlocking().single();
+    public void responseInteger(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseIntegerAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -476,7 +550,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseIntegerAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseIntegerAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseIntegerAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -485,7 +559,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>> responseIntegerAsync(String scenario) {
+    public Observable<Void> responseIntegerAsync(String scenario) {
+        return responseIntegerAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>> responseIntegerAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -520,8 +609,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramLong(String scenario, long value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramLongAsync(scenario, value).toBlocking().single();
+    public void paramLong(String scenario, long value) throws ErrorException, IOException, IllegalArgumentException {
+        paramLongAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -533,7 +622,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramLongAsync(String scenario, long value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramLongAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramLongAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -543,7 +632,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 105 or -2
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramLongAsync(String scenario, long value) {
+    public Observable<Void> paramLongAsync(String scenario, long value) {
+        return paramLongAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 105 or -2
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramLongAsyncWithServiceResponse(String scenario, long value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -577,8 +682,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders> responseLong(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseLongAsync(scenario).toBlocking().single();
+    public void responseLong(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseLongAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -589,7 +694,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseLongAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseLongAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseLongAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -598,7 +703,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>> responseLongAsync(String scenario) {
+    public Observable<Void> responseLongAsync(String scenario) {
+        return responseLongAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>> responseLongAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -633,8 +753,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramFloat(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramFloatAsync(scenario, value).toBlocking().single();
+    public void paramFloat(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException {
+        paramFloatAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -646,7 +766,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramFloatAsync(String scenario, double value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramFloatAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramFloatAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -656,7 +776,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 0.07 or -3.0
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramFloatAsync(String scenario, double value) {
+    public Observable<Void> paramFloatAsync(String scenario, double value) {
+        return paramFloatAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 0.07 or -3.0
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramFloatAsyncWithServiceResponse(String scenario, double value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -690,8 +826,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders> responseFloat(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseFloatAsync(scenario).toBlocking().single();
+    public void responseFloat(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseFloatAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -702,7 +838,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseFloatAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseFloatAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseFloatAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -711,7 +847,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>> responseFloatAsync(String scenario) {
+    public Observable<Void> responseFloatAsync(String scenario) {
+        return responseFloatAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>> responseFloatAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -746,8 +897,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramDouble(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramDoubleAsync(scenario, value).toBlocking().single();
+    public void paramDouble(String scenario, double value) throws ErrorException, IOException, IllegalArgumentException {
+        paramDoubleAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -759,7 +910,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDoubleAsync(String scenario, double value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDoubleAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDoubleAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -769,7 +920,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 7e120 or -3.0
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDoubleAsync(String scenario, double value) {
+    public Observable<Void> paramDoubleAsync(String scenario, double value) {
+        return paramDoubleAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 7e120 or -3.0
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramDoubleAsyncWithServiceResponse(String scenario, double value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -803,8 +970,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders> responseDouble(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseDoubleAsync(scenario).toBlocking().single();
+    public void responseDouble(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseDoubleAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -815,7 +982,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDoubleAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDoubleAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDoubleAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -824,7 +991,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>> responseDoubleAsync(String scenario) {
+    public Observable<Void> responseDoubleAsync(String scenario) {
+        return responseDoubleAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>> responseDoubleAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -859,8 +1041,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramBool(String scenario, boolean value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramBoolAsync(scenario, value).toBlocking().single();
+    public void paramBool(String scenario, boolean value) throws ErrorException, IOException, IllegalArgumentException {
+        paramBoolAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -872,7 +1054,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramBoolAsync(String scenario, boolean value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramBoolAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramBoolAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -882,7 +1064,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values true or false
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramBoolAsync(String scenario, boolean value) {
+    public Observable<Void> paramBoolAsync(String scenario, boolean value) {
+        return paramBoolAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false"
+     * @param value Send a post request with header values true or false
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramBoolAsyncWithServiceResponse(String scenario, boolean value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -916,8 +1114,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders> responseBool(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseBoolAsync(scenario).toBlocking().single();
+    public void responseBool(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseBoolAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -928,7 +1126,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseBoolAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseBoolAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseBoolAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -937,7 +1135,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "true" or "false"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>> responseBoolAsync(String scenario) {
+    public Observable<Void> responseBoolAsync(String scenario) {
+        return responseBoolAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>> responseBoolAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -971,8 +1184,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramString(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return paramStringAsync(scenario).toBlocking().single();
+    public void paramString(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        paramStringAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -983,7 +1196,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramStringAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramStringAsync(scenario), serviceCallback);
+        return ServiceCall.create(paramStringAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -992,7 +1205,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramStringAsync(String scenario) {
+    public Observable<Void> paramStringAsync(String scenario) {
+        return paramStringAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramStringAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1021,8 +1249,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramString(String scenario, String value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramStringAsync(scenario, value).toBlocking().single();
+    public void paramString(String scenario, String value) throws ErrorException, IOException, IllegalArgumentException {
+        paramStringAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1034,7 +1262,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramStringAsync(String scenario, String value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramStringAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramStringAsyncWithServiceResponse(scenario, value), serviceCallback);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> paramStringAsync(String scenario, String value) {
+        return paramStringAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1044,7 +1287,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramStringAsync(String scenario, String value) {
+    public Observable<ServiceResponse<Void>> paramStringAsyncWithServiceResponse(String scenario, String value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1078,8 +1321,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> responseString(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseStringAsync(scenario).toBlocking().single();
+    public void responseString(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseStringAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1090,7 +1333,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseStringAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseStringAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseStringAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1099,7 +1342,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>> responseStringAsync(String scenario) {
+    public Observable<Void> responseStringAsync(String scenario) {
+        return responseStringAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>> responseStringAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1134,8 +1392,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramDate(String scenario, LocalDate value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramDateAsync(scenario, value).toBlocking().single();
+    public void paramDate(String scenario, LocalDate value) throws ErrorException, IOException, IllegalArgumentException {
+        paramDateAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1147,7 +1405,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDateAsync(String scenario, LocalDate value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDateAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDateAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -1157,7 +1415,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDateAsync(String scenario, LocalDate value) {
+    public Observable<Void> paramDateAsync(String scenario, LocalDate value) {
+        return paramDateAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramDateAsyncWithServiceResponse(String scenario, LocalDate value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1194,8 +1468,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders> responseDate(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseDateAsync(scenario).toBlocking().single();
+    public void responseDate(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseDateAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1206,7 +1480,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDateAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDateAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDateAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1215,7 +1489,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>> responseDateAsync(String scenario) {
+    public Observable<Void> responseDateAsync(String scenario) {
+        return responseDateAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>> responseDateAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1250,8 +1539,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramDatetime(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramDatetimeAsync(scenario, value).toBlocking().single();
+    public void paramDatetime(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException {
+        paramDatetimeAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1263,7 +1552,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDatetimeAsync(String scenario, DateTime value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDatetimeAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDatetimeAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -1273,7 +1562,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDatetimeAsync(String scenario, DateTime value) {
+    public Observable<Void> paramDatetimeAsync(String scenario, DateTime value) {
+        return paramDatetimeAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramDatetimeAsyncWithServiceResponse(String scenario, DateTime value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1310,8 +1615,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders> responseDatetime(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseDatetimeAsync(scenario).toBlocking().single();
+    public void responseDatetime(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseDatetimeAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1322,7 +1627,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDatetimeAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDatetimeAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDatetimeAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1331,7 +1636,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>> responseDatetimeAsync(String scenario) {
+    public Observable<Void> responseDatetimeAsync(String scenario) {
+        return responseDatetimeAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>> responseDatetimeAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1365,8 +1685,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return paramDatetimeRfc1123Async(scenario).toBlocking().single();
+    public void paramDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        paramDatetimeRfc1123AsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1377,7 +1697,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDatetimeRfc1123Async(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDatetimeRfc1123Async(scenario), serviceCallback);
+        return ServiceCall.create(paramDatetimeRfc1123AsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1386,7 +1706,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDatetimeRfc1123Async(String scenario) {
+    public Observable<Void> paramDatetimeRfc1123Async(String scenario) {
+        return paramDatetimeRfc1123AsyncWithServiceResponse(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramDatetimeRfc1123AsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1419,8 +1754,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramDatetimeRfc1123(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramDatetimeRfc1123Async(scenario, value).toBlocking().single();
+    public void paramDatetimeRfc1123(String scenario, DateTime value) throws ErrorException, IOException, IllegalArgumentException {
+        paramDatetimeRfc1123AsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1432,7 +1767,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDatetimeRfc1123Async(String scenario, DateTime value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDatetimeRfc1123Async(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDatetimeRfc1123AsyncWithServiceResponse(scenario, value), serviceCallback);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> paramDatetimeRfc1123Async(String scenario, DateTime value) {
+        return paramDatetimeRfc1123AsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1442,7 +1792,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDatetimeRfc1123Async(String scenario, DateTime value) {
+    public Observable<ServiceResponse<Void>> paramDatetimeRfc1123AsyncWithServiceResponse(String scenario, DateTime value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1480,8 +1830,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers> responseDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseDatetimeRfc1123Async(scenario).toBlocking().single();
+    public void responseDatetimeRfc1123(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseDatetimeRfc1123AsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1492,7 +1842,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDatetimeRfc1123Async(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDatetimeRfc1123Async(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDatetimeRfc1123AsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1501,7 +1851,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>> responseDatetimeRfc1123Async(String scenario) {
+    public Observable<Void> responseDatetimeRfc1123Async(String scenario) {
+        return responseDatetimeRfc1123AsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>> responseDatetimeRfc1123AsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1536,8 +1901,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramDuration(String scenario, Period value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramDurationAsync(scenario, value).toBlocking().single();
+    public void paramDuration(String scenario, Period value) throws ErrorException, IOException, IllegalArgumentException {
+        paramDurationAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1549,7 +1914,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramDurationAsync(String scenario, Period value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramDurationAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramDurationAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -1559,7 +1924,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "P123DT22H14M12.011S"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramDurationAsync(String scenario, Period value) {
+    public Observable<Void> paramDurationAsync(String scenario, Period value) {
+        return paramDurationAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @param value Send a post request with header values "P123DT22H14M12.011S"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramDurationAsyncWithServiceResponse(String scenario, Period value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1596,8 +1977,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders> responseDuration(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseDurationAsync(scenario).toBlocking().single();
+    public void responseDuration(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseDurationAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1608,7 +1989,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseDurationAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseDurationAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseDurationAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1617,7 +1998,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>> responseDurationAsync(String scenario) {
+    public Observable<Void> responseDurationAsync(String scenario) {
+        return responseDurationAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>> responseDurationAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1652,8 +2048,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramByte(String scenario, byte[] value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramByteAsync(scenario, value).toBlocking().single();
+    public void paramByte(String scenario, byte[] value) throws ErrorException, IOException, IllegalArgumentException {
+        paramByteAsyncWithServiceResponse(scenario, value).toBlocking().single().getBody();
     }
 
     /**
@@ -1665,7 +2061,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramByteAsync(String scenario, byte[] value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramByteAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramByteAsyncWithServiceResponse(scenario, value), serviceCallback);
     }
 
     /**
@@ -1675,7 +2071,23 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramByteAsync(String scenario, byte[] value) {
+    public Observable<Void> paramByteAsync(String scenario, byte[] value) {
+        return paramByteAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramByteAsyncWithServiceResponse(String scenario, byte[] value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1713,8 +2125,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders> responseByte(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseByteAsync(scenario).toBlocking().single();
+    public void responseByte(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseByteAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1725,7 +2137,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseByteAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseByteAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseByteAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1734,7 +2146,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>> responseByteAsync(String scenario) {
+    public Observable<Void> responseByteAsync(String scenario) {
+        return responseByteAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>> responseByteAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1768,8 +2195,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return paramEnumAsync(scenario).toBlocking().single();
+    public void paramEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        paramEnumAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1780,7 +2207,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramEnumAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramEnumAsync(scenario), serviceCallback);
+        return ServiceCall.create(paramEnumAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1789,7 +2216,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramEnumAsync(String scenario) {
+    public Observable<Void> paramEnumAsync(String scenario) {
+        return paramEnumAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> paramEnumAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1818,8 +2260,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> paramEnum(String scenario, GreyscaleColors value) throws ErrorException, IOException, IllegalArgumentException {
-        return paramEnumAsync(scenario, value).toBlocking().single();
+    public void paramEnum(String scenario, GreyscaleColors value) throws ErrorException, IOException, IllegalArgumentException {
+        paramEnumAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1831,7 +2273,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> paramEnumAsync(String scenario, GreyscaleColors value, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(paramEnumAsync(scenario, value), serviceCallback);
+        return ServiceCall.create(paramEnumAsyncWithServiceResponse(scenario, value), serviceCallback);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> paramEnumAsync(String scenario, GreyscaleColors value) {
+        return paramEnumAsyncWithServiceResponse(scenario, value).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1841,7 +2298,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param value Send a post request with header values 'GREY' . Possible values include: 'White', 'black', 'GREY'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> paramEnumAsync(String scenario, GreyscaleColors value) {
+    public Observable<ServiceResponse<Void>> paramEnumAsyncWithServiceResponse(String scenario, GreyscaleColors value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1875,8 +2332,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders> responseEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException {
-        return responseEnumAsync(scenario).toBlocking().single();
+    public void responseEnum(String scenario) throws ErrorException, IOException, IllegalArgumentException {
+        responseEnumAsyncWithServiceResponse(scenario).toBlocking().single().getBody();
     }
 
     /**
@@ -1887,7 +2344,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> responseEnumAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(responseEnumAsync(scenario), serviceCallback);
+        return ServiceCall.createWithHeaders(responseEnumAsyncWithServiceResponse(scenario), serviceCallback);
     }
 
     /**
@@ -1896,7 +2353,22 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>> responseEnumAsync(String scenario) {
+    public Observable<Void> responseEnumAsync(String scenario) {
+        return responseEnumAsyncWithServiceResponse(scenario).map(new Func1<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>> responseEnumAsyncWithServiceResponse(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1928,8 +2400,8 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> customRequestId() throws ErrorException, IOException {
-        return customRequestIdAsync().toBlocking().single();
+    public void customRequestId() throws ErrorException, IOException {
+        customRequestIdAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1939,7 +2411,7 @@ public final class HeadersImpl implements fixtures.header.Headers {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> customRequestIdAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(customRequestIdAsync(), serviceCallback);
+        return ServiceCall.create(customRequestIdAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1947,7 +2419,21 @@ public final class HeadersImpl implements fixtures.header.Headers {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> customRequestIdAsync() {
+    public Observable<Void> customRequestIdAsync() {
+        return customRequestIdAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> customRequestIdAsyncWithServiceResponse() {
         return service.customRequestId()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpClientFailures.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpClientFailures.java
@@ -28,7 +28,7 @@ public interface HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error head400() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> head400WithServiceResponseAsync();
 
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error get400() throws ErrorException, IOException;
 
@@ -83,14 +83,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> get400WithServiceResponseAsync();
 
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error put400() throws ErrorException, IOException;
 
@@ -105,7 +105,6 @@ public interface HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> put400Async();
@@ -113,17 +112,16 @@ public interface HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> put400WithServiceResponseAsync();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error put400(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -150,14 +148,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put400AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> put400WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error patch400() throws ErrorException, IOException;
 
@@ -172,7 +170,6 @@ public interface HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> patch400Async();
@@ -180,17 +177,16 @@ public interface HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> patch400WithServiceResponseAsync();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error patch400(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -217,14 +213,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch400AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> patch400WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error post400() throws ErrorException, IOException;
 
@@ -239,7 +235,6 @@ public interface HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> post400Async();
@@ -247,17 +242,16 @@ public interface HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> post400WithServiceResponseAsync();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error post400(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -284,14 +278,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post400AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> post400WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error delete400() throws ErrorException, IOException;
 
@@ -306,7 +300,6 @@ public interface HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> delete400Async();
@@ -314,17 +307,16 @@ public interface HttpClientFailures {
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete400AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> delete400WithServiceResponseAsync();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error delete400(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -351,14 +343,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete400AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> delete400WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 401 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error head401() throws ErrorException, IOException;
 
@@ -382,14 +374,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head401AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> head401WithServiceResponseAsync();
 
     /**
      * Return 402 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error get402() throws ErrorException, IOException;
 
@@ -413,14 +405,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get402AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> get402WithServiceResponseAsync();
 
     /**
      * Return 403 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error get403() throws ErrorException, IOException;
 
@@ -444,14 +436,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get403AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> get403WithServiceResponseAsync();
 
     /**
      * Return 404 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error put404() throws ErrorException, IOException;
 
@@ -466,7 +458,6 @@ public interface HttpClientFailures {
     /**
      * Return 404 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> put404Async();
@@ -474,17 +465,16 @@ public interface HttpClientFailures {
     /**
      * Return 404 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put404AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> put404WithServiceResponseAsync();
     /**
      * Return 404 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error put404(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -511,14 +501,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put404AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> put404WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 405 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error patch405() throws ErrorException, IOException;
 
@@ -533,7 +523,6 @@ public interface HttpClientFailures {
     /**
      * Return 405 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> patch405Async();
@@ -541,17 +530,16 @@ public interface HttpClientFailures {
     /**
      * Return 405 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch405AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> patch405WithServiceResponseAsync();
     /**
      * Return 405 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error patch405(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -578,14 +566,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch405AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> patch405WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 406 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error post406() throws ErrorException, IOException;
 
@@ -600,7 +588,6 @@ public interface HttpClientFailures {
     /**
      * Return 406 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> post406Async();
@@ -608,17 +595,16 @@ public interface HttpClientFailures {
     /**
      * Return 406 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post406AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> post406WithServiceResponseAsync();
     /**
      * Return 406 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error post406(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -645,14 +631,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post406AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> post406WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 407 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error delete407() throws ErrorException, IOException;
 
@@ -667,7 +653,6 @@ public interface HttpClientFailures {
     /**
      * Return 407 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> delete407Async();
@@ -675,17 +660,16 @@ public interface HttpClientFailures {
     /**
      * Return 407 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete407AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> delete407WithServiceResponseAsync();
     /**
      * Return 407 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error delete407(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -712,14 +696,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete407AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> delete407WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 409 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error put409() throws ErrorException, IOException;
 
@@ -734,7 +718,6 @@ public interface HttpClientFailures {
     /**
      * Return 409 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> put409Async();
@@ -742,17 +725,16 @@ public interface HttpClientFailures {
     /**
      * Return 409 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put409AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> put409WithServiceResponseAsync();
     /**
      * Return 409 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error put409(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -779,14 +761,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put409AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> put409WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 410 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error head410() throws ErrorException, IOException;
 
@@ -810,14 +792,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head410AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> head410WithServiceResponseAsync();
 
     /**
      * Return 411 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error get411() throws ErrorException, IOException;
 
@@ -841,14 +823,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get411AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> get411WithServiceResponseAsync();
 
     /**
      * Return 412 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error get412() throws ErrorException, IOException;
 
@@ -872,14 +854,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get412AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> get412WithServiceResponseAsync();
 
     /**
      * Return 413 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error put413() throws ErrorException, IOException;
 
@@ -894,7 +876,6 @@ public interface HttpClientFailures {
     /**
      * Return 413 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> put413Async();
@@ -902,17 +883,16 @@ public interface HttpClientFailures {
     /**
      * Return 413 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put413AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> put413WithServiceResponseAsync();
     /**
      * Return 413 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error put413(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -939,14 +919,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put413AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> put413WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 414 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error patch414() throws ErrorException, IOException;
 
@@ -961,7 +941,6 @@ public interface HttpClientFailures {
     /**
      * Return 414 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> patch414Async();
@@ -969,17 +948,16 @@ public interface HttpClientFailures {
     /**
      * Return 414 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch414AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> patch414WithServiceResponseAsync();
     /**
      * Return 414 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error patch414(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -1006,14 +984,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch414AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> patch414WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 415 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error post415() throws ErrorException, IOException;
 
@@ -1028,7 +1006,6 @@ public interface HttpClientFailures {
     /**
      * Return 415 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> post415Async();
@@ -1036,17 +1013,16 @@ public interface HttpClientFailures {
     /**
      * Return 415 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post415AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> post415WithServiceResponseAsync();
     /**
      * Return 415 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error post415(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -1073,14 +1049,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post415AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> post415WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 416 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error get416() throws ErrorException, IOException;
 
@@ -1104,14 +1080,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get416AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> get416WithServiceResponseAsync();
 
     /**
      * Return 417 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error delete417() throws ErrorException, IOException;
 
@@ -1126,7 +1102,6 @@ public interface HttpClientFailures {
     /**
      * Return 417 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> delete417Async();
@@ -1134,17 +1109,16 @@ public interface HttpClientFailures {
     /**
      * Return 417 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete417AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> delete417WithServiceResponseAsync();
     /**
      * Return 417 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error delete417(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -1171,14 +1145,14 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete417AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> delete417WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 429 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error head429() throws ErrorException, IOException;
 
@@ -1202,6 +1176,6 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head429AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> head429WithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpClientFailures.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpClientFailures.java
@@ -30,7 +30,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> head400() throws ErrorException, IOException;
+    Error head400() throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -45,7 +45,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head400Async();
+    Observable<Error> head400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> head400AsyncWithServiceResponse();
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -54,7 +61,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> get400() throws ErrorException, IOException;
+    Error get400() throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -69,7 +76,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get400Async();
+    Observable<Error> get400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> get400AsyncWithServiceResponse();
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -78,7 +92,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> put400() throws ErrorException, IOException;
+    Error put400() throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -87,6 +101,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> put400Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> put400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> put400AsyncWithServiceResponse();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
@@ -95,7 +125,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> put400(Boolean booleanValue) throws ErrorException, IOException;
+    Error put400(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -112,7 +142,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put400Async(Boolean booleanValue);
+    Observable<Error> put400Async(Boolean booleanValue);
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> put400AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -121,7 +159,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> patch400() throws ErrorException, IOException;
+    Error patch400() throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -130,6 +168,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> patch400Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> patch400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> patch400AsyncWithServiceResponse();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
@@ -138,7 +192,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> patch400(Boolean booleanValue) throws ErrorException, IOException;
+    Error patch400(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -155,7 +209,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch400Async(Boolean booleanValue);
+    Observable<Error> patch400Async(Boolean booleanValue);
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> patch400AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -164,7 +226,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> post400() throws ErrorException, IOException;
+    Error post400() throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -173,6 +235,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> post400Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> post400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> post400AsyncWithServiceResponse();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
@@ -181,7 +259,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> post400(Boolean booleanValue) throws ErrorException, IOException;
+    Error post400(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -198,7 +276,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post400Async(Boolean booleanValue);
+    Observable<Error> post400Async(Boolean booleanValue);
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> post400AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -207,7 +293,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> delete400() throws ErrorException, IOException;
+    Error delete400() throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -216,6 +302,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> delete400Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> delete400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> delete400AsyncWithServiceResponse();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
@@ -224,7 +326,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> delete400(Boolean booleanValue) throws ErrorException, IOException;
+    Error delete400(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -241,7 +343,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete400Async(Boolean booleanValue);
+    Observable<Error> delete400Async(Boolean booleanValue);
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> delete400AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 401 status code - should be represented in the client as an error.
@@ -250,7 +360,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> head401() throws ErrorException, IOException;
+    Error head401() throws ErrorException, IOException;
 
     /**
      * Return 401 status code - should be represented in the client as an error.
@@ -265,7 +375,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head401Async();
+    Observable<Error> head401Async();
+
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> head401AsyncWithServiceResponse();
 
     /**
      * Return 402 status code - should be represented in the client as an error.
@@ -274,7 +391,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> get402() throws ErrorException, IOException;
+    Error get402() throws ErrorException, IOException;
 
     /**
      * Return 402 status code - should be represented in the client as an error.
@@ -289,7 +406,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get402Async();
+    Observable<Error> get402Async();
+
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> get402AsyncWithServiceResponse();
 
     /**
      * Return 403 status code - should be represented in the client as an error.
@@ -298,7 +422,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> get403() throws ErrorException, IOException;
+    Error get403() throws ErrorException, IOException;
 
     /**
      * Return 403 status code - should be represented in the client as an error.
@@ -313,7 +437,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get403Async();
+    Observable<Error> get403Async();
+
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> get403AsyncWithServiceResponse();
 
     /**
      * Return 404 status code - should be represented in the client as an error.
@@ -322,7 +453,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> put404() throws ErrorException, IOException;
+    Error put404() throws ErrorException, IOException;
 
     /**
      * Return 404 status code - should be represented in the client as an error.
@@ -331,6 +462,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> put404Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> put404Async();
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> put404AsyncWithServiceResponse();
     /**
      * Return 404 status code - should be represented in the client as an error.
      *
@@ -339,7 +486,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> put404(Boolean booleanValue) throws ErrorException, IOException;
+    Error put404(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 404 status code - should be represented in the client as an error.
@@ -356,7 +503,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put404Async(Boolean booleanValue);
+    Observable<Error> put404Async(Boolean booleanValue);
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> put404AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 405 status code - should be represented in the client as an error.
@@ -365,7 +520,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> patch405() throws ErrorException, IOException;
+    Error patch405() throws ErrorException, IOException;
 
     /**
      * Return 405 status code - should be represented in the client as an error.
@@ -374,6 +529,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> patch405Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> patch405Async();
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> patch405AsyncWithServiceResponse();
     /**
      * Return 405 status code - should be represented in the client as an error.
      *
@@ -382,7 +553,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> patch405(Boolean booleanValue) throws ErrorException, IOException;
+    Error patch405(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 405 status code - should be represented in the client as an error.
@@ -399,7 +570,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch405Async(Boolean booleanValue);
+    Observable<Error> patch405Async(Boolean booleanValue);
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> patch405AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 406 status code - should be represented in the client as an error.
@@ -408,7 +587,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> post406() throws ErrorException, IOException;
+    Error post406() throws ErrorException, IOException;
 
     /**
      * Return 406 status code - should be represented in the client as an error.
@@ -417,6 +596,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> post406Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> post406Async();
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> post406AsyncWithServiceResponse();
     /**
      * Return 406 status code - should be represented in the client as an error.
      *
@@ -425,7 +620,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> post406(Boolean booleanValue) throws ErrorException, IOException;
+    Error post406(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 406 status code - should be represented in the client as an error.
@@ -442,7 +637,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post406Async(Boolean booleanValue);
+    Observable<Error> post406Async(Boolean booleanValue);
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> post406AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 407 status code - should be represented in the client as an error.
@@ -451,7 +654,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> delete407() throws ErrorException, IOException;
+    Error delete407() throws ErrorException, IOException;
 
     /**
      * Return 407 status code - should be represented in the client as an error.
@@ -460,6 +663,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> delete407Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> delete407Async();
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> delete407AsyncWithServiceResponse();
     /**
      * Return 407 status code - should be represented in the client as an error.
      *
@@ -468,7 +687,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> delete407(Boolean booleanValue) throws ErrorException, IOException;
+    Error delete407(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 407 status code - should be represented in the client as an error.
@@ -485,7 +704,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete407Async(Boolean booleanValue);
+    Observable<Error> delete407Async(Boolean booleanValue);
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> delete407AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 409 status code - should be represented in the client as an error.
@@ -494,7 +721,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> put409() throws ErrorException, IOException;
+    Error put409() throws ErrorException, IOException;
 
     /**
      * Return 409 status code - should be represented in the client as an error.
@@ -503,6 +730,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> put409Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> put409Async();
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> put409AsyncWithServiceResponse();
     /**
      * Return 409 status code - should be represented in the client as an error.
      *
@@ -511,7 +754,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> put409(Boolean booleanValue) throws ErrorException, IOException;
+    Error put409(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 409 status code - should be represented in the client as an error.
@@ -528,7 +771,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put409Async(Boolean booleanValue);
+    Observable<Error> put409Async(Boolean booleanValue);
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> put409AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 410 status code - should be represented in the client as an error.
@@ -537,7 +788,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> head410() throws ErrorException, IOException;
+    Error head410() throws ErrorException, IOException;
 
     /**
      * Return 410 status code - should be represented in the client as an error.
@@ -552,7 +803,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head410Async();
+    Observable<Error> head410Async();
+
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> head410AsyncWithServiceResponse();
 
     /**
      * Return 411 status code - should be represented in the client as an error.
@@ -561,7 +819,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> get411() throws ErrorException, IOException;
+    Error get411() throws ErrorException, IOException;
 
     /**
      * Return 411 status code - should be represented in the client as an error.
@@ -576,7 +834,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get411Async();
+    Observable<Error> get411Async();
+
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> get411AsyncWithServiceResponse();
 
     /**
      * Return 412 status code - should be represented in the client as an error.
@@ -585,7 +850,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> get412() throws ErrorException, IOException;
+    Error get412() throws ErrorException, IOException;
 
     /**
      * Return 412 status code - should be represented in the client as an error.
@@ -600,7 +865,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get412Async();
+    Observable<Error> get412Async();
+
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> get412AsyncWithServiceResponse();
 
     /**
      * Return 413 status code - should be represented in the client as an error.
@@ -609,7 +881,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> put413() throws ErrorException, IOException;
+    Error put413() throws ErrorException, IOException;
 
     /**
      * Return 413 status code - should be represented in the client as an error.
@@ -618,6 +890,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> put413Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> put413Async();
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> put413AsyncWithServiceResponse();
     /**
      * Return 413 status code - should be represented in the client as an error.
      *
@@ -626,7 +914,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> put413(Boolean booleanValue) throws ErrorException, IOException;
+    Error put413(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 413 status code - should be represented in the client as an error.
@@ -643,7 +931,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> put413Async(Boolean booleanValue);
+    Observable<Error> put413Async(Boolean booleanValue);
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> put413AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 414 status code - should be represented in the client as an error.
@@ -652,7 +948,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> patch414() throws ErrorException, IOException;
+    Error patch414() throws ErrorException, IOException;
 
     /**
      * Return 414 status code - should be represented in the client as an error.
@@ -661,6 +957,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> patch414Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> patch414Async();
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> patch414AsyncWithServiceResponse();
     /**
      * Return 414 status code - should be represented in the client as an error.
      *
@@ -669,7 +981,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> patch414(Boolean booleanValue) throws ErrorException, IOException;
+    Error patch414(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 414 status code - should be represented in the client as an error.
@@ -686,7 +998,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> patch414Async(Boolean booleanValue);
+    Observable<Error> patch414Async(Boolean booleanValue);
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> patch414AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 415 status code - should be represented in the client as an error.
@@ -695,7 +1015,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> post415() throws ErrorException, IOException;
+    Error post415() throws ErrorException, IOException;
 
     /**
      * Return 415 status code - should be represented in the client as an error.
@@ -704,6 +1024,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> post415Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> post415Async();
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> post415AsyncWithServiceResponse();
     /**
      * Return 415 status code - should be represented in the client as an error.
      *
@@ -712,7 +1048,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> post415(Boolean booleanValue) throws ErrorException, IOException;
+    Error post415(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 415 status code - should be represented in the client as an error.
@@ -729,7 +1065,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post415Async(Boolean booleanValue);
+    Observable<Error> post415Async(Boolean booleanValue);
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> post415AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 416 status code - should be represented in the client as an error.
@@ -738,7 +1082,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> get416() throws ErrorException, IOException;
+    Error get416() throws ErrorException, IOException;
 
     /**
      * Return 416 status code - should be represented in the client as an error.
@@ -753,7 +1097,14 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get416Async();
+    Observable<Error> get416Async();
+
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> get416AsyncWithServiceResponse();
 
     /**
      * Return 417 status code - should be represented in the client as an error.
@@ -762,7 +1113,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> delete417() throws ErrorException, IOException;
+    Error delete417() throws ErrorException, IOException;
 
     /**
      * Return 417 status code - should be represented in the client as an error.
@@ -771,6 +1122,22 @@ public interface HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> delete417Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> delete417Async();
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> delete417AsyncWithServiceResponse();
     /**
      * Return 417 status code - should be represented in the client as an error.
      *
@@ -779,7 +1146,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> delete417(Boolean booleanValue) throws ErrorException, IOException;
+    Error delete417(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 417 status code - should be represented in the client as an error.
@@ -796,7 +1163,15 @@ public interface HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete417Async(Boolean booleanValue);
+    Observable<Error> delete417Async(Boolean booleanValue);
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> delete417AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 429 status code - should be represented in the client as an error.
@@ -805,7 +1180,7 @@ public interface HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> head429() throws ErrorException, IOException;
+    Error head429() throws ErrorException, IOException;
 
     /**
      * Return 429 status code - should be represented in the client as an error.
@@ -820,6 +1195,13 @@ public interface HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head429Async();
+    Observable<Error> head429Async();
+
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> head429AsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpFailures.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpFailures.java
@@ -28,7 +28,7 @@ public interface HttpFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean getEmptyError() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getEmptyErrorAsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> getEmptyErrorWithServiceResponseAsync();
 
     /**
      * Get empty error form server.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean getNoModelError() throws ServiceException, IOException;
 
@@ -83,14 +83,14 @@ public interface HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getNoModelErrorAsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> getNoModelErrorWithServiceResponseAsync();
 
     /**
      * Get empty response from server.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean getNoModelEmpty() throws ServiceException, IOException;
 
@@ -114,6 +114,6 @@ public interface HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getNoModelEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> getNoModelEmptyWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpFailures.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpFailures.java
@@ -30,7 +30,7 @@ public interface HttpFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> getEmptyError() throws ErrorException, IOException;
+    boolean getEmptyError() throws ErrorException, IOException;
 
     /**
      * Get empty error form server.
@@ -45,7 +45,14 @@ public interface HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getEmptyErrorAsync();
+    Observable<Boolean> getEmptyErrorAsync();
+
+    /**
+     * Get empty error form server.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> getEmptyErrorAsyncWithServiceResponse();
 
     /**
      * Get empty error form server.
@@ -54,7 +61,7 @@ public interface HttpFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> getNoModelError() throws ServiceException, IOException;
+    boolean getNoModelError() throws ServiceException, IOException;
 
     /**
      * Get empty error form server.
@@ -69,7 +76,14 @@ public interface HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getNoModelErrorAsync();
+    Observable<Boolean> getNoModelErrorAsync();
+
+    /**
+     * Get empty error form server.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> getNoModelErrorAsyncWithServiceResponse();
 
     /**
      * Get empty response from server.
@@ -78,7 +92,7 @@ public interface HttpFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> getNoModelEmpty() throws ServiceException, IOException;
+    boolean getNoModelEmpty() throws ServiceException, IOException;
 
     /**
      * Get empty response from server.
@@ -93,6 +107,13 @@ public interface HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> getNoModelEmptyAsync();
+    Observable<Boolean> getNoModelEmptyAsync();
+
+    /**
+     * Get empty response from server.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> getNoModelEmptyAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpRedirects.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpRedirects.java
@@ -43,7 +43,6 @@ public interface HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void head300() throws ErrorException, IOException;
 
@@ -67,14 +66,14 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>> head300AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>> head300WithServiceResponseAsync();
 
     /**
      * Return 300 status code and redirect to /http/success/200.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;String&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the List&lt;String&gt; object if successful.
      */
     List<String> get300() throws ErrorException, IOException;
 
@@ -98,14 +97,13 @@ public interface HttpRedirects {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>> get300AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>> get300WithServiceResponseAsync();
 
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void head301() throws ErrorException, IOException;
 
@@ -129,14 +127,13 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>> head301AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>> head301WithServiceResponseAsync();
 
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void get301() throws ErrorException, IOException;
 
@@ -160,14 +157,13 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>> get301AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>> get301WithServiceResponseAsync();
 
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void put301() throws ErrorException, IOException;
 
@@ -182,7 +178,6 @@ public interface HttpRedirects {
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> put301Async();
@@ -190,17 +185,15 @@ public interface HttpRedirects {
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301WithServiceResponseAsync();
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void put301(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -227,14 +220,13 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void head302() throws ErrorException, IOException;
 
@@ -258,14 +250,13 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>> head302AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>> head302WithServiceResponseAsync();
 
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void get302() throws ErrorException, IOException;
 
@@ -289,14 +280,13 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>> get302AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>> get302WithServiceResponseAsync();
 
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void patch302() throws ErrorException, IOException;
 
@@ -311,7 +301,6 @@ public interface HttpRedirects {
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> patch302Async();
@@ -319,17 +308,15 @@ public interface HttpRedirects {
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302WithServiceResponseAsync();
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void patch302(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -356,14 +343,13 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post303() throws ErrorException, IOException;
 
@@ -378,7 +364,6 @@ public interface HttpRedirects {
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> post303Async();
@@ -386,17 +371,15 @@ public interface HttpRedirects {
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303WithServiceResponseAsync();
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post303(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -423,14 +406,13 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Redirect with 307, resulting in a 200 success.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void head307() throws ErrorException, IOException;
 
@@ -454,14 +436,13 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>> head307AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>> head307WithServiceResponseAsync();
 
     /**
      * Redirect get with 307, resulting in a 200 success.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void get307() throws ErrorException, IOException;
 
@@ -485,14 +466,13 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>> get307AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>> get307WithServiceResponseAsync();
 
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void put307() throws ErrorException, IOException;
 
@@ -507,7 +487,6 @@ public interface HttpRedirects {
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> put307Async();
@@ -515,17 +494,15 @@ public interface HttpRedirects {
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307WithServiceResponseAsync();
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void put307(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -552,14 +529,13 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void patch307() throws ErrorException, IOException;
 
@@ -574,7 +550,6 @@ public interface HttpRedirects {
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> patch307Async();
@@ -582,17 +557,15 @@ public interface HttpRedirects {
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307WithServiceResponseAsync();
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void patch307(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -619,14 +592,13 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post307() throws ErrorException, IOException;
 
@@ -641,7 +613,6 @@ public interface HttpRedirects {
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> post307Async();
@@ -649,17 +620,15 @@ public interface HttpRedirects {
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307WithServiceResponseAsync();
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void post307(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -686,14 +655,13 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void delete307() throws ErrorException, IOException;
 
@@ -708,7 +676,6 @@ public interface HttpRedirects {
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<Void> delete307Async();
@@ -716,17 +683,15 @@ public interface HttpRedirects {
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307AsyncWithServiceResponse();
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307WithServiceResponseAsync();
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     void delete307(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -753,6 +718,6 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307WithServiceResponseAsync(Boolean booleanValue);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpRedirects.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpRedirects.java
@@ -45,7 +45,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers> head300() throws ErrorException, IOException;
+    void head300() throws ErrorException, IOException;
 
     /**
      * Return 300 status code and redirect to /http/success/200.
@@ -60,7 +60,14 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>> head300Async();
+    Observable<Void> head300Async();
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>> head300AsyncWithServiceResponse();
 
     /**
      * Return 300 status code and redirect to /http/success/200.
@@ -69,7 +76,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;String&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers> get300() throws ErrorException, IOException;
+    List<String> get300() throws ErrorException, IOException;
 
     /**
      * Return 300 status code and redirect to /http/success/200.
@@ -84,7 +91,14 @@ public interface HttpRedirects {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>> get300Async();
+    Observable<List<String>> get300Async();
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @return the observable to the List&lt;String&gt; object
+     */
+    Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>> get300AsyncWithServiceResponse();
 
     /**
      * Return 301 status code and redirect to /http/success/200.
@@ -93,7 +107,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers> head301() throws ErrorException, IOException;
+    void head301() throws ErrorException, IOException;
 
     /**
      * Return 301 status code and redirect to /http/success/200.
@@ -108,7 +122,14 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>> head301Async();
+    Observable<Void> head301Async();
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>> head301AsyncWithServiceResponse();
 
     /**
      * Return 301 status code and redirect to /http/success/200.
@@ -117,7 +138,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers> get301() throws ErrorException, IOException;
+    void get301() throws ErrorException, IOException;
 
     /**
      * Return 301 status code and redirect to /http/success/200.
@@ -132,7 +153,14 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>> get301Async();
+    Observable<Void> get301Async();
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>> get301AsyncWithServiceResponse();
 
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
@@ -141,7 +169,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> put301() throws ErrorException, IOException;
+    void put301() throws ErrorException, IOException;
 
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
@@ -150,6 +178,22 @@ public interface HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> put301Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> put301Async();
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301AsyncWithServiceResponse();
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
      *
@@ -158,7 +202,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> put301(Boolean booleanValue) throws ErrorException, IOException;
+    void put301(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
@@ -175,7 +219,15 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301Async(Boolean booleanValue);
+    Observable<Void> put301Async(Boolean booleanValue);
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 302 status code and redirect to /http/success/200.
@@ -184,7 +236,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers> head302() throws ErrorException, IOException;
+    void head302() throws ErrorException, IOException;
 
     /**
      * Return 302 status code and redirect to /http/success/200.
@@ -199,7 +251,14 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>> head302Async();
+    Observable<Void> head302Async();
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>> head302AsyncWithServiceResponse();
 
     /**
      * Return 302 status code and redirect to /http/success/200.
@@ -208,7 +267,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers> get302() throws ErrorException, IOException;
+    void get302() throws ErrorException, IOException;
 
     /**
      * Return 302 status code and redirect to /http/success/200.
@@ -223,7 +282,14 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>> get302Async();
+    Observable<Void> get302Async();
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>> get302AsyncWithServiceResponse();
 
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
@@ -232,7 +298,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> patch302() throws ErrorException, IOException;
+    void patch302() throws ErrorException, IOException;
 
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
@@ -241,6 +307,22 @@ public interface HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> patch302Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> patch302Async();
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302AsyncWithServiceResponse();
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
      *
@@ -249,7 +331,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> patch302(Boolean booleanValue) throws ErrorException, IOException;
+    void patch302(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
@@ -266,7 +348,15 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302Async(Boolean booleanValue);
+    Observable<Void> patch302Async(Boolean booleanValue);
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
@@ -275,7 +365,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> post303() throws ErrorException, IOException;
+    void post303() throws ErrorException, IOException;
 
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
@@ -284,6 +374,22 @@ public interface HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post303Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> post303Async();
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303AsyncWithServiceResponse();
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
      *
@@ -292,7 +398,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> post303(Boolean booleanValue) throws ErrorException, IOException;
+    void post303(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
@@ -309,7 +415,15 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303Async(Boolean booleanValue);
+    Observable<Void> post303Async(Boolean booleanValue);
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Redirect with 307, resulting in a 200 success.
@@ -318,7 +432,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers> head307() throws ErrorException, IOException;
+    void head307() throws ErrorException, IOException;
 
     /**
      * Redirect with 307, resulting in a 200 success.
@@ -333,7 +447,14 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>> head307Async();
+    Observable<Void> head307Async();
+
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>> head307AsyncWithServiceResponse();
 
     /**
      * Redirect get with 307, resulting in a 200 success.
@@ -342,7 +463,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers> get307() throws ErrorException, IOException;
+    void get307() throws ErrorException, IOException;
 
     /**
      * Redirect get with 307, resulting in a 200 success.
@@ -357,7 +478,14 @@ public interface HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>> get307Async();
+    Observable<Void> get307Async();
+
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>> get307AsyncWithServiceResponse();
 
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
@@ -366,7 +494,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> put307() throws ErrorException, IOException;
+    void put307() throws ErrorException, IOException;
 
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
@@ -375,6 +503,22 @@ public interface HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> put307Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> put307Async();
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307AsyncWithServiceResponse();
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
@@ -383,7 +527,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> put307(Boolean booleanValue) throws ErrorException, IOException;
+    void put307(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
@@ -400,7 +544,15 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307Async(Boolean booleanValue);
+    Observable<Void> put307Async(Boolean booleanValue);
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
@@ -409,7 +561,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> patch307() throws ErrorException, IOException;
+    void patch307() throws ErrorException, IOException;
 
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
@@ -418,6 +570,22 @@ public interface HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> patch307Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> patch307Async();
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307AsyncWithServiceResponse();
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
@@ -426,7 +594,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> patch307(Boolean booleanValue) throws ErrorException, IOException;
+    void patch307(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
@@ -443,7 +611,15 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307Async(Boolean booleanValue);
+    Observable<Void> patch307Async(Boolean booleanValue);
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
@@ -452,7 +628,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> post307() throws ErrorException, IOException;
+    void post307() throws ErrorException, IOException;
 
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
@@ -461,6 +637,22 @@ public interface HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post307Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> post307Async();
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307AsyncWithServiceResponse();
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
@@ -469,7 +661,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> post307(Boolean booleanValue) throws ErrorException, IOException;
+    void post307(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
@@ -486,7 +678,15 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307Async(Boolean booleanValue);
+    Observable<Void> post307Async(Boolean booleanValue);
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
@@ -495,7 +695,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> delete307() throws ErrorException, IOException;
+    void delete307() throws ErrorException, IOException;
 
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
@@ -504,6 +704,22 @@ public interface HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> delete307Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<Void> delete307Async();
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307AsyncWithServiceResponse();
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
@@ -512,7 +728,7 @@ public interface HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> delete307(Boolean booleanValue) throws ErrorException, IOException;
+    void delete307(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
@@ -529,6 +745,14 @@ public interface HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307Async(Boolean booleanValue);
+    Observable<Void> delete307Async(Boolean booleanValue);
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307AsyncWithServiceResponse(Boolean booleanValue);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpRetrys.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpRetrys.java
@@ -27,7 +27,6 @@ public interface HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void head408() throws ErrorException, IOException;
 
@@ -51,14 +50,13 @@ public interface HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head408AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> head408WithServiceResponseAsync();
 
     /**
      * Return 500 status code, then 200 after retry.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put500() throws ErrorException, IOException;
 
@@ -73,7 +71,6 @@ public interface HttpRetrys {
     /**
      * Return 500 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> put500Async();
@@ -81,17 +78,15 @@ public interface HttpRetrys {
     /**
      * Return 500 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put500AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> put500WithServiceResponseAsync();
     /**
      * Return 500 status code, then 200 after retry.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put500(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -118,14 +113,13 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put500AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> put500WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 500 status code, then 200 after retry.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch500() throws ErrorException, IOException;
 
@@ -140,7 +134,6 @@ public interface HttpRetrys {
     /**
      * Return 500 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> patch500Async();
@@ -148,17 +141,15 @@ public interface HttpRetrys {
     /**
      * Return 500 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch500AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> patch500WithServiceResponseAsync();
     /**
      * Return 500 status code, then 200 after retry.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch500(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -185,14 +176,13 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch500AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> patch500WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 502 status code, then 200 after retry.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get502() throws ErrorException, IOException;
 
@@ -216,14 +206,13 @@ public interface HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get502AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> get502WithServiceResponseAsync();
 
     /**
      * Return 503 status code, then 200 after retry.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post503() throws ErrorException, IOException;
 
@@ -238,7 +227,6 @@ public interface HttpRetrys {
     /**
      * Return 503 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> post503Async();
@@ -246,17 +234,15 @@ public interface HttpRetrys {
     /**
      * Return 503 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post503AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> post503WithServiceResponseAsync();
     /**
      * Return 503 status code, then 200 after retry.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post503(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -283,14 +269,13 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post503AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> post503WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 503 status code, then 200 after retry.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete503() throws ErrorException, IOException;
 
@@ -305,7 +290,6 @@ public interface HttpRetrys {
     /**
      * Return 503 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> delete503Async();
@@ -313,17 +297,15 @@ public interface HttpRetrys {
     /**
      * Return 503 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete503AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> delete503WithServiceResponseAsync();
     /**
      * Return 503 status code, then 200 after retry.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete503(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -350,14 +332,13 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete503AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> delete503WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 504 status code, then 200 after retry.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put504() throws ErrorException, IOException;
 
@@ -372,7 +353,6 @@ public interface HttpRetrys {
     /**
      * Return 504 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> put504Async();
@@ -380,17 +360,15 @@ public interface HttpRetrys {
     /**
      * Return 504 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put504AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> put504WithServiceResponseAsync();
     /**
      * Return 504 status code, then 200 after retry.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put504(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -417,14 +395,13 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put504AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> put504WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 504 status code, then 200 after retry.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch504() throws ErrorException, IOException;
 
@@ -439,7 +416,6 @@ public interface HttpRetrys {
     /**
      * Return 504 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> patch504Async();
@@ -447,17 +423,15 @@ public interface HttpRetrys {
     /**
      * Return 504 status code, then 200 after retry.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch504AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> patch504WithServiceResponseAsync();
     /**
      * Return 504 status code, then 200 after retry.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch504(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -484,6 +458,6 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch504AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> patch504WithServiceResponseAsync(Boolean booleanValue);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpRetrys.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpRetrys.java
@@ -29,7 +29,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> head408() throws ErrorException, IOException;
+    void head408() throws ErrorException, IOException;
 
     /**
      * Return 408 status code, then 200 after retry.
@@ -44,7 +44,14 @@ public interface HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head408Async();
+    Observable<Void> head408Async();
+
+    /**
+     * Return 408 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> head408AsyncWithServiceResponse();
 
     /**
      * Return 500 status code, then 200 after retry.
@@ -53,7 +60,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put500() throws ErrorException, IOException;
+    void put500() throws ErrorException, IOException;
 
     /**
      * Return 500 status code, then 200 after retry.
@@ -62,6 +69,22 @@ public interface HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> put500Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> put500Async();
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put500AsyncWithServiceResponse();
     /**
      * Return 500 status code, then 200 after retry.
      *
@@ -70,7 +93,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put500(Boolean booleanValue) throws ErrorException, IOException;
+    void put500(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 500 status code, then 200 after retry.
@@ -87,7 +110,15 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put500Async(Boolean booleanValue);
+    Observable<Void> put500Async(Boolean booleanValue);
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put500AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 500 status code, then 200 after retry.
@@ -96,7 +127,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch500() throws ErrorException, IOException;
+    void patch500() throws ErrorException, IOException;
 
     /**
      * Return 500 status code, then 200 after retry.
@@ -105,6 +136,22 @@ public interface HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> patch500Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> patch500Async();
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch500AsyncWithServiceResponse();
     /**
      * Return 500 status code, then 200 after retry.
      *
@@ -113,7 +160,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch500(Boolean booleanValue) throws ErrorException, IOException;
+    void patch500(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 500 status code, then 200 after retry.
@@ -130,7 +177,15 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch500Async(Boolean booleanValue);
+    Observable<Void> patch500Async(Boolean booleanValue);
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch500AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 502 status code, then 200 after retry.
@@ -139,7 +194,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get502() throws ErrorException, IOException;
+    void get502() throws ErrorException, IOException;
 
     /**
      * Return 502 status code, then 200 after retry.
@@ -154,7 +209,14 @@ public interface HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get502Async();
+    Observable<Void> get502Async();
+
+    /**
+     * Return 502 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> get502AsyncWithServiceResponse();
 
     /**
      * Return 503 status code, then 200 after retry.
@@ -163,7 +225,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post503() throws ErrorException, IOException;
+    void post503() throws ErrorException, IOException;
 
     /**
      * Return 503 status code, then 200 after retry.
@@ -172,6 +234,22 @@ public interface HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post503Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> post503Async();
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post503AsyncWithServiceResponse();
     /**
      * Return 503 status code, then 200 after retry.
      *
@@ -180,7 +258,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post503(Boolean booleanValue) throws ErrorException, IOException;
+    void post503(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 503 status code, then 200 after retry.
@@ -197,7 +275,15 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post503Async(Boolean booleanValue);
+    Observable<Void> post503Async(Boolean booleanValue);
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post503AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 503 status code, then 200 after retry.
@@ -206,7 +292,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete503() throws ErrorException, IOException;
+    void delete503() throws ErrorException, IOException;
 
     /**
      * Return 503 status code, then 200 after retry.
@@ -215,6 +301,22 @@ public interface HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> delete503Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> delete503Async();
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete503AsyncWithServiceResponse();
     /**
      * Return 503 status code, then 200 after retry.
      *
@@ -223,7 +325,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete503(Boolean booleanValue) throws ErrorException, IOException;
+    void delete503(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 503 status code, then 200 after retry.
@@ -240,7 +342,15 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete503Async(Boolean booleanValue);
+    Observable<Void> delete503Async(Boolean booleanValue);
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete503AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 504 status code, then 200 after retry.
@@ -249,7 +359,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put504() throws ErrorException, IOException;
+    void put504() throws ErrorException, IOException;
 
     /**
      * Return 504 status code, then 200 after retry.
@@ -258,6 +368,22 @@ public interface HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> put504Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> put504Async();
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put504AsyncWithServiceResponse();
     /**
      * Return 504 status code, then 200 after retry.
      *
@@ -266,7 +392,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put504(Boolean booleanValue) throws ErrorException, IOException;
+    void put504(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 504 status code, then 200 after retry.
@@ -283,7 +409,15 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put504Async(Boolean booleanValue);
+    Observable<Void> put504Async(Boolean booleanValue);
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put504AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 504 status code, then 200 after retry.
@@ -292,7 +426,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch504() throws ErrorException, IOException;
+    void patch504() throws ErrorException, IOException;
 
     /**
      * Return 504 status code, then 200 after retry.
@@ -301,6 +435,22 @@ public interface HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> patch504Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> patch504Async();
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch504AsyncWithServiceResponse();
     /**
      * Return 504 status code, then 200 after retry.
      *
@@ -309,7 +459,7 @@ public interface HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch504(Boolean booleanValue) throws ErrorException, IOException;
+    void patch504(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 504 status code, then 200 after retry.
@@ -326,6 +476,14 @@ public interface HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch504Async(Boolean booleanValue);
+    Observable<Void> patch504Async(Boolean booleanValue);
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch504AsyncWithServiceResponse(Boolean booleanValue);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpServerFailures.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpServerFailures.java
@@ -28,7 +28,7 @@ public interface HttpServerFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error head501() throws ErrorException, IOException;
 
@@ -52,14 +52,14 @@ public interface HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head501AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> head501WithServiceResponseAsync();
 
     /**
      * Return 501 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error get501() throws ErrorException, IOException;
 
@@ -83,14 +83,14 @@ public interface HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get501AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> get501WithServiceResponseAsync();
 
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error post505() throws ErrorException, IOException;
 
@@ -105,7 +105,6 @@ public interface HttpServerFailures {
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> post505Async();
@@ -113,17 +112,16 @@ public interface HttpServerFailures {
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post505AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> post505WithServiceResponseAsync();
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error post505(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -150,14 +148,14 @@ public interface HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post505AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> post505WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error delete505() throws ErrorException, IOException;
 
@@ -172,7 +170,6 @@ public interface HttpServerFailures {
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
     Observable<Error> delete505Async();
@@ -180,17 +177,16 @@ public interface HttpServerFailures {
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
-     * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete505AsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> delete505WithServiceResponseAsync();
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error delete505(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -217,6 +213,6 @@ public interface HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete505AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Error>> delete505WithServiceResponseAsync(Boolean booleanValue);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpServerFailures.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpServerFailures.java
@@ -30,7 +30,7 @@ public interface HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> head501() throws ErrorException, IOException;
+    Error head501() throws ErrorException, IOException;
 
     /**
      * Return 501 status code - should be represented in the client as an error.
@@ -45,7 +45,14 @@ public interface HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> head501Async();
+    Observable<Error> head501Async();
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> head501AsyncWithServiceResponse();
 
     /**
      * Return 501 status code - should be represented in the client as an error.
@@ -54,7 +61,7 @@ public interface HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> get501() throws ErrorException, IOException;
+    Error get501() throws ErrorException, IOException;
 
     /**
      * Return 501 status code - should be represented in the client as an error.
@@ -69,7 +76,14 @@ public interface HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> get501Async();
+    Observable<Error> get501Async();
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> get501AsyncWithServiceResponse();
 
     /**
      * Return 505 status code - should be represented in the client as an error.
@@ -78,7 +92,7 @@ public interface HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> post505() throws ErrorException, IOException;
+    Error post505() throws ErrorException, IOException;
 
     /**
      * Return 505 status code - should be represented in the client as an error.
@@ -87,6 +101,22 @@ public interface HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> post505Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> post505Async();
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> post505AsyncWithServiceResponse();
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
@@ -95,7 +125,7 @@ public interface HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> post505(Boolean booleanValue) throws ErrorException, IOException;
+    Error post505(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 505 status code - should be represented in the client as an error.
@@ -112,7 +142,15 @@ public interface HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> post505Async(Boolean booleanValue);
+    Observable<Error> post505Async(Boolean booleanValue);
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> post505AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 505 status code - should be represented in the client as an error.
@@ -121,7 +159,7 @@ public interface HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> delete505() throws ErrorException, IOException;
+    Error delete505() throws ErrorException, IOException;
 
     /**
      * Return 505 status code - should be represented in the client as an error.
@@ -130,6 +168,22 @@ public interface HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Error> delete505Async(final ServiceCallback<Error> serviceCallback);
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<Error> delete505Async();
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> delete505AsyncWithServiceResponse();
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
@@ -138,7 +192,7 @@ public interface HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> delete505(Boolean booleanValue) throws ErrorException, IOException;
+    Error delete505(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Return 505 status code - should be represented in the client as an error.
@@ -155,6 +209,14 @@ public interface HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> delete505Async(Boolean booleanValue);
+    Observable<Error> delete505Async(Boolean booleanValue);
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> delete505AsyncWithServiceResponse(Boolean booleanValue);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpSuccess.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpSuccess.java
@@ -29,7 +29,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> head200() throws ErrorException, IOException;
+    void head200() throws ErrorException, IOException;
 
     /**
      * Return 200 status code if successful.
@@ -44,7 +44,14 @@ public interface HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head200Async();
+    Observable<Void> head200Async();
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> head200AsyncWithServiceResponse();
 
     /**
      * Get 200 success.
@@ -53,7 +60,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Boolean> get200() throws ErrorException, IOException;
+    boolean get200() throws ErrorException, IOException;
 
     /**
      * Get 200 success.
@@ -68,7 +75,14 @@ public interface HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> get200Async();
+    Observable<Boolean> get200Async();
+
+    /**
+     * Get 200 success.
+     *
+     * @return the observable to the boolean object
+     */
+    Observable<ServiceResponse<Boolean>> get200AsyncWithServiceResponse();
 
     /**
      * Put boolean value true returning 200 success.
@@ -77,7 +91,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put200() throws ErrorException, IOException;
+    void put200() throws ErrorException, IOException;
 
     /**
      * Put boolean value true returning 200 success.
@@ -86,6 +100,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> put200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> put200Async();
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put200AsyncWithServiceResponse();
     /**
      * Put boolean value true returning 200 success.
      *
@@ -94,7 +124,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put200(Boolean booleanValue) throws ErrorException, IOException;
+    void put200(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Put boolean value true returning 200 success.
@@ -111,7 +141,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put200Async(Boolean booleanValue);
+    Observable<Void> put200Async(Boolean booleanValue);
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put200AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Patch true Boolean value in request returning 200.
@@ -120,7 +158,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch200() throws ErrorException, IOException;
+    void patch200() throws ErrorException, IOException;
 
     /**
      * Patch true Boolean value in request returning 200.
@@ -129,6 +167,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> patch200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> patch200Async();
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch200AsyncWithServiceResponse();
     /**
      * Patch true Boolean value in request returning 200.
      *
@@ -137,7 +191,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch200(Boolean booleanValue) throws ErrorException, IOException;
+    void patch200(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Patch true Boolean value in request returning 200.
@@ -154,7 +208,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch200Async(Boolean booleanValue);
+    Observable<Void> patch200Async(Boolean booleanValue);
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch200AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Post bollean value true in request that returns a 200.
@@ -163,7 +225,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post200() throws ErrorException, IOException;
+    void post200() throws ErrorException, IOException;
 
     /**
      * Post bollean value true in request that returns a 200.
@@ -172,6 +234,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> post200Async();
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post200AsyncWithServiceResponse();
     /**
      * Post bollean value true in request that returns a 200.
      *
@@ -180,7 +258,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post200(Boolean booleanValue) throws ErrorException, IOException;
+    void post200(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Post bollean value true in request that returns a 200.
@@ -197,7 +275,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post200Async(Boolean booleanValue);
+    Observable<Void> post200Async(Boolean booleanValue);
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post200AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Delete simple boolean value true returns 200.
@@ -206,7 +292,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete200() throws ErrorException, IOException;
+    void delete200() throws ErrorException, IOException;
 
     /**
      * Delete simple boolean value true returns 200.
@@ -215,6 +301,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> delete200Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> delete200Async();
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete200AsyncWithServiceResponse();
     /**
      * Delete simple boolean value true returns 200.
      *
@@ -223,7 +325,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete200(Boolean booleanValue) throws ErrorException, IOException;
+    void delete200(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Delete simple boolean value true returns 200.
@@ -240,7 +342,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete200Async(Boolean booleanValue);
+    Observable<Void> delete200Async(Boolean booleanValue);
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete200AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Put true Boolean value in request returns 201.
@@ -249,7 +359,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put201() throws ErrorException, IOException;
+    void put201() throws ErrorException, IOException;
 
     /**
      * Put true Boolean value in request returns 201.
@@ -258,6 +368,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> put201Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> put201Async();
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put201AsyncWithServiceResponse();
     /**
      * Put true Boolean value in request returns 201.
      *
@@ -266,7 +392,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put201(Boolean booleanValue) throws ErrorException, IOException;
+    void put201(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Put true Boolean value in request returns 201.
@@ -283,7 +409,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put201Async(Boolean booleanValue);
+    Observable<Void> put201Async(Boolean booleanValue);
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put201AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Post true Boolean value in request returns 201 (Created).
@@ -292,7 +426,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post201() throws ErrorException, IOException;
+    void post201() throws ErrorException, IOException;
 
     /**
      * Post true Boolean value in request returns 201 (Created).
@@ -301,6 +435,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post201Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> post201Async();
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post201AsyncWithServiceResponse();
     /**
      * Post true Boolean value in request returns 201 (Created).
      *
@@ -309,7 +459,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post201(Boolean booleanValue) throws ErrorException, IOException;
+    void post201(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Post true Boolean value in request returns 201 (Created).
@@ -326,7 +476,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post201Async(Boolean booleanValue);
+    Observable<Void> post201Async(Boolean booleanValue);
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post201AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Put true Boolean value in request returns 202 (Accepted).
@@ -335,7 +493,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put202() throws ErrorException, IOException;
+    void put202() throws ErrorException, IOException;
 
     /**
      * Put true Boolean value in request returns 202 (Accepted).
@@ -344,6 +502,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> put202Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> put202Async();
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put202AsyncWithServiceResponse();
     /**
      * Put true Boolean value in request returns 202 (Accepted).
      *
@@ -352,7 +526,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put202(Boolean booleanValue) throws ErrorException, IOException;
+    void put202(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Put true Boolean value in request returns 202 (Accepted).
@@ -369,7 +543,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put202Async(Boolean booleanValue);
+    Observable<Void> put202Async(Boolean booleanValue);
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put202AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Patch true Boolean value in request returns 202.
@@ -378,7 +560,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch202() throws ErrorException, IOException;
+    void patch202() throws ErrorException, IOException;
 
     /**
      * Patch true Boolean value in request returns 202.
@@ -387,6 +569,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> patch202Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> patch202Async();
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch202AsyncWithServiceResponse();
     /**
      * Patch true Boolean value in request returns 202.
      *
@@ -395,7 +593,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch202(Boolean booleanValue) throws ErrorException, IOException;
+    void patch202(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Patch true Boolean value in request returns 202.
@@ -412,7 +610,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch202Async(Boolean booleanValue);
+    Observable<Void> patch202Async(Boolean booleanValue);
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch202AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Post true Boolean value in request returns 202 (Accepted).
@@ -421,7 +627,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post202() throws ErrorException, IOException;
+    void post202() throws ErrorException, IOException;
 
     /**
      * Post true Boolean value in request returns 202 (Accepted).
@@ -430,6 +636,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post202Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> post202Async();
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post202AsyncWithServiceResponse();
     /**
      * Post true Boolean value in request returns 202 (Accepted).
      *
@@ -438,7 +660,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post202(Boolean booleanValue) throws ErrorException, IOException;
+    void post202(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Post true Boolean value in request returns 202 (Accepted).
@@ -455,7 +677,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post202Async(Boolean booleanValue);
+    Observable<Void> post202Async(Boolean booleanValue);
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post202AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Delete true Boolean value in request returns 202 (accepted).
@@ -464,7 +694,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete202() throws ErrorException, IOException;
+    void delete202() throws ErrorException, IOException;
 
     /**
      * Delete true Boolean value in request returns 202 (accepted).
@@ -473,6 +703,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> delete202Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> delete202Async();
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete202AsyncWithServiceResponse();
     /**
      * Delete true Boolean value in request returns 202 (accepted).
      *
@@ -481,7 +727,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete202(Boolean booleanValue) throws ErrorException, IOException;
+    void delete202(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Delete true Boolean value in request returns 202 (accepted).
@@ -498,7 +744,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete202Async(Boolean booleanValue);
+    Observable<Void> delete202Async(Boolean booleanValue);
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete202AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 204 status code if successful.
@@ -507,7 +761,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> head204() throws ErrorException, IOException;
+    void head204() throws ErrorException, IOException;
 
     /**
      * Return 204 status code if successful.
@@ -522,7 +776,14 @@ public interface HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head204Async();
+    Observable<Void> head204Async();
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> head204AsyncWithServiceResponse();
 
     /**
      * Put true Boolean value in request returns 204 (no content).
@@ -531,7 +792,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put204() throws ErrorException, IOException;
+    void put204() throws ErrorException, IOException;
 
     /**
      * Put true Boolean value in request returns 204 (no content).
@@ -540,6 +801,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> put204Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> put204Async();
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put204AsyncWithServiceResponse();
     /**
      * Put true Boolean value in request returns 204 (no content).
      *
@@ -548,7 +825,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> put204(Boolean booleanValue) throws ErrorException, IOException;
+    void put204(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Put true Boolean value in request returns 204 (no content).
@@ -565,7 +842,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put204Async(Boolean booleanValue);
+    Observable<Void> put204Async(Boolean booleanValue);
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> put204AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Patch true Boolean value in request returns 204 (no content).
@@ -574,7 +859,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch204() throws ErrorException, IOException;
+    void patch204() throws ErrorException, IOException;
 
     /**
      * Patch true Boolean value in request returns 204 (no content).
@@ -583,6 +868,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> patch204Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> patch204Async();
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch204AsyncWithServiceResponse();
     /**
      * Patch true Boolean value in request returns 204 (no content).
      *
@@ -591,7 +892,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> patch204(Boolean booleanValue) throws ErrorException, IOException;
+    void patch204(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Patch true Boolean value in request returns 204 (no content).
@@ -608,7 +909,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch204Async(Boolean booleanValue);
+    Observable<Void> patch204Async(Boolean booleanValue);
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> patch204AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Post true Boolean value in request returns 204 (no content).
@@ -617,7 +926,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post204() throws ErrorException, IOException;
+    void post204() throws ErrorException, IOException;
 
     /**
      * Post true Boolean value in request returns 204 (no content).
@@ -626,6 +935,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> post204Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> post204Async();
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post204AsyncWithServiceResponse();
     /**
      * Post true Boolean value in request returns 204 (no content).
      *
@@ -634,7 +959,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> post204(Boolean booleanValue) throws ErrorException, IOException;
+    void post204(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Post true Boolean value in request returns 204 (no content).
@@ -651,7 +976,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post204Async(Boolean booleanValue);
+    Observable<Void> post204Async(Boolean booleanValue);
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> post204AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Delete true Boolean value in request returns 204 (no content).
@@ -660,7 +993,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete204() throws ErrorException, IOException;
+    void delete204() throws ErrorException, IOException;
 
     /**
      * Delete true Boolean value in request returns 204 (no content).
@@ -669,6 +1002,22 @@ public interface HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> delete204Async(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> delete204Async();
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete204AsyncWithServiceResponse();
     /**
      * Delete true Boolean value in request returns 204 (no content).
      *
@@ -677,7 +1026,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> delete204(Boolean booleanValue) throws ErrorException, IOException;
+    void delete204(Boolean booleanValue) throws ErrorException, IOException;
 
     /**
      * Delete true Boolean value in request returns 204 (no content).
@@ -694,7 +1043,15 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete204Async(Boolean booleanValue);
+    Observable<Void> delete204Async(Boolean booleanValue);
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> delete204AsyncWithServiceResponse(Boolean booleanValue);
 
     /**
      * Return 404 status code.
@@ -703,7 +1060,7 @@ public interface HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> head404() throws ErrorException, IOException;
+    void head404() throws ErrorException, IOException;
 
     /**
      * Return 404 status code.
@@ -718,6 +1075,13 @@ public interface HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head404Async();
+    Observable<Void> head404Async();
+
+    /**
+     * Return 404 status code.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> head404AsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpSuccess.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/HttpSuccess.java
@@ -27,7 +27,6 @@ public interface HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void head200() throws ErrorException, IOException;
 
@@ -51,14 +50,14 @@ public interface HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> head200WithServiceResponseAsync();
 
     /**
      * Get 200 success.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     boolean get200() throws ErrorException, IOException;
 
@@ -82,14 +81,13 @@ public interface HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    Observable<ServiceResponse<Boolean>> get200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Boolean>> get200WithServiceResponseAsync();
 
     /**
      * Put boolean value true returning 200 success.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put200() throws ErrorException, IOException;
 
@@ -104,7 +102,6 @@ public interface HttpSuccess {
     /**
      * Put boolean value true returning 200 success.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> put200Async();
@@ -112,17 +109,15 @@ public interface HttpSuccess {
     /**
      * Put boolean value true returning 200 success.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> put200WithServiceResponseAsync();
     /**
      * Put boolean value true returning 200 success.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put200(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -149,14 +144,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put200AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> put200WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Patch true Boolean value in request returning 200.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch200() throws ErrorException, IOException;
 
@@ -171,7 +165,6 @@ public interface HttpSuccess {
     /**
      * Patch true Boolean value in request returning 200.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> patch200Async();
@@ -179,17 +172,15 @@ public interface HttpSuccess {
     /**
      * Patch true Boolean value in request returning 200.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> patch200WithServiceResponseAsync();
     /**
      * Patch true Boolean value in request returning 200.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch200(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -216,14 +207,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch200AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> patch200WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Post bollean value true in request that returns a 200.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post200() throws ErrorException, IOException;
 
@@ -238,7 +228,6 @@ public interface HttpSuccess {
     /**
      * Post bollean value true in request that returns a 200.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> post200Async();
@@ -246,17 +235,15 @@ public interface HttpSuccess {
     /**
      * Post bollean value true in request that returns a 200.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> post200WithServiceResponseAsync();
     /**
      * Post bollean value true in request that returns a 200.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post200(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -283,14 +270,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post200AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> post200WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Delete simple boolean value true returns 200.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete200() throws ErrorException, IOException;
 
@@ -305,7 +291,6 @@ public interface HttpSuccess {
     /**
      * Delete simple boolean value true returns 200.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> delete200Async();
@@ -313,17 +298,15 @@ public interface HttpSuccess {
     /**
      * Delete simple boolean value true returns 200.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete200AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> delete200WithServiceResponseAsync();
     /**
      * Delete simple boolean value true returns 200.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete200(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -350,14 +333,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete200AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> delete200WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Put true Boolean value in request returns 201.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put201() throws ErrorException, IOException;
 
@@ -372,7 +354,6 @@ public interface HttpSuccess {
     /**
      * Put true Boolean value in request returns 201.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> put201Async();
@@ -380,17 +361,15 @@ public interface HttpSuccess {
     /**
      * Put true Boolean value in request returns 201.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put201AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> put201WithServiceResponseAsync();
     /**
      * Put true Boolean value in request returns 201.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put201(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -417,14 +396,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put201AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> put201WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Post true Boolean value in request returns 201 (Created).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post201() throws ErrorException, IOException;
 
@@ -439,7 +417,6 @@ public interface HttpSuccess {
     /**
      * Post true Boolean value in request returns 201 (Created).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> post201Async();
@@ -447,17 +424,15 @@ public interface HttpSuccess {
     /**
      * Post true Boolean value in request returns 201 (Created).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post201AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> post201WithServiceResponseAsync();
     /**
      * Post true Boolean value in request returns 201 (Created).
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post201(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -484,14 +459,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post201AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> post201WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Put true Boolean value in request returns 202 (Accepted).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put202() throws ErrorException, IOException;
 
@@ -506,7 +480,6 @@ public interface HttpSuccess {
     /**
      * Put true Boolean value in request returns 202 (Accepted).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> put202Async();
@@ -514,17 +487,15 @@ public interface HttpSuccess {
     /**
      * Put true Boolean value in request returns 202 (Accepted).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put202AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> put202WithServiceResponseAsync();
     /**
      * Put true Boolean value in request returns 202 (Accepted).
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put202(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -551,14 +522,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put202AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> put202WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Patch true Boolean value in request returns 202.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch202() throws ErrorException, IOException;
 
@@ -573,7 +543,6 @@ public interface HttpSuccess {
     /**
      * Patch true Boolean value in request returns 202.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> patch202Async();
@@ -581,17 +550,15 @@ public interface HttpSuccess {
     /**
      * Patch true Boolean value in request returns 202.
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch202AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> patch202WithServiceResponseAsync();
     /**
      * Patch true Boolean value in request returns 202.
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch202(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -618,14 +585,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch202AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> patch202WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Post true Boolean value in request returns 202 (Accepted).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post202() throws ErrorException, IOException;
 
@@ -640,7 +606,6 @@ public interface HttpSuccess {
     /**
      * Post true Boolean value in request returns 202 (Accepted).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> post202Async();
@@ -648,17 +613,15 @@ public interface HttpSuccess {
     /**
      * Post true Boolean value in request returns 202 (Accepted).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post202AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> post202WithServiceResponseAsync();
     /**
      * Post true Boolean value in request returns 202 (Accepted).
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post202(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -685,14 +648,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post202AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> post202WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Delete true Boolean value in request returns 202 (accepted).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete202() throws ErrorException, IOException;
 
@@ -707,7 +669,6 @@ public interface HttpSuccess {
     /**
      * Delete true Boolean value in request returns 202 (accepted).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> delete202Async();
@@ -715,17 +676,15 @@ public interface HttpSuccess {
     /**
      * Delete true Boolean value in request returns 202 (accepted).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete202AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> delete202WithServiceResponseAsync();
     /**
      * Delete true Boolean value in request returns 202 (accepted).
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete202(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -752,14 +711,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete202AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> delete202WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 204 status code if successful.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void head204() throws ErrorException, IOException;
 
@@ -783,14 +741,13 @@ public interface HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> head204WithServiceResponseAsync();
 
     /**
      * Put true Boolean value in request returns 204 (no content).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put204() throws ErrorException, IOException;
 
@@ -805,7 +762,6 @@ public interface HttpSuccess {
     /**
      * Put true Boolean value in request returns 204 (no content).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> put204Async();
@@ -813,17 +769,15 @@ public interface HttpSuccess {
     /**
      * Put true Boolean value in request returns 204 (no content).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> put204WithServiceResponseAsync();
     /**
      * Put true Boolean value in request returns 204 (no content).
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void put204(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -850,14 +804,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> put204AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> put204WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Patch true Boolean value in request returns 204 (no content).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch204() throws ErrorException, IOException;
 
@@ -872,7 +825,6 @@ public interface HttpSuccess {
     /**
      * Patch true Boolean value in request returns 204 (no content).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> patch204Async();
@@ -880,17 +832,15 @@ public interface HttpSuccess {
     /**
      * Patch true Boolean value in request returns 204 (no content).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> patch204WithServiceResponseAsync();
     /**
      * Patch true Boolean value in request returns 204 (no content).
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void patch204(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -917,14 +867,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> patch204AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> patch204WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Post true Boolean value in request returns 204 (no content).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post204() throws ErrorException, IOException;
 
@@ -939,7 +888,6 @@ public interface HttpSuccess {
     /**
      * Post true Boolean value in request returns 204 (no content).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> post204Async();
@@ -947,17 +895,15 @@ public interface HttpSuccess {
     /**
      * Post true Boolean value in request returns 204 (no content).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> post204WithServiceResponseAsync();
     /**
      * Post true Boolean value in request returns 204 (no content).
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void post204(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -984,14 +930,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> post204AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> post204WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Delete true Boolean value in request returns 204 (no content).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete204() throws ErrorException, IOException;
 
@@ -1006,7 +951,6 @@ public interface HttpSuccess {
     /**
      * Delete true Boolean value in request returns 204 (no content).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> delete204Async();
@@ -1014,17 +958,15 @@ public interface HttpSuccess {
     /**
      * Delete true Boolean value in request returns 204 (no content).
      *
-     * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete204AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> delete204WithServiceResponseAsync();
     /**
      * Delete true Boolean value in request returns 204 (no content).
      *
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void delete204(Boolean booleanValue) throws ErrorException, IOException;
 
@@ -1051,14 +993,13 @@ public interface HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> delete204AsyncWithServiceResponse(Boolean booleanValue);
+    Observable<ServiceResponse<Void>> delete204WithServiceResponseAsync(Boolean booleanValue);
 
     /**
      * Return 404 status code.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void head404() throws ErrorException, IOException;
 
@@ -1082,6 +1023,6 @@ public interface HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> head404AsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> head404WithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/MultipleResponses.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/MultipleResponses.java
@@ -30,7 +30,7 @@ public interface MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200Model204NoModelDefaultError200Valid() throws ErrorException, IOException;
 
@@ -54,14 +54,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError200ValidWithServiceResponseAsync();
 
     /**
      * Send a 204 response with no payload.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200Model204NoModelDefaultError204Valid() throws ErrorException, IOException;
 
@@ -85,14 +85,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError204ValidWithServiceResponseAsync();
 
     /**
      * Send a 201 response with valid payload: {'statusCode': '201'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200Model204NoModelDefaultError201Invalid() throws ErrorException, IOException;
 
@@ -116,14 +116,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError201InvalidWithServiceResponseAsync();
 
     /**
      * Send a 202 response with no payload:.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200Model204NoModelDefaultError202None() throws ErrorException, IOException;
 
@@ -147,14 +147,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError202NoneWithServiceResponseAsync();
 
     /**
      * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200Model204NoModelDefaultError400Valid() throws ErrorException, IOException;
 
@@ -178,14 +178,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError400ValidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200Model201ModelDefaultError200Valid() throws ErrorException, IOException;
 
@@ -209,14 +209,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model201ModelDefaultError200ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200Model201ModelDefaultError200ValidWithServiceResponseAsync();
 
     /**
      * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200Model201ModelDefaultError201Valid() throws ErrorException, IOException;
 
@@ -240,14 +240,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model201ModelDefaultError201ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200Model201ModelDefaultError201ValidWithServiceResponseAsync();
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200Model201ModelDefaultError400Valid() throws ErrorException, IOException;
 
@@ -271,14 +271,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model201ModelDefaultError400ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200Model201ModelDefaultError400ValidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Object object wrapped in {@link ServiceResponse} if successful.
+     * @return the Object object if successful.
      */
     Object get200ModelA201ModelC404ModelDDefaultError200Valid() throws ErrorException, IOException;
 
@@ -302,14 +302,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with valid payload: {'httpCode': '201'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Object object wrapped in {@link ServiceResponse} if successful.
+     * @return the Object object if successful.
      */
     Object get200ModelA201ModelC404ModelDDefaultError201Valid() throws ErrorException, IOException;
 
@@ -333,14 +333,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Object object wrapped in {@link ServiceResponse} if successful.
+     * @return the Object object if successful.
      */
     Object get200ModelA201ModelC404ModelDDefaultError404Valid() throws ErrorException, IOException;
 
@@ -364,14 +364,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidWithServiceResponseAsync();
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Object object wrapped in {@link ServiceResponse} if successful.
+     * @return the Object object if successful.
      */
     Object get200ModelA201ModelC404ModelDDefaultError400Valid() throws ErrorException, IOException;
 
@@ -395,14 +395,13 @@ public interface MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidWithServiceResponseAsync();
 
     /**
      * Send a 202 response with no payload.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get202None204NoneDefaultError202None() throws ErrorException, IOException;
 
@@ -426,14 +425,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultError202NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultError202NoneWithServiceResponseAsync();
 
     /**
      * Send a 204 response with no payload.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get202None204NoneDefaultError204None() throws ErrorException, IOException;
 
@@ -457,14 +455,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultError204NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultError204NoneWithServiceResponseAsync();
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get202None204NoneDefaultError400Valid() throws ErrorException, IOException;
 
@@ -488,14 +485,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultError400ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultError400ValidWithServiceResponseAsync();
 
     /**
      * Send a 202 response with an unexpected payload {'property': 'value'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get202None204NoneDefaultNone202Invalid() throws ServiceException, IOException;
 
@@ -519,14 +515,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone202InvalidWithServiceResponseAsync();
 
     /**
      * Send a 204 response with no payload.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get202None204NoneDefaultNone204None() throws ServiceException, IOException;
 
@@ -550,14 +545,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone204NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone204NoneWithServiceResponseAsync();
 
     /**
      * Send a 400 response with no payload.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get202None204NoneDefaultNone400None() throws ServiceException, IOException;
 
@@ -581,14 +575,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400NoneWithServiceResponseAsync();
 
     /**
      * Send a 400 response with an unexpected payload {'property': 'value'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void get202None204NoneDefaultNone400Invalid() throws ServiceException, IOException;
 
@@ -612,14 +605,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400InvalidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
      * @throws MyException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A getDefaultModelA200Valid() throws MyException, IOException;
 
@@ -643,14 +636,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> getDefaultModelA200ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> getDefaultModelA200ValidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with no payload.
      *
      * @throws MyException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A getDefaultModelA200None() throws MyException, IOException;
 
@@ -674,14 +667,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> getDefaultModelA200NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> getDefaultModelA200NoneWithServiceResponseAsync();
 
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
      * @throws MyException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A getDefaultModelA400Valid() throws MyException, IOException;
 
@@ -705,14 +698,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> getDefaultModelA400ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> getDefaultModelA400ValidWithServiceResponseAsync();
 
     /**
      * Send a 400 response with no payload.
      *
      * @throws MyException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A getDefaultModelA400None() throws MyException, IOException;
 
@@ -736,14 +729,13 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> getDefaultModelA400NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> getDefaultModelA400NoneWithServiceResponseAsync();
 
     /**
      * Send a 200 response with invalid payload: {'statusCode': '200'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getDefaultNone200Invalid() throws ServiceException, IOException;
 
@@ -767,14 +759,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getDefaultNone200InvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getDefaultNone200InvalidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with no payload.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getDefaultNone200None() throws ServiceException, IOException;
 
@@ -798,14 +789,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getDefaultNone200NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getDefaultNone200NoneWithServiceResponseAsync();
 
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getDefaultNone400Invalid() throws ServiceException, IOException;
 
@@ -829,14 +819,13 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getDefaultNone400InvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getDefaultNone400InvalidWithServiceResponseAsync();
 
     /**
      * Send a 400 response with no payload.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getDefaultNone400None() throws ServiceException, IOException;
 
@@ -860,14 +849,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getDefaultNone400NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getDefaultNone400NoneWithServiceResponseAsync();
 
     /**
      * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200ModelA200None() throws ServiceException, IOException;
 
@@ -891,14 +880,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA200NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200ModelA200NoneWithServiceResponseAsync();
 
     /**
      * Send a 200 response with payload {'statusCode': '200'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200ModelA200Valid() throws ServiceException, IOException;
 
@@ -922,14 +911,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA200ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200ModelA200ValidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200ModelA200Invalid() throws ServiceException, IOException;
 
@@ -953,14 +942,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA200InvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200ModelA200InvalidWithServiceResponseAsync();
 
     /**
      * Send a 400 response with no payload client should treat as an http error with no error model.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200ModelA400None() throws ServiceException, IOException;
 
@@ -984,14 +973,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA400NoneAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200ModelA400NoneWithServiceResponseAsync();
 
     /**
      * Send a 200 response with payload {'statusCode': '400'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200ModelA400Valid() throws ServiceException, IOException;
 
@@ -1015,14 +1004,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA400ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200ModelA400ValidWithServiceResponseAsync();
 
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200ModelA400Invalid() throws ServiceException, IOException;
 
@@ -1046,14 +1035,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA400InvalidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200ModelA400InvalidWithServiceResponseAsync();
 
     /**
      * Send a 202 response with payload {'statusCode': '202'}.
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     A get200ModelA202Valid() throws ServiceException, IOException;
 
@@ -1077,6 +1066,6 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA202ValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<A>> get200ModelA202ValidWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/MultipleResponses.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/MultipleResponses.java
@@ -32,7 +32,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200Model204NoModelDefaultError200Valid() throws ErrorException, IOException;
+    A get200Model204NoModelDefaultError200Valid() throws ErrorException, IOException;
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
@@ -47,7 +47,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError200ValidAsync();
+    Observable<A> get200Model204NoModelDefaultError200ValidAsync();
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse();
 
     /**
      * Send a 204 response with no payload.
@@ -56,7 +63,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200Model204NoModelDefaultError204Valid() throws ErrorException, IOException;
+    A get200Model204NoModelDefaultError204Valid() throws ErrorException, IOException;
 
     /**
      * Send a 204 response with no payload.
@@ -71,7 +78,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError204ValidAsync();
+    Observable<A> get200Model204NoModelDefaultError204ValidAsync();
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse();
 
     /**
      * Send a 201 response with valid payload: {'statusCode': '201'}.
@@ -80,7 +94,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200Model204NoModelDefaultError201Invalid() throws ErrorException, IOException;
+    A get200Model204NoModelDefaultError201Invalid() throws ErrorException, IOException;
 
     /**
      * Send a 201 response with valid payload: {'statusCode': '201'}.
@@ -95,7 +109,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError201InvalidAsync();
+    Observable<A> get200Model204NoModelDefaultError201InvalidAsync();
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse();
 
     /**
      * Send a 202 response with no payload:.
@@ -104,7 +125,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200Model204NoModelDefaultError202None() throws ErrorException, IOException;
+    A get200Model204NoModelDefaultError202None() throws ErrorException, IOException;
 
     /**
      * Send a 202 response with no payload:.
@@ -119,7 +140,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError202NoneAsync();
+    Observable<A> get200Model204NoModelDefaultError202NoneAsync();
+
+    /**
+     * Send a 202 response with no payload:.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
@@ -128,7 +156,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200Model204NoModelDefaultError400Valid() throws ErrorException, IOException;
+    A get200Model204NoModelDefaultError400Valid() throws ErrorException, IOException;
 
     /**
      * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
@@ -143,7 +171,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError400ValidAsync();
+    Observable<A> get200Model204NoModelDefaultError400ValidAsync();
+
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
@@ -152,7 +187,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200Model201ModelDefaultError200Valid() throws ErrorException, IOException;
+    A get200Model201ModelDefaultError200Valid() throws ErrorException, IOException;
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
@@ -167,7 +202,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model201ModelDefaultError200ValidAsync();
+    Observable<A> get200Model201ModelDefaultError200ValidAsync();
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200Model201ModelDefaultError200ValidAsyncWithServiceResponse();
 
     /**
      * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
@@ -176,7 +218,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200Model201ModelDefaultError201Valid() throws ErrorException, IOException;
+    A get200Model201ModelDefaultError201Valid() throws ErrorException, IOException;
 
     /**
      * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
@@ -191,7 +233,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model201ModelDefaultError201ValidAsync();
+    Observable<A> get200Model201ModelDefaultError201ValidAsync();
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200Model201ModelDefaultError201ValidAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
@@ -200,7 +249,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200Model201ModelDefaultError400Valid() throws ErrorException, IOException;
+    A get200Model201ModelDefaultError400Valid() throws ErrorException, IOException;
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
@@ -215,7 +264,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200Model201ModelDefaultError400ValidAsync();
+    Observable<A> get200Model201ModelDefaultError400ValidAsync();
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200Model201ModelDefaultError400ValidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
@@ -224,7 +280,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Object object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Object> get200ModelA201ModelC404ModelDDefaultError200Valid() throws ErrorException, IOException;
+    Object get200ModelA201ModelC404ModelDDefaultError200Valid() throws ErrorException, IOException;
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
@@ -239,7 +295,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidAsync();
+    Observable<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync();
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @return the observable to the Object object
+     */
+    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with valid payload: {'httpCode': '201'}.
@@ -248,7 +311,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Object object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Object> get200ModelA201ModelC404ModelDDefaultError201Valid() throws ErrorException, IOException;
+    Object get200ModelA201ModelC404ModelDDefaultError201Valid() throws ErrorException, IOException;
 
     /**
      * Send a 200 response with valid payload: {'httpCode': '201'}.
@@ -263,7 +326,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidAsync();
+    Observable<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync();
+
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     *
+     * @return the observable to the Object object
+     */
+    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
@@ -272,7 +342,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Object object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Object> get200ModelA201ModelC404ModelDDefaultError404Valid() throws ErrorException, IOException;
+    Object get200ModelA201ModelC404ModelDDefaultError404Valid() throws ErrorException, IOException;
 
     /**
      * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
@@ -287,7 +357,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidAsync();
+    Observable<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync();
+
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     *
+     * @return the observable to the Object object
+     */
+    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
@@ -296,7 +373,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Object object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Object> get200ModelA201ModelC404ModelDDefaultError400Valid() throws ErrorException, IOException;
+    Object get200ModelA201ModelC404ModelDDefaultError400Valid() throws ErrorException, IOException;
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
@@ -311,7 +388,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidAsync();
+    Observable<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync();
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @return the observable to the Object object
+     */
+    Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse();
 
     /**
      * Send a 202 response with no payload.
@@ -320,7 +404,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get202None204NoneDefaultError202None() throws ErrorException, IOException;
+    void get202None204NoneDefaultError202None() throws ErrorException, IOException;
 
     /**
      * Send a 202 response with no payload.
@@ -335,7 +419,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultError202NoneAsync();
+    Observable<Void> get202None204NoneDefaultError202NoneAsync();
+
+    /**
+     * Send a 202 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultError202NoneAsyncWithServiceResponse();
 
     /**
      * Send a 204 response with no payload.
@@ -344,7 +435,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get202None204NoneDefaultError204None() throws ErrorException, IOException;
+    void get202None204NoneDefaultError204None() throws ErrorException, IOException;
 
     /**
      * Send a 204 response with no payload.
@@ -359,7 +450,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultError204NoneAsync();
+    Observable<Void> get202None204NoneDefaultError204NoneAsync();
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultError204NoneAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
@@ -368,7 +466,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get202None204NoneDefaultError400Valid() throws ErrorException, IOException;
+    void get202None204NoneDefaultError400Valid() throws ErrorException, IOException;
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
@@ -383,7 +481,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultError400ValidAsync();
+    Observable<Void> get202None204NoneDefaultError400ValidAsync();
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultError400ValidAsyncWithServiceResponse();
 
     /**
      * Send a 202 response with an unexpected payload {'property': 'value'}.
@@ -392,7 +497,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get202None204NoneDefaultNone202Invalid() throws ServiceException, IOException;
+    void get202None204NoneDefaultNone202Invalid() throws ServiceException, IOException;
 
     /**
      * Send a 202 response with an unexpected payload {'property': 'value'}.
@@ -407,7 +512,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone202InvalidAsync();
+    Observable<Void> get202None204NoneDefaultNone202InvalidAsync();
+
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse();
 
     /**
      * Send a 204 response with no payload.
@@ -416,7 +528,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get202None204NoneDefaultNone204None() throws ServiceException, IOException;
+    void get202None204NoneDefaultNone204None() throws ServiceException, IOException;
 
     /**
      * Send a 204 response with no payload.
@@ -431,7 +543,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone204NoneAsync();
+    Observable<Void> get202None204NoneDefaultNone204NoneAsync();
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone204NoneAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with no payload.
@@ -440,7 +559,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get202None204NoneDefaultNone400None() throws ServiceException, IOException;
+    void get202None204NoneDefaultNone400None() throws ServiceException, IOException;
 
     /**
      * Send a 400 response with no payload.
@@ -455,7 +574,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400NoneAsync();
+    Observable<Void> get202None204NoneDefaultNone400NoneAsync();
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400NoneAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with an unexpected payload {'property': 'value'}.
@@ -464,7 +590,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> get202None204NoneDefaultNone400Invalid() throws ServiceException, IOException;
+    void get202None204NoneDefaultNone400Invalid() throws ServiceException, IOException;
 
     /**
      * Send a 400 response with an unexpected payload {'property': 'value'}.
@@ -479,7 +605,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400InvalidAsync();
+    Observable<Void> get202None204NoneDefaultNone400InvalidAsync();
+
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
@@ -488,7 +621,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> getDefaultModelA200Valid() throws MyException, IOException;
+    A getDefaultModelA200Valid() throws MyException, IOException;
 
     /**
      * Send a 200 response with valid payload: {'statusCode': '200'}.
@@ -503,7 +636,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> getDefaultModelA200ValidAsync();
+    Observable<A> getDefaultModelA200ValidAsync();
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> getDefaultModelA200ValidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with no payload.
@@ -512,7 +652,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> getDefaultModelA200None() throws MyException, IOException;
+    A getDefaultModelA200None() throws MyException, IOException;
 
     /**
      * Send a 200 response with no payload.
@@ -527,7 +667,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> getDefaultModelA200NoneAsync();
+    Observable<A> getDefaultModelA200NoneAsync();
+
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> getDefaultModelA200NoneAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
@@ -536,7 +683,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> getDefaultModelA400Valid() throws MyException, IOException;
+    A getDefaultModelA400Valid() throws MyException, IOException;
 
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
@@ -551,7 +698,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> getDefaultModelA400ValidAsync();
+    Observable<A> getDefaultModelA400ValidAsync();
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> getDefaultModelA400ValidAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with no payload.
@@ -560,7 +714,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> getDefaultModelA400None() throws MyException, IOException;
+    A getDefaultModelA400None() throws MyException, IOException;
 
     /**
      * Send a 400 response with no payload.
@@ -575,7 +729,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> getDefaultModelA400NoneAsync();
+    Observable<A> getDefaultModelA400NoneAsync();
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> getDefaultModelA400NoneAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with invalid payload: {'statusCode': '200'}.
@@ -584,7 +745,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getDefaultNone200Invalid() throws ServiceException, IOException;
+    void getDefaultNone200Invalid() throws ServiceException, IOException;
 
     /**
      * Send a 200 response with invalid payload: {'statusCode': '200'}.
@@ -599,7 +760,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getDefaultNone200InvalidAsync();
+    Observable<Void> getDefaultNone200InvalidAsync();
+
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getDefaultNone200InvalidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with no payload.
@@ -608,7 +776,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getDefaultNone200None() throws ServiceException, IOException;
+    void getDefaultNone200None() throws ServiceException, IOException;
 
     /**
      * Send a 200 response with no payload.
@@ -623,7 +791,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getDefaultNone200NoneAsync();
+    Observable<Void> getDefaultNone200NoneAsync();
+
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getDefaultNone200NoneAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
@@ -632,7 +807,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getDefaultNone400Invalid() throws ServiceException, IOException;
+    void getDefaultNone400Invalid() throws ServiceException, IOException;
 
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
@@ -647,7 +822,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getDefaultNone400InvalidAsync();
+    Observable<Void> getDefaultNone400InvalidAsync();
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getDefaultNone400InvalidAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with no payload.
@@ -656,7 +838,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getDefaultNone400None() throws ServiceException, IOException;
+    void getDefaultNone400None() throws ServiceException, IOException;
 
     /**
      * Send a 400 response with no payload.
@@ -671,7 +853,14 @@ public interface MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getDefaultNone400NoneAsync();
+    Observable<Void> getDefaultNone400NoneAsync();
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getDefaultNone400NoneAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
@@ -680,7 +869,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200ModelA200None() throws ServiceException, IOException;
+    A get200ModelA200None() throws ServiceException, IOException;
 
     /**
      * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
@@ -695,7 +884,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA200NoneAsync();
+    Observable<A> get200ModelA200NoneAsync();
+
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200ModelA200NoneAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with payload {'statusCode': '200'}.
@@ -704,7 +900,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200ModelA200Valid() throws ServiceException, IOException;
+    A get200ModelA200Valid() throws ServiceException, IOException;
 
     /**
      * Send a 200 response with payload {'statusCode': '200'}.
@@ -719,7 +915,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA200ValidAsync();
+    Observable<A> get200ModelA200ValidAsync();
+
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200ModelA200ValidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
@@ -728,7 +931,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200ModelA200Invalid() throws ServiceException, IOException;
+    A get200ModelA200Invalid() throws ServiceException, IOException;
 
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
@@ -743,7 +946,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA200InvalidAsync();
+    Observable<A> get200ModelA200InvalidAsync();
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200ModelA200InvalidAsyncWithServiceResponse();
 
     /**
      * Send a 400 response with no payload client should treat as an http error with no error model.
@@ -752,7 +962,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200ModelA400None() throws ServiceException, IOException;
+    A get200ModelA400None() throws ServiceException, IOException;
 
     /**
      * Send a 400 response with no payload client should treat as an http error with no error model.
@@ -767,7 +977,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA400NoneAsync();
+    Observable<A> get200ModelA400NoneAsync();
+
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200ModelA400NoneAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with payload {'statusCode': '400'}.
@@ -776,7 +993,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200ModelA400Valid() throws ServiceException, IOException;
+    A get200ModelA400Valid() throws ServiceException, IOException;
 
     /**
      * Send a 200 response with payload {'statusCode': '400'}.
@@ -791,7 +1008,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA400ValidAsync();
+    Observable<A> get200ModelA400ValidAsync();
+
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200ModelA400ValidAsyncWithServiceResponse();
 
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
@@ -800,7 +1024,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200ModelA400Invalid() throws ServiceException, IOException;
+    A get200ModelA400Invalid() throws ServiceException, IOException;
 
     /**
      * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
@@ -815,7 +1039,14 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA400InvalidAsync();
+    Observable<A> get200ModelA400InvalidAsync();
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200ModelA400InvalidAsyncWithServiceResponse();
 
     /**
      * Send a 202 response with payload {'statusCode': '202'}.
@@ -824,7 +1055,7 @@ public interface MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<A> get200ModelA202Valid() throws ServiceException, IOException;
+    A get200ModelA202Valid() throws ServiceException, IOException;
 
     /**
      * Send a 202 response with payload {'statusCode': '202'}.
@@ -839,6 +1070,13 @@ public interface MultipleResponses {
      *
      * @return the observable to the A object
      */
-    Observable<ServiceResponse<A>> get200ModelA202ValidAsync();
+    Observable<A> get200ModelA202ValidAsync();
+
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     *
+     * @return the observable to the A object
+     */
+    Observable<ServiceResponse<A>> get200ModelA202ValidAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpClientFailuresImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpClientFailuresImpl.java
@@ -159,8 +159,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> head400() throws ErrorException, IOException {
-        return head400Async().toBlocking().single();
+    public Error head400() throws ErrorException, IOException {
+        return head400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -170,7 +170,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head400Async(), serviceCallback);
+        return ServiceCall.create(head400AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -178,7 +178,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head400Async() {
+    public Observable<Error> head400Async() {
+        return head400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> head400AsyncWithServiceResponse() {
         return service.head400()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -206,8 +220,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> get400() throws ErrorException, IOException {
-        return get400Async().toBlocking().single();
+    public Error get400() throws ErrorException, IOException {
+        return get400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -217,7 +231,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get400Async(), serviceCallback);
+        return ServiceCall.create(get400AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -225,7 +239,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get400Async() {
+    public Observable<Error> get400Async() {
+        return get400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> get400AsyncWithServiceResponse() {
         return service.get400()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -253,8 +281,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> put400() throws ErrorException, IOException {
-        return put400Async().toBlocking().single();
+    public Error put400() throws ErrorException, IOException {
+        return put400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -264,7 +292,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put400Async(), serviceCallback);
+        return ServiceCall.create(put400AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -272,7 +300,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put400Async() {
+    public Observable<Error> put400Async() {
+        return put400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> put400AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -296,8 +338,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> put400(Boolean booleanValue) throws ErrorException, IOException {
-        return put400Async(booleanValue).toBlocking().single();
+    public Error put400(Boolean booleanValue) throws ErrorException, IOException {
+        return put400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -308,7 +350,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put400Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put400AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> put400Async(Boolean booleanValue) {
+        return put400AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -317,7 +373,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put400Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> put400AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -345,8 +401,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> patch400() throws ErrorException, IOException {
-        return patch400Async().toBlocking().single();
+    public Error patch400() throws ErrorException, IOException {
+        return patch400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -356,7 +412,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch400Async(), serviceCallback);
+        return ServiceCall.create(patch400AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -364,7 +420,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch400Async() {
+    public Observable<Error> patch400Async() {
+        return patch400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> patch400AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -388,8 +458,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> patch400(Boolean booleanValue) throws ErrorException, IOException {
-        return patch400Async(booleanValue).toBlocking().single();
+    public Error patch400(Boolean booleanValue) throws ErrorException, IOException {
+        return patch400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -400,7 +470,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch400Async(booleanValue), serviceCallback);
+        return ServiceCall.create(patch400AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> patch400Async(Boolean booleanValue) {
+        return patch400AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -409,7 +493,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch400Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> patch400AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -437,8 +521,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> post400() throws ErrorException, IOException {
-        return post400Async().toBlocking().single();
+    public Error post400() throws ErrorException, IOException {
+        return post400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -448,7 +532,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post400Async(), serviceCallback);
+        return ServiceCall.create(post400AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -456,7 +540,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post400Async() {
+    public Observable<Error> post400Async() {
+        return post400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> post400AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -480,8 +578,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> post400(Boolean booleanValue) throws ErrorException, IOException {
-        return post400Async(booleanValue).toBlocking().single();
+    public Error post400(Boolean booleanValue) throws ErrorException, IOException {
+        return post400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -492,7 +590,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post400Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post400AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> post400Async(Boolean booleanValue) {
+        return post400AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -501,7 +613,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post400Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> post400AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -529,8 +641,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> delete400() throws ErrorException, IOException {
-        return delete400Async().toBlocking().single();
+    public Error delete400() throws ErrorException, IOException {
+        return delete400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -540,7 +652,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete400Async(), serviceCallback);
+        return ServiceCall.create(delete400AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -548,7 +660,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete400Async() {
+    public Observable<Error> delete400Async() {
+        return delete400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> delete400AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -572,8 +698,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> delete400(Boolean booleanValue) throws ErrorException, IOException {
-        return delete400Async(booleanValue).toBlocking().single();
+    public Error delete400(Boolean booleanValue) throws ErrorException, IOException {
+        return delete400AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -584,7 +710,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete400Async(booleanValue), serviceCallback);
+        return ServiceCall.create(delete400AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> delete400Async(Boolean booleanValue) {
+        return delete400AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -593,7 +733,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete400Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> delete400AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -621,8 +761,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> head401() throws ErrorException, IOException {
-        return head401Async().toBlocking().single();
+    public Error head401() throws ErrorException, IOException {
+        return head401AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -632,7 +772,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head401Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head401Async(), serviceCallback);
+        return ServiceCall.create(head401AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -640,7 +780,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head401Async() {
+    public Observable<Error> head401Async() {
+        return head401AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> head401AsyncWithServiceResponse() {
         return service.head401()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -668,8 +822,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> get402() throws ErrorException, IOException {
-        return get402Async().toBlocking().single();
+    public Error get402() throws ErrorException, IOException {
+        return get402AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -679,7 +833,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get402Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get402Async(), serviceCallback);
+        return ServiceCall.create(get402AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -687,7 +841,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get402Async() {
+    public Observable<Error> get402Async() {
+        return get402AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> get402AsyncWithServiceResponse() {
         return service.get402()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -715,8 +883,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> get403() throws ErrorException, IOException {
-        return get403Async().toBlocking().single();
+    public Error get403() throws ErrorException, IOException {
+        return get403AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -726,7 +894,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get403Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get403Async(), serviceCallback);
+        return ServiceCall.create(get403AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -734,7 +902,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get403Async() {
+    public Observable<Error> get403Async() {
+        return get403AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> get403AsyncWithServiceResponse() {
         return service.get403()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -762,8 +944,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> put404() throws ErrorException, IOException {
-        return put404Async().toBlocking().single();
+    public Error put404() throws ErrorException, IOException {
+        return put404AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -773,7 +955,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put404Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put404Async(), serviceCallback);
+        return ServiceCall.create(put404AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -781,7 +963,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put404Async() {
+    public Observable<Error> put404Async() {
+        return put404AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> put404AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put404(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -805,8 +1001,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> put404(Boolean booleanValue) throws ErrorException, IOException {
-        return put404Async(booleanValue).toBlocking().single();
+    public Error put404(Boolean booleanValue) throws ErrorException, IOException {
+        return put404AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -817,7 +1013,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put404Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put404Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put404AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> put404Async(Boolean booleanValue) {
+        return put404AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -826,7 +1036,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put404Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> put404AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put404(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -854,8 +1064,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> patch405() throws ErrorException, IOException {
-        return patch405Async().toBlocking().single();
+    public Error patch405() throws ErrorException, IOException {
+        return patch405AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -865,7 +1075,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch405Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch405Async(), serviceCallback);
+        return ServiceCall.create(patch405AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -873,7 +1083,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch405Async() {
+    public Observable<Error> patch405Async() {
+        return patch405AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> patch405AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch405(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -897,8 +1121,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> patch405(Boolean booleanValue) throws ErrorException, IOException {
-        return patch405Async(booleanValue).toBlocking().single();
+    public Error patch405(Boolean booleanValue) throws ErrorException, IOException {
+        return patch405AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -909,7 +1133,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch405Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch405Async(booleanValue), serviceCallback);
+        return ServiceCall.create(patch405AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> patch405Async(Boolean booleanValue) {
+        return patch405AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -918,7 +1156,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch405Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> patch405AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch405(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -946,8 +1184,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> post406() throws ErrorException, IOException {
-        return post406Async().toBlocking().single();
+    public Error post406() throws ErrorException, IOException {
+        return post406AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -957,7 +1195,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post406Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post406Async(), serviceCallback);
+        return ServiceCall.create(post406AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -965,7 +1203,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post406Async() {
+    public Observable<Error> post406Async() {
+        return post406AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> post406AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post406(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -989,8 +1241,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> post406(Boolean booleanValue) throws ErrorException, IOException {
-        return post406Async(booleanValue).toBlocking().single();
+    public Error post406(Boolean booleanValue) throws ErrorException, IOException {
+        return post406AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1001,7 +1253,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post406Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post406Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post406AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> post406Async(Boolean booleanValue) {
+        return post406AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1010,7 +1276,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post406Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> post406AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post406(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1038,8 +1304,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> delete407() throws ErrorException, IOException {
-        return delete407Async().toBlocking().single();
+    public Error delete407() throws ErrorException, IOException {
+        return delete407AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1049,7 +1315,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete407Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete407Async(), serviceCallback);
+        return ServiceCall.create(delete407AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1057,7 +1323,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete407Async() {
+    public Observable<Error> delete407Async() {
+        return delete407AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> delete407AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete407(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1081,8 +1361,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> delete407(Boolean booleanValue) throws ErrorException, IOException {
-        return delete407Async(booleanValue).toBlocking().single();
+    public Error delete407(Boolean booleanValue) throws ErrorException, IOException {
+        return delete407AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1093,7 +1373,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete407Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete407Async(booleanValue), serviceCallback);
+        return ServiceCall.create(delete407AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> delete407Async(Boolean booleanValue) {
+        return delete407AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1102,7 +1396,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete407Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> delete407AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete407(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1130,8 +1424,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> put409() throws ErrorException, IOException {
-        return put409Async().toBlocking().single();
+    public Error put409() throws ErrorException, IOException {
+        return put409AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1141,7 +1435,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put409Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put409Async(), serviceCallback);
+        return ServiceCall.create(put409AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1149,7 +1443,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put409Async() {
+    public Observable<Error> put409Async() {
+        return put409AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> put409AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put409(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1173,8 +1481,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> put409(Boolean booleanValue) throws ErrorException, IOException {
-        return put409Async(booleanValue).toBlocking().single();
+    public Error put409(Boolean booleanValue) throws ErrorException, IOException {
+        return put409AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1185,7 +1493,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put409Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put409Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put409AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> put409Async(Boolean booleanValue) {
+        return put409AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1194,7 +1516,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put409Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> put409AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put409(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1222,8 +1544,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> head410() throws ErrorException, IOException {
-        return head410Async().toBlocking().single();
+    public Error head410() throws ErrorException, IOException {
+        return head410AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1233,7 +1555,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head410Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head410Async(), serviceCallback);
+        return ServiceCall.create(head410AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1241,7 +1563,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head410Async() {
+    public Observable<Error> head410Async() {
+        return head410AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> head410AsyncWithServiceResponse() {
         return service.head410()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1269,8 +1605,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> get411() throws ErrorException, IOException {
-        return get411Async().toBlocking().single();
+    public Error get411() throws ErrorException, IOException {
+        return get411AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1280,7 +1616,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get411Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get411Async(), serviceCallback);
+        return ServiceCall.create(get411AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1288,7 +1624,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get411Async() {
+    public Observable<Error> get411Async() {
+        return get411AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> get411AsyncWithServiceResponse() {
         return service.get411()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1316,8 +1666,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> get412() throws ErrorException, IOException {
-        return get412Async().toBlocking().single();
+    public Error get412() throws ErrorException, IOException {
+        return get412AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1327,7 +1677,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get412Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get412Async(), serviceCallback);
+        return ServiceCall.create(get412AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1335,7 +1685,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get412Async() {
+    public Observable<Error> get412Async() {
+        return get412AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> get412AsyncWithServiceResponse() {
         return service.get412()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1363,8 +1727,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> put413() throws ErrorException, IOException {
-        return put413Async().toBlocking().single();
+    public Error put413() throws ErrorException, IOException {
+        return put413AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1374,7 +1738,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put413Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put413Async(), serviceCallback);
+        return ServiceCall.create(put413AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1382,7 +1746,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put413Async() {
+    public Observable<Error> put413Async() {
+        return put413AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> put413AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put413(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1406,8 +1784,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> put413(Boolean booleanValue) throws ErrorException, IOException {
-        return put413Async(booleanValue).toBlocking().single();
+    public Error put413(Boolean booleanValue) throws ErrorException, IOException {
+        return put413AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1418,7 +1796,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put413Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put413Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put413AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> put413Async(Boolean booleanValue) {
+        return put413AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1427,7 +1819,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put413Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> put413AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put413(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1455,8 +1847,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> patch414() throws ErrorException, IOException {
-        return patch414Async().toBlocking().single();
+    public Error patch414() throws ErrorException, IOException {
+        return patch414AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1466,7 +1858,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch414Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch414Async(), serviceCallback);
+        return ServiceCall.create(patch414AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1474,7 +1866,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch414Async() {
+    public Observable<Error> patch414Async() {
+        return patch414AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> patch414AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch414(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1498,8 +1904,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> patch414(Boolean booleanValue) throws ErrorException, IOException {
-        return patch414Async(booleanValue).toBlocking().single();
+    public Error patch414(Boolean booleanValue) throws ErrorException, IOException {
+        return patch414AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1510,7 +1916,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch414Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch414Async(booleanValue), serviceCallback);
+        return ServiceCall.create(patch414AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> patch414Async(Boolean booleanValue) {
+        return patch414AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1519,7 +1939,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch414Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> patch414AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch414(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1547,8 +1967,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> post415() throws ErrorException, IOException {
-        return post415Async().toBlocking().single();
+    public Error post415() throws ErrorException, IOException {
+        return post415AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1558,7 +1978,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post415Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post415Async(), serviceCallback);
+        return ServiceCall.create(post415AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1566,7 +1986,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post415Async() {
+    public Observable<Error> post415Async() {
+        return post415AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> post415AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post415(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1590,8 +2024,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> post415(Boolean booleanValue) throws ErrorException, IOException {
-        return post415Async(booleanValue).toBlocking().single();
+    public Error post415(Boolean booleanValue) throws ErrorException, IOException {
+        return post415AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1602,7 +2036,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post415Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post415Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post415AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> post415Async(Boolean booleanValue) {
+        return post415AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1611,7 +2059,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post415Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> post415AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post415(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1639,8 +2087,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> get416() throws ErrorException, IOException {
-        return get416Async().toBlocking().single();
+    public Error get416() throws ErrorException, IOException {
+        return get416AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1650,7 +2098,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get416Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get416Async(), serviceCallback);
+        return ServiceCall.create(get416AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1658,7 +2106,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get416Async() {
+    public Observable<Error> get416Async() {
+        return get416AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> get416AsyncWithServiceResponse() {
         return service.get416()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1686,8 +2148,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> delete417() throws ErrorException, IOException {
-        return delete417Async().toBlocking().single();
+    public Error delete417() throws ErrorException, IOException {
+        return delete417AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1697,7 +2159,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete417Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete417Async(), serviceCallback);
+        return ServiceCall.create(delete417AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1705,7 +2167,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete417Async() {
+    public Observable<Error> delete417Async() {
+        return delete417AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> delete417AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete417(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1729,8 +2205,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> delete417(Boolean booleanValue) throws ErrorException, IOException {
-        return delete417Async(booleanValue).toBlocking().single();
+    public Error delete417(Boolean booleanValue) throws ErrorException, IOException {
+        return delete417AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1741,7 +2217,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete417Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete417Async(booleanValue), serviceCallback);
+        return ServiceCall.create(delete417AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> delete417Async(Boolean booleanValue) {
+        return delete417AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1750,7 +2240,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete417Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> delete417AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete417(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1778,8 +2268,8 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> head429() throws ErrorException, IOException {
-        return head429Async().toBlocking().single();
+    public Error head429() throws ErrorException, IOException {
+        return head429AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1789,7 +2279,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head429Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head429Async(), serviceCallback);
+        return ServiceCall.create(head429AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1797,7 +2287,21 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head429Async() {
+    public Observable<Error> head429Async() {
+        return head429AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> head429AsyncWithServiceResponse() {
         return service.head429()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpClientFailuresImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpClientFailuresImpl.java
@@ -157,10 +157,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error head400() throws ErrorException, IOException {
-        return head400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return head400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -170,7 +170,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head400AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -179,12 +179,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> head400Async() {
-        return head400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return head400WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -192,7 +192,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head400AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> head400WithServiceResponseAsync() {
         return service.head400()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -218,10 +218,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error get400() throws ErrorException, IOException {
-        return get400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -231,7 +231,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get400AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -240,12 +240,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> get400Async() {
-        return get400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return get400WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -253,7 +253,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get400AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> get400WithServiceResponseAsync() {
         return service.get400()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -279,10 +279,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error put400() throws ErrorException, IOException {
-        return put400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return put400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -292,7 +292,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put400AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -301,12 +301,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> put400Async() {
-        return put400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return put400WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -314,7 +314,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put400AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> put400WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -336,10 +336,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error put400(Boolean booleanValue) throws ErrorException, IOException {
-        return put400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return put400WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -350,21 +350,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put400AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 400 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> put400Async(Boolean booleanValue) {
-        return put400AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put400WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -373,7 +359,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put400AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> put400Async(Boolean booleanValue) {
+        return put400WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> put400WithServiceResponseAsync(Boolean booleanValue) {
         return service.put400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -399,10 +400,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error patch400() throws ErrorException, IOException {
-        return patch400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return patch400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -412,7 +413,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch400AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(patch400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -421,12 +422,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> patch400Async() {
-        return patch400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return patch400WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -434,7 +435,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch400AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> patch400WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -456,10 +457,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error patch400(Boolean booleanValue) throws ErrorException, IOException {
-        return patch400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return patch400WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -470,21 +471,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch400AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 400 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> patch400Async(Boolean booleanValue) {
-        return patch400AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(patch400WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -493,7 +480,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch400AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> patch400Async(Boolean booleanValue) {
+        return patch400WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> patch400WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -519,10 +521,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error post400() throws ErrorException, IOException {
-        return post400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return post400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -532,7 +534,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post400AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -541,12 +543,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> post400Async() {
-        return post400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return post400WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -554,7 +556,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post400AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> post400WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -576,10 +578,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error post400(Boolean booleanValue) throws ErrorException, IOException {
-        return post400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return post400WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -590,21 +592,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post400AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 400 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> post400Async(Boolean booleanValue) {
-        return post400AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post400WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -613,7 +601,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post400AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> post400Async(Boolean booleanValue) {
+        return post400WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> post400WithServiceResponseAsync(Boolean booleanValue) {
         return service.post400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -639,10 +642,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error delete400() throws ErrorException, IOException {
-        return delete400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return delete400WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -652,7 +655,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete400Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete400AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(delete400WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -661,12 +664,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> delete400Async() {
-        return delete400AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return delete400WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -674,7 +677,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete400AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> delete400WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -696,10 +699,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error delete400(Boolean booleanValue) throws ErrorException, IOException {
-        return delete400AsyncWithServiceResponse().toBlocking().single().getBody();
+        return delete400WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -710,21 +713,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete400AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 400 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> delete400Async(Boolean booleanValue) {
-        return delete400AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(delete400WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -733,7 +722,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete400AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> delete400Async(Boolean booleanValue) {
+        return delete400WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> delete400WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete400(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -759,10 +763,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error head401() throws ErrorException, IOException {
-        return head401AsyncWithServiceResponse().toBlocking().single().getBody();
+        return head401WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -772,7 +776,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head401Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head401AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head401WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -781,12 +785,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> head401Async() {
-        return head401AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return head401WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -794,7 +798,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head401AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> head401WithServiceResponseAsync() {
         return service.head401()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -820,10 +824,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error get402() throws ErrorException, IOException {
-        return get402AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get402WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -833,7 +837,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get402Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get402AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get402WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -842,12 +846,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> get402Async() {
-        return get402AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return get402WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -855,7 +859,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get402AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> get402WithServiceResponseAsync() {
         return service.get402()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -881,10 +885,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error get403() throws ErrorException, IOException {
-        return get403AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get403WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -894,7 +898,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get403Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get403AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get403WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -903,12 +907,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> get403Async() {
-        return get403AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return get403WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -916,7 +920,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get403AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> get403WithServiceResponseAsync() {
         return service.get403()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -942,10 +946,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error put404() throws ErrorException, IOException {
-        return put404AsyncWithServiceResponse().toBlocking().single().getBody();
+        return put404WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -955,7 +959,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put404Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put404AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put404WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -964,12 +968,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> put404Async() {
-        return put404AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return put404WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -977,7 +981,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put404AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> put404WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put404(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -999,10 +1003,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error put404(Boolean booleanValue) throws ErrorException, IOException {
-        return put404AsyncWithServiceResponse().toBlocking().single().getBody();
+        return put404WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1013,21 +1017,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put404Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put404AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 404 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> put404Async(Boolean booleanValue) {
-        return put404AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put404WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1036,7 +1026,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put404AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> put404Async(Boolean booleanValue) {
+        return put404WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> put404WithServiceResponseAsync(Boolean booleanValue) {
         return service.put404(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1062,10 +1067,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error patch405() throws ErrorException, IOException {
-        return patch405AsyncWithServiceResponse().toBlocking().single().getBody();
+        return patch405WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1075,7 +1080,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch405Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch405AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(patch405WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1084,12 +1089,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> patch405Async() {
-        return patch405AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return patch405WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1097,7 +1102,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch405AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> patch405WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch405(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1119,10 +1124,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error patch405(Boolean booleanValue) throws ErrorException, IOException {
-        return patch405AsyncWithServiceResponse().toBlocking().single().getBody();
+        return patch405WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1133,21 +1138,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch405Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch405AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 405 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> patch405Async(Boolean booleanValue) {
-        return patch405AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(patch405WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1156,7 +1147,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch405AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> patch405Async(Boolean booleanValue) {
+        return patch405WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> patch405WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch405(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1182,10 +1188,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error post406() throws ErrorException, IOException {
-        return post406AsyncWithServiceResponse().toBlocking().single().getBody();
+        return post406WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1195,7 +1201,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post406Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post406AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post406WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1204,12 +1210,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> post406Async() {
-        return post406AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return post406WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1217,7 +1223,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post406AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> post406WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post406(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1239,10 +1245,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error post406(Boolean booleanValue) throws ErrorException, IOException {
-        return post406AsyncWithServiceResponse().toBlocking().single().getBody();
+        return post406WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1253,21 +1259,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post406Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post406AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 406 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> post406Async(Boolean booleanValue) {
-        return post406AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post406WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1276,7 +1268,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post406AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> post406Async(Boolean booleanValue) {
+        return post406WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> post406WithServiceResponseAsync(Boolean booleanValue) {
         return service.post406(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1302,10 +1309,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error delete407() throws ErrorException, IOException {
-        return delete407AsyncWithServiceResponse().toBlocking().single().getBody();
+        return delete407WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1315,7 +1322,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete407Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete407AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(delete407WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1324,12 +1331,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> delete407Async() {
-        return delete407AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return delete407WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1337,7 +1344,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete407AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> delete407WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete407(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1359,10 +1366,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error delete407(Boolean booleanValue) throws ErrorException, IOException {
-        return delete407AsyncWithServiceResponse().toBlocking().single().getBody();
+        return delete407WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1373,21 +1380,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete407Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete407AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 407 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> delete407Async(Boolean booleanValue) {
-        return delete407AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(delete407WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1396,7 +1389,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete407AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> delete407Async(Boolean booleanValue) {
+        return delete407WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> delete407WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete407(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1422,10 +1430,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error put409() throws ErrorException, IOException {
-        return put409AsyncWithServiceResponse().toBlocking().single().getBody();
+        return put409WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1435,7 +1443,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put409Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put409AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put409WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1444,12 +1452,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> put409Async() {
-        return put409AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return put409WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1457,7 +1465,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put409AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> put409WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put409(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1479,10 +1487,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error put409(Boolean booleanValue) throws ErrorException, IOException {
-        return put409AsyncWithServiceResponse().toBlocking().single().getBody();
+        return put409WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1493,21 +1501,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put409Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put409AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 409 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> put409Async(Boolean booleanValue) {
-        return put409AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put409WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1516,7 +1510,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put409AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> put409Async(Boolean booleanValue) {
+        return put409WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> put409WithServiceResponseAsync(Boolean booleanValue) {
         return service.put409(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1542,10 +1551,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error head410() throws ErrorException, IOException {
-        return head410AsyncWithServiceResponse().toBlocking().single().getBody();
+        return head410WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1555,7 +1564,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head410Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head410AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head410WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1564,12 +1573,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> head410Async() {
-        return head410AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return head410WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1577,7 +1586,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head410AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> head410WithServiceResponseAsync() {
         return service.head410()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1603,10 +1612,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error get411() throws ErrorException, IOException {
-        return get411AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get411WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1616,7 +1625,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get411Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get411AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get411WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1625,12 +1634,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> get411Async() {
-        return get411AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return get411WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1638,7 +1647,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get411AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> get411WithServiceResponseAsync() {
         return service.get411()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1664,10 +1673,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error get412() throws ErrorException, IOException {
-        return get412AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get412WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1677,7 +1686,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get412Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get412AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get412WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1686,12 +1695,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> get412Async() {
-        return get412AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return get412WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1699,7 +1708,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get412AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> get412WithServiceResponseAsync() {
         return service.get412()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1725,10 +1734,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error put413() throws ErrorException, IOException {
-        return put413AsyncWithServiceResponse().toBlocking().single().getBody();
+        return put413WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1738,7 +1747,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put413Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put413AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put413WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1747,12 +1756,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> put413Async() {
-        return put413AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return put413WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1760,7 +1769,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put413AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> put413WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put413(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1782,10 +1791,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error put413(Boolean booleanValue) throws ErrorException, IOException {
-        return put413AsyncWithServiceResponse().toBlocking().single().getBody();
+        return put413WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1796,21 +1805,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> put413Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(put413AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 413 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> put413Async(Boolean booleanValue) {
-        return put413AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put413WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1819,7 +1814,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> put413AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> put413Async(Boolean booleanValue) {
+        return put413WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> put413WithServiceResponseAsync(Boolean booleanValue) {
         return service.put413(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1845,10 +1855,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error patch414() throws ErrorException, IOException {
-        return patch414AsyncWithServiceResponse().toBlocking().single().getBody();
+        return patch414WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1858,7 +1868,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch414Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch414AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(patch414WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1867,12 +1877,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> patch414Async() {
-        return patch414AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return patch414WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1880,7 +1890,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch414AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> patch414WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch414(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -1902,10 +1912,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error patch414(Boolean booleanValue) throws ErrorException, IOException {
-        return patch414AsyncWithServiceResponse().toBlocking().single().getBody();
+        return patch414WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1916,21 +1926,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> patch414Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(patch414AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 414 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> patch414Async(Boolean booleanValue) {
-        return patch414AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(patch414WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1939,7 +1935,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> patch414AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> patch414Async(Boolean booleanValue) {
+        return patch414WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> patch414WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch414(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -1965,10 +1976,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error post415() throws ErrorException, IOException {
-        return post415AsyncWithServiceResponse().toBlocking().single().getBody();
+        return post415WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1978,7 +1989,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post415Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post415AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post415WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1987,12 +1998,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> post415Async() {
-        return post415AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return post415WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2000,7 +2011,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post415AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> post415WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post415(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -2022,10 +2033,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error post415(Boolean booleanValue) throws ErrorException, IOException {
-        return post415AsyncWithServiceResponse().toBlocking().single().getBody();
+        return post415WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -2036,21 +2047,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post415Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post415AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 415 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> post415Async(Boolean booleanValue) {
-        return post415AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post415WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -2059,7 +2056,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post415AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> post415Async(Boolean booleanValue) {
+        return post415WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> post415WithServiceResponseAsync(Boolean booleanValue) {
         return service.post415(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -2085,10 +2097,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error get416() throws ErrorException, IOException {
-        return get416AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get416WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2098,7 +2110,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get416Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get416AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get416WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2107,12 +2119,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> get416Async() {
-        return get416AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return get416WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2120,7 +2132,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get416AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> get416WithServiceResponseAsync() {
         return service.get416()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -2146,10 +2158,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error delete417() throws ErrorException, IOException {
-        return delete417AsyncWithServiceResponse().toBlocking().single().getBody();
+        return delete417WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2159,7 +2171,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete417Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete417AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(delete417WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2168,12 +2180,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> delete417Async() {
-        return delete417AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return delete417WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2181,7 +2193,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete417AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> delete417WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete417(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -2203,10 +2215,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error delete417(Boolean booleanValue) throws ErrorException, IOException {
-        return delete417AsyncWithServiceResponse().toBlocking().single().getBody();
+        return delete417WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -2217,21 +2229,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete417Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete417AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 417 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> delete417Async(Boolean booleanValue) {
-        return delete417AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(delete417WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -2240,7 +2238,22 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete417AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> delete417Async(Boolean booleanValue) {
+        return delete417WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> delete417WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete417(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -2266,10 +2279,10 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error head429() throws ErrorException, IOException {
-        return head429AsyncWithServiceResponse().toBlocking().single().getBody();
+        return head429WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2279,7 +2292,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head429Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head429AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head429WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2288,12 +2301,12 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> head429Async() {
-        return head429AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return head429WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2301,7 +2314,7 @@ public final class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head429AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> head429WithServiceResponseAsync() {
         return service.head429()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpFailuresImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpFailuresImpl.java
@@ -74,8 +74,8 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Boolean> getEmptyError() throws ErrorException, IOException {
-        return getEmptyErrorAsync().toBlocking().single();
+    public boolean getEmptyError() throws ErrorException, IOException {
+        return getEmptyErrorAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -85,7 +85,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getEmptyErrorAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getEmptyErrorAsync(), serviceCallback);
+        return ServiceCall.create(getEmptyErrorAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -93,7 +93,21 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getEmptyErrorAsync() {
+    public Observable<Boolean> getEmptyErrorAsync() {
+        return getEmptyErrorAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty error form server.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> getEmptyErrorAsyncWithServiceResponse() {
         return service.getEmptyError()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -122,8 +136,8 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Boolean> getNoModelError() throws ServiceException, IOException {
-        return getNoModelErrorAsync().toBlocking().single();
+    public boolean getNoModelError() throws ServiceException, IOException {
+        return getNoModelErrorAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -133,7 +147,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getNoModelErrorAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getNoModelErrorAsync(), serviceCallback);
+        return ServiceCall.create(getNoModelErrorAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -141,7 +155,21 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getNoModelErrorAsync() {
+    public Observable<Boolean> getNoModelErrorAsync() {
+        return getNoModelErrorAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty error form server.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> getNoModelErrorAsyncWithServiceResponse() {
         return service.getNoModelError()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -169,8 +197,8 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Boolean> getNoModelEmpty() throws ServiceException, IOException {
-        return getNoModelEmptyAsync().toBlocking().single();
+    public boolean getNoModelEmpty() throws ServiceException, IOException {
+        return getNoModelEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -180,7 +208,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getNoModelEmptyAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getNoModelEmptyAsync(), serviceCallback);
+        return ServiceCall.create(getNoModelEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -188,7 +216,21 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getNoModelEmptyAsync() {
+    public Observable<Boolean> getNoModelEmptyAsync() {
+        return getNoModelEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get empty response from server.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> getNoModelEmptyAsyncWithServiceResponse() {
         return service.getNoModelEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpFailuresImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpFailuresImpl.java
@@ -72,10 +72,10 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     public boolean getEmptyError() throws ErrorException, IOException {
-        return getEmptyErrorAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getEmptyErrorWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -85,7 +85,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getEmptyErrorAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getEmptyErrorAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getEmptyErrorWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -94,12 +94,12 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the observable to the boolean object
      */
     public Observable<Boolean> getEmptyErrorAsync() {
-        return getEmptyErrorAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+        return getEmptyErrorWithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
             @Override
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -107,7 +107,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getEmptyErrorAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Boolean>> getEmptyErrorWithServiceResponseAsync() {
         return service.getEmptyError()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -134,10 +134,10 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     public boolean getNoModelError() throws ServiceException, IOException {
-        return getNoModelErrorAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNoModelErrorWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -147,7 +147,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getNoModelErrorAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getNoModelErrorAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNoModelErrorWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -156,12 +156,12 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the observable to the boolean object
      */
     public Observable<Boolean> getNoModelErrorAsync() {
-        return getNoModelErrorAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+        return getNoModelErrorWithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
             @Override
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -169,7 +169,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getNoModelErrorAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Boolean>> getNoModelErrorWithServiceResponseAsync() {
         return service.getNoModelError()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -195,10 +195,10 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     public boolean getNoModelEmpty() throws ServiceException, IOException {
-        return getNoModelEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getNoModelEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -208,7 +208,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> getNoModelEmptyAsync(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(getNoModelEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNoModelEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -217,12 +217,12 @@ public final class HttpFailuresImpl implements HttpFailures {
      * @return the observable to the boolean object
      */
     public Observable<Boolean> getNoModelEmptyAsync() {
-        return getNoModelEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+        return getNoModelEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
             @Override
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -230,7 +230,7 @@ public final class HttpFailuresImpl implements HttpFailures {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> getNoModelEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Boolean>> getNoModelEmptyWithServiceResponseAsync() {
         return service.getNoModelEmpty()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpRedirectsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpRedirectsImpl.java
@@ -143,8 +143,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers> head300() throws ErrorException, IOException {
-        return head300Async().toBlocking().single();
+    public void head300() throws ErrorException, IOException {
+        head300AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -154,7 +154,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head300Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(head300Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(head300AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -162,7 +162,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>> head300Async() {
+    public Observable<Void> head300Async() {
+        return head300AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>> head300AsyncWithServiceResponse() {
         return service.head300()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>>>() {
                 @Override
@@ -192,8 +206,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;String&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
-    public ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers> get300() throws ErrorException, IOException {
-        return get300Async().toBlocking().single();
+    public List<String> get300() throws ErrorException, IOException {
+        return get300AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -203,7 +217,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<String>> get300Async(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceCall.createWithHeaders(get300Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(get300AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -211,7 +225,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    public Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>> get300Async() {
+    public Observable<List<String>> get300Async() {
+        return get300AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>, List<String>>() {
+            @Override
+            public List<String> call(ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @return the observable to the List&lt;String&gt; object
+     */
+    public Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>> get300AsyncWithServiceResponse() {
         return service.get300()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>>>() {
                 @Override
@@ -241,8 +269,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers> head301() throws ErrorException, IOException {
-        return head301Async().toBlocking().single();
+    public void head301() throws ErrorException, IOException {
+        head301AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -252,7 +280,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(head301Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(head301AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -260,7 +288,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>> head301Async() {
+    public Observable<Void> head301Async() {
+        return head301AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>> head301AsyncWithServiceResponse() {
         return service.head301()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>>>() {
                 @Override
@@ -290,8 +332,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers> get301() throws ErrorException, IOException {
-        return get301Async().toBlocking().single();
+    public void get301() throws ErrorException, IOException {
+        get301AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -301,7 +343,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(get301Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(get301AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -309,7 +351,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>> get301Async() {
+    public Observable<Void> get301Async() {
+        return get301AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>> get301AsyncWithServiceResponse() {
         return service.get301()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>>>() {
                 @Override
@@ -339,8 +395,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> put301() throws ErrorException, IOException {
-        return put301Async().toBlocking().single();
+    public void put301() throws ErrorException, IOException {
+        put301AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -350,7 +406,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(put301Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(put301AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -358,7 +414,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301Async() {
+    public Observable<Void> put301Async() {
+        return put301AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put301(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>>>() {
@@ -382,8 +452,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> put301(Boolean booleanValue) throws ErrorException, IOException {
-        return put301Async(booleanValue).toBlocking().single();
+    public void put301(Boolean booleanValue) throws ErrorException, IOException {
+        put301AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -394,7 +464,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put301Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(put301Async(booleanValue), serviceCallback);
+        return ServiceCall.createWithHeaders(put301AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> put301Async(Boolean booleanValue) {
+        return put301AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -403,7 +487,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301Async(Boolean booleanValue) {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put301(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>>>() {
                 @Override
@@ -432,8 +516,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers> head302() throws ErrorException, IOException {
-        return head302Async().toBlocking().single();
+    public void head302() throws ErrorException, IOException {
+        head302AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -443,7 +527,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(head302Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(head302AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -451,7 +535,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>> head302Async() {
+    public Observable<Void> head302Async() {
+        return head302AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>> head302AsyncWithServiceResponse() {
         return service.head302()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>>>() {
                 @Override
@@ -481,8 +579,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers> get302() throws ErrorException, IOException {
-        return get302Async().toBlocking().single();
+    public void get302() throws ErrorException, IOException {
+        get302AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -492,7 +590,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(get302Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(get302AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -500,7 +598,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>> get302Async() {
+    public Observable<Void> get302Async() {
+        return get302AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>> get302AsyncWithServiceResponse() {
         return service.get302()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>>>() {
                 @Override
@@ -530,8 +642,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> patch302() throws ErrorException, IOException {
-        return patch302Async().toBlocking().single();
+    public void patch302() throws ErrorException, IOException {
+        patch302AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -541,7 +653,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(patch302Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(patch302AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -549,7 +661,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302Async() {
+    public Observable<Void> patch302Async() {
+        return patch302AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch302(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>>>() {
@@ -573,8 +699,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> patch302(Boolean booleanValue) throws ErrorException, IOException {
-        return patch302Async(booleanValue).toBlocking().single();
+    public void patch302(Boolean booleanValue) throws ErrorException, IOException {
+        patch302AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -585,7 +711,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch302Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(patch302Async(booleanValue), serviceCallback);
+        return ServiceCall.createWithHeaders(patch302AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> patch302Async(Boolean booleanValue) {
+        return patch302AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -594,7 +734,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302Async(Boolean booleanValue) {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch302(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>>>() {
                 @Override
@@ -623,8 +763,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> post303() throws ErrorException, IOException {
-        return post303Async().toBlocking().single();
+    public void post303() throws ErrorException, IOException {
+        post303AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -634,7 +774,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post303Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post303Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post303AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -642,7 +782,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303Async() {
+    public Observable<Void> post303Async() {
+        return post303AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post303(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>>>() {
@@ -666,8 +820,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> post303(Boolean booleanValue) throws ErrorException, IOException {
-        return post303Async(booleanValue).toBlocking().single();
+    public void post303(Boolean booleanValue) throws ErrorException, IOException {
+        post303AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -678,7 +832,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post303Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post303Async(booleanValue), serviceCallback);
+        return ServiceCall.createWithHeaders(post303AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> post303Async(Boolean booleanValue) {
+        return post303AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -687,7 +855,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303Async(Boolean booleanValue) {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post303(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>>>() {
                 @Override
@@ -717,8 +885,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers> head307() throws ErrorException, IOException {
-        return head307Async().toBlocking().single();
+    public void head307() throws ErrorException, IOException {
+        head307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -728,7 +896,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(head307Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(head307AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -736,7 +904,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>> head307Async() {
+    public Observable<Void> head307Async() {
+        return head307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>> head307AsyncWithServiceResponse() {
         return service.head307()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>>>() {
                 @Override
@@ -766,8 +948,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers> get307() throws ErrorException, IOException {
-        return get307Async().toBlocking().single();
+    public void get307() throws ErrorException, IOException {
+        get307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -777,7 +959,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(get307Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(get307AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -785,7 +967,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>> get307Async() {
+    public Observable<Void> get307Async() {
+        return get307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>> get307AsyncWithServiceResponse() {
         return service.get307()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>>>() {
                 @Override
@@ -815,8 +1011,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> put307() throws ErrorException, IOException {
-        return put307Async().toBlocking().single();
+    public void put307() throws ErrorException, IOException {
+        put307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -826,7 +1022,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(put307Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(put307AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -834,7 +1030,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307Async() {
+    public Observable<Void> put307Async() {
+        return put307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>>>() {
@@ -858,8 +1068,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> put307(Boolean booleanValue) throws ErrorException, IOException {
-        return put307Async(booleanValue).toBlocking().single();
+    public void put307(Boolean booleanValue) throws ErrorException, IOException {
+        put307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -870,7 +1080,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(put307Async(booleanValue), serviceCallback);
+        return ServiceCall.createWithHeaders(put307AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> put307Async(Boolean booleanValue) {
+        return put307AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -879,7 +1103,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307Async(Boolean booleanValue) {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>>>() {
                 @Override
@@ -909,8 +1133,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> patch307() throws ErrorException, IOException {
-        return patch307Async().toBlocking().single();
+    public void patch307() throws ErrorException, IOException {
+        patch307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -920,7 +1144,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(patch307Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(patch307AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -928,7 +1152,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307Async() {
+    public Observable<Void> patch307Async() {
+        return patch307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>>>() {
@@ -952,8 +1190,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> patch307(Boolean booleanValue) throws ErrorException, IOException {
-        return patch307Async(booleanValue).toBlocking().single();
+    public void patch307(Boolean booleanValue) throws ErrorException, IOException {
+        patch307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -964,7 +1202,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(patch307Async(booleanValue), serviceCallback);
+        return ServiceCall.createWithHeaders(patch307AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> patch307Async(Boolean booleanValue) {
+        return patch307AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -973,7 +1225,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307Async(Boolean booleanValue) {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>>>() {
                 @Override
@@ -1003,8 +1255,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> post307() throws ErrorException, IOException {
-        return post307Async().toBlocking().single();
+    public void post307() throws ErrorException, IOException {
+        post307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1014,7 +1266,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post307Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(post307AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1022,7 +1274,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307Async() {
+    public Observable<Void> post307Async() {
+        return post307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>>>() {
@@ -1046,8 +1312,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> post307(Boolean booleanValue) throws ErrorException, IOException {
-        return post307Async(booleanValue).toBlocking().single();
+    public void post307(Boolean booleanValue) throws ErrorException, IOException {
+        post307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1058,7 +1324,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post307Async(booleanValue), serviceCallback);
+        return ServiceCall.createWithHeaders(post307AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> post307Async(Boolean booleanValue) {
+        return post307AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1067,7 +1347,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307Async(Boolean booleanValue) {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>>>() {
                 @Override
@@ -1097,8 +1377,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> delete307() throws ErrorException, IOException {
-        return delete307Async().toBlocking().single();
+    public void delete307() throws ErrorException, IOException {
+        delete307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1108,7 +1388,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete307Async(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete307AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1116,7 +1396,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307Async() {
+    public Observable<Void> delete307Async() {
+        return delete307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>>>() {
@@ -1140,8 +1434,8 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> delete307(Boolean booleanValue) throws ErrorException, IOException {
-        return delete307Async(booleanValue).toBlocking().single();
+    public void delete307(Boolean booleanValue) throws ErrorException, IOException {
+        delete307AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1152,7 +1446,21 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete307Async(booleanValue), serviceCallback);
+        return ServiceCall.createWithHeaders(delete307AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<Void> delete307Async(Boolean booleanValue) {
+        return delete307AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1161,7 +1469,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307Async(Boolean booleanValue) {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpRedirectsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpRedirectsImpl.java
@@ -141,10 +141,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void head300() throws ErrorException, IOException {
-        head300AsyncWithServiceResponse().toBlocking().single().getBody();
+        head300WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -154,7 +153,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head300Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(head300AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(head300WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -163,12 +162,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> head300Async() {
-        return head300AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>, Void>() {
+        return head300WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -176,7 +175,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>> head300AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>> head300WithServiceResponseAsync() {
         return service.head300()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>>>() {
                 @Override
@@ -204,10 +203,10 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;String&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
+     * @return the List&lt;String&gt; object if successful.
      */
     public List<String> get300() throws ErrorException, IOException {
-        return get300AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get300WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -217,7 +216,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<String>> get300Async(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceCall.createWithHeaders(get300AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(get300WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -226,12 +225,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the observable to the List&lt;String&gt; object
      */
     public Observable<List<String>> get300Async() {
-        return get300AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>, List<String>>() {
+        return get300WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>, List<String>>() {
             @Override
             public List<String> call(ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -239,7 +238,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the observable to the List&lt;String&gt; object
      */
-    public Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>> get300AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>> get300WithServiceResponseAsync() {
         return service.get300()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>>>() {
                 @Override
@@ -267,10 +266,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void head301() throws ErrorException, IOException {
-        head301AsyncWithServiceResponse().toBlocking().single().getBody();
+        head301WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -280,7 +278,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(head301AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(head301WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -289,12 +287,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> head301Async() {
-        return head301AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>, Void>() {
+        return head301WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -302,7 +300,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>> head301AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>> head301WithServiceResponseAsync() {
         return service.head301()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>>>() {
                 @Override
@@ -330,10 +328,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void get301() throws ErrorException, IOException {
-        get301AsyncWithServiceResponse().toBlocking().single().getBody();
+        get301WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -343,7 +340,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(get301AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(get301WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -352,12 +349,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> get301Async() {
-        return get301AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>, Void>() {
+        return get301WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -365,7 +362,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>> get301AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>> get301WithServiceResponseAsync() {
         return service.get301()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>>>() {
                 @Override
@@ -393,10 +390,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void put301() throws ErrorException, IOException {
-        put301AsyncWithServiceResponse().toBlocking().single().getBody();
+        put301WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -406,7 +402,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(put301AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(put301WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -415,12 +411,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> put301Async() {
-        return put301AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>, Void>() {
+        return put301WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -428,7 +424,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put301(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>>>() {
@@ -450,10 +446,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void put301(Boolean booleanValue) throws ErrorException, IOException {
-        put301AsyncWithServiceResponse().toBlocking().single().getBody();
+        put301WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -464,21 +459,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put301Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(put301AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
-     *
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
-     */
-    public Observable<Void> put301Async(Boolean booleanValue) {
-        return put301AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>, Void>() {
-            @Override
-            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.createWithHeaders(put301WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -487,7 +468,22 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> put301Async(Boolean booleanValue) {
+        return put301WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>> put301WithServiceResponseAsync(Boolean booleanValue) {
         return service.put301(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>>>() {
                 @Override
@@ -514,10 +510,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void head302() throws ErrorException, IOException {
-        head302AsyncWithServiceResponse().toBlocking().single().getBody();
+        head302WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -527,7 +522,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(head302AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(head302WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -536,12 +531,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> head302Async() {
-        return head302AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>, Void>() {
+        return head302WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -549,7 +544,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>> head302AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>> head302WithServiceResponseAsync() {
         return service.head302()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>>>() {
                 @Override
@@ -577,10 +572,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void get302() throws ErrorException, IOException {
-        get302AsyncWithServiceResponse().toBlocking().single().getBody();
+        get302WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -590,7 +584,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(get302AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(get302WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -599,12 +593,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> get302Async() {
-        return get302AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>, Void>() {
+        return get302WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -612,7 +606,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>> get302AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>> get302WithServiceResponseAsync() {
         return service.get302()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>>>() {
                 @Override
@@ -640,10 +634,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void patch302() throws ErrorException, IOException {
-        patch302AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch302WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -653,7 +646,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(patch302AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(patch302WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -662,12 +655,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> patch302Async() {
-        return patch302AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>, Void>() {
+        return patch302WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -675,7 +668,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch302(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>>>() {
@@ -697,10 +690,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void patch302(Boolean booleanValue) throws ErrorException, IOException {
-        patch302AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch302WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -711,21 +703,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch302Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(patch302AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
-     *
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
-     */
-    public Observable<Void> patch302Async(Boolean booleanValue) {
-        return patch302AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>, Void>() {
-            @Override
-            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.createWithHeaders(patch302WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -734,7 +712,22 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> patch302Async(Boolean booleanValue) {
+        return patch302WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>> patch302WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch302(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>>>() {
                 @Override
@@ -761,10 +754,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void post303() throws ErrorException, IOException {
-        post303AsyncWithServiceResponse().toBlocking().single().getBody();
+        post303WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -774,7 +766,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post303Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post303AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(post303WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -783,12 +775,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> post303Async() {
-        return post303AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>, Void>() {
+        return post303WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -796,7 +788,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post303(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>>>() {
@@ -818,10 +810,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void post303(Boolean booleanValue) throws ErrorException, IOException {
-        post303AsyncWithServiceResponse().toBlocking().single().getBody();
+        post303WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -832,21 +823,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post303Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post303AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
-     *
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
-     */
-    public Observable<Void> post303Async(Boolean booleanValue) {
-        return post303AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>, Void>() {
-            @Override
-            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.createWithHeaders(post303WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -855,7 +832,22 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> post303Async(Boolean booleanValue) {
+        return post303WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>> post303WithServiceResponseAsync(Boolean booleanValue) {
         return service.post303(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>>>() {
                 @Override
@@ -883,10 +875,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void head307() throws ErrorException, IOException {
-        head307AsyncWithServiceResponse().toBlocking().single().getBody();
+        head307WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -896,7 +887,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(head307AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(head307WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -905,12 +896,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> head307Async() {
-        return head307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>, Void>() {
+        return head307WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -918,7 +909,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>> head307AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>> head307WithServiceResponseAsync() {
         return service.head307()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>>>() {
                 @Override
@@ -946,10 +937,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void get307() throws ErrorException, IOException {
-        get307AsyncWithServiceResponse().toBlocking().single().getBody();
+        get307WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -959,7 +949,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(get307AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(get307WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -968,12 +958,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> get307Async() {
-        return get307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>, Void>() {
+        return get307WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -981,7 +971,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>> get307AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>> get307WithServiceResponseAsync() {
         return service.get307()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>>>() {
                 @Override
@@ -1009,10 +999,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void put307() throws ErrorException, IOException {
-        put307AsyncWithServiceResponse().toBlocking().single().getBody();
+        put307WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1022,7 +1011,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(put307AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(put307WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1031,12 +1020,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> put307Async() {
-        return put307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>, Void>() {
+        return put307WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1044,7 +1033,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>>>() {
@@ -1066,10 +1055,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void put307(Boolean booleanValue) throws ErrorException, IOException {
-        put307AsyncWithServiceResponse().toBlocking().single().getBody();
+        put307WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1080,21 +1068,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(put307AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Put redirected with 307, resulting in a 200 after redirect.
-     *
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
-     */
-    public Observable<Void> put307Async(Boolean booleanValue) {
-        return put307AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>, Void>() {
-            @Override
-            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.createWithHeaders(put307WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1103,7 +1077,22 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> put307Async(Boolean booleanValue) {
+        return put307WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>> put307WithServiceResponseAsync(Boolean booleanValue) {
         return service.put307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>>>() {
                 @Override
@@ -1131,10 +1120,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void patch307() throws ErrorException, IOException {
-        patch307AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch307WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1144,7 +1132,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(patch307AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(patch307WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1153,12 +1141,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> patch307Async() {
-        return patch307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>, Void>() {
+        return patch307WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1166,7 +1154,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>>>() {
@@ -1188,10 +1176,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void patch307(Boolean booleanValue) throws ErrorException, IOException {
-        patch307AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch307WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1202,21 +1189,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(patch307AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Patch redirected with 307, resulting in a 200 after redirect.
-     *
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
-     */
-    public Observable<Void> patch307Async(Boolean booleanValue) {
-        return patch307AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>, Void>() {
-            @Override
-            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.createWithHeaders(patch307WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1225,7 +1198,22 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> patch307Async(Boolean booleanValue) {
+        return patch307WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>> patch307WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>>>() {
                 @Override
@@ -1253,10 +1241,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void post307() throws ErrorException, IOException {
-        post307AsyncWithServiceResponse().toBlocking().single().getBody();
+        post307WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1266,7 +1253,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post307AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(post307WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1275,12 +1262,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> post307Async() {
-        return post307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>, Void>() {
+        return post307WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1288,7 +1275,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>>>() {
@@ -1310,10 +1297,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void post307(Boolean booleanValue) throws ErrorException, IOException {
-        post307AsyncWithServiceResponse().toBlocking().single().getBody();
+        post307WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1324,21 +1310,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(post307AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Post redirected with 307, resulting in a 200 after redirect.
-     *
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
-     */
-    public Observable<Void> post307Async(Boolean booleanValue) {
-        return post307AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>, Void>() {
-            @Override
-            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.createWithHeaders(post307WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1347,7 +1319,22 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> post307Async(Boolean booleanValue) {
+        return post307WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>> post307WithServiceResponseAsync(Boolean booleanValue) {
         return service.post307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>>>() {
                 @Override
@@ -1375,10 +1362,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void delete307() throws ErrorException, IOException {
-        delete307AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete307WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1388,7 +1374,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete307AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.createWithHeaders(delete307WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1397,12 +1383,12 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public Observable<Void> delete307Async() {
-        return delete307AsyncWithServiceResponse().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>, Void>() {
+        return delete307WithServiceResponseAsync().map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>, Void>() {
             @Override
             public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1410,7 +1396,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      *
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307AsyncWithServiceResponse() {
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>>>() {
@@ -1432,10 +1418,9 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     public void delete307(Boolean booleanValue) throws ErrorException, IOException {
-        delete307AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete307WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1446,21 +1431,7 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.createWithHeaders(delete307AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Delete redirected with 307, resulting in a 200 after redirect.
-     *
-     * @return the {@link ServiceResponseWithHeaders} object if successful.
-     */
-    public Observable<Void> delete307Async(Boolean booleanValue) {
-        return delete307AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>, Void>() {
-            @Override
-            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.createWithHeaders(delete307WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1469,7 +1440,22 @@ public final class HttpRedirectsImpl implements HttpRedirects {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> delete307Async(Boolean booleanValue) {
+        return delete307WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>, Void>() {
+            @Override
+            public Void call(ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponseWithHeaders} object if successful.
+     */
+    public Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>> delete307WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete307(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpRetrysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpRetrysImpl.java
@@ -99,8 +99,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head408() throws ErrorException, IOException {
-        return head408Async().toBlocking().single();
+    public void head408() throws ErrorException, IOException {
+        head408AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -110,7 +110,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head408Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head408Async(), serviceCallback);
+        return ServiceCall.create(head408AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -118,7 +118,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head408Async() {
+    public Observable<Void> head408Async() {
+        return head408AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 408 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head408AsyncWithServiceResponse() {
         return service.head408()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -147,8 +161,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put500() throws ErrorException, IOException {
-        return put500Async().toBlocking().single();
+    public void put500() throws ErrorException, IOException {
+        put500AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -158,7 +172,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put500Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put500Async(), serviceCallback);
+        return ServiceCall.create(put500AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -166,7 +180,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put500Async() {
+    public Observable<Void> put500Async() {
+        return put500AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put500AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put500(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -190,8 +218,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put500(Boolean booleanValue) throws ErrorException, IOException {
-        return put500Async(booleanValue).toBlocking().single();
+    public void put500(Boolean booleanValue) throws ErrorException, IOException {
+        put500AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -202,7 +230,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put500Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put500Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put500AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> put500Async(Boolean booleanValue) {
+        return put500AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -211,7 +253,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put500Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> put500AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put500(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -240,8 +282,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch500() throws ErrorException, IOException {
-        return patch500Async().toBlocking().single();
+    public void patch500() throws ErrorException, IOException {
+        patch500AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -251,7 +293,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch500Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch500Async(), serviceCallback);
+        return ServiceCall.create(patch500AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -259,7 +301,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch500Async() {
+    public Observable<Void> patch500Async() {
+        return patch500AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch500AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch500(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -283,8 +339,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch500(Boolean booleanValue) throws ErrorException, IOException {
-        return patch500Async(booleanValue).toBlocking().single();
+    public void patch500(Boolean booleanValue) throws ErrorException, IOException {
+        patch500AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -295,7 +351,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch500Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch500Async(booleanValue), serviceCallback);
+        return ServiceCall.create(patch500AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> patch500Async(Boolean booleanValue) {
+        return patch500AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -304,7 +374,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch500Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> patch500AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch500(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -333,8 +403,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get502() throws ErrorException, IOException {
-        return get502Async().toBlocking().single();
+    public void get502() throws ErrorException, IOException {
+        get502AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -344,7 +414,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get502Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get502Async(), serviceCallback);
+        return ServiceCall.create(get502AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -352,7 +422,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get502Async() {
+    public Observable<Void> get502Async() {
+        return get502AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 502 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> get502AsyncWithServiceResponse() {
         return service.get502()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -381,8 +465,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post503() throws ErrorException, IOException {
-        return post503Async().toBlocking().single();
+    public void post503() throws ErrorException, IOException {
+        post503AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -392,7 +476,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post503Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post503Async(), serviceCallback);
+        return ServiceCall.create(post503AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -400,7 +484,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post503Async() {
+    public Observable<Void> post503Async() {
+        return post503AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post503AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post503(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -424,8 +522,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post503(Boolean booleanValue) throws ErrorException, IOException {
-        return post503Async(booleanValue).toBlocking().single();
+    public void post503(Boolean booleanValue) throws ErrorException, IOException {
+        post503AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -436,7 +534,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post503Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post503Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post503AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> post503Async(Boolean booleanValue) {
+        return post503AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -445,7 +557,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post503Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> post503AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post503(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -474,8 +586,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> delete503() throws ErrorException, IOException {
-        return delete503Async().toBlocking().single();
+    public void delete503() throws ErrorException, IOException {
+        delete503AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -485,7 +597,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete503Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete503Async(), serviceCallback);
+        return ServiceCall.create(delete503AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -493,7 +605,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete503Async() {
+    public Observable<Void> delete503Async() {
+        return delete503AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> delete503AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete503(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -517,8 +643,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> delete503(Boolean booleanValue) throws ErrorException, IOException {
-        return delete503Async(booleanValue).toBlocking().single();
+    public void delete503(Boolean booleanValue) throws ErrorException, IOException {
+        delete503AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -529,7 +655,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete503Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete503Async(booleanValue), serviceCallback);
+        return ServiceCall.create(delete503AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> delete503Async(Boolean booleanValue) {
+        return delete503AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -538,7 +678,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete503Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> delete503AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete503(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -567,8 +707,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put504() throws ErrorException, IOException {
-        return put504Async().toBlocking().single();
+    public void put504() throws ErrorException, IOException {
+        put504AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -578,7 +718,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put504Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put504Async(), serviceCallback);
+        return ServiceCall.create(put504AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -586,7 +726,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put504Async() {
+    public Observable<Void> put504Async() {
+        return put504AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put504AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put504(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -610,8 +764,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put504(Boolean booleanValue) throws ErrorException, IOException {
-        return put504Async(booleanValue).toBlocking().single();
+    public void put504(Boolean booleanValue) throws ErrorException, IOException {
+        put504AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -622,7 +776,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put504Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put504Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put504AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> put504Async(Boolean booleanValue) {
+        return put504AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -631,7 +799,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put504Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> put504AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put504(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -660,8 +828,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch504() throws ErrorException, IOException {
-        return patch504Async().toBlocking().single();
+    public void patch504() throws ErrorException, IOException {
+        patch504AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -671,7 +839,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch504Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch504Async(), serviceCallback);
+        return ServiceCall.create(patch504AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -679,7 +847,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch504Async() {
+    public Observable<Void> patch504Async() {
+        return patch504AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch504AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch504(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -703,8 +885,8 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch504(Boolean booleanValue) throws ErrorException, IOException {
-        return patch504Async(booleanValue).toBlocking().single();
+    public void patch504(Boolean booleanValue) throws ErrorException, IOException {
+        patch504AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -715,7 +897,21 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch504Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch504Async(booleanValue), serviceCallback);
+        return ServiceCall.create(patch504AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> patch504Async(Boolean booleanValue) {
+        return patch504AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -724,7 +920,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch504Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> patch504AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch504(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpRetrysImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpRetrysImpl.java
@@ -97,10 +97,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void head408() throws ErrorException, IOException {
-        head408AsyncWithServiceResponse().toBlocking().single().getBody();
+        head408WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -110,7 +109,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head408Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head408AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head408WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -119,12 +118,12 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> head408Async() {
-        return head408AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return head408WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -132,7 +131,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head408AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> head408WithServiceResponseAsync() {
         return service.head408()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -159,10 +158,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put500() throws ErrorException, IOException {
-        put500AsyncWithServiceResponse().toBlocking().single().getBody();
+        put500WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -172,7 +170,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put500Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put500AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put500WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -181,12 +179,12 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> put500Async() {
-        return put500AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return put500WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -194,7 +192,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put500AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> put500WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put500(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -216,10 +214,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put500(Boolean booleanValue) throws ErrorException, IOException {
-        put500AsyncWithServiceResponse().toBlocking().single().getBody();
+        put500WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -230,21 +227,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put500Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put500AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 500 status code, then 200 after retry.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> put500Async(Boolean booleanValue) {
-        return put500AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put500WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -253,7 +236,22 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put500AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> put500Async(Boolean booleanValue) {
+        return put500WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put500WithServiceResponseAsync(Boolean booleanValue) {
         return service.put500(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -280,10 +278,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch500() throws ErrorException, IOException {
-        patch500AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch500WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -293,7 +290,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch500Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch500AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(patch500WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -302,12 +299,12 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> patch500Async() {
-        return patch500AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return patch500WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -315,7 +312,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch500AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> patch500WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch500(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -337,10 +334,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch500(Boolean booleanValue) throws ErrorException, IOException {
-        patch500AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch500WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -351,21 +347,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch500Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch500AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 500 status code, then 200 after retry.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> patch500Async(Boolean booleanValue) {
-        return patch500AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(patch500WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -374,7 +356,22 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch500AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> patch500Async(Boolean booleanValue) {
+        return patch500WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch500WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch500(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -401,10 +398,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void get502() throws ErrorException, IOException {
-        get502AsyncWithServiceResponse().toBlocking().single().getBody();
+        get502WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -414,7 +410,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get502Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get502AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get502WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -423,12 +419,12 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> get502Async() {
-        return get502AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return get502WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -436,7 +432,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get502AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> get502WithServiceResponseAsync() {
         return service.get502()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -463,10 +459,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post503() throws ErrorException, IOException {
-        post503AsyncWithServiceResponse().toBlocking().single().getBody();
+        post503WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -476,7 +471,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post503Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post503AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post503WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -485,12 +480,12 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> post503Async() {
-        return post503AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return post503WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -498,7 +493,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post503AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> post503WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post503(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -520,10 +515,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post503(Boolean booleanValue) throws ErrorException, IOException {
-        post503AsyncWithServiceResponse().toBlocking().single().getBody();
+        post503WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -534,21 +528,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post503Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post503AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 503 status code, then 200 after retry.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> post503Async(Boolean booleanValue) {
-        return post503AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post503WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -557,7 +537,22 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post503AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> post503Async(Boolean booleanValue) {
+        return post503WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post503WithServiceResponseAsync(Boolean booleanValue) {
         return service.post503(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -584,10 +579,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void delete503() throws ErrorException, IOException {
-        delete503AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete503WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -597,7 +591,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete503Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete503AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(delete503WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -606,12 +600,12 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> delete503Async() {
-        return delete503AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return delete503WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -619,7 +613,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete503AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> delete503WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete503(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -641,10 +635,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void delete503(Boolean booleanValue) throws ErrorException, IOException {
-        delete503AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete503WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -655,21 +648,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete503Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete503AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 503 status code, then 200 after retry.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> delete503Async(Boolean booleanValue) {
-        return delete503AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(delete503WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -678,7 +657,22 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete503AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> delete503Async(Boolean booleanValue) {
+        return delete503WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> delete503WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete503(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -705,10 +699,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put504() throws ErrorException, IOException {
-        put504AsyncWithServiceResponse().toBlocking().single().getBody();
+        put504WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -718,7 +711,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put504Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put504AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put504WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -727,12 +720,12 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> put504Async() {
-        return put504AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return put504WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -740,7 +733,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put504AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> put504WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put504(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -762,10 +755,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put504(Boolean booleanValue) throws ErrorException, IOException {
-        put504AsyncWithServiceResponse().toBlocking().single().getBody();
+        put504WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -776,21 +768,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put504Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put504AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 504 status code, then 200 after retry.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> put504Async(Boolean booleanValue) {
-        return put504AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put504WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -799,7 +777,22 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put504AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> put504Async(Boolean booleanValue) {
+        return put504WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put504WithServiceResponseAsync(Boolean booleanValue) {
         return service.put504(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -826,10 +819,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch504() throws ErrorException, IOException {
-        patch504AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch504WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -839,7 +831,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch504Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch504AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(patch504WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -848,12 +840,12 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> patch504Async() {
-        return patch504AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return patch504WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -861,7 +853,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch504AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> patch504WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch504(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -883,10 +875,9 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch504(Boolean booleanValue) throws ErrorException, IOException {
-        patch504AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch504WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -897,21 +888,7 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch504Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch504AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 504 status code, then 200 after retry.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> patch504Async(Boolean booleanValue) {
-        return patch504AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(patch504WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -920,7 +897,22 @@ public final class HttpRetrysImpl implements HttpRetrys {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch504AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> patch504Async(Boolean booleanValue) {
+        return patch504WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch504WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch504(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpServerFailuresImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpServerFailuresImpl.java
@@ -79,10 +79,10 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error head501() throws ErrorException, IOException {
-        return head501AsyncWithServiceResponse().toBlocking().single().getBody();
+        return head501WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -92,7 +92,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head501Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head501AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head501WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -101,12 +101,12 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> head501Async() {
-        return head501AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return head501WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -114,7 +114,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head501AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> head501WithServiceResponseAsync() {
         return service.head501()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -140,10 +140,10 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error get501() throws ErrorException, IOException {
-        return get501AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get501WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -153,7 +153,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get501Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get501AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get501WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -162,12 +162,12 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> get501Async() {
-        return get501AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return get501WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -175,7 +175,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get501AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> get501WithServiceResponseAsync() {
         return service.get501()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -201,10 +201,10 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error post505() throws ErrorException, IOException {
-        return post505AsyncWithServiceResponse().toBlocking().single().getBody();
+        return post505WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -214,7 +214,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post505Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post505AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post505WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -223,12 +223,12 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> post505Async() {
-        return post505AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return post505WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -236,7 +236,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post505AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> post505WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post505(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -258,10 +258,10 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error post505(Boolean booleanValue) throws ErrorException, IOException {
-        return post505AsyncWithServiceResponse().toBlocking().single().getBody();
+        return post505WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -272,21 +272,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post505Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post505AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 505 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> post505Async(Boolean booleanValue) {
-        return post505AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post505WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -295,7 +281,22 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post505AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> post505Async(Boolean booleanValue) {
+        return post505WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> post505WithServiceResponseAsync(Boolean booleanValue) {
         return service.post505(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -321,10 +322,10 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error delete505() throws ErrorException, IOException {
-        return delete505AsyncWithServiceResponse().toBlocking().single().getBody();
+        return delete505WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -334,7 +335,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete505Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete505AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(delete505WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -343,12 +344,12 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the observable to the Error object
      */
     public Observable<Error> delete505Async() {
-        return delete505AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return delete505WithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -356,7 +357,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete505AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> delete505WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete505(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -378,10 +379,10 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error delete505(Boolean booleanValue) throws ErrorException, IOException {
-        return delete505AsyncWithServiceResponse().toBlocking().single().getBody();
+        return delete505WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -392,21 +393,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete505Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete505AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Return 505 status code - should be represented in the client as an error.
-     *
-     * @return the observable to the Error object
-     */
-    public Observable<Error> delete505Async(Boolean booleanValue) {
-        return delete505AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
-            @Override
-            public Error call(ServiceResponse<Error> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(delete505WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -415,7 +402,22 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete505AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Error> delete505Async(Boolean booleanValue) {
+        return delete505WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> delete505WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete505(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpServerFailuresImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpServerFailuresImpl.java
@@ -81,8 +81,8 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> head501() throws ErrorException, IOException {
-        return head501Async().toBlocking().single();
+    public Error head501() throws ErrorException, IOException {
+        return head501AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -92,7 +92,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> head501Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(head501Async(), serviceCallback);
+        return ServiceCall.create(head501AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -100,7 +100,21 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> head501Async() {
+    public Observable<Error> head501Async() {
+        return head501AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> head501AsyncWithServiceResponse() {
         return service.head501()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -128,8 +142,8 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> get501() throws ErrorException, IOException {
-        return get501Async().toBlocking().single();
+    public Error get501() throws ErrorException, IOException {
+        return get501AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -139,7 +153,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> get501Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(get501Async(), serviceCallback);
+        return ServiceCall.create(get501AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -147,7 +161,21 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> get501Async() {
+    public Observable<Error> get501Async() {
+        return get501AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> get501AsyncWithServiceResponse() {
         return service.get501()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -175,8 +203,8 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> post505() throws ErrorException, IOException {
-        return post505Async().toBlocking().single();
+    public Error post505() throws ErrorException, IOException {
+        return post505AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -186,7 +214,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post505Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post505Async(), serviceCallback);
+        return ServiceCall.create(post505AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -194,7 +222,21 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post505Async() {
+    public Observable<Error> post505Async() {
+        return post505AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> post505AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post505(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -218,8 +260,8 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> post505(Boolean booleanValue) throws ErrorException, IOException {
-        return post505Async(booleanValue).toBlocking().single();
+    public Error post505(Boolean booleanValue) throws ErrorException, IOException {
+        return post505AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -230,7 +272,21 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> post505Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(post505Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post505AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> post505Async(Boolean booleanValue) {
+        return post505AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -239,7 +295,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> post505Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> post505AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post505(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -267,8 +323,8 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> delete505() throws ErrorException, IOException {
-        return delete505Async().toBlocking().single();
+    public Error delete505() throws ErrorException, IOException {
+        return delete505AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -278,7 +334,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete505Async(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete505Async(), serviceCallback);
+        return ServiceCall.create(delete505AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -286,7 +342,21 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete505Async() {
+    public Observable<Error> delete505Async() {
+        return delete505AsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> delete505AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete505(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
@@ -310,8 +380,8 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> delete505(Boolean booleanValue) throws ErrorException, IOException {
-        return delete505Async(booleanValue).toBlocking().single();
+    public Error delete505(Boolean booleanValue) throws ErrorException, IOException {
+        return delete505AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -322,7 +392,21 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> delete505Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(delete505Async(booleanValue), serviceCallback);
+        return ServiceCall.create(delete505AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<Error> delete505Async(Boolean booleanValue) {
+        return delete505AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -331,7 +415,7 @@ public final class HttpServerFailuresImpl implements HttpServerFailures {
      * @param booleanValue Simple boolean value true
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> delete505Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Error>> delete505AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete505(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpSuccessImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpSuccessImpl.java
@@ -137,10 +137,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void head200() throws ErrorException, IOException {
-        head200AsyncWithServiceResponse().toBlocking().single().getBody();
+        head200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -150,7 +149,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head200AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -159,12 +158,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> head200Async() {
-        return head200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return head200WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -172,7 +171,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head200AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> head200WithServiceResponseAsync() {
         return service.head200()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -199,10 +198,10 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the boolean object wrapped in {@link ServiceResponse} if successful.
+     * @return the boolean object if successful.
      */
     public boolean get200() throws ErrorException, IOException {
-        return get200AsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -212,7 +211,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> get200Async(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(get200AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -221,12 +220,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the observable to the boolean object
      */
     public Observable<Boolean> get200Async() {
-        return get200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+        return get200WithServiceResponseAsync().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
             @Override
             public Boolean call(ServiceResponse<Boolean> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -234,7 +233,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> get200AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Boolean>> get200WithServiceResponseAsync() {
         return service.get200()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -261,10 +260,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put200() throws ErrorException, IOException {
-        put200AsyncWithServiceResponse().toBlocking().single().getBody();
+        put200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -274,7 +272,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put200AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -283,12 +281,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> put200Async() {
-        return put200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return put200WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -296,7 +294,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put200AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> put200WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -318,10 +316,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put200(Boolean booleanValue) throws ErrorException, IOException {
-        put200AsyncWithServiceResponse().toBlocking().single().getBody();
+        put200WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -332,21 +329,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put200AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Put boolean value true returning 200 success.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> put200Async(Boolean booleanValue) {
-        return put200AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put200WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -355,7 +338,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put200AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> put200Async(Boolean booleanValue) {
+        return put200WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put200WithServiceResponseAsync(Boolean booleanValue) {
         return service.put200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -382,10 +380,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch200() throws ErrorException, IOException {
-        patch200AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -395,7 +392,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch200AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(patch200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -404,12 +401,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> patch200Async() {
-        return patch200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return patch200WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -417,7 +414,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch200AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> patch200WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -439,10 +436,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch200(Boolean booleanValue) throws ErrorException, IOException {
-        patch200AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch200WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -453,21 +449,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch200AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Patch true Boolean value in request returning 200.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> patch200Async(Boolean booleanValue) {
-        return patch200AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(patch200WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -476,7 +458,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch200AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> patch200Async(Boolean booleanValue) {
+        return patch200WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch200WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -503,10 +500,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post200() throws ErrorException, IOException {
-        post200AsyncWithServiceResponse().toBlocking().single().getBody();
+        post200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -516,7 +512,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post200AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -525,12 +521,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> post200Async() {
-        return post200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return post200WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -538,7 +534,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post200AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> post200WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -560,10 +556,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post200(Boolean booleanValue) throws ErrorException, IOException {
-        post200AsyncWithServiceResponse().toBlocking().single().getBody();
+        post200WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -574,21 +569,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post200AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Post bollean value true in request that returns a 200.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> post200Async(Boolean booleanValue) {
-        return post200AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post200WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -597,7 +578,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post200AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> post200Async(Boolean booleanValue) {
+        return post200WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post200WithServiceResponseAsync(Boolean booleanValue) {
         return service.post200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -624,10 +620,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void delete200() throws ErrorException, IOException {
-        delete200AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete200WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -637,7 +632,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete200AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(delete200WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -646,12 +641,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> delete200Async() {
-        return delete200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return delete200WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -659,7 +654,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete200AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> delete200WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -681,10 +676,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void delete200(Boolean booleanValue) throws ErrorException, IOException {
-        delete200AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete200WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -695,21 +689,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete200AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Delete simple boolean value true returns 200.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> delete200Async(Boolean booleanValue) {
-        return delete200AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(delete200WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -718,7 +698,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete200AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> delete200Async(Boolean booleanValue) {
+        return delete200WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> delete200WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -745,10 +740,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put201() throws ErrorException, IOException {
-        put201AsyncWithServiceResponse().toBlocking().single().getBody();
+        put201WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -758,7 +752,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put201Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put201AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put201WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -767,12 +761,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> put201Async() {
-        return put201AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return put201WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -780,7 +774,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put201AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> put201WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put201(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -802,10 +796,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put201(Boolean booleanValue) throws ErrorException, IOException {
-        put201AsyncWithServiceResponse().toBlocking().single().getBody();
+        put201WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -816,21 +809,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put201Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put201AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Put true Boolean value in request returns 201.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> put201Async(Boolean booleanValue) {
-        return put201AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put201WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -839,7 +818,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put201AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> put201Async(Boolean booleanValue) {
+        return put201WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put201WithServiceResponseAsync(Boolean booleanValue) {
         return service.put201(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -866,10 +860,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post201() throws ErrorException, IOException {
-        post201AsyncWithServiceResponse().toBlocking().single().getBody();
+        post201WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -879,7 +872,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post201Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post201AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post201WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -888,12 +881,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> post201Async() {
-        return post201AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return post201WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -901,7 +894,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post201AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> post201WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post201(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -923,10 +916,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post201(Boolean booleanValue) throws ErrorException, IOException {
-        post201AsyncWithServiceResponse().toBlocking().single().getBody();
+        post201WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -937,21 +929,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post201Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post201AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Post true Boolean value in request returns 201 (Created).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> post201Async(Boolean booleanValue) {
-        return post201AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post201WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -960,7 +938,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post201AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> post201Async(Boolean booleanValue) {
+        return post201WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post201WithServiceResponseAsync(Boolean booleanValue) {
         return service.post201(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -987,10 +980,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put202() throws ErrorException, IOException {
-        put202AsyncWithServiceResponse().toBlocking().single().getBody();
+        put202WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1000,7 +992,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put202Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put202AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put202WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1009,12 +1001,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> put202Async() {
-        return put202AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return put202WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1022,7 +1014,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put202AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> put202WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1044,10 +1036,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put202(Boolean booleanValue) throws ErrorException, IOException {
-        put202AsyncWithServiceResponse().toBlocking().single().getBody();
+        put202WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1058,21 +1049,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put202AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Put true Boolean value in request returns 202 (Accepted).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> put202Async(Boolean booleanValue) {
-        return put202AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put202WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1081,7 +1058,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put202AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> put202Async(Boolean booleanValue) {
+        return put202WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put202WithServiceResponseAsync(Boolean booleanValue) {
         return service.put202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1108,10 +1100,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch202() throws ErrorException, IOException {
-        patch202AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch202WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1121,7 +1112,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch202Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch202AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(patch202WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1130,12 +1121,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> patch202Async() {
-        return patch202AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return patch202WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1143,7 +1134,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch202AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> patch202WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1165,10 +1156,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch202(Boolean booleanValue) throws ErrorException, IOException {
-        patch202AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch202WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1179,21 +1169,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch202AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Patch true Boolean value in request returns 202.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> patch202Async(Boolean booleanValue) {
-        return patch202AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(patch202WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1202,7 +1178,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch202AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> patch202Async(Boolean booleanValue) {
+        return patch202WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch202WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1229,10 +1220,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post202() throws ErrorException, IOException {
-        post202AsyncWithServiceResponse().toBlocking().single().getBody();
+        post202WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1242,7 +1232,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post202AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post202WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1251,12 +1241,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> post202Async() {
-        return post202AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return post202WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1264,7 +1254,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post202AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> post202WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1286,10 +1276,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post202(Boolean booleanValue) throws ErrorException, IOException {
-        post202AsyncWithServiceResponse().toBlocking().single().getBody();
+        post202WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1300,21 +1289,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post202AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Post true Boolean value in request returns 202 (Accepted).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> post202Async(Boolean booleanValue) {
-        return post202AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post202WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1323,7 +1298,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post202AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> post202Async(Boolean booleanValue) {
+        return post202WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post202WithServiceResponseAsync(Boolean booleanValue) {
         return service.post202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1350,10 +1340,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void delete202() throws ErrorException, IOException {
-        delete202AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete202WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1363,7 +1352,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete202AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(delete202WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1372,12 +1361,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> delete202Async() {
-        return delete202AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return delete202WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1385,7 +1374,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete202AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> delete202WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1407,10 +1396,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void delete202(Boolean booleanValue) throws ErrorException, IOException {
-        delete202AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete202WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1421,21 +1409,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete202AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Delete true Boolean value in request returns 202 (accepted).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> delete202Async(Boolean booleanValue) {
-        return delete202AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(delete202WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1444,7 +1418,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete202AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> delete202Async(Boolean booleanValue) {
+        return delete202WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> delete202WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1471,10 +1460,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void head204() throws ErrorException, IOException {
-        head204AsyncWithServiceResponse().toBlocking().single().getBody();
+        head204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1484,7 +1472,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head204AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1493,12 +1481,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> head204Async() {
-        return head204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return head204WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1506,7 +1494,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head204AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> head204WithServiceResponseAsync() {
         return service.head204()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1533,10 +1521,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put204() throws ErrorException, IOException {
-        put204AsyncWithServiceResponse().toBlocking().single().getBody();
+        put204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1546,7 +1533,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put204AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(put204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1555,12 +1542,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> put204Async() {
-        return put204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return put204WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1568,7 +1555,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put204AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> put204WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.put204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1590,10 +1577,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void put204(Boolean booleanValue) throws ErrorException, IOException {
-        put204AsyncWithServiceResponse().toBlocking().single().getBody();
+        put204WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1604,21 +1590,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put204AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Put true Boolean value in request returns 204 (no content).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> put204Async(Boolean booleanValue) {
-        return put204AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(put204WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1627,7 +1599,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put204AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> put204Async(Boolean booleanValue) {
+        return put204WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put204WithServiceResponseAsync(Boolean booleanValue) {
         return service.put204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1654,10 +1641,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch204() throws ErrorException, IOException {
-        patch204AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1667,7 +1653,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch204AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(patch204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1676,12 +1662,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> patch204Async() {
-        return patch204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return patch204WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1689,7 +1675,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch204AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> patch204WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1711,10 +1697,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void patch204(Boolean booleanValue) throws ErrorException, IOException {
-        patch204AsyncWithServiceResponse().toBlocking().single().getBody();
+        patch204WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1725,21 +1710,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch204AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Patch true Boolean value in request returns 204 (no content).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> patch204Async(Boolean booleanValue) {
-        return patch204AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(patch204WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1748,7 +1719,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch204AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> patch204Async(Boolean booleanValue) {
+        return patch204WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch204WithServiceResponseAsync(Boolean booleanValue) {
         return service.patch204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1775,10 +1761,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post204() throws ErrorException, IOException {
-        post204AsyncWithServiceResponse().toBlocking().single().getBody();
+        post204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1788,7 +1773,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post204AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(post204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1797,12 +1782,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> post204Async() {
-        return post204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return post204WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1810,7 +1795,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post204AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> post204WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.post204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1832,10 +1817,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void post204(Boolean booleanValue) throws ErrorException, IOException {
-        post204AsyncWithServiceResponse().toBlocking().single().getBody();
+        post204WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1846,21 +1830,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post204AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Post true Boolean value in request returns 204 (no content).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> post204Async(Boolean booleanValue) {
-        return post204AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(post204WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1869,7 +1839,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post204AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> post204Async(Boolean booleanValue) {
+        return post204WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post204WithServiceResponseAsync(Boolean booleanValue) {
         return service.post204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1896,10 +1881,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void delete204() throws ErrorException, IOException {
-        delete204AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete204WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1909,7 +1893,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete204AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(delete204WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1918,12 +1902,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> delete204Async() {
-        return delete204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return delete204WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1931,7 +1915,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete204AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> delete204WithServiceResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1953,10 +1937,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void delete204(Boolean booleanValue) throws ErrorException, IOException {
-        delete204AsyncWithServiceResponse().toBlocking().single().getBody();
+        delete204WithServiceResponseAsync(booleanValue).toBlocking().single().getBody();
     }
 
     /**
@@ -1967,21 +1950,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete204AsyncWithServiceResponse(booleanValue), serviceCallback);
-    }
-
-    /**
-     * Delete true Boolean value in request returns 204 (no content).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> delete204Async(Boolean booleanValue) {
-        return delete204AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(delete204WithServiceResponseAsync(booleanValue), serviceCallback);
     }
 
     /**
@@ -1990,7 +1959,22 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete204AsyncWithServiceResponse(Boolean booleanValue) {
+    public Observable<Void> delete204Async(Boolean booleanValue) {
+        return delete204WithServiceResponseAsync(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> delete204WithServiceResponseAsync(Boolean booleanValue) {
         return service.delete204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -2017,10 +2001,9 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void head404() throws ErrorException, IOException {
-        head404AsyncWithServiceResponse().toBlocking().single().getBody();
+        head404WithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2030,7 +2013,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head404Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head404AsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(head404WithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2039,12 +2022,12 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> head404Async() {
-        return head404AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return head404WithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2052,7 +2035,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head404AsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> head404WithServiceResponseAsync() {
         return service.head404()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpSuccessImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/HttpSuccessImpl.java
@@ -139,8 +139,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head200() throws ErrorException, IOException {
-        return head200Async().toBlocking().single();
+    public void head200() throws ErrorException, IOException {
+        head200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -150,7 +150,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head200Async(), serviceCallback);
+        return ServiceCall.create(head200AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -158,7 +158,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head200Async() {
+    public Observable<Void> head200Async() {
+        return head200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head200AsyncWithServiceResponse() {
         return service.head200()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -187,8 +201,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the boolean object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Boolean> get200() throws ErrorException, IOException {
-        return get200Async().toBlocking().single();
+    public boolean get200() throws ErrorException, IOException {
+        return get200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -198,7 +212,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Boolean> get200Async(final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceCall.create(get200Async(), serviceCallback);
+        return ServiceCall.create(get200AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -206,7 +220,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the observable to the boolean object
      */
-    public Observable<ServiceResponse<Boolean>> get200Async() {
+    public Observable<Boolean> get200Async() {
+        return get200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Boolean>, Boolean>() {
+            @Override
+            public Boolean call(ServiceResponse<Boolean> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get 200 success.
+     *
+     * @return the observable to the boolean object
+     */
+    public Observable<ServiceResponse<Boolean>> get200AsyncWithServiceResponse() {
         return service.get200()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Boolean>>>() {
                 @Override
@@ -235,8 +263,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put200() throws ErrorException, IOException {
-        return put200Async().toBlocking().single();
+    public void put200() throws ErrorException, IOException {
+        put200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -246,7 +274,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put200Async(), serviceCallback);
+        return ServiceCall.create(put200AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -254,7 +282,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put200Async() {
+    public Observable<Void> put200Async() {
+        return put200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put200AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -278,8 +320,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put200(Boolean booleanValue) throws ErrorException, IOException {
-        return put200Async(booleanValue).toBlocking().single();
+    public void put200(Boolean booleanValue) throws ErrorException, IOException {
+        put200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -290,7 +332,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put200Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put200AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> put200Async(Boolean booleanValue) {
+        return put200AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -299,7 +355,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put200Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> put200AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -328,8 +384,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch200() throws ErrorException, IOException {
-        return patch200Async().toBlocking().single();
+    public void patch200() throws ErrorException, IOException {
+        patch200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -339,7 +395,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch200Async(), serviceCallback);
+        return ServiceCall.create(patch200AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -347,7 +403,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch200Async() {
+    public Observable<Void> patch200Async() {
+        return patch200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch200AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -371,8 +441,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch200(Boolean booleanValue) throws ErrorException, IOException {
-        return patch200Async(booleanValue).toBlocking().single();
+    public void patch200(Boolean booleanValue) throws ErrorException, IOException {
+        patch200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -383,7 +453,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch200Async(booleanValue), serviceCallback);
+        return ServiceCall.create(patch200AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> patch200Async(Boolean booleanValue) {
+        return patch200AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -392,7 +476,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch200Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> patch200AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -421,8 +505,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post200() throws ErrorException, IOException {
-        return post200Async().toBlocking().single();
+    public void post200() throws ErrorException, IOException {
+        post200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -432,7 +516,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post200Async(), serviceCallback);
+        return ServiceCall.create(post200AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -440,7 +524,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post200Async() {
+    public Observable<Void> post200Async() {
+        return post200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post200AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -464,8 +562,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post200(Boolean booleanValue) throws ErrorException, IOException {
-        return post200Async(booleanValue).toBlocking().single();
+    public void post200(Boolean booleanValue) throws ErrorException, IOException {
+        post200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -476,7 +574,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post200Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post200AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> post200Async(Boolean booleanValue) {
+        return post200AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -485,7 +597,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post200Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> post200AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -514,8 +626,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> delete200() throws ErrorException, IOException {
-        return delete200Async().toBlocking().single();
+    public void delete200() throws ErrorException, IOException {
+        delete200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -525,7 +637,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete200Async(), serviceCallback);
+        return ServiceCall.create(delete200AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -533,7 +645,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete200Async() {
+    public Observable<Void> delete200Async() {
+        return delete200AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> delete200AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -557,8 +683,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> delete200(Boolean booleanValue) throws ErrorException, IOException {
-        return delete200Async(booleanValue).toBlocking().single();
+    public void delete200(Boolean booleanValue) throws ErrorException, IOException {
+        delete200AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -569,7 +695,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete200Async(booleanValue), serviceCallback);
+        return ServiceCall.create(delete200AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> delete200Async(Boolean booleanValue) {
+        return delete200AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -578,7 +718,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete200Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> delete200AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete200(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -607,8 +747,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put201() throws ErrorException, IOException {
-        return put201Async().toBlocking().single();
+    public void put201() throws ErrorException, IOException {
+        put201AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -618,7 +758,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put201Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put201Async(), serviceCallback);
+        return ServiceCall.create(put201AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -626,7 +766,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put201Async() {
+    public Observable<Void> put201Async() {
+        return put201AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put201AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put201(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -650,8 +804,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put201(Boolean booleanValue) throws ErrorException, IOException {
-        return put201Async(booleanValue).toBlocking().single();
+    public void put201(Boolean booleanValue) throws ErrorException, IOException {
+        put201AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -662,7 +816,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put201Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put201Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put201AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> put201Async(Boolean booleanValue) {
+        return put201AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -671,7 +839,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put201Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> put201AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put201(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -700,8 +868,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post201() throws ErrorException, IOException {
-        return post201Async().toBlocking().single();
+    public void post201() throws ErrorException, IOException {
+        post201AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -711,7 +879,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post201Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post201Async(), serviceCallback);
+        return ServiceCall.create(post201AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -719,7 +887,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post201Async() {
+    public Observable<Void> post201Async() {
+        return post201AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post201AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post201(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -743,8 +925,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post201(Boolean booleanValue) throws ErrorException, IOException {
-        return post201Async(booleanValue).toBlocking().single();
+    public void post201(Boolean booleanValue) throws ErrorException, IOException {
+        post201AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -755,7 +937,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post201Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post201Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post201AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> post201Async(Boolean booleanValue) {
+        return post201AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -764,7 +960,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post201Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> post201AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post201(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -793,8 +989,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put202() throws ErrorException, IOException {
-        return put202Async().toBlocking().single();
+    public void put202() throws ErrorException, IOException {
+        put202AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -804,7 +1000,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put202Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put202Async(), serviceCallback);
+        return ServiceCall.create(put202AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -812,7 +1008,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put202Async() {
+    public Observable<Void> put202Async() {
+        return put202AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put202AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -836,8 +1046,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put202(Boolean booleanValue) throws ErrorException, IOException {
-        return put202Async(booleanValue).toBlocking().single();
+    public void put202(Boolean booleanValue) throws ErrorException, IOException {
+        put202AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -848,7 +1058,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put202Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put202AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> put202Async(Boolean booleanValue) {
+        return put202AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -857,7 +1081,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put202Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> put202AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -886,8 +1110,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch202() throws ErrorException, IOException {
-        return patch202Async().toBlocking().single();
+    public void patch202() throws ErrorException, IOException {
+        patch202AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -897,7 +1121,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch202Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch202Async(), serviceCallback);
+        return ServiceCall.create(patch202AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -905,7 +1129,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch202Async() {
+    public Observable<Void> patch202Async() {
+        return patch202AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch202AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -929,8 +1167,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch202(Boolean booleanValue) throws ErrorException, IOException {
-        return patch202Async(booleanValue).toBlocking().single();
+    public void patch202(Boolean booleanValue) throws ErrorException, IOException {
+        patch202AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -941,7 +1179,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch202Async(booleanValue), serviceCallback);
+        return ServiceCall.create(patch202AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> patch202Async(Boolean booleanValue) {
+        return patch202AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -950,7 +1202,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch202Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> patch202AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -979,8 +1231,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post202() throws ErrorException, IOException {
-        return post202Async().toBlocking().single();
+    public void post202() throws ErrorException, IOException {
+        post202AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -990,7 +1242,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post202Async(), serviceCallback);
+        return ServiceCall.create(post202AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -998,7 +1250,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post202Async() {
+    public Observable<Void> post202Async() {
+        return post202AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post202AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1022,8 +1288,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post202(Boolean booleanValue) throws ErrorException, IOException {
-        return post202Async(booleanValue).toBlocking().single();
+    public void post202(Boolean booleanValue) throws ErrorException, IOException {
+        post202AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1034,7 +1300,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post202Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post202AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> post202Async(Boolean booleanValue) {
+        return post202AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1043,7 +1323,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post202Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> post202AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1072,8 +1352,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> delete202() throws ErrorException, IOException {
-        return delete202Async().toBlocking().single();
+    public void delete202() throws ErrorException, IOException {
+        delete202AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1083,7 +1363,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete202Async(), serviceCallback);
+        return ServiceCall.create(delete202AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1091,7 +1371,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete202Async() {
+    public Observable<Void> delete202Async() {
+        return delete202AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> delete202AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1115,8 +1409,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> delete202(Boolean booleanValue) throws ErrorException, IOException {
-        return delete202Async(booleanValue).toBlocking().single();
+    public void delete202(Boolean booleanValue) throws ErrorException, IOException {
+        delete202AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1127,7 +1421,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete202Async(booleanValue), serviceCallback);
+        return ServiceCall.create(delete202AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> delete202Async(Boolean booleanValue) {
+        return delete202AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1136,7 +1444,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete202Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> delete202AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete202(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1165,8 +1473,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head204() throws ErrorException, IOException {
-        return head204Async().toBlocking().single();
+    public void head204() throws ErrorException, IOException {
+        head204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1176,7 +1484,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head204Async(), serviceCallback);
+        return ServiceCall.create(head204AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1184,7 +1492,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head204Async() {
+    public Observable<Void> head204Async() {
+        return head204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head204AsyncWithServiceResponse() {
         return service.head204()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1213,8 +1535,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put204() throws ErrorException, IOException {
-        return put204Async().toBlocking().single();
+    public void put204() throws ErrorException, IOException {
+        put204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1224,7 +1546,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put204Async(), serviceCallback);
+        return ServiceCall.create(put204AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1232,7 +1554,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put204Async() {
+    public Observable<Void> put204Async() {
+        return put204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> put204AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.put204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1256,8 +1592,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> put204(Boolean booleanValue) throws ErrorException, IOException {
-        return put204Async(booleanValue).toBlocking().single();
+    public void put204(Boolean booleanValue) throws ErrorException, IOException {
+        put204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1268,7 +1604,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> put204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(put204Async(booleanValue), serviceCallback);
+        return ServiceCall.create(put204AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> put204Async(Boolean booleanValue) {
+        return put204AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1277,7 +1627,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> put204Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> put204AsyncWithServiceResponse(Boolean booleanValue) {
         return service.put204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1306,8 +1656,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch204() throws ErrorException, IOException {
-        return patch204Async().toBlocking().single();
+    public void patch204() throws ErrorException, IOException {
+        patch204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1317,7 +1667,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch204Async(), serviceCallback);
+        return ServiceCall.create(patch204AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1325,7 +1675,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch204Async() {
+    public Observable<Void> patch204Async() {
+        return patch204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> patch204AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.patch204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1349,8 +1713,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> patch204(Boolean booleanValue) throws ErrorException, IOException {
-        return patch204Async(booleanValue).toBlocking().single();
+    public void patch204(Boolean booleanValue) throws ErrorException, IOException {
+        patch204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1361,7 +1725,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> patch204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(patch204Async(booleanValue), serviceCallback);
+        return ServiceCall.create(patch204AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> patch204Async(Boolean booleanValue) {
+        return patch204AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1370,7 +1748,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> patch204Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> patch204AsyncWithServiceResponse(Boolean booleanValue) {
         return service.patch204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1399,8 +1777,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post204() throws ErrorException, IOException {
-        return post204Async().toBlocking().single();
+    public void post204() throws ErrorException, IOException {
+        post204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1410,7 +1788,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post204Async(), serviceCallback);
+        return ServiceCall.create(post204AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1418,7 +1796,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post204Async() {
+    public Observable<Void> post204Async() {
+        return post204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> post204AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.post204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1442,8 +1834,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> post204(Boolean booleanValue) throws ErrorException, IOException {
-        return post204Async(booleanValue).toBlocking().single();
+    public void post204(Boolean booleanValue) throws ErrorException, IOException {
+        post204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1454,7 +1846,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> post204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(post204Async(booleanValue), serviceCallback);
+        return ServiceCall.create(post204AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> post204Async(Boolean booleanValue) {
+        return post204AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1463,7 +1869,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> post204Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> post204AsyncWithServiceResponse(Boolean booleanValue) {
         return service.post204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1492,8 +1898,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> delete204() throws ErrorException, IOException {
-        return delete204Async().toBlocking().single();
+    public void delete204() throws ErrorException, IOException {
+        delete204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1503,7 +1909,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete204Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete204Async(), serviceCallback);
+        return ServiceCall.create(delete204AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1511,7 +1917,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete204Async() {
+    public Observable<Void> delete204Async() {
+        return delete204AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> delete204AsyncWithServiceResponse() {
         final Boolean booleanValue = null;
         return service.delete204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1535,8 +1955,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> delete204(Boolean booleanValue) throws ErrorException, IOException {
-        return delete204Async(booleanValue).toBlocking().single();
+    public void delete204(Boolean booleanValue) throws ErrorException, IOException {
+        delete204AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1547,7 +1967,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> delete204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(delete204Async(booleanValue), serviceCallback);
+        return ServiceCall.create(delete204AsyncWithServiceResponse(booleanValue), serviceCallback);
+    }
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> delete204Async(Boolean booleanValue) {
+        return delete204AsyncWithServiceResponse(booleanValue).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1556,7 +1990,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @param booleanValue Simple boolean value true
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> delete204Async(Boolean booleanValue) {
+    public Observable<ServiceResponse<Void>> delete204AsyncWithServiceResponse(Boolean booleanValue) {
         return service.delete204(booleanValue)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1585,8 +2019,8 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> head404() throws ErrorException, IOException {
-        return head404Async().toBlocking().single();
+    public void head404() throws ErrorException, IOException {
+        head404AsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1596,7 +2030,7 @@ public final class HttpSuccessImpl implements HttpSuccess {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> head404Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(head404Async(), serviceCallback);
+        return ServiceCall.create(head404AsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1604,7 +2038,21 @@ public final class HttpSuccessImpl implements HttpSuccess {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> head404Async() {
+    public Observable<Void> head404Async() {
+        return head404AsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Return 404 status code.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> head404AsyncWithServiceResponse() {
         return service.head404()
             .flatMap(new Func1<Response<Void>, Observable<ServiceResponse<Void>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/MultipleResponsesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/MultipleResponsesImpl.java
@@ -201,10 +201,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200Model204NoModelDefaultError200Valid() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200Model204NoModelDefaultError200ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -214,7 +214,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError200ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError200ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -223,12 +223,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200Model204NoModelDefaultError200ValidAsync() {
-        return get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200Model204NoModelDefaultError200ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -236,7 +236,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError200ValidWithServiceResponseAsync() {
         return service.get200Model204NoModelDefaultError200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -264,10 +264,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200Model204NoModelDefaultError204Valid() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200Model204NoModelDefaultError204ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -277,7 +277,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError204ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError204ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -286,12 +286,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200Model204NoModelDefaultError204ValidAsync() {
-        return get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200Model204NoModelDefaultError204ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -299,7 +299,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError204ValidWithServiceResponseAsync() {
         return service.get200Model204NoModelDefaultError204Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -327,10 +327,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200Model204NoModelDefaultError201Invalid() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200Model204NoModelDefaultError201InvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -340,7 +340,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError201InvalidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError201InvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -349,12 +349,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200Model204NoModelDefaultError201InvalidAsync() {
-        return get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200Model204NoModelDefaultError201InvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -362,7 +362,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError201InvalidWithServiceResponseAsync() {
         return service.get200Model204NoModelDefaultError201Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -390,10 +390,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200Model204NoModelDefaultError202None() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200Model204NoModelDefaultError202NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -403,7 +403,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError202NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError202NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -412,12 +412,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200Model204NoModelDefaultError202NoneAsync() {
-        return get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200Model204NoModelDefaultError202NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -425,7 +425,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError202NoneWithServiceResponseAsync() {
         return service.get200Model204NoModelDefaultError202None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -453,10 +453,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200Model204NoModelDefaultError400Valid() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200Model204NoModelDefaultError400ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -466,7 +466,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError400ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError400ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -475,12 +475,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200Model204NoModelDefaultError400ValidAsync() {
-        return get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200Model204NoModelDefaultError400ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -488,7 +488,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError400ValidWithServiceResponseAsync() {
         return service.get200Model204NoModelDefaultError400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -516,10 +516,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200Model201ModelDefaultError200Valid() throws ErrorException, IOException {
-        return get200Model201ModelDefaultError200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200Model201ModelDefaultError200ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -529,7 +529,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model201ModelDefaultError200ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model201ModelDefaultError200ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200Model201ModelDefaultError200ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -538,12 +538,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200Model201ModelDefaultError200ValidAsync() {
-        return get200Model201ModelDefaultError200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200Model201ModelDefaultError200ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -551,7 +551,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError200ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError200ValidWithServiceResponseAsync() {
         return service.get200Model201ModelDefaultError200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -579,10 +579,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200Model201ModelDefaultError201Valid() throws ErrorException, IOException {
-        return get200Model201ModelDefaultError201ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200Model201ModelDefaultError201ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -592,7 +592,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model201ModelDefaultError201ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model201ModelDefaultError201ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200Model201ModelDefaultError201ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -601,12 +601,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200Model201ModelDefaultError201ValidAsync() {
-        return get200Model201ModelDefaultError201ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200Model201ModelDefaultError201ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -614,7 +614,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError201ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError201ValidWithServiceResponseAsync() {
         return service.get200Model201ModelDefaultError201Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -642,10 +642,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200Model201ModelDefaultError400Valid() throws ErrorException, IOException {
-        return get200Model201ModelDefaultError400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200Model201ModelDefaultError400ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -655,7 +655,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model201ModelDefaultError400ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model201ModelDefaultError400ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200Model201ModelDefaultError400ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -664,12 +664,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200Model201ModelDefaultError400ValidAsync() {
-        return get200Model201ModelDefaultError400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200Model201ModelDefaultError400ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -677,7 +677,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError400ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError400ValidWithServiceResponseAsync() {
         return service.get200Model201ModelDefaultError400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -705,10 +705,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Object object wrapped in {@link ServiceResponse} if successful.
+     * @return the Object object if successful.
      */
     public Object get200ModelA201ModelC404ModelDDefaultError200Valid() throws ErrorException, IOException {
-        return get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA201ModelC404ModelDDefaultError200ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -718,7 +718,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync(final ServiceCallback<Object> serviceCallback) {
-        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError200ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -727,12 +727,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the Object object
      */
     public Observable<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync() {
-        return get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Object>, Object>() {
+        return get200ModelA201ModelC404ModelDDefaultError200ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Object>, Object>() {
             @Override
             public Object call(ServiceResponse<Object> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -740,7 +740,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidWithServiceResponseAsync() {
         return service.get200ModelA201ModelC404ModelDDefaultError200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Object>>>() {
                 @Override
@@ -769,10 +769,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Object object wrapped in {@link ServiceResponse} if successful.
+     * @return the Object object if successful.
      */
     public Object get200ModelA201ModelC404ModelDDefaultError201Valid() throws ErrorException, IOException {
-        return get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA201ModelC404ModelDDefaultError201ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -782,7 +782,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync(final ServiceCallback<Object> serviceCallback) {
-        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError201ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -791,12 +791,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the Object object
      */
     public Observable<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync() {
-        return get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Object>, Object>() {
+        return get200ModelA201ModelC404ModelDDefaultError201ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Object>, Object>() {
             @Override
             public Object call(ServiceResponse<Object> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -804,7 +804,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidWithServiceResponseAsync() {
         return service.get200ModelA201ModelC404ModelDDefaultError201Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Object>>>() {
                 @Override
@@ -833,10 +833,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Object object wrapped in {@link ServiceResponse} if successful.
+     * @return the Object object if successful.
      */
     public Object get200ModelA201ModelC404ModelDDefaultError404Valid() throws ErrorException, IOException {
-        return get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA201ModelC404ModelDDefaultError404ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -846,7 +846,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync(final ServiceCallback<Object> serviceCallback) {
-        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError404ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -855,12 +855,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the Object object
      */
     public Observable<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync() {
-        return get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Object>, Object>() {
+        return get200ModelA201ModelC404ModelDDefaultError404ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Object>, Object>() {
             @Override
             public Object call(ServiceResponse<Object> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -868,7 +868,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidWithServiceResponseAsync() {
         return service.get200ModelA201ModelC404ModelDDefaultError404Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Object>>>() {
                 @Override
@@ -897,10 +897,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Object object wrapped in {@link ServiceResponse} if successful.
+     * @return the Object object if successful.
      */
     public Object get200ModelA201ModelC404ModelDDefaultError400Valid() throws ErrorException, IOException {
-        return get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA201ModelC404ModelDDefaultError400ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -910,7 +910,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync(final ServiceCallback<Object> serviceCallback) {
-        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError400ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -919,12 +919,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the Object object
      */
     public Observable<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync() {
-        return get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Object>, Object>() {
+        return get200ModelA201ModelC404ModelDDefaultError400ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Object>, Object>() {
             @Override
             public Object call(ServiceResponse<Object> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -932,7 +932,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidWithServiceResponseAsync() {
         return service.get200ModelA201ModelC404ModelDDefaultError400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Object>>>() {
                 @Override
@@ -961,10 +961,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void get202None204NoneDefaultError202None() throws ErrorException, IOException {
-        get202None204NoneDefaultError202NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        get202None204NoneDefaultError202NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -974,7 +973,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultError202NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultError202NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultError202NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -983,12 +982,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> get202None204NoneDefaultError202NoneAsync() {
-        return get202None204NoneDefaultError202NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return get202None204NoneDefaultError202NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -996,7 +995,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError202NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError202NoneWithServiceResponseAsync() {
         return service.get202None204NoneDefaultError202None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1024,10 +1023,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void get202None204NoneDefaultError204None() throws ErrorException, IOException {
-        get202None204NoneDefaultError204NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        get202None204NoneDefaultError204NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1037,7 +1035,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultError204NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultError204NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultError204NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1046,12 +1044,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> get202None204NoneDefaultError204NoneAsync() {
-        return get202None204NoneDefaultError204NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return get202None204NoneDefaultError204NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1059,7 +1057,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError204NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError204NoneWithServiceResponseAsync() {
         return service.get202None204NoneDefaultError204None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1087,10 +1085,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void get202None204NoneDefaultError400Valid() throws ErrorException, IOException {
-        get202None204NoneDefaultError400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        get202None204NoneDefaultError400ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1100,7 +1097,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultError400ValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultError400ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultError400ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1109,12 +1106,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> get202None204NoneDefaultError400ValidAsync() {
-        return get202None204NoneDefaultError400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return get202None204NoneDefaultError400ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1122,7 +1119,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError400ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError400ValidWithServiceResponseAsync() {
         return service.get202None204NoneDefaultError400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1150,10 +1147,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void get202None204NoneDefaultNone202Invalid() throws ServiceException, IOException {
-        get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        get202None204NoneDefaultNone202InvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1163,7 +1159,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultNone202InvalidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultNone202InvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1172,12 +1168,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> get202None204NoneDefaultNone202InvalidAsync() {
-        return get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return get202None204NoneDefaultNone202InvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1185,7 +1181,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone202InvalidWithServiceResponseAsync() {
         return service.get202None204NoneDefaultNone202Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1212,10 +1208,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void get202None204NoneDefaultNone204None() throws ServiceException, IOException {
-        get202None204NoneDefaultNone204NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        get202None204NoneDefaultNone204NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1225,7 +1220,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultNone204NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultNone204NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultNone204NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1234,12 +1229,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> get202None204NoneDefaultNone204NoneAsync() {
-        return get202None204NoneDefaultNone204NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return get202None204NoneDefaultNone204NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1247,7 +1242,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone204NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone204NoneWithServiceResponseAsync() {
         return service.get202None204NoneDefaultNone204None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1274,10 +1269,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void get202None204NoneDefaultNone400None() throws ServiceException, IOException {
-        get202None204NoneDefaultNone400NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        get202None204NoneDefaultNone400NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1287,7 +1281,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultNone400NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultNone400NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultNone400NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1296,12 +1290,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> get202None204NoneDefaultNone400NoneAsync() {
-        return get202None204NoneDefaultNone400NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return get202None204NoneDefaultNone400NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1309,7 +1303,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400NoneWithServiceResponseAsync() {
         return service.get202None204NoneDefaultNone400None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1336,10 +1330,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void get202None204NoneDefaultNone400Invalid() throws ServiceException, IOException {
-        get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        get202None204NoneDefaultNone400InvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1349,7 +1342,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultNone400InvalidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultNone400InvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1358,12 +1351,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> get202None204NoneDefaultNone400InvalidAsync() {
-        return get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return get202None204NoneDefaultNone400InvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1371,7 +1364,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400InvalidWithServiceResponseAsync() {
         return service.get202None204NoneDefaultNone400Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1398,10 +1391,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws MyException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A getDefaultModelA200Valid() throws MyException, IOException {
-        return getDefaultModelA200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDefaultModelA200ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1411,7 +1404,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> getDefaultModelA200ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(getDefaultModelA200ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDefaultModelA200ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1420,12 +1413,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> getDefaultModelA200ValidAsync() {
-        return getDefaultModelA200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return getDefaultModelA200ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1433,7 +1426,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> getDefaultModelA200ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> getDefaultModelA200ValidWithServiceResponseAsync() {
         return service.getDefaultModelA200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1459,10 +1452,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws MyException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A getDefaultModelA200None() throws MyException, IOException {
-        return getDefaultModelA200NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDefaultModelA200NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1472,7 +1465,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> getDefaultModelA200NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(getDefaultModelA200NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDefaultModelA200NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1481,12 +1474,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> getDefaultModelA200NoneAsync() {
-        return getDefaultModelA200NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return getDefaultModelA200NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1494,7 +1487,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> getDefaultModelA200NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> getDefaultModelA200NoneWithServiceResponseAsync() {
         return service.getDefaultModelA200None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1520,10 +1513,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws MyException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A getDefaultModelA400Valid() throws MyException, IOException {
-        return getDefaultModelA400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDefaultModelA400ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1533,7 +1526,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> getDefaultModelA400ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(getDefaultModelA400ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDefaultModelA400ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1542,12 +1535,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> getDefaultModelA400ValidAsync() {
-        return getDefaultModelA400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return getDefaultModelA400ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1555,7 +1548,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> getDefaultModelA400ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> getDefaultModelA400ValidWithServiceResponseAsync() {
         return service.getDefaultModelA400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1581,10 +1574,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws MyException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A getDefaultModelA400None() throws MyException, IOException {
-        return getDefaultModelA400NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDefaultModelA400NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1594,7 +1587,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> getDefaultModelA400NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(getDefaultModelA400NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDefaultModelA400NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1603,12 +1596,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> getDefaultModelA400NoneAsync() {
-        return getDefaultModelA400NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return getDefaultModelA400NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1616,7 +1609,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> getDefaultModelA400NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> getDefaultModelA400NoneWithServiceResponseAsync() {
         return service.getDefaultModelA400None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1642,10 +1635,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getDefaultNone200Invalid() throws ServiceException, IOException {
-        getDefaultNone200InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        getDefaultNone200InvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1655,7 +1647,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getDefaultNone200InvalidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getDefaultNone200InvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDefaultNone200InvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1664,12 +1656,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getDefaultNone200InvalidAsync() {
-        return getDefaultNone200InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getDefaultNone200InvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1677,7 +1669,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getDefaultNone200InvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getDefaultNone200InvalidWithServiceResponseAsync() {
         return service.getDefaultNone200Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1702,10 +1694,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getDefaultNone200None() throws ServiceException, IOException {
-        getDefaultNone200NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        getDefaultNone200NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1715,7 +1706,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getDefaultNone200NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getDefaultNone200NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDefaultNone200NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1724,12 +1715,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getDefaultNone200NoneAsync() {
-        return getDefaultNone200NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getDefaultNone200NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1737,7 +1728,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getDefaultNone200NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getDefaultNone200NoneWithServiceResponseAsync() {
         return service.getDefaultNone200None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1762,10 +1753,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getDefaultNone400Invalid() throws ServiceException, IOException {
-        getDefaultNone400InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        getDefaultNone400InvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1775,7 +1765,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getDefaultNone400InvalidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getDefaultNone400InvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDefaultNone400InvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1784,12 +1774,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getDefaultNone400InvalidAsync() {
-        return getDefaultNone400InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getDefaultNone400InvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1797,7 +1787,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getDefaultNone400InvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getDefaultNone400InvalidWithServiceResponseAsync() {
         return service.getDefaultNone400Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1822,10 +1812,9 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getDefaultNone400None() throws ServiceException, IOException {
-        getDefaultNone400NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        getDefaultNone400NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1835,7 +1824,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getDefaultNone400NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getDefaultNone400NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDefaultNone400NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1844,12 +1833,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getDefaultNone400NoneAsync() {
-        return getDefaultNone400NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getDefaultNone400NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1857,7 +1846,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getDefaultNone400NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getDefaultNone400NoneWithServiceResponseAsync() {
         return service.getDefaultNone400None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1882,10 +1871,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200ModelA200None() throws ServiceException, IOException {
-        return get200ModelA200NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA200NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1895,7 +1884,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA200NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA200NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA200NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1904,12 +1893,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200ModelA200NoneAsync() {
-        return get200ModelA200NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200ModelA200NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1917,7 +1906,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA200NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200ModelA200NoneWithServiceResponseAsync() {
         return service.get200ModelA200None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1943,10 +1932,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200ModelA200Valid() throws ServiceException, IOException {
-        return get200ModelA200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA200ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1956,7 +1945,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA200ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA200ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA200ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1965,12 +1954,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200ModelA200ValidAsync() {
-        return get200ModelA200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200ModelA200ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1978,7 +1967,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA200ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200ModelA200ValidWithServiceResponseAsync() {
         return service.get200ModelA200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -2004,10 +1993,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200ModelA200Invalid() throws ServiceException, IOException {
-        return get200ModelA200InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA200InvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2017,7 +2006,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA200InvalidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA200InvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA200InvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2026,12 +2015,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200ModelA200InvalidAsync() {
-        return get200ModelA200InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200ModelA200InvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2039,7 +2028,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA200InvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200ModelA200InvalidWithServiceResponseAsync() {
         return service.get200ModelA200Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -2065,10 +2054,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200ModelA400None() throws ServiceException, IOException {
-        return get200ModelA400NoneAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA400NoneWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2078,7 +2067,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA400NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA400NoneAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA400NoneWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2087,12 +2076,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200ModelA400NoneAsync() {
-        return get200ModelA400NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200ModelA400NoneWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2100,7 +2089,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA400NoneAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200ModelA400NoneWithServiceResponseAsync() {
         return service.get200ModelA400None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -2126,10 +2115,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200ModelA400Valid() throws ServiceException, IOException {
-        return get200ModelA400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA400ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2139,7 +2128,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA400ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA400ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA400ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2148,12 +2137,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200ModelA400ValidAsync() {
-        return get200ModelA400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200ModelA400ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2161,7 +2150,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA400ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200ModelA400ValidWithServiceResponseAsync() {
         return service.get200ModelA400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -2187,10 +2176,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200ModelA400Invalid() throws ServiceException, IOException {
-        return get200ModelA400InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA400InvalidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2200,7 +2189,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA400InvalidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA400InvalidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA400InvalidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2209,12 +2198,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200ModelA400InvalidAsync() {
-        return get200ModelA400InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200ModelA400InvalidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2222,7 +2211,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA400InvalidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200ModelA400InvalidWithServiceResponseAsync() {
         return service.get200ModelA400Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -2248,10 +2237,10 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the A object wrapped in {@link ServiceResponse} if successful.
+     * @return the A object if successful.
      */
     public A get200ModelA202Valid() throws ServiceException, IOException {
-        return get200ModelA202ValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        return get200ModelA202ValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2261,7 +2250,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA202ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA202ValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(get200ModelA202ValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2270,12 +2259,12 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the observable to the A object
      */
     public Observable<A> get200ModelA202ValidAsync() {
-        return get200ModelA202ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+        return get200ModelA202ValidWithServiceResponseAsync().map(new Func1<ServiceResponse<A>, A>() {
             @Override
             public A call(ServiceResponse<A> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2283,7 +2272,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA202ValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<A>> get200ModelA202ValidWithServiceResponseAsync() {
         return service.get200ModelA202Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/MultipleResponsesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/http/implementation/MultipleResponsesImpl.java
@@ -203,8 +203,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200Model204NoModelDefaultError200Valid() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError200ValidAsync().toBlocking().single();
+    public A get200Model204NoModelDefaultError200Valid() throws ErrorException, IOException {
+        return get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -214,7 +214,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError200ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError200ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -222,7 +222,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError200ValidAsync() {
+    public Observable<A> get200Model204NoModelDefaultError200ValidAsync() {
+        return get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError200ValidAsyncWithServiceResponse() {
         return service.get200Model204NoModelDefaultError200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -252,8 +266,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200Model204NoModelDefaultError204Valid() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError204ValidAsync().toBlocking().single();
+    public A get200Model204NoModelDefaultError204Valid() throws ErrorException, IOException {
+        return get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -263,7 +277,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError204ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError204ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -271,7 +285,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError204ValidAsync() {
+    public Observable<A> get200Model204NoModelDefaultError204ValidAsync() {
+        return get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError204ValidAsyncWithServiceResponse() {
         return service.get200Model204NoModelDefaultError204Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -301,8 +329,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200Model204NoModelDefaultError201Invalid() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError201InvalidAsync().toBlocking().single();
+    public A get200Model204NoModelDefaultError201Invalid() throws ErrorException, IOException {
+        return get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -312,7 +340,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError201InvalidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError201InvalidAsync(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -320,7 +348,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError201InvalidAsync() {
+    public Observable<A> get200Model204NoModelDefaultError201InvalidAsync() {
+        return get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError201InvalidAsyncWithServiceResponse() {
         return service.get200Model204NoModelDefaultError201Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -350,8 +392,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200Model204NoModelDefaultError202None() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError202NoneAsync().toBlocking().single();
+    public A get200Model204NoModelDefaultError202None() throws ErrorException, IOException {
+        return get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -361,7 +403,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError202NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError202NoneAsync(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -369,7 +411,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError202NoneAsync() {
+    public Observable<A> get200Model204NoModelDefaultError202NoneAsync() {
+        return get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 202 response with no payload:.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError202NoneAsyncWithServiceResponse() {
         return service.get200Model204NoModelDefaultError202None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -399,8 +455,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200Model204NoModelDefaultError400Valid() throws ErrorException, IOException {
-        return get200Model204NoModelDefaultError400ValidAsync().toBlocking().single();
+    public A get200Model204NoModelDefaultError400Valid() throws ErrorException, IOException {
+        return get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -410,7 +466,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model204NoModelDefaultError400ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model204NoModelDefaultError400ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -418,7 +474,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError400ValidAsync() {
+    public Observable<A> get200Model204NoModelDefaultError400ValidAsync() {
+        return get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200Model204NoModelDefaultError400ValidAsyncWithServiceResponse() {
         return service.get200Model204NoModelDefaultError400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -448,8 +518,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200Model201ModelDefaultError200Valid() throws ErrorException, IOException {
-        return get200Model201ModelDefaultError200ValidAsync().toBlocking().single();
+    public A get200Model201ModelDefaultError200Valid() throws ErrorException, IOException {
+        return get200Model201ModelDefaultError200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -459,7 +529,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model201ModelDefaultError200ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model201ModelDefaultError200ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200Model201ModelDefaultError200ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -467,7 +537,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError200ValidAsync() {
+    public Observable<A> get200Model201ModelDefaultError200ValidAsync() {
+        return get200Model201ModelDefaultError200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError200ValidAsyncWithServiceResponse() {
         return service.get200Model201ModelDefaultError200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -497,8 +581,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200Model201ModelDefaultError201Valid() throws ErrorException, IOException {
-        return get200Model201ModelDefaultError201ValidAsync().toBlocking().single();
+    public A get200Model201ModelDefaultError201Valid() throws ErrorException, IOException {
+        return get200Model201ModelDefaultError201ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -508,7 +592,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model201ModelDefaultError201ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model201ModelDefaultError201ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200Model201ModelDefaultError201ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -516,7 +600,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError201ValidAsync() {
+    public Observable<A> get200Model201ModelDefaultError201ValidAsync() {
+        return get200Model201ModelDefaultError201ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError201ValidAsyncWithServiceResponse() {
         return service.get200Model201ModelDefaultError201Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -546,8 +644,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200Model201ModelDefaultError400Valid() throws ErrorException, IOException {
-        return get200Model201ModelDefaultError400ValidAsync().toBlocking().single();
+    public A get200Model201ModelDefaultError400Valid() throws ErrorException, IOException {
+        return get200Model201ModelDefaultError400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -557,7 +655,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200Model201ModelDefaultError400ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200Model201ModelDefaultError400ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200Model201ModelDefaultError400ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -565,7 +663,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError400ValidAsync() {
+    public Observable<A> get200Model201ModelDefaultError400ValidAsync() {
+        return get200Model201ModelDefaultError400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200Model201ModelDefaultError400ValidAsyncWithServiceResponse() {
         return service.get200Model201ModelDefaultError400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -595,8 +707,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Object object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Object> get200ModelA201ModelC404ModelDDefaultError200Valid() throws ErrorException, IOException {
-        return get200ModelA201ModelC404ModelDDefaultError200ValidAsync().toBlocking().single();
+    public Object get200ModelA201ModelC404ModelDDefaultError200Valid() throws ErrorException, IOException {
+        return get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -606,7 +718,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync(final ServiceCallback<Object> serviceCallback) {
-        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError200ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -614,7 +726,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidAsync() {
+    public Observable<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync() {
+        return get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Object>, Object>() {
+            @Override
+            public Object call(ServiceResponse<Object> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @return the observable to the Object object
+     */
+    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidAsyncWithServiceResponse() {
         return service.get200ModelA201ModelC404ModelDDefaultError200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Object>>>() {
                 @Override
@@ -645,8 +771,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Object object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Object> get200ModelA201ModelC404ModelDDefaultError201Valid() throws ErrorException, IOException {
-        return get200ModelA201ModelC404ModelDDefaultError201ValidAsync().toBlocking().single();
+    public Object get200ModelA201ModelC404ModelDDefaultError201Valid() throws ErrorException, IOException {
+        return get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -656,7 +782,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync(final ServiceCallback<Object> serviceCallback) {
-        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError201ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -664,7 +790,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidAsync() {
+    public Observable<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync() {
+        return get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Object>, Object>() {
+            @Override
+            public Object call(ServiceResponse<Object> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     *
+     * @return the observable to the Object object
+     */
+    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidAsyncWithServiceResponse() {
         return service.get200ModelA201ModelC404ModelDDefaultError201Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Object>>>() {
                 @Override
@@ -695,8 +835,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Object object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Object> get200ModelA201ModelC404ModelDDefaultError404Valid() throws ErrorException, IOException {
-        return get200ModelA201ModelC404ModelDDefaultError404ValidAsync().toBlocking().single();
+    public Object get200ModelA201ModelC404ModelDDefaultError404Valid() throws ErrorException, IOException {
+        return get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -706,7 +846,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync(final ServiceCallback<Object> serviceCallback) {
-        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError404ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -714,7 +854,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidAsync() {
+    public Observable<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync() {
+        return get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Object>, Object>() {
+            @Override
+            public Object call(ServiceResponse<Object> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     *
+     * @return the observable to the Object object
+     */
+    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidAsyncWithServiceResponse() {
         return service.get200ModelA201ModelC404ModelDDefaultError404Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Object>>>() {
                 @Override
@@ -745,8 +899,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Object object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Object> get200ModelA201ModelC404ModelDDefaultError400Valid() throws ErrorException, IOException {
-        return get200ModelA201ModelC404ModelDDefaultError400ValidAsync().toBlocking().single();
+    public Object get200ModelA201ModelC404ModelDDefaultError400Valid() throws ErrorException, IOException {
+        return get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -756,7 +910,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync(final ServiceCallback<Object> serviceCallback) {
-        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError400ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -764,7 +918,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the Object object
      */
-    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidAsync() {
+    public Observable<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync() {
+        return get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Object>, Object>() {
+            @Override
+            public Object call(ServiceResponse<Object> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @return the observable to the Object object
+     */
+    public Observable<ServiceResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidAsyncWithServiceResponse() {
         return service.get200ModelA201ModelC404ModelDDefaultError400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Object>>>() {
                 @Override
@@ -795,8 +963,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get202None204NoneDefaultError202None() throws ErrorException, IOException {
-        return get202None204NoneDefaultError202NoneAsync().toBlocking().single();
+    public void get202None204NoneDefaultError202None() throws ErrorException, IOException {
+        get202None204NoneDefaultError202NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -806,7 +974,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultError202NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultError202NoneAsync(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultError202NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -814,7 +982,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError202NoneAsync() {
+    public Observable<Void> get202None204NoneDefaultError202NoneAsync() {
+        return get202None204NoneDefaultError202NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 202 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError202NoneAsyncWithServiceResponse() {
         return service.get202None204NoneDefaultError202None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -844,8 +1026,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get202None204NoneDefaultError204None() throws ErrorException, IOException {
-        return get202None204NoneDefaultError204NoneAsync().toBlocking().single();
+    public void get202None204NoneDefaultError204None() throws ErrorException, IOException {
+        get202None204NoneDefaultError204NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -855,7 +1037,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultError204NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultError204NoneAsync(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultError204NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -863,7 +1045,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError204NoneAsync() {
+    public Observable<Void> get202None204NoneDefaultError204NoneAsync() {
+        return get202None204NoneDefaultError204NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError204NoneAsyncWithServiceResponse() {
         return service.get202None204NoneDefaultError204None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -893,8 +1089,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get202None204NoneDefaultError400Valid() throws ErrorException, IOException {
-        return get202None204NoneDefaultError400ValidAsync().toBlocking().single();
+    public void get202None204NoneDefaultError400Valid() throws ErrorException, IOException {
+        get202None204NoneDefaultError400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -904,7 +1100,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultError400ValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultError400ValidAsync(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultError400ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -912,7 +1108,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError400ValidAsync() {
+    public Observable<Void> get202None204NoneDefaultError400ValidAsync() {
+        return get202None204NoneDefaultError400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultError400ValidAsyncWithServiceResponse() {
         return service.get202None204NoneDefaultError400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -942,8 +1152,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get202None204NoneDefaultNone202Invalid() throws ServiceException, IOException {
-        return get202None204NoneDefaultNone202InvalidAsync().toBlocking().single();
+    public void get202None204NoneDefaultNone202Invalid() throws ServiceException, IOException {
+        get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -953,7 +1163,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultNone202InvalidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultNone202InvalidAsync(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -961,7 +1171,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone202InvalidAsync() {
+    public Observable<Void> get202None204NoneDefaultNone202InvalidAsync() {
+        return get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone202InvalidAsyncWithServiceResponse() {
         return service.get202None204NoneDefaultNone202Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -990,8 +1214,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get202None204NoneDefaultNone204None() throws ServiceException, IOException {
-        return get202None204NoneDefaultNone204NoneAsync().toBlocking().single();
+    public void get202None204NoneDefaultNone204None() throws ServiceException, IOException {
+        get202None204NoneDefaultNone204NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1001,7 +1225,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultNone204NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultNone204NoneAsync(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultNone204NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1009,7 +1233,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone204NoneAsync() {
+    public Observable<Void> get202None204NoneDefaultNone204NoneAsync() {
+        return get202None204NoneDefaultNone204NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone204NoneAsyncWithServiceResponse() {
         return service.get202None204NoneDefaultNone204None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1038,8 +1276,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get202None204NoneDefaultNone400None() throws ServiceException, IOException {
-        return get202None204NoneDefaultNone400NoneAsync().toBlocking().single();
+    public void get202None204NoneDefaultNone400None() throws ServiceException, IOException {
+        get202None204NoneDefaultNone400NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1049,7 +1287,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultNone400NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultNone400NoneAsync(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultNone400NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1057,7 +1295,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400NoneAsync() {
+    public Observable<Void> get202None204NoneDefaultNone400NoneAsync() {
+        return get202None204NoneDefaultNone400NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400NoneAsyncWithServiceResponse() {
         return service.get202None204NoneDefaultNone400None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1086,8 +1338,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> get202None204NoneDefaultNone400Invalid() throws ServiceException, IOException {
-        return get202None204NoneDefaultNone400InvalidAsync().toBlocking().single();
+    public void get202None204NoneDefaultNone400Invalid() throws ServiceException, IOException {
+        get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1097,7 +1349,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> get202None204NoneDefaultNone400InvalidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(get202None204NoneDefaultNone400InvalidAsync(), serviceCallback);
+        return ServiceCall.create(get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1105,7 +1357,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400InvalidAsync() {
+    public Observable<Void> get202None204NoneDefaultNone400InvalidAsync() {
+        return get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> get202None204NoneDefaultNone400InvalidAsyncWithServiceResponse() {
         return service.get202None204NoneDefaultNone400Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1134,8 +1400,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> getDefaultModelA200Valid() throws MyException, IOException {
-        return getDefaultModelA200ValidAsync().toBlocking().single();
+    public A getDefaultModelA200Valid() throws MyException, IOException {
+        return getDefaultModelA200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1145,7 +1411,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> getDefaultModelA200ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(getDefaultModelA200ValidAsync(), serviceCallback);
+        return ServiceCall.create(getDefaultModelA200ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1153,7 +1419,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> getDefaultModelA200ValidAsync() {
+    public Observable<A> getDefaultModelA200ValidAsync() {
+        return getDefaultModelA200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> getDefaultModelA200ValidAsyncWithServiceResponse() {
         return service.getDefaultModelA200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1181,8 +1461,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> getDefaultModelA200None() throws MyException, IOException {
-        return getDefaultModelA200NoneAsync().toBlocking().single();
+    public A getDefaultModelA200None() throws MyException, IOException {
+        return getDefaultModelA200NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1192,7 +1472,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> getDefaultModelA200NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(getDefaultModelA200NoneAsync(), serviceCallback);
+        return ServiceCall.create(getDefaultModelA200NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1200,7 +1480,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> getDefaultModelA200NoneAsync() {
+    public Observable<A> getDefaultModelA200NoneAsync() {
+        return getDefaultModelA200NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> getDefaultModelA200NoneAsyncWithServiceResponse() {
         return service.getDefaultModelA200None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1228,8 +1522,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> getDefaultModelA400Valid() throws MyException, IOException {
-        return getDefaultModelA400ValidAsync().toBlocking().single();
+    public A getDefaultModelA400Valid() throws MyException, IOException {
+        return getDefaultModelA400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1239,7 +1533,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> getDefaultModelA400ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(getDefaultModelA400ValidAsync(), serviceCallback);
+        return ServiceCall.create(getDefaultModelA400ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1247,7 +1541,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> getDefaultModelA400ValidAsync() {
+    public Observable<A> getDefaultModelA400ValidAsync() {
+        return getDefaultModelA400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> getDefaultModelA400ValidAsyncWithServiceResponse() {
         return service.getDefaultModelA400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1275,8 +1583,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> getDefaultModelA400None() throws MyException, IOException {
-        return getDefaultModelA400NoneAsync().toBlocking().single();
+    public A getDefaultModelA400None() throws MyException, IOException {
+        return getDefaultModelA400NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1286,7 +1594,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> getDefaultModelA400NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(getDefaultModelA400NoneAsync(), serviceCallback);
+        return ServiceCall.create(getDefaultModelA400NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1294,7 +1602,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> getDefaultModelA400NoneAsync() {
+    public Observable<A> getDefaultModelA400NoneAsync() {
+        return getDefaultModelA400NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> getDefaultModelA400NoneAsyncWithServiceResponse() {
         return service.getDefaultModelA400None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1322,8 +1644,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getDefaultNone200Invalid() throws ServiceException, IOException {
-        return getDefaultNone200InvalidAsync().toBlocking().single();
+    public void getDefaultNone200Invalid() throws ServiceException, IOException {
+        getDefaultNone200InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1333,7 +1655,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getDefaultNone200InvalidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getDefaultNone200InvalidAsync(), serviceCallback);
+        return ServiceCall.create(getDefaultNone200InvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1341,7 +1663,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getDefaultNone200InvalidAsync() {
+    public Observable<Void> getDefaultNone200InvalidAsync() {
+        return getDefaultNone200InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getDefaultNone200InvalidAsyncWithServiceResponse() {
         return service.getDefaultNone200Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1368,8 +1704,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getDefaultNone200None() throws ServiceException, IOException {
-        return getDefaultNone200NoneAsync().toBlocking().single();
+    public void getDefaultNone200None() throws ServiceException, IOException {
+        getDefaultNone200NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1379,7 +1715,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getDefaultNone200NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getDefaultNone200NoneAsync(), serviceCallback);
+        return ServiceCall.create(getDefaultNone200NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1387,7 +1723,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getDefaultNone200NoneAsync() {
+    public Observable<Void> getDefaultNone200NoneAsync() {
+        return getDefaultNone200NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getDefaultNone200NoneAsyncWithServiceResponse() {
         return service.getDefaultNone200None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1414,8 +1764,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getDefaultNone400Invalid() throws ServiceException, IOException {
-        return getDefaultNone400InvalidAsync().toBlocking().single();
+    public void getDefaultNone400Invalid() throws ServiceException, IOException {
+        getDefaultNone400InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1425,7 +1775,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getDefaultNone400InvalidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getDefaultNone400InvalidAsync(), serviceCallback);
+        return ServiceCall.create(getDefaultNone400InvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1433,7 +1783,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getDefaultNone400InvalidAsync() {
+    public Observable<Void> getDefaultNone400InvalidAsync() {
+        return getDefaultNone400InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getDefaultNone400InvalidAsyncWithServiceResponse() {
         return service.getDefaultNone400Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1460,8 +1824,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getDefaultNone400None() throws ServiceException, IOException {
-        return getDefaultNone400NoneAsync().toBlocking().single();
+    public void getDefaultNone400None() throws ServiceException, IOException {
+        getDefaultNone400NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1471,7 +1835,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getDefaultNone400NoneAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getDefaultNone400NoneAsync(), serviceCallback);
+        return ServiceCall.create(getDefaultNone400NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1479,7 +1843,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getDefaultNone400NoneAsync() {
+    public Observable<Void> getDefaultNone400NoneAsync() {
+        return getDefaultNone400NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getDefaultNone400NoneAsyncWithServiceResponse() {
         return service.getDefaultNone400None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1506,8 +1884,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200ModelA200None() throws ServiceException, IOException {
-        return get200ModelA200NoneAsync().toBlocking().single();
+    public A get200ModelA200None() throws ServiceException, IOException {
+        return get200ModelA200NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1517,7 +1895,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA200NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA200NoneAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA200NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1525,7 +1903,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA200NoneAsync() {
+    public Observable<A> get200ModelA200NoneAsync() {
+        return get200ModelA200NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200ModelA200NoneAsyncWithServiceResponse() {
         return service.get200ModelA200None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1553,8 +1945,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200ModelA200Valid() throws ServiceException, IOException {
-        return get200ModelA200ValidAsync().toBlocking().single();
+    public A get200ModelA200Valid() throws ServiceException, IOException {
+        return get200ModelA200ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1564,7 +1956,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA200ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA200ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA200ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1572,7 +1964,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA200ValidAsync() {
+    public Observable<A> get200ModelA200ValidAsync() {
+        return get200ModelA200ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200ModelA200ValidAsyncWithServiceResponse() {
         return service.get200ModelA200Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1600,8 +2006,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200ModelA200Invalid() throws ServiceException, IOException {
-        return get200ModelA200InvalidAsync().toBlocking().single();
+    public A get200ModelA200Invalid() throws ServiceException, IOException {
+        return get200ModelA200InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1611,7 +2017,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA200InvalidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA200InvalidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA200InvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1619,7 +2025,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA200InvalidAsync() {
+    public Observable<A> get200ModelA200InvalidAsync() {
+        return get200ModelA200InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200ModelA200InvalidAsyncWithServiceResponse() {
         return service.get200ModelA200Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1647,8 +2067,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200ModelA400None() throws ServiceException, IOException {
-        return get200ModelA400NoneAsync().toBlocking().single();
+    public A get200ModelA400None() throws ServiceException, IOException {
+        return get200ModelA400NoneAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1658,7 +2078,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA400NoneAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA400NoneAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA400NoneAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1666,7 +2086,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA400NoneAsync() {
+    public Observable<A> get200ModelA400NoneAsync() {
+        return get200ModelA400NoneAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200ModelA400NoneAsyncWithServiceResponse() {
         return service.get200ModelA400None()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1694,8 +2128,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200ModelA400Valid() throws ServiceException, IOException {
-        return get200ModelA400ValidAsync().toBlocking().single();
+    public A get200ModelA400Valid() throws ServiceException, IOException {
+        return get200ModelA400ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1705,7 +2139,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA400ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA400ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA400ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1713,7 +2147,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA400ValidAsync() {
+    public Observable<A> get200ModelA400ValidAsync() {
+        return get200ModelA400ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200ModelA400ValidAsyncWithServiceResponse() {
         return service.get200ModelA400Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1741,8 +2189,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200ModelA400Invalid() throws ServiceException, IOException {
-        return get200ModelA400InvalidAsync().toBlocking().single();
+    public A get200ModelA400Invalid() throws ServiceException, IOException {
+        return get200ModelA400InvalidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1752,7 +2200,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA400InvalidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA400InvalidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA400InvalidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1760,7 +2208,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA400InvalidAsync() {
+    public Observable<A> get200ModelA400InvalidAsync() {
+        return get200ModelA400InvalidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200ModelA400InvalidAsyncWithServiceResponse() {
         return service.get200ModelA400Invalid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override
@@ -1788,8 +2250,8 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the A object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<A> get200ModelA202Valid() throws ServiceException, IOException {
-        return get200ModelA202ValidAsync().toBlocking().single();
+    public A get200ModelA202Valid() throws ServiceException, IOException {
+        return get200ModelA202ValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1799,7 +2261,7 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<A> get200ModelA202ValidAsync(final ServiceCallback<A> serviceCallback) {
-        return ServiceCall.create(get200ModelA202ValidAsync(), serviceCallback);
+        return ServiceCall.create(get200ModelA202ValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1807,7 +2269,21 @@ public final class MultipleResponsesImpl implements MultipleResponses {
      *
      * @return the observable to the A object
      */
-    public Observable<ServiceResponse<A>> get200ModelA202ValidAsync() {
+    public Observable<A> get200ModelA202ValidAsync() {
+        return get200ModelA202ValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<A>, A>() {
+            @Override
+            public A call(ServiceResponse<A> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     *
+     * @return the observable to the A object
+     */
+    public Observable<ServiceResponse<A>> get200ModelA202ValidAsyncWithServiceResponse() {
         return service.get200ModelA202Valid()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<A>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
@@ -40,7 +40,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putArray() throws ErrorException, IOException;
+    void putArray() throws ErrorException, IOException;
 
     /**
      * Put External Resource as an Array.
@@ -49,6 +49,22 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putArrayAsync();
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse();
     /**
      * Put External Resource as an Array.
      *
@@ -57,7 +73,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putArray(List<Resource> resourceArray) throws ErrorException, IOException;
+    void putArray(List<Resource> resourceArray) throws ErrorException, IOException;
 
     /**
      * Put External Resource as an Array.
@@ -74,7 +90,15 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayAsync(List<Resource> resourceArray);
+    Observable<Void> putArrayAsync(List<Resource> resourceArray);
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse(List<Resource> resourceArray);
 
     /**
      * Get External Resource as an Array.
@@ -83,7 +107,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<List<FlattenedProduct>> getArray() throws ErrorException, IOException;
+    List<FlattenedProduct> getArray() throws ErrorException, IOException;
 
     /**
      * Get External Resource as an Array.
@@ -98,7 +122,14 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
-    Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsync();
+    Observable<List<FlattenedProduct>> getArrayAsync();
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @return the observable to the List&lt;FlattenedProduct&gt; object
+     */
+    Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsyncWithServiceResponse();
 
     /**
      * Put External Resource as a Dictionary.
@@ -107,7 +138,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDictionary() throws ErrorException, IOException;
+    void putDictionary() throws ErrorException, IOException;
 
     /**
      * Put External Resource as a Dictionary.
@@ -116,6 +147,22 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putDictionaryAsync();
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse();
     /**
      * Put External Resource as a Dictionary.
      *
@@ -124,7 +171,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException;
+    void putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException;
 
     /**
      * Put External Resource as a Dictionary.
@@ -141,7 +188,15 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary);
+    Observable<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary);
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse(Map<String, FlattenedProduct> resourceDictionary);
 
     /**
      * Get External Resource as a Dictionary.
@@ -150,7 +205,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, FlattenedProduct>> getDictionary() throws ErrorException, IOException;
+    Map<String, FlattenedProduct> getDictionary() throws ErrorException, IOException;
 
     /**
      * Get External Resource as a Dictionary.
@@ -165,7 +220,14 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
-    Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsync();
+    Observable<Map<String, FlattenedProduct>> getDictionaryAsync();
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
+     */
+    Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsyncWithServiceResponse();
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -174,7 +236,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putResourceCollection() throws ErrorException, IOException;
+    void putResourceCollection() throws ErrorException, IOException;
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -183,6 +245,22 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putResourceCollectionAsync();
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse();
     /**
      * Put External Resource as a ResourceCollection.
      *
@@ -191,7 +269,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException;
+    void putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException;
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -208,7 +286,15 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putResourceCollectionAsync(ResourceCollection resourceComplexObject);
+    Observable<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject);
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse(ResourceCollection resourceComplexObject);
 
     /**
      * Get External Resource as a ResourceCollection.
@@ -217,7 +303,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ResourceCollection object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<ResourceCollection> getResourceCollection() throws ErrorException, IOException;
+    ResourceCollection getResourceCollection() throws ErrorException, IOException;
 
     /**
      * Get External Resource as a ResourceCollection.
@@ -232,7 +318,14 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the ResourceCollection object
      */
-    Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsync();
+    Observable<ResourceCollection> getResourceCollectionAsync();
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @return the observable to the ResourceCollection object
+     */
+    Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsyncWithServiceResponse();
 
     /**
      * Put Simple Product with client flattening true on the model.
@@ -241,7 +334,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SimpleProduct> putSimpleProduct() throws ErrorException, IOException;
+    SimpleProduct putSimpleProduct() throws ErrorException, IOException;
 
     /**
      * Put Simple Product with client flattening true on the model.
@@ -250,6 +343,22 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<SimpleProduct> putSimpleProductAsync(final ServiceCallback<SimpleProduct> serviceCallback);
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param simpleBodyProduct Simple body product to put
+     * @return the observable to the SimpleProduct object
+     */
+    Observable<SimpleProduct> putSimpleProductAsync();
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param simpleBodyProduct Simple body product to put
+     * @return the observable to the SimpleProduct object
+     */
+    Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsyncWithServiceResponse();
     /**
      * Put Simple Product with client flattening true on the model.
      *
@@ -258,7 +367,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SimpleProduct> putSimpleProduct(SimpleProduct simpleBodyProduct) throws ErrorException, IOException;
+    SimpleProduct putSimpleProduct(SimpleProduct simpleBodyProduct) throws ErrorException, IOException;
 
     /**
      * Put Simple Product with client flattening true on the model.
@@ -275,7 +384,15 @@ public interface AutoRestResourceFlatteningTestService {
      * @param simpleBodyProduct Simple body product to put
      * @return the observable to the SimpleProduct object
      */
-    Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsync(SimpleProduct simpleBodyProduct);
+    Observable<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct);
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param simpleBodyProduct Simple body product to put
+     * @return the observable to the SimpleProduct object
+     */
+    Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsyncWithServiceResponse(SimpleProduct simpleBodyProduct);
 
     /**
      * Put Flattened Simple Product with client flattening true on the parameter.
@@ -287,7 +404,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SimpleProduct> postFlattenedSimpleProduct(String productId, String maxProductDisplayName) throws ErrorException, IOException, IllegalArgumentException;
+    SimpleProduct postFlattenedSimpleProduct(String productId, String maxProductDisplayName) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put Flattened Simple Product with client flattening true on the parameter.
@@ -298,6 +415,30 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, final ServiceCallback<SimpleProduct> serviceCallback);
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @param description Description of product.
+     * @param genericValue Generic URL value.
+     * @param odatavalue URL value.
+     * @return the observable to the SimpleProduct object
+     */
+    Observable<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName);
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @param description Description of product.
+     * @param genericValue Generic URL value.
+     * @param odatavalue URL value.
+     * @return the observable to the SimpleProduct object
+     */
+    Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsyncWithServiceResponse(String productId, String maxProductDisplayName);
     /**
      * Put Flattened Simple Product with client flattening true on the parameter.
      *
@@ -311,7 +452,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SimpleProduct> postFlattenedSimpleProduct(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) throws ErrorException, IOException, IllegalArgumentException;
+    SimpleProduct postFlattenedSimpleProduct(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put Flattened Simple Product with client flattening true on the parameter.
@@ -336,7 +477,19 @@ public interface AutoRestResourceFlatteningTestService {
      * @param odatavalue URL value.
      * @return the observable to the SimpleProduct object
      */
-    Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue);
+    Observable<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue);
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @param description Description of product.
+     * @param genericValue Generic URL value.
+     * @param odatavalue URL value.
+     * @return the observable to the SimpleProduct object
+     */
+    Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsyncWithServiceResponse(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue);
 
     /**
      * Put Simple Product with client flattening true on the model.
@@ -347,7 +500,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<SimpleProduct> putSimpleProductWithGrouping(FlattenParameterGroup flattenParameterGroup) throws ErrorException, IOException, IllegalArgumentException;
+    SimpleProduct putSimpleProductWithGrouping(FlattenParameterGroup flattenParameterGroup) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Put Simple Product with client flattening true on the model.
@@ -364,6 +517,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @param flattenParameterGroup Additional parameters for the operation
      * @return the observable to the SimpleProduct object
      */
-    Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup);
+    Observable<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup);
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param flattenParameterGroup Additional parameters for the operation
+     * @return the observable to the SimpleProduct object
+     */
+    Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithGroupingAsyncWithServiceResponse(FlattenParameterGroup flattenParameterGroup);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
@@ -38,7 +38,6 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putArray() throws ErrorException, IOException;
 
@@ -53,7 +52,6 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as an Array.
      *
-     * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putArrayAsync();
@@ -61,17 +59,15 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as an Array.
      *
-     * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync();
     /**
      * Put External Resource as an Array.
      *
      * @param resourceArray External Resource as an Array to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putArray(List<Resource> resourceArray) throws ErrorException, IOException;
 
@@ -98,14 +94,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse(List<Resource> resourceArray);
+    Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync(List<Resource> resourceArray);
 
     /**
      * Get External Resource as an Array.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;FlattenedProduct&gt; object if successful.
      */
     List<FlattenedProduct> getArray() throws ErrorException, IOException;
 
@@ -129,14 +125,13 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
-    Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsyncWithServiceResponse();
+    Observable<ServiceResponse<List<FlattenedProduct>>> getArrayWithServiceResponseAsync();
 
     /**
      * Put External Resource as a Dictionary.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDictionary() throws ErrorException, IOException;
 
@@ -151,7 +146,6 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as a Dictionary.
      *
-     * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putDictionaryAsync();
@@ -159,17 +153,15 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as a Dictionary.
      *
-     * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync();
     /**
      * Put External Resource as a Dictionary.
      *
      * @param resourceDictionary External Resource as a Dictionary to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException;
 
@@ -196,14 +188,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse(Map<String, FlattenedProduct> resourceDictionary);
+    Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync(Map<String, FlattenedProduct> resourceDictionary);
 
     /**
      * Get External Resource as a Dictionary.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, FlattenedProduct&gt; object if successful.
      */
     Map<String, FlattenedProduct> getDictionary() throws ErrorException, IOException;
 
@@ -227,14 +219,13 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
-    Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryWithServiceResponseAsync();
 
     /**
      * Put External Resource as a ResourceCollection.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putResourceCollection() throws ErrorException, IOException;
 
@@ -249,7 +240,6 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as a ResourceCollection.
      *
-     * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putResourceCollectionAsync();
@@ -257,17 +247,15 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put External Resource as a ResourceCollection.
      *
-     * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync();
     /**
      * Put External Resource as a ResourceCollection.
      *
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException;
 
@@ -294,14 +282,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse(ResourceCollection resourceComplexObject);
+    Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync(ResourceCollection resourceComplexObject);
 
     /**
      * Get External Resource as a ResourceCollection.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ResourceCollection object wrapped in {@link ServiceResponse} if successful.
+     * @return the ResourceCollection object if successful.
      */
     ResourceCollection getResourceCollection() throws ErrorException, IOException;
 
@@ -325,14 +313,14 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @return the observable to the ResourceCollection object
      */
-    Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsyncWithServiceResponse();
+    Observable<ServiceResponse<ResourceCollection>> getResourceCollectionWithServiceResponseAsync();
 
     /**
      * Put Simple Product with client flattening true on the model.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     SimpleProduct putSimpleProduct() throws ErrorException, IOException;
 
@@ -347,7 +335,6 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put Simple Product with client flattening true on the model.
      *
-     * @param simpleBodyProduct Simple body product to put
      * @return the observable to the SimpleProduct object
      */
     Observable<SimpleProduct> putSimpleProductAsync();
@@ -355,17 +342,16 @@ public interface AutoRestResourceFlatteningTestService {
     /**
      * Put Simple Product with client flattening true on the model.
      *
-     * @param simpleBodyProduct Simple body product to put
      * @return the observable to the SimpleProduct object
      */
-    Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsyncWithServiceResponse();
+    Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithServiceResponseAsync();
     /**
      * Put Simple Product with client flattening true on the model.
      *
      * @param simpleBodyProduct Simple body product to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     SimpleProduct putSimpleProduct(SimpleProduct simpleBodyProduct) throws ErrorException, IOException;
 
@@ -392,7 +378,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @param simpleBodyProduct Simple body product to put
      * @return the observable to the SimpleProduct object
      */
-    Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsyncWithServiceResponse(SimpleProduct simpleBodyProduct);
+    Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithServiceResponseAsync(SimpleProduct simpleBodyProduct);
 
     /**
      * Put Flattened Simple Product with client flattening true on the parameter.
@@ -402,7 +388,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     SimpleProduct postFlattenedSimpleProduct(String productId, String maxProductDisplayName) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -421,9 +407,6 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
      * @param maxProductDisplayName Display name of product.
-     * @param description Description of product.
-     * @param genericValue Generic URL value.
-     * @param odatavalue URL value.
      * @return the observable to the SimpleProduct object
      */
     Observable<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName);
@@ -433,12 +416,9 @@ public interface AutoRestResourceFlatteningTestService {
      *
      * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
      * @param maxProductDisplayName Display name of product.
-     * @param description Description of product.
-     * @param genericValue Generic URL value.
-     * @param odatavalue URL value.
      * @return the observable to the SimpleProduct object
      */
-    Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsyncWithServiceResponse(String productId, String maxProductDisplayName);
+    Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductWithServiceResponseAsync(String productId, String maxProductDisplayName);
     /**
      * Put Flattened Simple Product with client flattening true on the parameter.
      *
@@ -450,7 +430,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     SimpleProduct postFlattenedSimpleProduct(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -489,7 +469,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @param odatavalue URL value.
      * @return the observable to the SimpleProduct object
      */
-    Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsyncWithServiceResponse(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue);
+    Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductWithServiceResponseAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue);
 
     /**
      * Put Simple Product with client flattening true on the model.
@@ -498,7 +478,7 @@ public interface AutoRestResourceFlatteningTestService {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     SimpleProduct putSimpleProductWithGrouping(FlattenParameterGroup flattenParameterGroup) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -525,6 +505,6 @@ public interface AutoRestResourceFlatteningTestService {
      * @param flattenParameterGroup Additional parameters for the operation
      * @return the observable to the SimpleProduct object
      */
-    Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithGroupingAsyncWithServiceResponse(FlattenParameterGroup flattenParameterGroup);
+    Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithGroupingWithServiceResponseAsync(FlattenParameterGroup flattenParameterGroup);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -145,10 +145,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putArray() throws ErrorException, IOException {
-        putArrayAsyncWithServiceResponse().toBlocking().single().getBody();
+        putArrayWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -158,7 +157,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(putArrayWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -167,12 +166,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putArrayAsync() {
-        return putArrayAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return putArrayWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -180,7 +179,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync() {
         final List<Resource> resourceArray = null;
         return service.putArray(resourceArray)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -202,10 +201,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceArray External Resource as an Array to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putArray(List<Resource> resourceArray) throws ErrorException, IOException {
-        putArrayAsyncWithServiceResponse().toBlocking().single().getBody();
+        putArrayWithServiceResponseAsync(resourceArray).toBlocking().single().getBody();
     }
 
     /**
@@ -216,21 +214,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayAsync(List<Resource> resourceArray, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayAsyncWithServiceResponse(resourceArray), serviceCallback);
-    }
-
-    /**
-     * Put External Resource as an Array.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> putArrayAsync(List<Resource> resourceArray) {
-        return putArrayAsyncWithServiceResponse(resourceArray).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(putArrayWithServiceResponseAsync(resourceArray), serviceCallback);
     }
 
     /**
@@ -239,7 +223,22 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse(List<Resource> resourceArray) {
+    public Observable<Void> putArrayAsync(List<Resource> resourceArray) {
+        return putArrayWithServiceResponseAsync(resourceArray).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putArrayWithServiceResponseAsync(List<Resource> resourceArray) {
         Validator.validate(resourceArray);
         return service.putArray(resourceArray)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -267,10 +266,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the List&lt;FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the List&lt;FlattenedProduct&gt; object if successful.
      */
     public List<FlattenedProduct> getArray() throws ErrorException, IOException {
-        return getArrayAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getArrayWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -280,7 +279,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<FlattenedProduct>> getArrayAsync(final ServiceCallback<List<FlattenedProduct>> serviceCallback) {
-        return ServiceCall.create(getArrayAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getArrayWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -289,12 +288,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
     public Observable<List<FlattenedProduct>> getArrayAsync() {
-        return getArrayAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<FlattenedProduct>>, List<FlattenedProduct>>() {
+        return getArrayWithServiceResponseAsync().map(new Func1<ServiceResponse<List<FlattenedProduct>>, List<FlattenedProduct>>() {
             @Override
             public List<FlattenedProduct> call(ServiceResponse<List<FlattenedProduct>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -302,7 +301,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
-    public Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<List<FlattenedProduct>>> getArrayWithServiceResponseAsync() {
         return service.getArray()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<FlattenedProduct>>>>() {
                 @Override
@@ -329,10 +328,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDictionary() throws ErrorException, IOException {
-        putDictionaryAsyncWithServiceResponse().toBlocking().single().getBody();
+        putDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -342,7 +340,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(putDictionaryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -351,12 +349,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putDictionaryAsync() {
-        return putDictionaryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return putDictionaryWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -364,7 +362,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync() {
         final Map<String, FlattenedProduct> resourceDictionary = null;
         return service.putDictionary(resourceDictionary)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -386,10 +384,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceDictionary External Resource as a Dictionary to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException {
-        putDictionaryAsyncWithServiceResponse().toBlocking().single().getBody();
+        putDictionaryWithServiceResponseAsync(resourceDictionary).toBlocking().single().getBody();
     }
 
     /**
@@ -400,21 +397,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryAsyncWithServiceResponse(resourceDictionary), serviceCallback);
-    }
-
-    /**
-     * Put External Resource as a Dictionary.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
-        return putDictionaryAsyncWithServiceResponse(resourceDictionary).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(putDictionaryWithServiceResponseAsync(resourceDictionary), serviceCallback);
     }
 
     /**
@@ -423,7 +406,22 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse(Map<String, FlattenedProduct> resourceDictionary) {
+    public Observable<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+        return putDictionaryWithServiceResponseAsync(resourceDictionary).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDictionaryWithServiceResponseAsync(Map<String, FlattenedProduct> resourceDictionary) {
         Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -451,10 +449,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, FlattenedProduct&gt; object if successful.
      */
     public Map<String, FlattenedProduct> getDictionary() throws ErrorException, IOException {
-        return getDictionaryAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getDictionaryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -464,7 +462,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, FlattenedProduct>> getDictionaryAsync(final ServiceCallback<Map<String, FlattenedProduct>> serviceCallback) {
-        return ServiceCall.create(getDictionaryAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getDictionaryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -473,12 +471,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
     public Observable<Map<String, FlattenedProduct>> getDictionaryAsync() {
-        return getDictionaryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, FlattenedProduct>>, Map<String, FlattenedProduct>>() {
+        return getDictionaryWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, FlattenedProduct>>, Map<String, FlattenedProduct>>() {
             @Override
             public Map<String, FlattenedProduct> call(ServiceResponse<Map<String, FlattenedProduct>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -486,7 +484,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
-    public Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryWithServiceResponseAsync() {
         return service.getDictionary()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, FlattenedProduct>>>>() {
                 @Override
@@ -513,10 +511,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putResourceCollection() throws ErrorException, IOException {
-        putResourceCollectionAsyncWithServiceResponse().toBlocking().single().getBody();
+        putResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -526,7 +523,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putResourceCollectionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(putResourceCollectionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -535,12 +532,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putResourceCollectionAsync() {
-        return putResourceCollectionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return putResourceCollectionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -548,7 +545,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync() {
         final ResourceCollection resourceComplexObject = null;
         return service.putResourceCollection(resourceComplexObject)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -570,10 +567,9 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException {
-        putResourceCollectionAsyncWithServiceResponse().toBlocking().single().getBody();
+        putResourceCollectionWithServiceResponseAsync(resourceComplexObject).toBlocking().single().getBody();
     }
 
     /**
@@ -584,21 +580,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putResourceCollectionAsyncWithServiceResponse(resourceComplexObject), serviceCallback);
-    }
-
-    /**
-     * Put External Resource as a ResourceCollection.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
-        return putResourceCollectionAsyncWithServiceResponse(resourceComplexObject).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(putResourceCollectionWithServiceResponseAsync(resourceComplexObject), serviceCallback);
     }
 
     /**
@@ -607,7 +589,22 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse(ResourceCollection resourceComplexObject) {
+    public Observable<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+        return putResourceCollectionWithServiceResponseAsync(resourceComplexObject).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putResourceCollectionWithServiceResponseAsync(ResourceCollection resourceComplexObject) {
         Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -635,10 +632,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the ResourceCollection object wrapped in {@link ServiceResponse} if successful.
+     * @return the ResourceCollection object if successful.
      */
     public ResourceCollection getResourceCollection() throws ErrorException, IOException {
-        return getResourceCollectionAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getResourceCollectionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -648,7 +645,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ResourceCollection> getResourceCollectionAsync(final ServiceCallback<ResourceCollection> serviceCallback) {
-        return ServiceCall.create(getResourceCollectionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getResourceCollectionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -657,12 +654,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the observable to the ResourceCollection object
      */
     public Observable<ResourceCollection> getResourceCollectionAsync() {
-        return getResourceCollectionAsyncWithServiceResponse().map(new Func1<ServiceResponse<ResourceCollection>, ResourceCollection>() {
+        return getResourceCollectionWithServiceResponseAsync().map(new Func1<ServiceResponse<ResourceCollection>, ResourceCollection>() {
             @Override
             public ResourceCollection call(ServiceResponse<ResourceCollection> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -670,7 +667,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the observable to the ResourceCollection object
      */
-    public Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<ResourceCollection>> getResourceCollectionWithServiceResponseAsync() {
         return service.getResourceCollection()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ResourceCollection>>>() {
                 @Override
@@ -697,10 +694,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     public SimpleProduct putSimpleProduct() throws ErrorException, IOException {
-        return putSimpleProductAsyncWithServiceResponse().toBlocking().single().getBody();
+        return putSimpleProductWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -710,7 +707,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> putSimpleProductAsync(final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(putSimpleProductAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(putSimpleProductWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -719,12 +716,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the observable to the SimpleProduct object
      */
     public Observable<SimpleProduct> putSimpleProductAsync() {
-        return putSimpleProductAsyncWithServiceResponse().map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+        return putSimpleProductWithServiceResponseAsync().map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
             @Override
             public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -732,7 +729,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithServiceResponseAsync() {
         final SimpleProduct simpleBodyProduct = null;
         return service.putSimpleProduct(simpleBodyProduct)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SimpleProduct>>>() {
@@ -754,10 +751,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param simpleBodyProduct Simple body product to put
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     public SimpleProduct putSimpleProduct(SimpleProduct simpleBodyProduct) throws ErrorException, IOException {
-        return putSimpleProductAsyncWithServiceResponse().toBlocking().single().getBody();
+        return putSimpleProductWithServiceResponseAsync(simpleBodyProduct).toBlocking().single().getBody();
     }
 
     /**
@@ -768,21 +765,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct, final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(putSimpleProductAsyncWithServiceResponse(simpleBodyProduct), serviceCallback);
-    }
-
-    /**
-     * Put Simple Product with client flattening true on the model.
-     *
-     * @return the observable to the SimpleProduct object
-     */
-    public Observable<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct) {
-        return putSimpleProductAsyncWithServiceResponse(simpleBodyProduct).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
-            @Override
-            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(putSimpleProductWithServiceResponseAsync(simpleBodyProduct), serviceCallback);
     }
 
     /**
@@ -791,7 +774,22 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param simpleBodyProduct Simple body product to put
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsyncWithServiceResponse(SimpleProduct simpleBodyProduct) {
+    public Observable<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct) {
+        return putSimpleProductWithServiceResponseAsync(simpleBodyProduct).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+            @Override
+            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param simpleBodyProduct Simple body product to put
+     * @return the observable to the SimpleProduct object
+     */
+    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithServiceResponseAsync(SimpleProduct simpleBodyProduct) {
         Validator.validate(simpleBodyProduct);
         return service.putSimpleProduct(simpleBodyProduct)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SimpleProduct>>>() {
@@ -822,10 +820,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     public SimpleProduct postFlattenedSimpleProduct(String productId, String maxProductDisplayName) throws ErrorException, IOException, IllegalArgumentException {
-        return postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName).toBlocking().single().getBody();
+        return postFlattenedSimpleProductWithServiceResponseAsync(productId, maxProductDisplayName).toBlocking().single().getBody();
     }
 
     /**
@@ -837,7 +835,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName), serviceCallback);
+        return ServiceCall.create(postFlattenedSimpleProductWithServiceResponseAsync(productId, maxProductDisplayName), serviceCallback);
     }
 
     /**
@@ -848,12 +846,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the observable to the SimpleProduct object
      */
     public Observable<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName) {
-        return postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+        return postFlattenedSimpleProductWithServiceResponseAsync(productId, maxProductDisplayName).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
             @Override
             public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -863,7 +861,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param maxProductDisplayName Display name of product.
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsyncWithServiceResponse(String productId, String maxProductDisplayName) {
+    public Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductWithServiceResponseAsync(String productId, String maxProductDisplayName) {
         if (productId == null) {
             throw new IllegalArgumentException("Parameter productId is required and cannot be null.");
         }
@@ -904,10 +902,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     public SimpleProduct postFlattenedSimpleProduct(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) throws ErrorException, IOException, IllegalArgumentException {
-        return postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName).toBlocking().single().getBody();
+        return postFlattenedSimpleProductWithServiceResponseAsync(productId, maxProductDisplayName, description, genericValue, odatavalue).toBlocking().single().getBody();
     }
 
     /**
@@ -922,23 +920,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue, final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName, description, genericValue, odatavalue), serviceCallback);
-    }
-
-    /**
-     * Put Flattened Simple Product with client flattening true on the parameter.
-     *
-     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
-     * @param maxProductDisplayName Display name of product.
-     * @return the observable to the SimpleProduct object
-     */
-    public Observable<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
-        return postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName, description, genericValue, odatavalue).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
-            @Override
-            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postFlattenedSimpleProductWithServiceResponseAsync(productId, maxProductDisplayName, description, genericValue, odatavalue), serviceCallback);
     }
 
     /**
@@ -951,7 +933,26 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param odatavalue URL value.
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsyncWithServiceResponse(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
+    public Observable<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
+        return postFlattenedSimpleProductWithServiceResponseAsync(productId, maxProductDisplayName, description, genericValue, odatavalue).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+            @Override
+            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @param description Description of product.
+     * @param genericValue Generic URL value.
+     * @param odatavalue URL value.
+     * @return the observable to the SimpleProduct object
+     */
+    public Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductWithServiceResponseAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
         if (productId == null) {
             throw new IllegalArgumentException("Parameter productId is required and cannot be null.");
         }
@@ -995,10 +996,10 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
+     * @return the SimpleProduct object if successful.
      */
     public SimpleProduct putSimpleProductWithGrouping(FlattenParameterGroup flattenParameterGroup) throws ErrorException, IOException, IllegalArgumentException {
-        return putSimpleProductWithGroupingAsyncWithServiceResponse(flattenParameterGroup).toBlocking().single().getBody();
+        return putSimpleProductWithGroupingWithServiceResponseAsync(flattenParameterGroup).toBlocking().single().getBody();
     }
 
     /**
@@ -1009,7 +1010,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup, final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(putSimpleProductWithGroupingAsyncWithServiceResponse(flattenParameterGroup), serviceCallback);
+        return ServiceCall.create(putSimpleProductWithGroupingWithServiceResponseAsync(flattenParameterGroup), serviceCallback);
     }
 
     /**
@@ -1019,12 +1020,12 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the observable to the SimpleProduct object
      */
     public Observable<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup) {
-        return putSimpleProductWithGroupingAsyncWithServiceResponse(flattenParameterGroup).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+        return putSimpleProductWithGroupingWithServiceResponseAsync(flattenParameterGroup).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
             @Override
             public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1033,7 +1034,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param flattenParameterGroup Additional parameters for the operation
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithGroupingAsyncWithServiceResponse(FlattenParameterGroup flattenParameterGroup) {
+    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithGroupingWithServiceResponseAsync(FlattenParameterGroup flattenParameterGroup) {
         if (flattenParameterGroup == null) {
             throw new IllegalArgumentException("Parameter flattenParameterGroup is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -147,8 +147,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putArray() throws ErrorException, IOException {
-        return putArrayAsync().toBlocking().single();
+    public void putArray() throws ErrorException, IOException {
+        putArrayAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -158,7 +158,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayAsync(), serviceCallback);
+        return ServiceCall.create(putArrayAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -166,7 +166,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayAsync() {
+    public Observable<Void> putArrayAsync() {
+        return putArrayAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse() {
         final List<Resource> resourceArray = null;
         return service.putArray(resourceArray)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -190,8 +204,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putArray(List<Resource> resourceArray) throws ErrorException, IOException {
-        return putArrayAsync(resourceArray).toBlocking().single();
+    public void putArray(List<Resource> resourceArray) throws ErrorException, IOException {
+        putArrayAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -202,7 +216,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putArrayAsync(List<Resource> resourceArray, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putArrayAsync(resourceArray), serviceCallback);
+        return ServiceCall.create(putArrayAsyncWithServiceResponse(resourceArray), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putArrayAsync(List<Resource> resourceArray) {
+        return putArrayAsyncWithServiceResponse(resourceArray).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -211,7 +239,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceArray External Resource as an Array to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putArrayAsync(List<Resource> resourceArray) {
+    public Observable<ServiceResponse<Void>> putArrayAsyncWithServiceResponse(List<Resource> resourceArray) {
         Validator.validate(resourceArray);
         return service.putArray(resourceArray)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -241,8 +269,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the List&lt;FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<List<FlattenedProduct>> getArray() throws ErrorException, IOException {
-        return getArrayAsync().toBlocking().single();
+    public List<FlattenedProduct> getArray() throws ErrorException, IOException {
+        return getArrayAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -252,7 +280,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<List<FlattenedProduct>> getArrayAsync(final ServiceCallback<List<FlattenedProduct>> serviceCallback) {
-        return ServiceCall.create(getArrayAsync(), serviceCallback);
+        return ServiceCall.create(getArrayAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -260,7 +288,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
-    public Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsync() {
+    public Observable<List<FlattenedProduct>> getArrayAsync() {
+        return getArrayAsyncWithServiceResponse().map(new Func1<ServiceResponse<List<FlattenedProduct>>, List<FlattenedProduct>>() {
+            @Override
+            public List<FlattenedProduct> call(ServiceResponse<List<FlattenedProduct>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @return the observable to the List&lt;FlattenedProduct&gt; object
+     */
+    public Observable<ServiceResponse<List<FlattenedProduct>>> getArrayAsyncWithServiceResponse() {
         return service.getArray()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<List<FlattenedProduct>>>>() {
                 @Override
@@ -289,8 +331,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDictionary() throws ErrorException, IOException {
-        return putDictionaryAsync().toBlocking().single();
+    public void putDictionary() throws ErrorException, IOException {
+        putDictionaryAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -300,7 +342,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryAsync(), serviceCallback);
+        return ServiceCall.create(putDictionaryAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -308,7 +350,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryAsync() {
+    public Observable<Void> putDictionaryAsync() {
+        return putDictionaryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse() {
         final Map<String, FlattenedProduct> resourceDictionary = null;
         return service.putDictionary(resourceDictionary)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -332,8 +388,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException {
-        return putDictionaryAsync(resourceDictionary).toBlocking().single();
+    public void putDictionary(Map<String, FlattenedProduct> resourceDictionary) throws ErrorException, IOException {
+        putDictionaryAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -344,7 +400,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putDictionaryAsync(resourceDictionary), serviceCallback);
+        return ServiceCall.create(putDictionaryAsyncWithServiceResponse(resourceDictionary), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+        return putDictionaryAsyncWithServiceResponse(resourceDictionary).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -353,7 +423,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceDictionary External Resource as a Dictionary to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+    public Observable<ServiceResponse<Void>> putDictionaryAsyncWithServiceResponse(Map<String, FlattenedProduct> resourceDictionary) {
         Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -383,8 +453,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, FlattenedProduct&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, FlattenedProduct>> getDictionary() throws ErrorException, IOException {
-        return getDictionaryAsync().toBlocking().single();
+    public Map<String, FlattenedProduct> getDictionary() throws ErrorException, IOException {
+        return getDictionaryAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -394,7 +464,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, FlattenedProduct>> getDictionaryAsync(final ServiceCallback<Map<String, FlattenedProduct>> serviceCallback) {
-        return ServiceCall.create(getDictionaryAsync(), serviceCallback);
+        return ServiceCall.create(getDictionaryAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -402,7 +472,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
-    public Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsync() {
+    public Observable<Map<String, FlattenedProduct>> getDictionaryAsync() {
+        return getDictionaryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, FlattenedProduct>>, Map<String, FlattenedProduct>>() {
+            @Override
+            public Map<String, FlattenedProduct> call(ServiceResponse<Map<String, FlattenedProduct>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, FlattenedProduct>>> getDictionaryAsyncWithServiceResponse() {
         return service.getDictionary()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, FlattenedProduct>>>>() {
                 @Override
@@ -431,8 +515,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putResourceCollection() throws ErrorException, IOException {
-        return putResourceCollectionAsync().toBlocking().single();
+    public void putResourceCollection() throws ErrorException, IOException {
+        putResourceCollectionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -442,7 +526,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putResourceCollectionAsync(), serviceCallback);
+        return ServiceCall.create(putResourceCollectionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -450,7 +534,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putResourceCollectionAsync() {
+    public Observable<Void> putResourceCollectionAsync() {
+        return putResourceCollectionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse() {
         final ResourceCollection resourceComplexObject = null;
         return service.putResourceCollection(resourceComplexObject)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -474,8 +572,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException {
-        return putResourceCollectionAsync(resourceComplexObject).toBlocking().single();
+    public void putResourceCollection(ResourceCollection resourceComplexObject) throws ErrorException, IOException {
+        putResourceCollectionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -486,7 +584,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putResourceCollectionAsync(resourceComplexObject), serviceCallback);
+        return ServiceCall.create(putResourceCollectionAsyncWithServiceResponse(resourceComplexObject), serviceCallback);
+    }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+        return putResourceCollectionAsyncWithServiceResponse(resourceComplexObject).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -495,7 +607,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+    public Observable<ServiceResponse<Void>> putResourceCollectionAsyncWithServiceResponse(ResourceCollection resourceComplexObject) {
         Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -525,8 +637,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the ResourceCollection object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<ResourceCollection> getResourceCollection() throws ErrorException, IOException {
-        return getResourceCollectionAsync().toBlocking().single();
+    public ResourceCollection getResourceCollection() throws ErrorException, IOException {
+        return getResourceCollectionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -536,7 +648,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<ResourceCollection> getResourceCollectionAsync(final ServiceCallback<ResourceCollection> serviceCallback) {
-        return ServiceCall.create(getResourceCollectionAsync(), serviceCallback);
+        return ServiceCall.create(getResourceCollectionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -544,7 +656,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the observable to the ResourceCollection object
      */
-    public Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsync() {
+    public Observable<ResourceCollection> getResourceCollectionAsync() {
+        return getResourceCollectionAsyncWithServiceResponse().map(new Func1<ServiceResponse<ResourceCollection>, ResourceCollection>() {
+            @Override
+            public ResourceCollection call(ServiceResponse<ResourceCollection> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @return the observable to the ResourceCollection object
+     */
+    public Observable<ServiceResponse<ResourceCollection>> getResourceCollectionAsyncWithServiceResponse() {
         return service.getResourceCollection()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<ResourceCollection>>>() {
                 @Override
@@ -573,8 +699,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<SimpleProduct> putSimpleProduct() throws ErrorException, IOException {
-        return putSimpleProductAsync().toBlocking().single();
+    public SimpleProduct putSimpleProduct() throws ErrorException, IOException {
+        return putSimpleProductAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -584,7 +710,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> putSimpleProductAsync(final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(putSimpleProductAsync(), serviceCallback);
+        return ServiceCall.create(putSimpleProductAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -592,7 +718,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      *
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsync() {
+    public Observable<SimpleProduct> putSimpleProductAsync() {
+        return putSimpleProductAsyncWithServiceResponse().map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+            @Override
+            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @return the observable to the SimpleProduct object
+     */
+    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsyncWithServiceResponse() {
         final SimpleProduct simpleBodyProduct = null;
         return service.putSimpleProduct(simpleBodyProduct)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SimpleProduct>>>() {
@@ -616,8 +756,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IOException exception thrown from serialization/deserialization
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<SimpleProduct> putSimpleProduct(SimpleProduct simpleBodyProduct) throws ErrorException, IOException {
-        return putSimpleProductAsync(simpleBodyProduct).toBlocking().single();
+    public SimpleProduct putSimpleProduct(SimpleProduct simpleBodyProduct) throws ErrorException, IOException {
+        return putSimpleProductAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -628,7 +768,21 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct, final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(putSimpleProductAsync(simpleBodyProduct), serviceCallback);
+        return ServiceCall.create(putSimpleProductAsyncWithServiceResponse(simpleBodyProduct), serviceCallback);
+    }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @return the observable to the SimpleProduct object
+     */
+    public Observable<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct) {
+        return putSimpleProductAsyncWithServiceResponse(simpleBodyProduct).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+            @Override
+            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -637,7 +791,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param simpleBodyProduct Simple body product to put
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsync(SimpleProduct simpleBodyProduct) {
+    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductAsyncWithServiceResponse(SimpleProduct simpleBodyProduct) {
         Validator.validate(simpleBodyProduct);
         return service.putSimpleProduct(simpleBodyProduct)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<SimpleProduct>>>() {
@@ -670,8 +824,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<SimpleProduct> postFlattenedSimpleProduct(String productId, String maxProductDisplayName) throws ErrorException, IOException, IllegalArgumentException {
-        return postFlattenedSimpleProductAsync(productId, maxProductDisplayName).toBlocking().single();
+    public SimpleProduct postFlattenedSimpleProduct(String productId, String maxProductDisplayName) throws ErrorException, IOException, IllegalArgumentException {
+        return postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName).toBlocking().single().getBody();
     }
 
     /**
@@ -683,7 +837,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(postFlattenedSimpleProductAsync(productId, maxProductDisplayName), serviceCallback);
+        return ServiceCall.create(postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName), serviceCallback);
     }
 
     /**
@@ -693,7 +847,23 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param maxProductDisplayName Display name of product.
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName) {
+    public Observable<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName) {
+        return postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+            @Override
+            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @return the observable to the SimpleProduct object
+     */
+    public Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsyncWithServiceResponse(String productId, String maxProductDisplayName) {
         if (productId == null) {
             throw new IllegalArgumentException("Parameter productId is required and cannot be null.");
         }
@@ -736,8 +906,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<SimpleProduct> postFlattenedSimpleProduct(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) throws ErrorException, IOException, IllegalArgumentException {
-        return postFlattenedSimpleProductAsync(productId, maxProductDisplayName, description, genericValue, odatavalue).toBlocking().single();
+    public SimpleProduct postFlattenedSimpleProduct(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) throws ErrorException, IOException, IllegalArgumentException {
+        return postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName).toBlocking().single().getBody();
     }
 
     /**
@@ -752,7 +922,23 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue, final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(postFlattenedSimpleProductAsync(productId, maxProductDisplayName, description, genericValue, odatavalue), serviceCallback);
+        return ServiceCall.create(postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName, description, genericValue, odatavalue), serviceCallback);
+    }
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @return the observable to the SimpleProduct object
+     */
+    public Observable<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
+        return postFlattenedSimpleProductAsyncWithServiceResponse(productId, maxProductDisplayName, description, genericValue, odatavalue).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+            @Override
+            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -765,7 +951,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param odatavalue URL value.
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
+    public Observable<ServiceResponse<SimpleProduct>> postFlattenedSimpleProductAsyncWithServiceResponse(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
         if (productId == null) {
             throw new IllegalArgumentException("Parameter productId is required and cannot be null.");
         }
@@ -811,8 +997,8 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the SimpleProduct object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<SimpleProduct> putSimpleProductWithGrouping(FlattenParameterGroup flattenParameterGroup) throws ErrorException, IOException, IllegalArgumentException {
-        return putSimpleProductWithGroupingAsync(flattenParameterGroup).toBlocking().single();
+    public SimpleProduct putSimpleProductWithGrouping(FlattenParameterGroup flattenParameterGroup) throws ErrorException, IOException, IllegalArgumentException {
+        return putSimpleProductWithGroupingAsyncWithServiceResponse(flattenParameterGroup).toBlocking().single().getBody();
     }
 
     /**
@@ -823,7 +1009,7 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup, final ServiceCallback<SimpleProduct> serviceCallback) {
-        return ServiceCall.create(putSimpleProductWithGroupingAsync(flattenParameterGroup), serviceCallback);
+        return ServiceCall.create(putSimpleProductWithGroupingAsyncWithServiceResponse(flattenParameterGroup), serviceCallback);
     }
 
     /**
@@ -832,7 +1018,22 @@ public final class AutoRestResourceFlatteningTestServiceImpl extends ServiceClie
      * @param flattenParameterGroup Additional parameters for the operation
      * @return the observable to the SimpleProduct object
      */
-    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup) {
+    public Observable<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup) {
+        return putSimpleProductWithGroupingAsyncWithServiceResponse(flattenParameterGroup).map(new Func1<ServiceResponse<SimpleProduct>, SimpleProduct>() {
+            @Override
+            public SimpleProduct call(ServiceResponse<SimpleProduct> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param flattenParameterGroup Additional parameters for the operation
+     * @return the observable to the SimpleProduct object
+     */
+    public Observable<ServiceResponse<SimpleProduct>> putSimpleProductWithGroupingAsyncWithServiceResponse(FlattenParameterGroup flattenParameterGroup) {
         if (flattenParameterGroup == null) {
             throw new IllegalArgumentException("Parameter flattenParameterGroup is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
@@ -32,7 +32,6 @@ public interface AvailabilitySets {
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void update(String resourceGroupName, String avset, Map<String, String> tags) throws ServiceException, IOException, IllegalArgumentException;
 
@@ -65,6 +64,6 @@ public interface AvailabilitySets {
      * @param tags A set of tags. A description about the set of tags.
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> updateAsyncWithServiceResponse(String resourceGroupName, String avset, Map<String, String> tags);
+    Observable<ServiceResponse<Void>> updateWithServiceResponseAsync(String resourceGroupName, String avset, Map<String, String> tags);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
@@ -34,7 +34,7 @@ public interface AvailabilitySets {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> update(String resourceGroupName, String avset, Map<String, String> tags) throws ServiceException, IOException, IllegalArgumentException;
+    void update(String resourceGroupName, String avset, Map<String, String> tags) throws ServiceException, IOException, IllegalArgumentException;
 
     /**
      * Updates the tags for an availability set.
@@ -55,6 +55,16 @@ public interface AvailabilitySets {
      * @param tags A set of tags. A description about the set of tags.
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> updateAsync(String resourceGroupName, String avset, Map<String, String> tags);
+    Observable<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags);
+
+    /**
+     * Updates the tags for an availability set.
+     *
+     * @param resourceGroupName The name of the resource group.
+     * @param avset The name of the storage availability set.
+     * @param tags A set of tags. A description about the set of tags.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> updateAsyncWithServiceResponse(String resourceGroupName, String avset, Map<String, String> tags);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/parameterflattening/implementation/AvailabilitySetsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/parameterflattening/implementation/AvailabilitySetsImpl.java
@@ -72,10 +72,9 @@ public final class AvailabilitySetsImpl implements AvailabilitySets {
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void update(String resourceGroupName, String avset, Map<String, String> tags) throws ServiceException, IOException, IllegalArgumentException {
-        updateAsyncWithServiceResponse(resourceGroupName, avset, tags).toBlocking().single().getBody();
+        updateWithServiceResponseAsync(resourceGroupName, avset, tags).toBlocking().single().getBody();
     }
 
     /**
@@ -88,7 +87,7 @@ public final class AvailabilitySetsImpl implements AvailabilitySets {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(updateAsyncWithServiceResponse(resourceGroupName, avset, tags), serviceCallback);
+        return ServiceCall.create(updateWithServiceResponseAsync(resourceGroupName, avset, tags), serviceCallback);
     }
 
     /**
@@ -100,12 +99,12 @@ public final class AvailabilitySetsImpl implements AvailabilitySets {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags) {
-        return updateAsyncWithServiceResponse(resourceGroupName, avset, tags).map(new Func1<ServiceResponse<Void>, Void>() {
+        return updateWithServiceResponseAsync(resourceGroupName, avset, tags).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -116,7 +115,7 @@ public final class AvailabilitySetsImpl implements AvailabilitySets {
      * @param tags A set of tags. A description about the set of tags.
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> updateAsyncWithServiceResponse(String resourceGroupName, String avset, Map<String, String> tags) {
+    public Observable<ServiceResponse<Void>> updateWithServiceResponseAsync(String resourceGroupName, String avset, Map<String, String> tags) {
         if (resourceGroupName == null) {
             throw new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/parameterflattening/implementation/AvailabilitySetsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/parameterflattening/implementation/AvailabilitySetsImpl.java
@@ -74,8 +74,8 @@ public final class AvailabilitySetsImpl implements AvailabilitySets {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> update(String resourceGroupName, String avset, Map<String, String> tags) throws ServiceException, IOException, IllegalArgumentException {
-        return updateAsync(resourceGroupName, avset, tags).toBlocking().single();
+    public void update(String resourceGroupName, String avset, Map<String, String> tags) throws ServiceException, IOException, IllegalArgumentException {
+        updateAsyncWithServiceResponse(resourceGroupName, avset, tags).toBlocking().single().getBody();
     }
 
     /**
@@ -88,7 +88,7 @@ public final class AvailabilitySetsImpl implements AvailabilitySets {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(updateAsync(resourceGroupName, avset, tags), serviceCallback);
+        return ServiceCall.create(updateAsyncWithServiceResponse(resourceGroupName, avset, tags), serviceCallback);
     }
 
     /**
@@ -99,7 +99,24 @@ public final class AvailabilitySetsImpl implements AvailabilitySets {
      * @param tags A set of tags. A description about the set of tags.
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> updateAsync(String resourceGroupName, String avset, Map<String, String> tags) {
+    public Observable<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags) {
+        return updateAsyncWithServiceResponse(resourceGroupName, avset, tags).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Updates the tags for an availability set.
+     *
+     * @param resourceGroupName The name of the resource group.
+     * @param avset The name of the storage availability set.
+     * @param tags A set of tags. A description about the set of tags.
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> updateAsyncWithServiceResponse(String resourceGroupName, String avset, Map<String, String> tags) {
         if (resourceGroupName == null) {
             throw new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/report/AutoRestReportService.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/report/AutoRestReportService.java
@@ -34,7 +34,7 @@ public interface AutoRestReportService {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Map<String, Integer>> getReport() throws ErrorException, IOException;
+    Map<String, Integer> getReport() throws ErrorException, IOException;
 
     /**
      * Get test coverage report.
@@ -49,6 +49,13 @@ public interface AutoRestReportService {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getReportAsync();
+    Observable<Map<String, Integer>> getReportAsync();
+
+    /**
+     * Get test coverage report.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Observable<ServiceResponse<Map<String, Integer>>> getReportAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/report/AutoRestReportService.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/report/AutoRestReportService.java
@@ -32,7 +32,7 @@ public interface AutoRestReportService {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     Map<String, Integer> getReport() throws ErrorException, IOException;
 
@@ -56,6 +56,6 @@ public interface AutoRestReportService {
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    Observable<ServiceResponse<Map<String, Integer>>> getReportAsyncWithServiceResponse();
+    Observable<ServiceResponse<Map<String, Integer>>> getReportWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
@@ -104,8 +104,8 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Map<String, Integer>> getReport() throws ErrorException, IOException {
-        return getReportAsync().toBlocking().single();
+    public Map<String, Integer> getReport() throws ErrorException, IOException {
+        return getReportAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -115,7 +115,7 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getReportAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getReportAsync(), serviceCallback);
+        return ServiceCall.create(getReportAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -123,7 +123,21 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getReportAsync() {
+    public Observable<Map<String, Integer>> getReportAsync() {
+        return getReportAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get test coverage report.
+     *
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    public Observable<ServiceResponse<Map<String, Integer>>> getReportAsyncWithServiceResponse() {
         return service.getReport()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
@@ -102,10 +102,10 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Map&lt;String, Integer&gt; object wrapped in {@link ServiceResponse} if successful.
+     * @return the Map&lt;String, Integer&gt; object if successful.
      */
     public Map<String, Integer> getReport() throws ErrorException, IOException {
-        return getReportAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getReportWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -115,7 +115,7 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Map<String, Integer>> getReportAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
-        return ServiceCall.create(getReportAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getReportWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -124,12 +124,12 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     public Observable<Map<String, Integer>> getReportAsync() {
-        return getReportAsyncWithServiceResponse().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
+        return getReportWithServiceResponseAsync().map(new Func1<ServiceResponse<Map<String, Integer>>, Map<String, Integer>>() {
             @Override
             public Map<String, Integer> call(ServiceResponse<Map<String, Integer>> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -137,7 +137,7 @@ public final class AutoRestReportServiceImpl extends ServiceClient implements Au
      *
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
-    public Observable<ServiceResponse<Map<String, Integer>>> getReportAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Map<String, Integer>>> getReportWithServiceResponseAsync() {
         return service.getReport()
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Map<String, Integer>>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/Explicits.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/Explicits.java
@@ -41,7 +41,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredIntegerParameter(int bodyParameter) throws ErrorException, IOException;
+    Error postRequiredIntegerParameter(int bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
@@ -58,7 +58,15 @@ public interface Explicits {
      * @param bodyParameter the int value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredIntegerParameterAsync(int bodyParameter);
+    Observable<Error> postRequiredIntegerParameterAsync(int bodyParameter);
+
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the int value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredIntegerParameterAsyncWithServiceResponse(int bodyParameter);
 
     /**
      * Test explicitly optional integer. Please put null.
@@ -67,7 +75,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalIntegerParameter() throws ErrorException, IOException;
+    void postOptionalIntegerParameter() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put null.
@@ -76,6 +84,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalIntegerParameterAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @param bodyParameter the Integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalIntegerParameterAsync();
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @param bodyParameter the Integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsyncWithServiceResponse();
     /**
      * Test explicitly optional integer. Please put null.
      *
@@ -84,7 +108,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalIntegerParameter(Integer bodyParameter) throws ErrorException, IOException;
+    void postOptionalIntegerParameter(Integer bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put null.
@@ -101,7 +125,15 @@ public interface Explicits {
      * @param bodyParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsync(Integer bodyParameter);
+    Observable<Void> postOptionalIntegerParameterAsync(Integer bodyParameter);
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @param bodyParameter the Integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsyncWithServiceResponse(Integer bodyParameter);
 
     /**
      * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -112,7 +144,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredIntegerProperty(IntWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredIntegerProperty(IntWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -129,7 +161,15 @@ public interface Explicits {
      * @param bodyParameter the IntWrapper value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter);
+    Observable<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter);
+
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the IntWrapper value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredIntegerPropertyAsyncWithServiceResponse(IntWrapper bodyParameter);
 
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
@@ -138,7 +178,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalIntegerProperty() throws ErrorException, IOException;
+    void postOptionalIntegerProperty() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
@@ -147,6 +187,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalIntegerPropertyAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the IntOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalIntegerPropertyAsync();
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the IntOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsyncWithServiceResponse();
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
      *
@@ -155,7 +211,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) throws ErrorException, IOException;
+    void postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
@@ -172,7 +228,15 @@ public interface Explicits {
      * @param bodyParameter the IntOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter);
+    Observable<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter);
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the IntOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsyncWithServiceResponse(IntOptionalWrapper bodyParameter);
 
     /**
      * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -182,7 +246,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredIntegerHeader(int headerParameter) throws ErrorException, IOException;
+    Error postRequiredIntegerHeader(int headerParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -199,7 +263,15 @@ public interface Explicits {
      * @param headerParameter the int value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredIntegerHeaderAsync(int headerParameter);
+    Observable<Error> postRequiredIntegerHeaderAsync(int headerParameter);
+
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the int value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredIntegerHeaderAsyncWithServiceResponse(int headerParameter);
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
@@ -208,7 +280,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalIntegerHeader() throws ErrorException, IOException;
+    void postOptionalIntegerHeader() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
@@ -217,6 +289,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalIntegerHeaderAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the Integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalIntegerHeaderAsync();
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the Integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsyncWithServiceResponse();
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
@@ -225,7 +313,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalIntegerHeader(Integer headerParameter) throws ErrorException, IOException;
+    void postOptionalIntegerHeader(Integer headerParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
@@ -242,7 +330,15 @@ public interface Explicits {
      * @param headerParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsync(Integer headerParameter);
+    Observable<Void> postOptionalIntegerHeaderAsync(Integer headerParameter);
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the Integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsyncWithServiceResponse(Integer headerParameter);
 
     /**
      * Test explicitly required string. Please put null and the client library should throw before the request is sent.
@@ -253,7 +349,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredStringParameter(String bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredStringParameter(String bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required string. Please put null and the client library should throw before the request is sent.
@@ -270,7 +366,15 @@ public interface Explicits {
      * @param bodyParameter the String value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredStringParameterAsync(String bodyParameter);
+    Observable<Error> postRequiredStringParameterAsync(String bodyParameter);
+
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the String value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredStringParameterAsyncWithServiceResponse(String bodyParameter);
 
     /**
      * Test explicitly optional string. Please put null.
@@ -279,7 +383,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalStringParameter() throws ErrorException, IOException;
+    void postOptionalStringParameter() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional string. Please put null.
@@ -288,6 +392,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalStringParameterAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalStringParameterAsync();
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalStringParameterAsyncWithServiceResponse();
     /**
      * Test explicitly optional string. Please put null.
      *
@@ -296,7 +416,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalStringParameter(String bodyParameter) throws ErrorException, IOException;
+    void postOptionalStringParameter(String bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional string. Please put null.
@@ -313,7 +433,15 @@ public interface Explicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringParameterAsync(String bodyParameter);
+    Observable<Void> postOptionalStringParameterAsync(String bodyParameter);
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalStringParameterAsyncWithServiceResponse(String bodyParameter);
 
     /**
      * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -324,7 +452,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredStringProperty(StringWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredStringProperty(StringWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -341,7 +469,15 @@ public interface Explicits {
      * @param bodyParameter the StringWrapper value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredStringPropertyAsync(StringWrapper bodyParameter);
+    Observable<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter);
+
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the StringWrapper value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredStringPropertyAsyncWithServiceResponse(StringWrapper bodyParameter);
 
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
@@ -350,7 +486,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalStringProperty() throws ErrorException, IOException;
+    void postOptionalStringProperty() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
@@ -359,6 +495,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalStringPropertyAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the StringOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalStringPropertyAsync();
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the StringOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalStringPropertyAsyncWithServiceResponse();
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
      *
@@ -367,7 +519,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalStringProperty(StringOptionalWrapper bodyParameter) throws ErrorException, IOException;
+    void postOptionalStringProperty(StringOptionalWrapper bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
@@ -384,7 +536,15 @@ public interface Explicits {
      * @param bodyParameter the StringOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter);
+    Observable<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter);
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the StringOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalStringPropertyAsyncWithServiceResponse(StringOptionalWrapper bodyParameter);
 
     /**
      * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -395,7 +555,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredStringHeader(String headerParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredStringHeader(String headerParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -412,7 +572,15 @@ public interface Explicits {
      * @param headerParameter the String value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredStringHeaderAsync(String headerParameter);
+    Observable<Error> postRequiredStringHeaderAsync(String headerParameter);
+
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the String value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredStringHeaderAsyncWithServiceResponse(String headerParameter);
 
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
@@ -421,7 +589,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalStringHeader() throws ErrorException, IOException;
+    void postOptionalStringHeader() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
@@ -430,6 +598,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalStringHeaderAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalStringHeaderAsync();
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalStringHeaderAsyncWithServiceResponse();
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
      *
@@ -438,7 +622,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalStringHeader(String bodyParameter) throws ErrorException, IOException;
+    void postOptionalStringHeader(String bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
@@ -455,7 +639,15 @@ public interface Explicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringHeaderAsync(String bodyParameter);
+    Observable<Void> postOptionalStringHeaderAsync(String bodyParameter);
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalStringHeaderAsyncWithServiceResponse(String bodyParameter);
 
     /**
      * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
@@ -466,7 +658,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredClassParameter(Product bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredClassParameter(Product bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
@@ -483,7 +675,15 @@ public interface Explicits {
      * @param bodyParameter the Product value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredClassParameterAsync(Product bodyParameter);
+    Observable<Error> postRequiredClassParameterAsync(Product bodyParameter);
+
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the Product value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredClassParameterAsyncWithServiceResponse(Product bodyParameter);
 
     /**
      * Test explicitly optional complex object. Please put null.
@@ -492,7 +692,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalClassParameter() throws ErrorException, IOException;
+    void postOptionalClassParameter() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional complex object. Please put null.
@@ -501,6 +701,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalClassParameterAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @param bodyParameter the Product value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalClassParameterAsync();
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @param bodyParameter the Product value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalClassParameterAsyncWithServiceResponse();
     /**
      * Test explicitly optional complex object. Please put null.
      *
@@ -509,7 +725,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalClassParameter(Product bodyParameter) throws ErrorException, IOException;
+    void postOptionalClassParameter(Product bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional complex object. Please put null.
@@ -526,7 +742,15 @@ public interface Explicits {
      * @param bodyParameter the Product value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalClassParameterAsync(Product bodyParameter);
+    Observable<Void> postOptionalClassParameterAsync(Product bodyParameter);
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @param bodyParameter the Product value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalClassParameterAsyncWithServiceResponse(Product bodyParameter);
 
     /**
      * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -537,7 +761,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredClassProperty(ClassWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredClassProperty(ClassWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -554,7 +778,15 @@ public interface Explicits {
      * @param bodyParameter the ClassWrapper value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredClassPropertyAsync(ClassWrapper bodyParameter);
+    Observable<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter);
+
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the ClassWrapper value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredClassPropertyAsyncWithServiceResponse(ClassWrapper bodyParameter);
 
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
@@ -563,7 +795,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalClassProperty() throws ErrorException, IOException;
+    void postOptionalClassProperty() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
@@ -572,6 +804,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalClassPropertyAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ClassOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalClassPropertyAsync();
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ClassOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalClassPropertyAsyncWithServiceResponse();
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
      *
@@ -580,7 +828,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalClassProperty(ClassOptionalWrapper bodyParameter) throws ErrorException, IOException;
+    void postOptionalClassProperty(ClassOptionalWrapper bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
@@ -597,7 +845,15 @@ public interface Explicits {
      * @param bodyParameter the ClassOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter);
+    Observable<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter);
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ClassOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalClassPropertyAsyncWithServiceResponse(ClassOptionalWrapper bodyParameter);
 
     /**
      * Test explicitly required array. Please put null and the client library should throw before the request is sent.
@@ -608,7 +864,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredArrayParameter(List<String> bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredArrayParameter(List<String> bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required array. Please put null and the client library should throw before the request is sent.
@@ -625,7 +881,15 @@ public interface Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredArrayParameterAsync(List<String> bodyParameter);
+    Observable<Error> postRequiredArrayParameterAsync(List<String> bodyParameter);
+
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredArrayParameterAsyncWithServiceResponse(List<String> bodyParameter);
 
     /**
      * Test explicitly optional array. Please put null.
@@ -634,7 +898,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalArrayParameter() throws ErrorException, IOException;
+    void postOptionalArrayParameter() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional array. Please put null.
@@ -643,6 +907,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalArrayParameterAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalArrayParameterAsync();
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalArrayParameterAsyncWithServiceResponse();
     /**
      * Test explicitly optional array. Please put null.
      *
@@ -651,7 +931,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalArrayParameter(List<String> bodyParameter) throws ErrorException, IOException;
+    void postOptionalArrayParameter(List<String> bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional array. Please put null.
@@ -668,7 +948,15 @@ public interface Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayParameterAsync(List<String> bodyParameter);
+    Observable<Void> postOptionalArrayParameterAsync(List<String> bodyParameter);
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalArrayParameterAsyncWithServiceResponse(List<String> bodyParameter);
 
     /**
      * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -679,7 +967,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredArrayProperty(ArrayWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredArrayProperty(ArrayWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -696,7 +984,15 @@ public interface Explicits {
      * @param bodyParameter the ArrayWrapper value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter);
+    Observable<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter);
+
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the ArrayWrapper value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredArrayPropertyAsyncWithServiceResponse(ArrayWrapper bodyParameter);
 
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
@@ -705,7 +1001,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalArrayProperty() throws ErrorException, IOException;
+    void postOptionalArrayProperty() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
@@ -714,6 +1010,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalArrayPropertyAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ArrayOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalArrayPropertyAsync();
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ArrayOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsyncWithServiceResponse();
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
      *
@@ -722,7 +1034,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) throws ErrorException, IOException;
+    void postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
@@ -739,7 +1051,15 @@ public interface Explicits {
      * @param bodyParameter the ArrayOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter);
+    Observable<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter);
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ArrayOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsyncWithServiceResponse(ArrayOptionalWrapper bodyParameter);
 
     /**
      * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -750,7 +1070,7 @@ public interface Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> postRequiredArrayHeader(List<String> headerParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error postRequiredArrayHeader(List<String> headerParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -767,7 +1087,15 @@ public interface Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredArrayHeaderAsync(List<String> headerParameter);
+    Observable<Error> postRequiredArrayHeaderAsync(List<String> headerParameter);
+
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> postRequiredArrayHeaderAsyncWithServiceResponse(List<String> headerParameter);
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
@@ -776,7 +1104,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalArrayHeader() throws ErrorException, IOException;
+    void postOptionalArrayHeader() throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
@@ -785,6 +1113,22 @@ public interface Explicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> postOptionalArrayHeaderAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> postOptionalArrayHeaderAsync();
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsyncWithServiceResponse();
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
@@ -793,7 +1137,7 @@ public interface Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> postOptionalArrayHeader(List<String> headerParameter) throws ErrorException, IOException;
+    void postOptionalArrayHeader(List<String> headerParameter) throws ErrorException, IOException;
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
@@ -810,6 +1154,14 @@ public interface Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsync(List<String> headerParameter);
+    Observable<Void> postOptionalArrayHeaderAsync(List<String> headerParameter);
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsyncWithServiceResponse(List<String> headerParameter);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/Explicits.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/Explicits.java
@@ -39,7 +39,7 @@ public interface Explicits {
      * @param bodyParameter the int value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredIntegerParameter(int bodyParameter) throws ErrorException, IOException;
 
@@ -66,14 +66,13 @@ public interface Explicits {
      * @param bodyParameter the int value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredIntegerParameterAsyncWithServiceResponse(int bodyParameter);
+    Observable<ServiceResponse<Error>> postRequiredIntegerParameterWithServiceResponseAsync(int bodyParameter);
 
     /**
      * Test explicitly optional integer. Please put null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalIntegerParameter() throws ErrorException, IOException;
 
@@ -88,7 +87,6 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put null.
      *
-     * @param bodyParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalIntegerParameterAsync();
@@ -96,17 +94,15 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put null.
      *
-     * @param bodyParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalIntegerParameterWithServiceResponseAsync();
     /**
      * Test explicitly optional integer. Please put null.
      *
      * @param bodyParameter the Integer value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalIntegerParameter(Integer bodyParameter) throws ErrorException, IOException;
 
@@ -133,7 +129,7 @@ public interface Explicits {
      * @param bodyParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsyncWithServiceResponse(Integer bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalIntegerParameterWithServiceResponseAsync(Integer bodyParameter);
 
     /**
      * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -142,7 +138,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredIntegerProperty(IntWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -169,14 +165,13 @@ public interface Explicits {
      * @param bodyParameter the IntWrapper value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredIntegerPropertyAsyncWithServiceResponse(IntWrapper bodyParameter);
+    Observable<ServiceResponse<Error>> postRequiredIntegerPropertyWithServiceResponseAsync(IntWrapper bodyParameter);
 
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalIntegerProperty() throws ErrorException, IOException;
 
@@ -191,7 +186,6 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
      *
-     * @param bodyParameter the IntOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalIntegerPropertyAsync();
@@ -199,17 +193,15 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
      *
-     * @param bodyParameter the IntOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalIntegerPropertyWithServiceResponseAsync();
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
      *
      * @param bodyParameter the IntOptionalWrapper value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) throws ErrorException, IOException;
 
@@ -236,7 +228,7 @@ public interface Explicits {
      * @param bodyParameter the IntOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsyncWithServiceResponse(IntOptionalWrapper bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalIntegerPropertyWithServiceResponseAsync(IntOptionalWrapper bodyParameter);
 
     /**
      * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -244,7 +236,7 @@ public interface Explicits {
      * @param headerParameter the int value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredIntegerHeader(int headerParameter) throws ErrorException, IOException;
 
@@ -271,14 +263,13 @@ public interface Explicits {
      * @param headerParameter the int value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredIntegerHeaderAsyncWithServiceResponse(int headerParameter);
+    Observable<ServiceResponse<Error>> postRequiredIntegerHeaderWithServiceResponseAsync(int headerParameter);
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalIntegerHeader() throws ErrorException, IOException;
 
@@ -293,7 +284,6 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
-     * @param headerParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalIntegerHeaderAsync();
@@ -301,17 +291,15 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
-     * @param headerParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalIntegerHeaderWithServiceResponseAsync();
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @param headerParameter the Integer value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalIntegerHeader(Integer headerParameter) throws ErrorException, IOException;
 
@@ -338,7 +326,7 @@ public interface Explicits {
      * @param headerParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsyncWithServiceResponse(Integer headerParameter);
+    Observable<ServiceResponse<Void>> postOptionalIntegerHeaderWithServiceResponseAsync(Integer headerParameter);
 
     /**
      * Test explicitly required string. Please put null and the client library should throw before the request is sent.
@@ -347,7 +335,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredStringParameter(String bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -374,14 +362,13 @@ public interface Explicits {
      * @param bodyParameter the String value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredStringParameterAsyncWithServiceResponse(String bodyParameter);
+    Observable<ServiceResponse<Error>> postRequiredStringParameterWithServiceResponseAsync(String bodyParameter);
 
     /**
      * Test explicitly optional string. Please put null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalStringParameter() throws ErrorException, IOException;
 
@@ -396,7 +383,6 @@ public interface Explicits {
     /**
      * Test explicitly optional string. Please put null.
      *
-     * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalStringParameterAsync();
@@ -404,17 +390,15 @@ public interface Explicits {
     /**
      * Test explicitly optional string. Please put null.
      *
-     * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringParameterAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalStringParameterWithServiceResponseAsync();
     /**
      * Test explicitly optional string. Please put null.
      *
      * @param bodyParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalStringParameter(String bodyParameter) throws ErrorException, IOException;
 
@@ -441,7 +425,7 @@ public interface Explicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringParameterAsyncWithServiceResponse(String bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalStringParameterWithServiceResponseAsync(String bodyParameter);
 
     /**
      * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -450,7 +434,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredStringProperty(StringWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -477,14 +461,13 @@ public interface Explicits {
      * @param bodyParameter the StringWrapper value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredStringPropertyAsyncWithServiceResponse(StringWrapper bodyParameter);
+    Observable<ServiceResponse<Error>> postRequiredStringPropertyWithServiceResponseAsync(StringWrapper bodyParameter);
 
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalStringProperty() throws ErrorException, IOException;
 
@@ -499,7 +482,6 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
      *
-     * @param bodyParameter the StringOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalStringPropertyAsync();
@@ -507,17 +489,15 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
      *
-     * @param bodyParameter the StringOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringPropertyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalStringPropertyWithServiceResponseAsync();
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
      *
      * @param bodyParameter the StringOptionalWrapper value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalStringProperty(StringOptionalWrapper bodyParameter) throws ErrorException, IOException;
 
@@ -544,7 +524,7 @@ public interface Explicits {
      * @param bodyParameter the StringOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringPropertyAsyncWithServiceResponse(StringOptionalWrapper bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalStringPropertyWithServiceResponseAsync(StringOptionalWrapper bodyParameter);
 
     /**
      * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -553,7 +533,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredStringHeader(String headerParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -580,14 +560,13 @@ public interface Explicits {
      * @param headerParameter the String value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredStringHeaderAsyncWithServiceResponse(String headerParameter);
+    Observable<ServiceResponse<Error>> postRequiredStringHeaderWithServiceResponseAsync(String headerParameter);
 
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalStringHeader() throws ErrorException, IOException;
 
@@ -602,7 +581,6 @@ public interface Explicits {
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
      *
-     * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalStringHeaderAsync();
@@ -610,17 +588,15 @@ public interface Explicits {
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
      *
-     * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalStringHeaderWithServiceResponseAsync();
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
      *
      * @param bodyParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalStringHeader(String bodyParameter) throws ErrorException, IOException;
 
@@ -647,7 +623,7 @@ public interface Explicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalStringHeaderAsyncWithServiceResponse(String bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalStringHeaderWithServiceResponseAsync(String bodyParameter);
 
     /**
      * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
@@ -656,7 +632,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredClassParameter(Product bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -683,14 +659,13 @@ public interface Explicits {
      * @param bodyParameter the Product value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredClassParameterAsyncWithServiceResponse(Product bodyParameter);
+    Observable<ServiceResponse<Error>> postRequiredClassParameterWithServiceResponseAsync(Product bodyParameter);
 
     /**
      * Test explicitly optional complex object. Please put null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalClassParameter() throws ErrorException, IOException;
 
@@ -705,7 +680,6 @@ public interface Explicits {
     /**
      * Test explicitly optional complex object. Please put null.
      *
-     * @param bodyParameter the Product value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalClassParameterAsync();
@@ -713,17 +687,15 @@ public interface Explicits {
     /**
      * Test explicitly optional complex object. Please put null.
      *
-     * @param bodyParameter the Product value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalClassParameterAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalClassParameterWithServiceResponseAsync();
     /**
      * Test explicitly optional complex object. Please put null.
      *
      * @param bodyParameter the Product value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalClassParameter(Product bodyParameter) throws ErrorException, IOException;
 
@@ -750,7 +722,7 @@ public interface Explicits {
      * @param bodyParameter the Product value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalClassParameterAsyncWithServiceResponse(Product bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalClassParameterWithServiceResponseAsync(Product bodyParameter);
 
     /**
      * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -759,7 +731,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredClassProperty(ClassWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -786,14 +758,13 @@ public interface Explicits {
      * @param bodyParameter the ClassWrapper value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredClassPropertyAsyncWithServiceResponse(ClassWrapper bodyParameter);
+    Observable<ServiceResponse<Error>> postRequiredClassPropertyWithServiceResponseAsync(ClassWrapper bodyParameter);
 
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalClassProperty() throws ErrorException, IOException;
 
@@ -808,7 +779,6 @@ public interface Explicits {
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
      *
-     * @param bodyParameter the ClassOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalClassPropertyAsync();
@@ -816,17 +786,15 @@ public interface Explicits {
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
      *
-     * @param bodyParameter the ClassOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalClassPropertyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalClassPropertyWithServiceResponseAsync();
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
      *
      * @param bodyParameter the ClassOptionalWrapper value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalClassProperty(ClassOptionalWrapper bodyParameter) throws ErrorException, IOException;
 
@@ -853,7 +821,7 @@ public interface Explicits {
      * @param bodyParameter the ClassOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalClassPropertyAsyncWithServiceResponse(ClassOptionalWrapper bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalClassPropertyWithServiceResponseAsync(ClassOptionalWrapper bodyParameter);
 
     /**
      * Test explicitly required array. Please put null and the client library should throw before the request is sent.
@@ -862,7 +830,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredArrayParameter(List<String> bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -889,14 +857,13 @@ public interface Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredArrayParameterAsyncWithServiceResponse(List<String> bodyParameter);
+    Observable<ServiceResponse<Error>> postRequiredArrayParameterWithServiceResponseAsync(List<String> bodyParameter);
 
     /**
      * Test explicitly optional array. Please put null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalArrayParameter() throws ErrorException, IOException;
 
@@ -911,7 +878,6 @@ public interface Explicits {
     /**
      * Test explicitly optional array. Please put null.
      *
-     * @param bodyParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalArrayParameterAsync();
@@ -919,17 +885,15 @@ public interface Explicits {
     /**
      * Test explicitly optional array. Please put null.
      *
-     * @param bodyParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayParameterAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalArrayParameterWithServiceResponseAsync();
     /**
      * Test explicitly optional array. Please put null.
      *
      * @param bodyParameter the List&lt;String&gt; value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalArrayParameter(List<String> bodyParameter) throws ErrorException, IOException;
 
@@ -956,7 +920,7 @@ public interface Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayParameterAsyncWithServiceResponse(List<String> bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalArrayParameterWithServiceResponseAsync(List<String> bodyParameter);
 
     /**
      * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -965,7 +929,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredArrayProperty(ArrayWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -992,14 +956,13 @@ public interface Explicits {
      * @param bodyParameter the ArrayWrapper value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredArrayPropertyAsyncWithServiceResponse(ArrayWrapper bodyParameter);
+    Observable<ServiceResponse<Error>> postRequiredArrayPropertyWithServiceResponseAsync(ArrayWrapper bodyParameter);
 
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalArrayProperty() throws ErrorException, IOException;
 
@@ -1014,7 +977,6 @@ public interface Explicits {
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
      *
-     * @param bodyParameter the ArrayOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalArrayPropertyAsync();
@@ -1022,17 +984,15 @@ public interface Explicits {
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
      *
-     * @param bodyParameter the ArrayOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalArrayPropertyWithServiceResponseAsync();
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
      *
      * @param bodyParameter the ArrayOptionalWrapper value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) throws ErrorException, IOException;
 
@@ -1059,7 +1019,7 @@ public interface Explicits {
      * @param bodyParameter the ArrayOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsyncWithServiceResponse(ArrayOptionalWrapper bodyParameter);
+    Observable<ServiceResponse<Void>> postOptionalArrayPropertyWithServiceResponseAsync(ArrayOptionalWrapper bodyParameter);
 
     /**
      * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
@@ -1068,7 +1028,7 @@ public interface Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error postRequiredArrayHeader(List<String> headerParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -1095,14 +1055,13 @@ public interface Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> postRequiredArrayHeaderAsyncWithServiceResponse(List<String> headerParameter);
+    Observable<ServiceResponse<Error>> postRequiredArrayHeaderWithServiceResponseAsync(List<String> headerParameter);
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalArrayHeader() throws ErrorException, IOException;
 
@@ -1117,7 +1076,6 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
-     * @param headerParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> postOptionalArrayHeaderAsync();
@@ -1125,17 +1083,15 @@ public interface Explicits {
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
-     * @param headerParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> postOptionalArrayHeaderWithServiceResponseAsync();
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @param headerParameter the List&lt;String&gt; value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void postOptionalArrayHeader(List<String> headerParameter) throws ErrorException, IOException;
 
@@ -1162,6 +1118,6 @@ public interface Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsyncWithServiceResponse(List<String> headerParameter);
+    Observable<ServiceResponse<Void>> postOptionalArrayHeaderWithServiceResponseAsync(List<String> headerParameter);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/Implicits.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/Implicits.java
@@ -30,7 +30,7 @@ public interface Implicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error getRequiredPath(String pathParameter) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -57,14 +57,13 @@ public interface Implicits {
      * @param pathParameter the String value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> getRequiredPathAsyncWithServiceResponse(String pathParameter);
+    Observable<ServiceResponse<Error>> getRequiredPathWithServiceResponseAsync(String pathParameter);
 
     /**
      * Test implicitly optional query parameter.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putOptionalQuery() throws ErrorException, IOException;
 
@@ -79,7 +78,6 @@ public interface Implicits {
     /**
      * Test implicitly optional query parameter.
      *
-     * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putOptionalQueryAsync();
@@ -87,17 +85,15 @@ public interface Implicits {
     /**
      * Test implicitly optional query parameter.
      *
-     * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalQueryAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putOptionalQueryWithServiceResponseAsync();
     /**
      * Test implicitly optional query parameter.
      *
      * @param queryParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putOptionalQuery(String queryParameter) throws ErrorException, IOException;
 
@@ -124,14 +120,13 @@ public interface Implicits {
      * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalQueryAsyncWithServiceResponse(String queryParameter);
+    Observable<ServiceResponse<Void>> putOptionalQueryWithServiceResponseAsync(String queryParameter);
 
     /**
      * Test implicitly optional header parameter.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putOptionalHeader() throws ErrorException, IOException;
 
@@ -146,7 +141,6 @@ public interface Implicits {
     /**
      * Test implicitly optional header parameter.
      *
-     * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putOptionalHeaderAsync();
@@ -154,17 +148,15 @@ public interface Implicits {
     /**
      * Test implicitly optional header parameter.
      *
-     * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalHeaderAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putOptionalHeaderWithServiceResponseAsync();
     /**
      * Test implicitly optional header parameter.
      *
      * @param queryParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putOptionalHeader(String queryParameter) throws ErrorException, IOException;
 
@@ -191,14 +183,13 @@ public interface Implicits {
      * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalHeaderAsyncWithServiceResponse(String queryParameter);
+    Observable<ServiceResponse<Void>> putOptionalHeaderWithServiceResponseAsync(String queryParameter);
 
     /**
      * Test implicitly optional body parameter.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putOptionalBody() throws ErrorException, IOException;
 
@@ -213,7 +204,6 @@ public interface Implicits {
     /**
      * Test implicitly optional body parameter.
      *
-     * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> putOptionalBodyAsync();
@@ -221,17 +211,15 @@ public interface Implicits {
     /**
      * Test implicitly optional body parameter.
      *
-     * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalBodyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> putOptionalBodyWithServiceResponseAsync();
     /**
      * Test implicitly optional body parameter.
      *
      * @param bodyParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void putOptionalBody(String bodyParameter) throws ErrorException, IOException;
 
@@ -258,7 +246,7 @@ public interface Implicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalBodyAsyncWithServiceResponse(String bodyParameter);
+    Observable<ServiceResponse<Void>> putOptionalBodyWithServiceResponseAsync(String bodyParameter);
 
     /**
      * Test implicitly required path parameter.
@@ -266,7 +254,7 @@ public interface Implicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error getRequiredGlobalPath() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -290,7 +278,7 @@ public interface Implicits {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> getRequiredGlobalPathAsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> getRequiredGlobalPathWithServiceResponseAsync();
 
     /**
      * Test implicitly required query parameter.
@@ -298,7 +286,7 @@ public interface Implicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error getRequiredGlobalQuery() throws ErrorException, IOException, IllegalArgumentException;
 
@@ -322,14 +310,14 @@ public interface Implicits {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> getRequiredGlobalQueryAsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> getRequiredGlobalQueryWithServiceResponseAsync();
 
     /**
      * Test implicitly optional query parameter.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     Error getOptionalGlobalQuery() throws ErrorException, IOException;
 
@@ -353,6 +341,6 @@ public interface Implicits {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> getOptionalGlobalQueryAsyncWithServiceResponse();
+    Observable<ServiceResponse<Error>> getOptionalGlobalQueryWithServiceResponseAsync();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/Implicits.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/Implicits.java
@@ -32,7 +32,7 @@ public interface Implicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> getRequiredPath(String pathParameter) throws ErrorException, IOException, IllegalArgumentException;
+    Error getRequiredPath(String pathParameter) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test implicitly required path parameter.
@@ -49,7 +49,15 @@ public interface Implicits {
      * @param pathParameter the String value
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> getRequiredPathAsync(String pathParameter);
+    Observable<Error> getRequiredPathAsync(String pathParameter);
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @param pathParameter the String value
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> getRequiredPathAsyncWithServiceResponse(String pathParameter);
 
     /**
      * Test implicitly optional query parameter.
@@ -58,7 +66,7 @@ public interface Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putOptionalQuery() throws ErrorException, IOException;
+    void putOptionalQuery() throws ErrorException, IOException;
 
     /**
      * Test implicitly optional query parameter.
@@ -67,6 +75,22 @@ public interface Implicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putOptionalQueryAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param queryParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putOptionalQueryAsync();
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param queryParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putOptionalQueryAsyncWithServiceResponse();
     /**
      * Test implicitly optional query parameter.
      *
@@ -75,7 +99,7 @@ public interface Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putOptionalQuery(String queryParameter) throws ErrorException, IOException;
+    void putOptionalQuery(String queryParameter) throws ErrorException, IOException;
 
     /**
      * Test implicitly optional query parameter.
@@ -92,7 +116,15 @@ public interface Implicits {
      * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalQueryAsync(String queryParameter);
+    Observable<Void> putOptionalQueryAsync(String queryParameter);
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param queryParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putOptionalQueryAsyncWithServiceResponse(String queryParameter);
 
     /**
      * Test implicitly optional header parameter.
@@ -101,7 +133,7 @@ public interface Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putOptionalHeader() throws ErrorException, IOException;
+    void putOptionalHeader() throws ErrorException, IOException;
 
     /**
      * Test implicitly optional header parameter.
@@ -110,6 +142,22 @@ public interface Implicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putOptionalHeaderAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @param queryParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putOptionalHeaderAsync();
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @param queryParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putOptionalHeaderAsyncWithServiceResponse();
     /**
      * Test implicitly optional header parameter.
      *
@@ -118,7 +166,7 @@ public interface Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putOptionalHeader(String queryParameter) throws ErrorException, IOException;
+    void putOptionalHeader(String queryParameter) throws ErrorException, IOException;
 
     /**
      * Test implicitly optional header parameter.
@@ -135,7 +183,15 @@ public interface Implicits {
      * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalHeaderAsync(String queryParameter);
+    Observable<Void> putOptionalHeaderAsync(String queryParameter);
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @param queryParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putOptionalHeaderAsyncWithServiceResponse(String queryParameter);
 
     /**
      * Test implicitly optional body parameter.
@@ -144,7 +200,7 @@ public interface Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putOptionalBody() throws ErrorException, IOException;
+    void putOptionalBody() throws ErrorException, IOException;
 
     /**
      * Test implicitly optional body parameter.
@@ -153,6 +209,22 @@ public interface Implicits {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> putOptionalBodyAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> putOptionalBodyAsync();
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putOptionalBodyAsyncWithServiceResponse();
     /**
      * Test implicitly optional body parameter.
      *
@@ -161,7 +233,7 @@ public interface Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> putOptionalBody(String bodyParameter) throws ErrorException, IOException;
+    void putOptionalBody(String bodyParameter) throws ErrorException, IOException;
 
     /**
      * Test implicitly optional body parameter.
@@ -178,7 +250,15 @@ public interface Implicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> putOptionalBodyAsync(String bodyParameter);
+    Observable<Void> putOptionalBodyAsync(String bodyParameter);
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> putOptionalBodyAsyncWithServiceResponse(String bodyParameter);
 
     /**
      * Test implicitly required path parameter.
@@ -188,7 +268,7 @@ public interface Implicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> getRequiredGlobalPath() throws ErrorException, IOException, IllegalArgumentException;
+    Error getRequiredGlobalPath() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test implicitly required path parameter.
@@ -203,7 +283,14 @@ public interface Implicits {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> getRequiredGlobalPathAsync();
+    Observable<Error> getRequiredGlobalPathAsync();
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> getRequiredGlobalPathAsyncWithServiceResponse();
 
     /**
      * Test implicitly required query parameter.
@@ -213,7 +300,7 @@ public interface Implicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> getRequiredGlobalQuery() throws ErrorException, IOException, IllegalArgumentException;
+    Error getRequiredGlobalQuery() throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Test implicitly required query parameter.
@@ -228,7 +315,14 @@ public interface Implicits {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> getRequiredGlobalQueryAsync();
+    Observable<Error> getRequiredGlobalQueryAsync();
+
+    /**
+     * Test implicitly required query parameter.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> getRequiredGlobalQueryAsyncWithServiceResponse();
 
     /**
      * Test implicitly optional query parameter.
@@ -237,7 +331,7 @@ public interface Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Error> getOptionalGlobalQuery() throws ErrorException, IOException;
+    Error getOptionalGlobalQuery() throws ErrorException, IOException;
 
     /**
      * Test implicitly optional query parameter.
@@ -252,6 +346,13 @@ public interface Implicits {
      *
      * @return the observable to the Error object
      */
-    Observable<ServiceResponse<Error>> getOptionalGlobalQueryAsync();
+    Observable<Error> getOptionalGlobalQueryAsync();
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @return the observable to the Error object
+     */
+    Observable<ServiceResponse<Error>> getOptionalGlobalQueryAsyncWithServiceResponse();
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/implementation/ExplicitsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/implementation/ExplicitsImpl.java
@@ -163,10 +163,10 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the int value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredIntegerParameter(int bodyParameter) throws ErrorException, IOException {
-        return postRequiredIntegerParameterAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
+        return postRequiredIntegerParameterWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -177,7 +177,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredIntegerParameterAsync(int bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredIntegerParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredIntegerParameterWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -187,12 +187,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredIntegerParameterAsync(int bodyParameter) {
-        return postRequiredIntegerParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredIntegerParameterWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -201,7 +201,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the int value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredIntegerParameterAsyncWithServiceResponse(int bodyParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredIntegerParameterWithServiceResponseAsync(int bodyParameter) {
         return service.postRequiredIntegerParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -227,10 +227,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalIntegerParameter() throws ErrorException, IOException {
-        postOptionalIntegerParameterAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalIntegerParameterWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -240,7 +239,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerParameterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerParameterAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerParameterWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -249,12 +248,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalIntegerParameterAsync() {
-        return postOptionalIntegerParameterAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalIntegerParameterWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -262,7 +261,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalIntegerParameterWithServiceResponseAsync() {
         final Integer bodyParameter = null;
         return service.postOptionalIntegerParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -284,10 +283,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the Integer value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalIntegerParameter(Integer bodyParameter) throws ErrorException, IOException {
-        postOptionalIntegerParameterAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalIntegerParameterWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -298,21 +296,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerParameterAsync(Integer bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional integer. Please put null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalIntegerParameterAsync(Integer bodyParameter) {
-        return postOptionalIntegerParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalIntegerParameterWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -321,7 +305,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsyncWithServiceResponse(Integer bodyParameter) {
+    public Observable<Void> postOptionalIntegerParameterAsync(Integer bodyParameter) {
+        return postOptionalIntegerParameterWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @param bodyParameter the Integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalIntegerParameterWithServiceResponseAsync(Integer bodyParameter) {
         return service.postOptionalIntegerParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -350,10 +349,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredIntegerProperty(IntWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredIntegerPropertyAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
+        return postRequiredIntegerPropertyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -364,7 +363,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredIntegerPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredIntegerPropertyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -374,12 +373,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter) {
-        return postRequiredIntegerPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredIntegerPropertyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -388,7 +387,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the IntWrapper value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredIntegerPropertyAsyncWithServiceResponse(IntWrapper bodyParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredIntegerPropertyWithServiceResponseAsync(IntWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -418,10 +417,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalIntegerProperty() throws ErrorException, IOException {
-        postOptionalIntegerPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalIntegerPropertyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -431,7 +429,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerPropertyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerPropertyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerPropertyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -440,12 +438,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalIntegerPropertyAsync() {
-        return postOptionalIntegerPropertyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalIntegerPropertyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -453,7 +451,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalIntegerPropertyWithServiceResponseAsync() {
         final IntOptionalWrapper bodyParameter = null;
         return service.postOptionalIntegerProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -475,10 +473,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the IntOptionalWrapper value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) throws ErrorException, IOException {
-        postOptionalIntegerPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalIntegerPropertyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -489,21 +486,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter) {
-        return postOptionalIntegerPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalIntegerPropertyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -512,7 +495,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the IntOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsyncWithServiceResponse(IntOptionalWrapper bodyParameter) {
+    public Observable<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter) {
+        return postOptionalIntegerPropertyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the IntOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalIntegerPropertyWithServiceResponseAsync(IntOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalIntegerProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -541,10 +539,10 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the int value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredIntegerHeader(int headerParameter) throws ErrorException, IOException {
-        return postRequiredIntegerHeaderAsyncWithServiceResponse(headerParameter).toBlocking().single().getBody();
+        return postRequiredIntegerHeaderWithServiceResponseAsync(headerParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -555,7 +553,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredIntegerHeaderAsync(int headerParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredIntegerHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
+        return ServiceCall.create(postRequiredIntegerHeaderWithServiceResponseAsync(headerParameter), serviceCallback);
     }
 
     /**
@@ -565,12 +563,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredIntegerHeaderAsync(int headerParameter) {
-        return postRequiredIntegerHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredIntegerHeaderWithServiceResponseAsync(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -579,7 +577,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the int value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredIntegerHeaderAsyncWithServiceResponse(int headerParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredIntegerHeaderWithServiceResponseAsync(int headerParameter) {
         return service.postRequiredIntegerHeader(headerParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -605,10 +603,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalIntegerHeader() throws ErrorException, IOException {
-        postOptionalIntegerHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalIntegerHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -618,7 +615,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerHeaderAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -627,12 +624,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalIntegerHeaderAsync() {
-        return postOptionalIntegerHeaderAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalIntegerHeaderWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -640,7 +637,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalIntegerHeaderWithServiceResponseAsync() {
         final Integer headerParameter = null;
         return service.postOptionalIntegerHeader(headerParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -662,10 +659,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the Integer value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalIntegerHeader(Integer headerParameter) throws ErrorException, IOException {
-        postOptionalIntegerHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalIntegerHeaderWithServiceResponseAsync(headerParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -676,21 +672,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerHeaderAsync(Integer headerParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalIntegerHeaderAsync(Integer headerParameter) {
-        return postOptionalIntegerHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalIntegerHeaderWithServiceResponseAsync(headerParameter), serviceCallback);
     }
 
     /**
@@ -699,7 +681,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsyncWithServiceResponse(Integer headerParameter) {
+    public Observable<Void> postOptionalIntegerHeaderAsync(Integer headerParameter) {
+        return postOptionalIntegerHeaderWithServiceResponseAsync(headerParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the Integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalIntegerHeaderWithServiceResponseAsync(Integer headerParameter) {
         return service.postOptionalIntegerHeader(headerParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -728,10 +725,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredStringParameter(String bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredStringParameterAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
+        return postRequiredStringParameterWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -742,7 +739,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredStringParameterAsync(String bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredStringParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredStringParameterWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -752,12 +749,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredStringParameterAsync(String bodyParameter) {
-        return postRequiredStringParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredStringParameterWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -766,7 +763,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the String value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredStringParameterAsyncWithServiceResponse(String bodyParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredStringParameterWithServiceResponseAsync(String bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -795,10 +792,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalStringParameter() throws ErrorException, IOException {
-        postOptionalStringParameterAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalStringParameterWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -808,7 +804,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringParameterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringParameterAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalStringParameterWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -817,12 +813,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalStringParameterAsync() {
-        return postOptionalStringParameterAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalStringParameterWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -830,7 +826,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringParameterAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalStringParameterWithServiceResponseAsync() {
         final String bodyParameter = null;
         return service.postOptionalStringParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -852,10 +848,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalStringParameter(String bodyParameter) throws ErrorException, IOException {
-        postOptionalStringParameterAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalStringParameterWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -866,21 +861,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringParameterAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional string. Please put null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalStringParameterAsync(String bodyParameter) {
-        return postOptionalStringParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalStringParameterWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -889,7 +870,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringParameterAsyncWithServiceResponse(String bodyParameter) {
+    public Observable<Void> postOptionalStringParameterAsync(String bodyParameter) {
+        return postOptionalStringParameterWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalStringParameterWithServiceResponseAsync(String bodyParameter) {
         return service.postOptionalStringParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -918,10 +914,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredStringProperty(StringWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredStringPropertyAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
+        return postRequiredStringPropertyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -932,7 +928,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredStringPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredStringPropertyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -942,12 +938,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter) {
-        return postRequiredStringPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredStringPropertyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -956,7 +952,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the StringWrapper value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredStringPropertyAsyncWithServiceResponse(StringWrapper bodyParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredStringPropertyWithServiceResponseAsync(StringWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -986,10 +982,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalStringProperty() throws ErrorException, IOException {
-        postOptionalStringPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalStringPropertyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -999,7 +994,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringPropertyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringPropertyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalStringPropertyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1008,12 +1003,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalStringPropertyAsync() {
-        return postOptionalStringPropertyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalStringPropertyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1021,7 +1016,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringPropertyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalStringPropertyWithServiceResponseAsync() {
         final StringOptionalWrapper bodyParameter = null;
         return service.postOptionalStringProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1043,10 +1038,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the StringOptionalWrapper value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalStringProperty(StringOptionalWrapper bodyParameter) throws ErrorException, IOException {
-        postOptionalStringPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalStringPropertyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1057,21 +1051,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter) {
-        return postOptionalStringPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalStringPropertyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1080,7 +1060,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the StringOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringPropertyAsyncWithServiceResponse(StringOptionalWrapper bodyParameter) {
+    public Observable<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter) {
+        return postOptionalStringPropertyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the StringOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalStringPropertyWithServiceResponseAsync(StringOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalStringProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1110,10 +1105,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredStringHeader(String headerParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredStringHeaderAsyncWithServiceResponse(headerParameter).toBlocking().single().getBody();
+        return postRequiredStringHeaderWithServiceResponseAsync(headerParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1124,7 +1119,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredStringHeaderAsync(String headerParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredStringHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
+        return ServiceCall.create(postRequiredStringHeaderWithServiceResponseAsync(headerParameter), serviceCallback);
     }
 
     /**
@@ -1134,12 +1129,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredStringHeaderAsync(String headerParameter) {
-        return postRequiredStringHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredStringHeaderWithServiceResponseAsync(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1148,7 +1143,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the String value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredStringHeaderAsyncWithServiceResponse(String headerParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredStringHeaderWithServiceResponseAsync(String headerParameter) {
         if (headerParameter == null) {
             throw new IllegalArgumentException("Parameter headerParameter is required and cannot be null.");
         }
@@ -1177,10 +1172,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalStringHeader() throws ErrorException, IOException {
-        postOptionalStringHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalStringHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1190,7 +1184,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringHeaderAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalStringHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1199,12 +1193,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalStringHeaderAsync() {
-        return postOptionalStringHeaderAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalStringHeaderWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1212,7 +1206,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringHeaderAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalStringHeaderWithServiceResponseAsync() {
         final String bodyParameter = null;
         return service.postOptionalStringHeader(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1234,10 +1228,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalStringHeader(String bodyParameter) throws ErrorException, IOException {
-        postOptionalStringHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalStringHeaderWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1248,21 +1241,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringHeaderAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringHeaderAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalStringHeaderAsync(String bodyParameter) {
-        return postOptionalStringHeaderAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalStringHeaderWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1271,7 +1250,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringHeaderAsyncWithServiceResponse(String bodyParameter) {
+    public Observable<Void> postOptionalStringHeaderAsync(String bodyParameter) {
+        return postOptionalStringHeaderWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalStringHeaderWithServiceResponseAsync(String bodyParameter) {
         return service.postOptionalStringHeader(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1300,10 +1294,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredClassParameter(Product bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredClassParameterAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
+        return postRequiredClassParameterWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1314,7 +1308,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredClassParameterAsync(Product bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredClassParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredClassParameterWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1324,12 +1318,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredClassParameterAsync(Product bodyParameter) {
-        return postRequiredClassParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredClassParameterWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1338,7 +1332,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the Product value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredClassParameterAsyncWithServiceResponse(Product bodyParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredClassParameterWithServiceResponseAsync(Product bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -1368,10 +1362,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalClassParameter() throws ErrorException, IOException {
-        postOptionalClassParameterAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalClassParameterWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1381,7 +1374,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalClassParameterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalClassParameterAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalClassParameterWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1390,12 +1383,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalClassParameterAsync() {
-        return postOptionalClassParameterAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalClassParameterWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1403,7 +1396,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalClassParameterAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalClassParameterWithServiceResponseAsync() {
         final Product bodyParameter = null;
         return service.postOptionalClassParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1425,10 +1418,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the Product value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalClassParameter(Product bodyParameter) throws ErrorException, IOException {
-        postOptionalClassParameterAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalClassParameterWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1439,21 +1431,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalClassParameterAsync(Product bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalClassParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional complex object. Please put null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalClassParameterAsync(Product bodyParameter) {
-        return postOptionalClassParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalClassParameterWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1462,7 +1440,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the Product value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalClassParameterAsyncWithServiceResponse(Product bodyParameter) {
+    public Observable<Void> postOptionalClassParameterAsync(Product bodyParameter) {
+        return postOptionalClassParameterWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @param bodyParameter the Product value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalClassParameterWithServiceResponseAsync(Product bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalClassParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1492,10 +1485,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredClassProperty(ClassWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredClassPropertyAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
+        return postRequiredClassPropertyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1506,7 +1499,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredClassPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredClassPropertyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1516,12 +1509,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter) {
-        return postRequiredClassPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredClassPropertyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1530,7 +1523,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ClassWrapper value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredClassPropertyAsyncWithServiceResponse(ClassWrapper bodyParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredClassPropertyWithServiceResponseAsync(ClassWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -1560,10 +1553,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalClassProperty() throws ErrorException, IOException {
-        postOptionalClassPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalClassPropertyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1573,7 +1565,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalClassPropertyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalClassPropertyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalClassPropertyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1582,12 +1574,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalClassPropertyAsync() {
-        return postOptionalClassPropertyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalClassPropertyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1595,7 +1587,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalClassPropertyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalClassPropertyWithServiceResponseAsync() {
         final ClassOptionalWrapper bodyParameter = null;
         return service.postOptionalClassProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1617,10 +1609,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ClassOptionalWrapper value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalClassProperty(ClassOptionalWrapper bodyParameter) throws ErrorException, IOException {
-        postOptionalClassPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalClassPropertyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1631,21 +1622,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalClassPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter) {
-        return postOptionalClassPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalClassPropertyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1654,7 +1631,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ClassOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalClassPropertyAsyncWithServiceResponse(ClassOptionalWrapper bodyParameter) {
+    public Observable<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter) {
+        return postOptionalClassPropertyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ClassOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalClassPropertyWithServiceResponseAsync(ClassOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalClassProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1684,10 +1676,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredArrayParameter(List<String> bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredArrayParameterAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
+        return postRequiredArrayParameterWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1698,7 +1690,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredArrayParameterAsync(List<String> bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredArrayParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredArrayParameterWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1708,12 +1700,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredArrayParameterAsync(List<String> bodyParameter) {
-        return postRequiredArrayParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredArrayParameterWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1722,7 +1714,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredArrayParameterAsyncWithServiceResponse(List<String> bodyParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredArrayParameterWithServiceResponseAsync(List<String> bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -1752,10 +1744,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalArrayParameter() throws ErrorException, IOException {
-        postOptionalArrayParameterAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalArrayParameterWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1765,7 +1756,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayParameterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayParameterAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalArrayParameterWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1774,12 +1765,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalArrayParameterAsync() {
-        return postOptionalArrayParameterAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalArrayParameterWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1787,7 +1778,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayParameterAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalArrayParameterWithServiceResponseAsync() {
         final List<String> bodyParameter = null;
         return service.postOptionalArrayParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1809,10 +1800,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalArrayParameter(List<String> bodyParameter) throws ErrorException, IOException {
-        postOptionalArrayParameterAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalArrayParameterWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1823,21 +1813,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayParameterAsync(List<String> bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional array. Please put null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalArrayParameterAsync(List<String> bodyParameter) {
-        return postOptionalArrayParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalArrayParameterWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1846,7 +1822,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayParameterAsyncWithServiceResponse(List<String> bodyParameter) {
+    public Observable<Void> postOptionalArrayParameterAsync(List<String> bodyParameter) {
+        return postOptionalArrayParameterWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalArrayParameterWithServiceResponseAsync(List<String> bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalArrayParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1876,10 +1867,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredArrayProperty(ArrayWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredArrayPropertyAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
+        return postRequiredArrayPropertyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1890,7 +1881,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredArrayPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredArrayPropertyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1900,12 +1891,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter) {
-        return postRequiredArrayPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredArrayPropertyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1914,7 +1905,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ArrayWrapper value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredArrayPropertyAsyncWithServiceResponse(ArrayWrapper bodyParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredArrayPropertyWithServiceResponseAsync(ArrayWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -1944,10 +1935,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalArrayProperty() throws ErrorException, IOException {
-        postOptionalArrayPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalArrayPropertyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1957,7 +1947,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayPropertyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayPropertyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalArrayPropertyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1966,12 +1956,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalArrayPropertyAsync() {
-        return postOptionalArrayPropertyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalArrayPropertyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1979,7 +1969,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalArrayPropertyWithServiceResponseAsync() {
         final ArrayOptionalWrapper bodyParameter = null;
         return service.postOptionalArrayProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2001,10 +1991,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ArrayOptionalWrapper value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) throws ErrorException, IOException {
-        postOptionalArrayPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalArrayPropertyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -2015,21 +2004,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter) {
-        return postOptionalArrayPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalArrayPropertyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -2038,7 +2013,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ArrayOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsyncWithServiceResponse(ArrayOptionalWrapper bodyParameter) {
+    public Observable<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter) {
+        return postOptionalArrayPropertyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ArrayOptionalWrapper value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalArrayPropertyWithServiceResponseAsync(ArrayOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalArrayProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2068,10 +2058,10 @@ public final class ExplicitsImpl implements Explicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error postRequiredArrayHeader(List<String> headerParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredArrayHeaderAsyncWithServiceResponse(headerParameter).toBlocking().single().getBody();
+        return postRequiredArrayHeaderWithServiceResponseAsync(headerParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -2082,7 +2072,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredArrayHeaderAsync(List<String> headerParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredArrayHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
+        return ServiceCall.create(postRequiredArrayHeaderWithServiceResponseAsync(headerParameter), serviceCallback);
     }
 
     /**
@@ -2092,12 +2082,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the observable to the Error object
      */
     public Observable<Error> postRequiredArrayHeaderAsync(List<String> headerParameter) {
-        return postRequiredArrayHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return postRequiredArrayHeaderWithServiceResponseAsync(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2106,7 +2096,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredArrayHeaderAsyncWithServiceResponse(List<String> headerParameter) {
+    public Observable<ServiceResponse<Error>> postRequiredArrayHeaderWithServiceResponseAsync(List<String> headerParameter) {
         if (headerParameter == null) {
             throw new IllegalArgumentException("Parameter headerParameter is required and cannot be null.");
         }
@@ -2137,10 +2127,9 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalArrayHeader() throws ErrorException, IOException {
-        postOptionalArrayHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalArrayHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2150,7 +2139,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayHeaderAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postOptionalArrayHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2159,12 +2148,12 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> postOptionalArrayHeaderAsync() {
-        return postOptionalArrayHeaderAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return postOptionalArrayHeaderWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2172,7 +2161,7 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> postOptionalArrayHeaderWithServiceResponseAsync() {
         final List<String> headerParameter = null;
         String headerParameterConverted = this.client.mapperAdapter().serializeList(headerParameter, CollectionFormat.CSV);
         return service.postOptionalArrayHeader(headerParameterConverted)
@@ -2195,10 +2184,9 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void postOptionalArrayHeader(List<String> headerParameter) throws ErrorException, IOException {
-        postOptionalArrayHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
+        postOptionalArrayHeaderWithServiceResponseAsync(headerParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -2209,21 +2197,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayHeaderAsync(List<String> headerParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
-    }
-
-    /**
-     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> postOptionalArrayHeaderAsync(List<String> headerParameter) {
-        return postOptionalArrayHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postOptionalArrayHeaderWithServiceResponseAsync(headerParameter), serviceCallback);
     }
 
     /**
@@ -2232,7 +2206,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsyncWithServiceResponse(List<String> headerParameter) {
+    public Observable<Void> postOptionalArrayHeaderAsync(List<String> headerParameter) {
+        return postOptionalArrayHeaderWithServiceResponseAsync(headerParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalArrayHeaderWithServiceResponseAsync(List<String> headerParameter) {
         Validator.validate(headerParameter);
         String headerParameterConverted = this.client.mapperAdapter().serializeList(headerParameter, CollectionFormat.CSV);
         return service.postOptionalArrayHeader(headerParameterConverted)

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/implementation/ExplicitsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/implementation/ExplicitsImpl.java
@@ -165,8 +165,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredIntegerParameter(int bodyParameter) throws ErrorException, IOException {
-        return postRequiredIntegerParameterAsync(bodyParameter).toBlocking().single();
+    public Error postRequiredIntegerParameter(int bodyParameter) throws ErrorException, IOException {
+        return postRequiredIntegerParameterAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -177,7 +177,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredIntegerParameterAsync(int bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredIntegerParameterAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredIntegerParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
     }
 
     /**
@@ -186,7 +186,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the int value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredIntegerParameterAsync(int bodyParameter) {
+    public Observable<Error> postRequiredIntegerParameterAsync(int bodyParameter) {
+        return postRequiredIntegerParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the int value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredIntegerParameterAsyncWithServiceResponse(int bodyParameter) {
         return service.postRequiredIntegerParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -214,8 +229,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalIntegerParameter() throws ErrorException, IOException {
-        return postOptionalIntegerParameterAsync().toBlocking().single();
+    public void postOptionalIntegerParameter() throws ErrorException, IOException {
+        postOptionalIntegerParameterAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -225,7 +240,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerParameterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerParameterAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerParameterAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -233,7 +248,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsync() {
+    public Observable<Void> postOptionalIntegerParameterAsync() {
+        return postOptionalIntegerParameterAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsyncWithServiceResponse() {
         final Integer bodyParameter = null;
         return service.postOptionalIntegerParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -257,8 +286,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalIntegerParameter(Integer bodyParameter) throws ErrorException, IOException {
-        return postOptionalIntegerParameterAsync(bodyParameter).toBlocking().single();
+    public void postOptionalIntegerParameter(Integer bodyParameter) throws ErrorException, IOException {
+        postOptionalIntegerParameterAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -269,7 +298,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerParameterAsync(Integer bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerParameterAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalIntegerParameterAsync(Integer bodyParameter) {
+        return postOptionalIntegerParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -278,7 +321,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsync(Integer bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalIntegerParameterAsyncWithServiceResponse(Integer bodyParameter) {
         return service.postOptionalIntegerParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -309,8 +352,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredIntegerProperty(IntWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredIntegerPropertyAsync(bodyParameter).toBlocking().single();
+    public Error postRequiredIntegerProperty(IntWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredIntegerPropertyAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -321,7 +364,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredIntegerPropertyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredIntegerPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
     }
 
     /**
@@ -330,7 +373,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the IntWrapper value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter) {
+    public Observable<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter) {
+        return postRequiredIntegerPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the IntWrapper value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredIntegerPropertyAsyncWithServiceResponse(IntWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -362,8 +420,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalIntegerProperty() throws ErrorException, IOException {
-        return postOptionalIntegerPropertyAsync().toBlocking().single();
+    public void postOptionalIntegerProperty() throws ErrorException, IOException {
+        postOptionalIntegerPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -373,7 +431,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerPropertyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerPropertyAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerPropertyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -381,7 +439,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsync() {
+    public Observable<Void> postOptionalIntegerPropertyAsync() {
+        return postOptionalIntegerPropertyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsyncWithServiceResponse() {
         final IntOptionalWrapper bodyParameter = null;
         return service.postOptionalIntegerProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -405,8 +477,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) throws ErrorException, IOException {
-        return postOptionalIntegerPropertyAsync(bodyParameter).toBlocking().single();
+    public void postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) throws ErrorException, IOException {
+        postOptionalIntegerPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -417,7 +489,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerPropertyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter) {
+        return postOptionalIntegerPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -426,7 +512,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the IntOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalIntegerPropertyAsyncWithServiceResponse(IntOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalIntegerProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -457,8 +543,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredIntegerHeader(int headerParameter) throws ErrorException, IOException {
-        return postRequiredIntegerHeaderAsync(headerParameter).toBlocking().single();
+    public Error postRequiredIntegerHeader(int headerParameter) throws ErrorException, IOException {
+        return postRequiredIntegerHeaderAsyncWithServiceResponse(headerParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -469,7 +555,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredIntegerHeaderAsync(int headerParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredIntegerHeaderAsync(headerParameter), serviceCallback);
+        return ServiceCall.create(postRequiredIntegerHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
     }
 
     /**
@@ -478,7 +564,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the int value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredIntegerHeaderAsync(int headerParameter) {
+    public Observable<Error> postRequiredIntegerHeaderAsync(int headerParameter) {
+        return postRequiredIntegerHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the int value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredIntegerHeaderAsyncWithServiceResponse(int headerParameter) {
         return service.postRequiredIntegerHeader(headerParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override
@@ -506,8 +607,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalIntegerHeader() throws ErrorException, IOException {
-        return postOptionalIntegerHeaderAsync().toBlocking().single();
+    public void postOptionalIntegerHeader() throws ErrorException, IOException {
+        postOptionalIntegerHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -517,7 +618,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerHeaderAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerHeaderAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -525,7 +626,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsync() {
+    public Observable<Void> postOptionalIntegerHeaderAsync() {
+        return postOptionalIntegerHeaderAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsyncWithServiceResponse() {
         final Integer headerParameter = null;
         return service.postOptionalIntegerHeader(headerParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -549,8 +664,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalIntegerHeader(Integer headerParameter) throws ErrorException, IOException {
-        return postOptionalIntegerHeaderAsync(headerParameter).toBlocking().single();
+    public void postOptionalIntegerHeader(Integer headerParameter) throws ErrorException, IOException {
+        postOptionalIntegerHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -561,7 +676,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalIntegerHeaderAsync(Integer headerParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalIntegerHeaderAsync(headerParameter), serviceCallback);
+        return ServiceCall.create(postOptionalIntegerHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalIntegerHeaderAsync(Integer headerParameter) {
+        return postOptionalIntegerHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -570,7 +699,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the Integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsync(Integer headerParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalIntegerHeaderAsyncWithServiceResponse(Integer headerParameter) {
         return service.postOptionalIntegerHeader(headerParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -601,8 +730,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredStringParameter(String bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredStringParameterAsync(bodyParameter).toBlocking().single();
+    public Error postRequiredStringParameter(String bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredStringParameterAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -613,7 +742,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredStringParameterAsync(String bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredStringParameterAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredStringParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
     }
 
     /**
@@ -622,7 +751,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the String value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredStringParameterAsync(String bodyParameter) {
+    public Observable<Error> postRequiredStringParameterAsync(String bodyParameter) {
+        return postRequiredStringParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the String value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredStringParameterAsyncWithServiceResponse(String bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -653,8 +797,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalStringParameter() throws ErrorException, IOException {
-        return postOptionalStringParameterAsync().toBlocking().single();
+    public void postOptionalStringParameter() throws ErrorException, IOException {
+        postOptionalStringParameterAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -664,7 +808,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringParameterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringParameterAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalStringParameterAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -672,7 +816,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringParameterAsync() {
+    public Observable<Void> postOptionalStringParameterAsync() {
+        return postOptionalStringParameterAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalStringParameterAsyncWithServiceResponse() {
         final String bodyParameter = null;
         return service.postOptionalStringParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -696,8 +854,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalStringParameter(String bodyParameter) throws ErrorException, IOException {
-        return postOptionalStringParameterAsync(bodyParameter).toBlocking().single();
+    public void postOptionalStringParameter(String bodyParameter) throws ErrorException, IOException {
+        postOptionalStringParameterAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -708,7 +866,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringParameterAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringParameterAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalStringParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalStringParameterAsync(String bodyParameter) {
+        return postOptionalStringParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -717,7 +889,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringParameterAsync(String bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalStringParameterAsyncWithServiceResponse(String bodyParameter) {
         return service.postOptionalStringParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -748,8 +920,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredStringProperty(StringWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredStringPropertyAsync(bodyParameter).toBlocking().single();
+    public Error postRequiredStringProperty(StringWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredStringPropertyAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -760,7 +932,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredStringPropertyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredStringPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
     }
 
     /**
@@ -769,7 +941,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the StringWrapper value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredStringPropertyAsync(StringWrapper bodyParameter) {
+    public Observable<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter) {
+        return postRequiredStringPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the StringWrapper value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredStringPropertyAsyncWithServiceResponse(StringWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -801,8 +988,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalStringProperty() throws ErrorException, IOException {
-        return postOptionalStringPropertyAsync().toBlocking().single();
+    public void postOptionalStringProperty() throws ErrorException, IOException {
+        postOptionalStringPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -812,7 +999,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringPropertyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringPropertyAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalStringPropertyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -820,7 +1007,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringPropertyAsync() {
+    public Observable<Void> postOptionalStringPropertyAsync() {
+        return postOptionalStringPropertyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalStringPropertyAsyncWithServiceResponse() {
         final StringOptionalWrapper bodyParameter = null;
         return service.postOptionalStringProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -844,8 +1045,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalStringProperty(StringOptionalWrapper bodyParameter) throws ErrorException, IOException {
-        return postOptionalStringPropertyAsync(bodyParameter).toBlocking().single();
+    public void postOptionalStringProperty(StringOptionalWrapper bodyParameter) throws ErrorException, IOException {
+        postOptionalStringPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -856,7 +1057,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringPropertyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalStringPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter) {
+        return postOptionalStringPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -865,7 +1080,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the StringOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalStringPropertyAsyncWithServiceResponse(StringOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalStringProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -897,8 +1112,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredStringHeader(String headerParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredStringHeaderAsync(headerParameter).toBlocking().single();
+    public Error postRequiredStringHeader(String headerParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredStringHeaderAsyncWithServiceResponse(headerParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -909,7 +1124,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredStringHeaderAsync(String headerParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredStringHeaderAsync(headerParameter), serviceCallback);
+        return ServiceCall.create(postRequiredStringHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
     }
 
     /**
@@ -918,7 +1133,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the String value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredStringHeaderAsync(String headerParameter) {
+    public Observable<Error> postRequiredStringHeaderAsync(String headerParameter) {
+        return postRequiredStringHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the String value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredStringHeaderAsyncWithServiceResponse(String headerParameter) {
         if (headerParameter == null) {
             throw new IllegalArgumentException("Parameter headerParameter is required and cannot be null.");
         }
@@ -949,8 +1179,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalStringHeader() throws ErrorException, IOException {
-        return postOptionalStringHeaderAsync().toBlocking().single();
+    public void postOptionalStringHeader() throws ErrorException, IOException {
+        postOptionalStringHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -960,7 +1190,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringHeaderAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalStringHeaderAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -968,7 +1198,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringHeaderAsync() {
+    public Observable<Void> postOptionalStringHeaderAsync() {
+        return postOptionalStringHeaderAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalStringHeaderAsyncWithServiceResponse() {
         final String bodyParameter = null;
         return service.postOptionalStringHeader(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -992,8 +1236,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalStringHeader(String bodyParameter) throws ErrorException, IOException {
-        return postOptionalStringHeaderAsync(bodyParameter).toBlocking().single();
+    public void postOptionalStringHeader(String bodyParameter) throws ErrorException, IOException {
+        postOptionalStringHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1004,7 +1248,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalStringHeaderAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalStringHeaderAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalStringHeaderAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalStringHeaderAsync(String bodyParameter) {
+        return postOptionalStringHeaderAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1013,7 +1271,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalStringHeaderAsync(String bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalStringHeaderAsyncWithServiceResponse(String bodyParameter) {
         return service.postOptionalStringHeader(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1044,8 +1302,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredClassParameter(Product bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredClassParameterAsync(bodyParameter).toBlocking().single();
+    public Error postRequiredClassParameter(Product bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredClassParameterAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1056,7 +1314,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredClassParameterAsync(Product bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredClassParameterAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredClassParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1065,7 +1323,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the Product value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredClassParameterAsync(Product bodyParameter) {
+    public Observable<Error> postRequiredClassParameterAsync(Product bodyParameter) {
+        return postRequiredClassParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the Product value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredClassParameterAsyncWithServiceResponse(Product bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -1097,8 +1370,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalClassParameter() throws ErrorException, IOException {
-        return postOptionalClassParameterAsync().toBlocking().single();
+    public void postOptionalClassParameter() throws ErrorException, IOException {
+        postOptionalClassParameterAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1108,7 +1381,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalClassParameterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalClassParameterAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalClassParameterAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1116,7 +1389,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalClassParameterAsync() {
+    public Observable<Void> postOptionalClassParameterAsync() {
+        return postOptionalClassParameterAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalClassParameterAsyncWithServiceResponse() {
         final Product bodyParameter = null;
         return service.postOptionalClassParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1140,8 +1427,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalClassParameter(Product bodyParameter) throws ErrorException, IOException {
-        return postOptionalClassParameterAsync(bodyParameter).toBlocking().single();
+    public void postOptionalClassParameter(Product bodyParameter) throws ErrorException, IOException {
+        postOptionalClassParameterAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1152,7 +1439,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalClassParameterAsync(Product bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalClassParameterAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalClassParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalClassParameterAsync(Product bodyParameter) {
+        return postOptionalClassParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1161,7 +1462,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the Product value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalClassParameterAsync(Product bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalClassParameterAsyncWithServiceResponse(Product bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalClassParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1193,8 +1494,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredClassProperty(ClassWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredClassPropertyAsync(bodyParameter).toBlocking().single();
+    public Error postRequiredClassProperty(ClassWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredClassPropertyAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1205,7 +1506,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredClassPropertyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredClassPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1214,7 +1515,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ClassWrapper value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredClassPropertyAsync(ClassWrapper bodyParameter) {
+    public Observable<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter) {
+        return postRequiredClassPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the ClassWrapper value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredClassPropertyAsyncWithServiceResponse(ClassWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -1246,8 +1562,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalClassProperty() throws ErrorException, IOException {
-        return postOptionalClassPropertyAsync().toBlocking().single();
+    public void postOptionalClassProperty() throws ErrorException, IOException {
+        postOptionalClassPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1257,7 +1573,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalClassPropertyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalClassPropertyAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalClassPropertyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1265,7 +1581,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalClassPropertyAsync() {
+    public Observable<Void> postOptionalClassPropertyAsync() {
+        return postOptionalClassPropertyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalClassPropertyAsyncWithServiceResponse() {
         final ClassOptionalWrapper bodyParameter = null;
         return service.postOptionalClassProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1289,8 +1619,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalClassProperty(ClassOptionalWrapper bodyParameter) throws ErrorException, IOException {
-        return postOptionalClassPropertyAsync(bodyParameter).toBlocking().single();
+    public void postOptionalClassProperty(ClassOptionalWrapper bodyParameter) throws ErrorException, IOException {
+        postOptionalClassPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1301,7 +1631,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalClassPropertyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalClassPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter) {
+        return postOptionalClassPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1310,7 +1654,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ClassOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalClassPropertyAsyncWithServiceResponse(ClassOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalClassProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1342,8 +1686,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredArrayParameter(List<String> bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredArrayParameterAsync(bodyParameter).toBlocking().single();
+    public Error postRequiredArrayParameter(List<String> bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredArrayParameterAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1354,7 +1698,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredArrayParameterAsync(List<String> bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredArrayParameterAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredArrayParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1363,7 +1707,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredArrayParameterAsync(List<String> bodyParameter) {
+    public Observable<Error> postRequiredArrayParameterAsync(List<String> bodyParameter) {
+        return postRequiredArrayParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredArrayParameterAsyncWithServiceResponse(List<String> bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -1395,8 +1754,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalArrayParameter() throws ErrorException, IOException {
-        return postOptionalArrayParameterAsync().toBlocking().single();
+    public void postOptionalArrayParameter() throws ErrorException, IOException {
+        postOptionalArrayParameterAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1406,7 +1765,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayParameterAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayParameterAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalArrayParameterAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1414,7 +1773,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayParameterAsync() {
+    public Observable<Void> postOptionalArrayParameterAsync() {
+        return postOptionalArrayParameterAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalArrayParameterAsyncWithServiceResponse() {
         final List<String> bodyParameter = null;
         return service.postOptionalArrayParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1438,8 +1811,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalArrayParameter(List<String> bodyParameter) throws ErrorException, IOException {
-        return postOptionalArrayParameterAsync(bodyParameter).toBlocking().single();
+    public void postOptionalArrayParameter(List<String> bodyParameter) throws ErrorException, IOException {
+        postOptionalArrayParameterAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1450,7 +1823,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayParameterAsync(List<String> bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayParameterAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalArrayParameterAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalArrayParameterAsync(List<String> bodyParameter) {
+        return postOptionalArrayParameterAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1459,7 +1846,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayParameterAsync(List<String> bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalArrayParameterAsyncWithServiceResponse(List<String> bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalArrayParameter(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1491,8 +1878,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredArrayProperty(ArrayWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredArrayPropertyAsync(bodyParameter).toBlocking().single();
+    public Error postRequiredArrayProperty(ArrayWrapper bodyParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredArrayPropertyAsyncWithServiceResponse(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1503,7 +1890,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredArrayPropertyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postRequiredArrayPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
     }
 
     /**
@@ -1512,7 +1899,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ArrayWrapper value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter) {
+    public Observable<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter) {
+        return postRequiredArrayPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the ArrayWrapper value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredArrayPropertyAsyncWithServiceResponse(ArrayWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
@@ -1544,8 +1946,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalArrayProperty() throws ErrorException, IOException {
-        return postOptionalArrayPropertyAsync().toBlocking().single();
+    public void postOptionalArrayProperty() throws ErrorException, IOException {
+        postOptionalArrayPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1555,7 +1957,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayPropertyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayPropertyAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalArrayPropertyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1563,7 +1965,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsync() {
+    public Observable<Void> postOptionalArrayPropertyAsync() {
+        return postOptionalArrayPropertyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsyncWithServiceResponse() {
         final ArrayOptionalWrapper bodyParameter = null;
         return service.postOptionalArrayProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1587,8 +2003,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) throws ErrorException, IOException {
-        return postOptionalArrayPropertyAsync(bodyParameter).toBlocking().single();
+    public void postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) throws ErrorException, IOException {
+        postOptionalArrayPropertyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1599,7 +2015,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayPropertyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(postOptionalArrayPropertyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter) {
+        return postOptionalArrayPropertyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1608,7 +2038,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param bodyParameter the ArrayOptionalWrapper value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalArrayPropertyAsyncWithServiceResponse(ArrayOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalArrayProperty(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1640,8 +2070,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> postRequiredArrayHeader(List<String> headerParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return postRequiredArrayHeaderAsync(headerParameter).toBlocking().single();
+    public Error postRequiredArrayHeader(List<String> headerParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return postRequiredArrayHeaderAsyncWithServiceResponse(headerParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -1652,7 +2082,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> postRequiredArrayHeaderAsync(List<String> headerParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(postRequiredArrayHeaderAsync(headerParameter), serviceCallback);
+        return ServiceCall.create(postRequiredArrayHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
     }
 
     /**
@@ -1661,7 +2091,22 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> postRequiredArrayHeaderAsync(List<String> headerParameter) {
+    public Observable<Error> postRequiredArrayHeaderAsync(List<String> headerParameter) {
+        return postRequiredArrayHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> postRequiredArrayHeaderAsyncWithServiceResponse(List<String> headerParameter) {
         if (headerParameter == null) {
             throw new IllegalArgumentException("Parameter headerParameter is required and cannot be null.");
         }
@@ -1694,8 +2139,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalArrayHeader() throws ErrorException, IOException {
-        return postOptionalArrayHeaderAsync().toBlocking().single();
+    public void postOptionalArrayHeader() throws ErrorException, IOException {
+        postOptionalArrayHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1705,7 +2150,7 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayHeaderAsync(), serviceCallback);
+        return ServiceCall.create(postOptionalArrayHeaderAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1713,7 +2158,21 @@ public final class ExplicitsImpl implements Explicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsync() {
+    public Observable<Void> postOptionalArrayHeaderAsync() {
+        return postOptionalArrayHeaderAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsyncWithServiceResponse() {
         final List<String> headerParameter = null;
         String headerParameterConverted = this.client.mapperAdapter().serializeList(headerParameter, CollectionFormat.CSV);
         return service.postOptionalArrayHeader(headerParameterConverted)
@@ -1738,8 +2197,8 @@ public final class ExplicitsImpl implements Explicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> postOptionalArrayHeader(List<String> headerParameter) throws ErrorException, IOException {
-        return postOptionalArrayHeaderAsync(headerParameter).toBlocking().single();
+    public void postOptionalArrayHeader(List<String> headerParameter) throws ErrorException, IOException {
+        postOptionalArrayHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1750,7 +2209,21 @@ public final class ExplicitsImpl implements Explicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> postOptionalArrayHeaderAsync(List<String> headerParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(postOptionalArrayHeaderAsync(headerParameter), serviceCallback);
+        return ServiceCall.create(postOptionalArrayHeaderAsyncWithServiceResponse(headerParameter), serviceCallback);
+    }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> postOptionalArrayHeaderAsync(List<String> headerParameter) {
+        return postOptionalArrayHeaderAsyncWithServiceResponse(headerParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1759,7 +2232,7 @@ public final class ExplicitsImpl implements Explicits {
      * @param headerParameter the List&lt;String&gt; value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsync(List<String> headerParameter) {
+    public Observable<ServiceResponse<Void>> postOptionalArrayHeaderAsyncWithServiceResponse(List<String> headerParameter) {
         Validator.validate(headerParameter);
         String headerParameterConverted = this.client.mapperAdapter().serializeList(headerParameter, CollectionFormat.CSV);
         return service.postOptionalArrayHeader(headerParameterConverted)

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/implementation/ImplicitsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/implementation/ImplicitsImpl.java
@@ -95,10 +95,10 @@ public final class ImplicitsImpl implements Implicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error getRequiredPath(String pathParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return getRequiredPathAsyncWithServiceResponse(pathParameter).toBlocking().single().getBody();
+        return getRequiredPathWithServiceResponseAsync(pathParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -109,7 +109,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> getRequiredPathAsync(String pathParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(getRequiredPathAsyncWithServiceResponse(pathParameter), serviceCallback);
+        return ServiceCall.create(getRequiredPathWithServiceResponseAsync(pathParameter), serviceCallback);
     }
 
     /**
@@ -119,12 +119,12 @@ public final class ImplicitsImpl implements Implicits {
      * @return the observable to the Error object
      */
     public Observable<Error> getRequiredPathAsync(String pathParameter) {
-        return getRequiredPathAsyncWithServiceResponse(pathParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+        return getRequiredPathWithServiceResponseAsync(pathParameter).map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -133,7 +133,7 @@ public final class ImplicitsImpl implements Implicits {
      * @param pathParameter the String value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> getRequiredPathAsyncWithServiceResponse(String pathParameter) {
+    public Observable<ServiceResponse<Error>> getRequiredPathWithServiceResponseAsync(String pathParameter) {
         if (pathParameter == null) {
             throw new IllegalArgumentException("Parameter pathParameter is required and cannot be null.");
         }
@@ -162,10 +162,9 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putOptionalQuery() throws ErrorException, IOException {
-        putOptionalQueryAsyncWithServiceResponse().toBlocking().single().getBody();
+        putOptionalQueryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -175,7 +174,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalQueryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalQueryAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(putOptionalQueryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -184,12 +183,12 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putOptionalQueryAsync() {
-        return putOptionalQueryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return putOptionalQueryWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -197,7 +196,7 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalQueryAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> putOptionalQueryWithServiceResponseAsync() {
         final String queryParameter = null;
         return service.putOptionalQuery(queryParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -219,10 +218,9 @@ public final class ImplicitsImpl implements Implicits {
      * @param queryParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putOptionalQuery(String queryParameter) throws ErrorException, IOException {
-        putOptionalQueryAsyncWithServiceResponse().toBlocking().single().getBody();
+        putOptionalQueryWithServiceResponseAsync(queryParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -233,21 +231,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalQueryAsync(String queryParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalQueryAsyncWithServiceResponse(queryParameter), serviceCallback);
-    }
-
-    /**
-     * Test implicitly optional query parameter.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> putOptionalQueryAsync(String queryParameter) {
-        return putOptionalQueryAsyncWithServiceResponse(queryParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(putOptionalQueryWithServiceResponseAsync(queryParameter), serviceCallback);
     }
 
     /**
@@ -256,7 +240,22 @@ public final class ImplicitsImpl implements Implicits {
      * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalQueryAsyncWithServiceResponse(String queryParameter) {
+    public Observable<Void> putOptionalQueryAsync(String queryParameter) {
+        return putOptionalQueryWithServiceResponseAsync(queryParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param queryParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putOptionalQueryWithServiceResponseAsync(String queryParameter) {
         return service.putOptionalQuery(queryParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -283,10 +282,9 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putOptionalHeader() throws ErrorException, IOException {
-        putOptionalHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
+        putOptionalHeaderWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -296,7 +294,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalHeaderAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(putOptionalHeaderWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -305,12 +303,12 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putOptionalHeaderAsync() {
-        return putOptionalHeaderAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return putOptionalHeaderWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -318,7 +316,7 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalHeaderAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> putOptionalHeaderWithServiceResponseAsync() {
         final String queryParameter = null;
         return service.putOptionalHeader(queryParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -340,10 +338,9 @@ public final class ImplicitsImpl implements Implicits {
      * @param queryParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putOptionalHeader(String queryParameter) throws ErrorException, IOException {
-        putOptionalHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
+        putOptionalHeaderWithServiceResponseAsync(queryParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -354,21 +351,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalHeaderAsync(String queryParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalHeaderAsyncWithServiceResponse(queryParameter), serviceCallback);
-    }
-
-    /**
-     * Test implicitly optional header parameter.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> putOptionalHeaderAsync(String queryParameter) {
-        return putOptionalHeaderAsyncWithServiceResponse(queryParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(putOptionalHeaderWithServiceResponseAsync(queryParameter), serviceCallback);
     }
 
     /**
@@ -377,7 +360,22 @@ public final class ImplicitsImpl implements Implicits {
      * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalHeaderAsyncWithServiceResponse(String queryParameter) {
+    public Observable<Void> putOptionalHeaderAsync(String queryParameter) {
+        return putOptionalHeaderWithServiceResponseAsync(queryParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @param queryParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putOptionalHeaderWithServiceResponseAsync(String queryParameter) {
         return service.putOptionalHeader(queryParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -404,10 +402,9 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putOptionalBody() throws ErrorException, IOException {
-        putOptionalBodyAsyncWithServiceResponse().toBlocking().single().getBody();
+        putOptionalBodyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -417,7 +414,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalBodyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalBodyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(putOptionalBodyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -426,12 +423,12 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> putOptionalBodyAsync() {
-        return putOptionalBodyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return putOptionalBodyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -439,7 +436,7 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalBodyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> putOptionalBodyWithServiceResponseAsync() {
         final String bodyParameter = null;
         return service.putOptionalBody(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -461,10 +458,9 @@ public final class ImplicitsImpl implements Implicits {
      * @param bodyParameter the String value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void putOptionalBody(String bodyParameter) throws ErrorException, IOException {
-        putOptionalBodyAsyncWithServiceResponse().toBlocking().single().getBody();
+        putOptionalBodyWithServiceResponseAsync(bodyParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -475,21 +471,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalBodyAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalBodyAsyncWithServiceResponse(bodyParameter), serviceCallback);
-    }
-
-    /**
-     * Test implicitly optional body parameter.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> putOptionalBodyAsync(String bodyParameter) {
-        return putOptionalBodyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(putOptionalBodyWithServiceResponseAsync(bodyParameter), serviceCallback);
     }
 
     /**
@@ -498,7 +480,22 @@ public final class ImplicitsImpl implements Implicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalBodyAsyncWithServiceResponse(String bodyParameter) {
+    public Observable<Void> putOptionalBodyAsync(String bodyParameter) {
+        return putOptionalBodyWithServiceResponseAsync(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter the String value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putOptionalBodyWithServiceResponseAsync(String bodyParameter) {
         return service.putOptionalBody(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -526,10 +523,10 @@ public final class ImplicitsImpl implements Implicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error getRequiredGlobalPath() throws ErrorException, IOException, IllegalArgumentException {
-        return getRequiredGlobalPathAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getRequiredGlobalPathWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -539,7 +536,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> getRequiredGlobalPathAsync(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(getRequiredGlobalPathAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getRequiredGlobalPathWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -548,12 +545,12 @@ public final class ImplicitsImpl implements Implicits {
      * @return the observable to the Error object
      */
     public Observable<Error> getRequiredGlobalPathAsync() {
-        return getRequiredGlobalPathAsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return getRequiredGlobalPathWithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -561,7 +558,7 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> getRequiredGlobalPathAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> getRequiredGlobalPathWithServiceResponseAsync() {
         if (this.client.requiredGlobalPath() == null) {
             throw new IllegalArgumentException("Parameter this.client.requiredGlobalPath() is required and cannot be null.");
         }
@@ -591,10 +588,10 @@ public final class ImplicitsImpl implements Implicits {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error getRequiredGlobalQuery() throws ErrorException, IOException, IllegalArgumentException {
-        return getRequiredGlobalQueryAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getRequiredGlobalQueryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -604,7 +601,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> getRequiredGlobalQueryAsync(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(getRequiredGlobalQueryAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getRequiredGlobalQueryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -613,12 +610,12 @@ public final class ImplicitsImpl implements Implicits {
      * @return the observable to the Error object
      */
     public Observable<Error> getRequiredGlobalQueryAsync() {
-        return getRequiredGlobalQueryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return getRequiredGlobalQueryWithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -626,7 +623,7 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> getRequiredGlobalQueryAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> getRequiredGlobalQueryWithServiceResponseAsync() {
         if (this.client.requiredGlobalQuery() == null) {
             throw new IllegalArgumentException("Parameter this.client.requiredGlobalQuery() is required and cannot be null.");
         }
@@ -655,10 +652,10 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Error object wrapped in {@link ServiceResponse} if successful.
+     * @return the Error object if successful.
      */
     public Error getOptionalGlobalQuery() throws ErrorException, IOException {
-        return getOptionalGlobalQueryAsyncWithServiceResponse().toBlocking().single().getBody();
+        return getOptionalGlobalQueryWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -668,7 +665,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> getOptionalGlobalQueryAsync(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(getOptionalGlobalQueryAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getOptionalGlobalQueryWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -677,12 +674,12 @@ public final class ImplicitsImpl implements Implicits {
      * @return the observable to the Error object
      */
     public Observable<Error> getOptionalGlobalQueryAsync() {
-        return getOptionalGlobalQueryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+        return getOptionalGlobalQueryWithServiceResponseAsync().map(new Func1<ServiceResponse<Error>, Error>() {
             @Override
             public Error call(ServiceResponse<Error> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -690,7 +687,7 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> getOptionalGlobalQueryAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Error>> getOptionalGlobalQueryWithServiceResponseAsync() {
         return service.getOptionalGlobalQuery(this.client.optionalGlobalQuery())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/implementation/ImplicitsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/requiredoptional/implementation/ImplicitsImpl.java
@@ -97,8 +97,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> getRequiredPath(String pathParameter) throws ErrorException, IOException, IllegalArgumentException {
-        return getRequiredPathAsync(pathParameter).toBlocking().single();
+    public Error getRequiredPath(String pathParameter) throws ErrorException, IOException, IllegalArgumentException {
+        return getRequiredPathAsyncWithServiceResponse(pathParameter).toBlocking().single().getBody();
     }
 
     /**
@@ -109,7 +109,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> getRequiredPathAsync(String pathParameter, final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(getRequiredPathAsync(pathParameter), serviceCallback);
+        return ServiceCall.create(getRequiredPathAsyncWithServiceResponse(pathParameter), serviceCallback);
     }
 
     /**
@@ -118,7 +118,22 @@ public final class ImplicitsImpl implements Implicits {
      * @param pathParameter the String value
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> getRequiredPathAsync(String pathParameter) {
+    public Observable<Error> getRequiredPathAsync(String pathParameter) {
+        return getRequiredPathAsyncWithServiceResponse(pathParameter).map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @param pathParameter the String value
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> getRequiredPathAsyncWithServiceResponse(String pathParameter) {
         if (pathParameter == null) {
             throw new IllegalArgumentException("Parameter pathParameter is required and cannot be null.");
         }
@@ -149,8 +164,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putOptionalQuery() throws ErrorException, IOException {
-        return putOptionalQueryAsync().toBlocking().single();
+    public void putOptionalQuery() throws ErrorException, IOException {
+        putOptionalQueryAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -160,7 +175,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalQueryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalQueryAsync(), serviceCallback);
+        return ServiceCall.create(putOptionalQueryAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -168,7 +183,21 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalQueryAsync() {
+    public Observable<Void> putOptionalQueryAsync() {
+        return putOptionalQueryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putOptionalQueryAsyncWithServiceResponse() {
         final String queryParameter = null;
         return service.putOptionalQuery(queryParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -192,8 +221,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putOptionalQuery(String queryParameter) throws ErrorException, IOException {
-        return putOptionalQueryAsync(queryParameter).toBlocking().single();
+    public void putOptionalQuery(String queryParameter) throws ErrorException, IOException {
+        putOptionalQueryAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -204,7 +233,21 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalQueryAsync(String queryParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalQueryAsync(queryParameter), serviceCallback);
+        return ServiceCall.create(putOptionalQueryAsyncWithServiceResponse(queryParameter), serviceCallback);
+    }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putOptionalQueryAsync(String queryParameter) {
+        return putOptionalQueryAsyncWithServiceResponse(queryParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -213,7 +256,7 @@ public final class ImplicitsImpl implements Implicits {
      * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalQueryAsync(String queryParameter) {
+    public Observable<ServiceResponse<Void>> putOptionalQueryAsyncWithServiceResponse(String queryParameter) {
         return service.putOptionalQuery(queryParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -242,8 +285,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putOptionalHeader() throws ErrorException, IOException {
-        return putOptionalHeaderAsync().toBlocking().single();
+    public void putOptionalHeader() throws ErrorException, IOException {
+        putOptionalHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -253,7 +296,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalHeaderAsync(), serviceCallback);
+        return ServiceCall.create(putOptionalHeaderAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -261,7 +304,21 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalHeaderAsync() {
+    public Observable<Void> putOptionalHeaderAsync() {
+        return putOptionalHeaderAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putOptionalHeaderAsyncWithServiceResponse() {
         final String queryParameter = null;
         return service.putOptionalHeader(queryParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -285,8 +342,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putOptionalHeader(String queryParameter) throws ErrorException, IOException {
-        return putOptionalHeaderAsync(queryParameter).toBlocking().single();
+    public void putOptionalHeader(String queryParameter) throws ErrorException, IOException {
+        putOptionalHeaderAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -297,7 +354,21 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalHeaderAsync(String queryParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalHeaderAsync(queryParameter), serviceCallback);
+        return ServiceCall.create(putOptionalHeaderAsyncWithServiceResponse(queryParameter), serviceCallback);
+    }
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putOptionalHeaderAsync(String queryParameter) {
+        return putOptionalHeaderAsyncWithServiceResponse(queryParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -306,7 +377,7 @@ public final class ImplicitsImpl implements Implicits {
      * @param queryParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalHeaderAsync(String queryParameter) {
+    public Observable<ServiceResponse<Void>> putOptionalHeaderAsyncWithServiceResponse(String queryParameter) {
         return service.putOptionalHeader(queryParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -335,8 +406,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putOptionalBody() throws ErrorException, IOException {
-        return putOptionalBodyAsync().toBlocking().single();
+    public void putOptionalBody() throws ErrorException, IOException {
+        putOptionalBodyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -346,7 +417,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalBodyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalBodyAsync(), serviceCallback);
+        return ServiceCall.create(putOptionalBodyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -354,7 +425,21 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalBodyAsync() {
+    public Observable<Void> putOptionalBodyAsync() {
+        return putOptionalBodyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> putOptionalBodyAsyncWithServiceResponse() {
         final String bodyParameter = null;
         return service.putOptionalBody(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -378,8 +463,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> putOptionalBody(String bodyParameter) throws ErrorException, IOException {
-        return putOptionalBodyAsync(bodyParameter).toBlocking().single();
+    public void putOptionalBody(String bodyParameter) throws ErrorException, IOException {
+        putOptionalBodyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -390,7 +475,21 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> putOptionalBodyAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(putOptionalBodyAsync(bodyParameter), serviceCallback);
+        return ServiceCall.create(putOptionalBodyAsyncWithServiceResponse(bodyParameter), serviceCallback);
+    }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> putOptionalBodyAsync(String bodyParameter) {
+        return putOptionalBodyAsyncWithServiceResponse(bodyParameter).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -399,7 +498,7 @@ public final class ImplicitsImpl implements Implicits {
      * @param bodyParameter the String value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> putOptionalBodyAsync(String bodyParameter) {
+    public Observable<ServiceResponse<Void>> putOptionalBodyAsyncWithServiceResponse(String bodyParameter) {
         return service.putOptionalBody(bodyParameter)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -429,8 +528,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> getRequiredGlobalPath() throws ErrorException, IOException, IllegalArgumentException {
-        return getRequiredGlobalPathAsync().toBlocking().single();
+    public Error getRequiredGlobalPath() throws ErrorException, IOException, IllegalArgumentException {
+        return getRequiredGlobalPathAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -440,7 +539,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> getRequiredGlobalPathAsync(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(getRequiredGlobalPathAsync(), serviceCallback);
+        return ServiceCall.create(getRequiredGlobalPathAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -448,7 +547,21 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> getRequiredGlobalPathAsync() {
+    public Observable<Error> getRequiredGlobalPathAsync() {
+        return getRequiredGlobalPathAsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> getRequiredGlobalPathAsyncWithServiceResponse() {
         if (this.client.requiredGlobalPath() == null) {
             throw new IllegalArgumentException("Parameter this.client.requiredGlobalPath() is required and cannot be null.");
         }
@@ -480,8 +593,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> getRequiredGlobalQuery() throws ErrorException, IOException, IllegalArgumentException {
-        return getRequiredGlobalQueryAsync().toBlocking().single();
+    public Error getRequiredGlobalQuery() throws ErrorException, IOException, IllegalArgumentException {
+        return getRequiredGlobalQueryAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -491,7 +604,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> getRequiredGlobalQueryAsync(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(getRequiredGlobalQueryAsync(), serviceCallback);
+        return ServiceCall.create(getRequiredGlobalQueryAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -499,7 +612,21 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> getRequiredGlobalQueryAsync() {
+    public Observable<Error> getRequiredGlobalQueryAsync() {
+        return getRequiredGlobalQueryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test implicitly required query parameter.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> getRequiredGlobalQueryAsyncWithServiceResponse() {
         if (this.client.requiredGlobalQuery() == null) {
             throw new IllegalArgumentException("Parameter this.client.requiredGlobalQuery() is required and cannot be null.");
         }
@@ -530,8 +657,8 @@ public final class ImplicitsImpl implements Implicits {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Error object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Error> getOptionalGlobalQuery() throws ErrorException, IOException {
-        return getOptionalGlobalQueryAsync().toBlocking().single();
+    public Error getOptionalGlobalQuery() throws ErrorException, IOException {
+        return getOptionalGlobalQueryAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -541,7 +668,7 @@ public final class ImplicitsImpl implements Implicits {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Error> getOptionalGlobalQueryAsync(final ServiceCallback<Error> serviceCallback) {
-        return ServiceCall.create(getOptionalGlobalQueryAsync(), serviceCallback);
+        return ServiceCall.create(getOptionalGlobalQueryAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -549,7 +676,21 @@ public final class ImplicitsImpl implements Implicits {
      *
      * @return the observable to the Error object
      */
-    public Observable<ServiceResponse<Error>> getOptionalGlobalQueryAsync() {
+    public Observable<Error> getOptionalGlobalQueryAsync() {
+        return getOptionalGlobalQueryAsyncWithServiceResponse().map(new Func1<ServiceResponse<Error>, Error>() {
+            @Override
+            public Error call(ServiceResponse<Error> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @return the observable to the Error object
+     */
+    public Observable<ServiceResponse<Error>> getOptionalGlobalQueryAsyncWithServiceResponse() {
         return service.getOptionalGlobalQuery(this.client.optionalGlobalQuery())
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Error>>>() {
                 @Override

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/PathItems.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/PathItems.java
@@ -30,7 +30,6 @@ public interface PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getAllWithValues(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -49,8 +48,6 @@ public interface PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @param localStringQuery should contain value 'localStringQuery'
-     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath);
@@ -60,11 +57,9 @@ public interface PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @param localStringQuery should contain value 'localStringQuery'
-     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getAllWithValuesAsyncWithServiceResponse(String localStringPath, String pathItemStringPath);
+    Observable<ServiceResponse<Void>> getAllWithValuesWithServiceResponseAsync(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
      *
@@ -75,7 +70,6 @@ public interface PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getAllWithValues(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -111,7 +105,7 @@ public interface PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getAllWithValuesAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    Observable<ServiceResponse<Void>> getAllWithValuesWithServiceResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
@@ -121,7 +115,6 @@ public interface PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getGlobalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -140,8 +133,6 @@ public interface PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @param localStringQuery should contain value 'localStringQuery'
-     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath);
@@ -151,11 +142,9 @@ public interface PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @param localStringQuery should contain value 'localStringQuery'
-     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getGlobalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath);
+    Observable<ServiceResponse<Void>> getGlobalQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
      *
@@ -166,7 +155,6 @@ public interface PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getGlobalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -202,7 +190,7 @@ public interface PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getGlobalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    Observable<ServiceResponse<Void>> getGlobalQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
     /**
      * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
@@ -212,7 +200,6 @@ public interface PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -231,8 +218,6 @@ public interface PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @param localStringQuery should contain null value
-     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath);
@@ -242,11 +227,9 @@ public interface PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @param localStringQuery should contain null value
-     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath);
+    Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
      *
@@ -257,7 +240,6 @@ public interface PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -293,7 +275,7 @@ public interface PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
@@ -303,7 +285,6 @@ public interface PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -322,8 +303,6 @@ public interface PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @param localStringQuery should contain value null
-     * @param pathItemStringQuery should contain value null
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath);
@@ -333,11 +312,9 @@ public interface PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @param localStringQuery should contain value null
-     * @param pathItemStringQuery should contain value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath);
+    Observable<ServiceResponse<Void>> getLocalPathItemQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
      *
@@ -348,7 +325,6 @@ public interface PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -384,6 +360,6 @@ public interface PathItems {
      * @param pathItemStringQuery should contain value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    Observable<ServiceResponse<Void>> getLocalPathItemQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/PathItems.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/PathItems.java
@@ -32,7 +32,7 @@ public interface PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getAllWithValues(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
+    void getAllWithValues(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
@@ -43,6 +43,28 @@ public interface PathItems {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getAllWithValuesAsyncWithServiceResponse(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
      *
@@ -55,7 +77,7 @@ public interface PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getAllWithValues(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
+    void getAllWithValues(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
@@ -78,7 +100,18 @@ public interface PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    Observable<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getAllWithValuesAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
@@ -90,7 +123,7 @@ public interface PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getGlobalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
+    void getGlobalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
@@ -101,6 +134,28 @@ public interface PathItems {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getGlobalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
      *
@@ -113,7 +168,7 @@ public interface PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getGlobalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
+    void getGlobalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
@@ -136,7 +191,18 @@ public interface PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    Observable<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getGlobalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
     /**
      * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
@@ -148,7 +214,7 @@ public interface PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
+    void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
@@ -159,6 +225,28 @@ public interface PathItems {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain null value
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath);
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain null value
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
      *
@@ -171,7 +259,7 @@ public interface PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
+    void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
@@ -194,7 +282,18 @@ public interface PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    Observable<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain null value
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
@@ -206,7 +305,7 @@ public interface PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
+    void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
@@ -217,6 +316,28 @@ public interface PathItems {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value null
+     * @param pathItemStringQuery should contain value null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value null
+     * @param pathItemStringQuery should contain value null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
      *
@@ -229,7 +350,7 @@ public interface PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
+    void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
@@ -252,6 +373,17 @@ public interface PathItems {
      * @param pathItemStringQuery should contain value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    Observable<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value null
+     * @param pathItemStringQuery should contain value null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/Paths.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/Paths.java
@@ -31,7 +31,6 @@ public interface Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getBooleanTrue() throws ErrorException, IOException;
 
@@ -55,14 +54,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanTrueAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getBooleanTrueWithServiceResponseAsync();
 
     /**
      * Get false Boolean value on path.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getBooleanFalse() throws ErrorException, IOException;
 
@@ -86,14 +84,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanFalseAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getBooleanFalseWithServiceResponseAsync();
 
     /**
      * Get '1000000' integer value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getIntOneMillion() throws ErrorException, IOException;
 
@@ -117,14 +114,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntOneMillionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getIntOneMillionWithServiceResponseAsync();
 
     /**
      * Get '-1000000' integer value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getIntNegativeOneMillion() throws ErrorException, IOException;
 
@@ -148,14 +144,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getIntNegativeOneMillionWithServiceResponseAsync();
 
     /**
      * Get '10000000000' 64 bit integer value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getTenBillion() throws ErrorException, IOException;
 
@@ -179,14 +174,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getTenBillionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getTenBillionWithServiceResponseAsync();
 
     /**
      * Get '-10000000000' 64 bit integer value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getNegativeTenBillion() throws ErrorException, IOException;
 
@@ -210,14 +204,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getNegativeTenBillionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getNegativeTenBillionWithServiceResponseAsync();
 
     /**
      * Get '1.034E+20' numeric value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void floatScientificPositive() throws ErrorException, IOException;
 
@@ -241,14 +234,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatScientificPositiveAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> floatScientificPositiveWithServiceResponseAsync();
 
     /**
      * Get '-1.034E-20' numeric value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void floatScientificNegative() throws ErrorException, IOException;
 
@@ -272,14 +264,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatScientificNegativeAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> floatScientificNegativeWithServiceResponseAsync();
 
     /**
      * Get '9999999.999' numeric value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void doubleDecimalPositive() throws ErrorException, IOException;
 
@@ -303,14 +294,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleDecimalPositiveAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> doubleDecimalPositiveWithServiceResponseAsync();
 
     /**
      * Get '-9999999.999' numeric value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void doubleDecimalNegative() throws ErrorException, IOException;
 
@@ -334,14 +324,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleDecimalNegativeAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> doubleDecimalNegativeWithServiceResponseAsync();
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringUnicode() throws ErrorException, IOException;
 
@@ -365,14 +354,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringUnicodeAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> stringUnicodeWithServiceResponseAsync();
 
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringUrlEncoded() throws ErrorException, IOException;
 
@@ -396,14 +384,13 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringUrlEncodedAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> stringUrlEncodedWithServiceResponseAsync();
 
     /**
      * Get ''.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringEmpty() throws ErrorException, IOException;
 
@@ -427,7 +414,7 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> stringEmptyWithServiceResponseAsync();
 
     /**
      * Get null (should throw).
@@ -436,7 +423,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringNull(String stringPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -463,7 +449,7 @@ public interface Paths {
      * @param stringPath null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse(String stringPath);
+    Observable<ServiceResponse<Void>> stringNullWithServiceResponseAsync(String stringPath);
 
     /**
      * Get using uri with 'green color' in path parameter.
@@ -472,7 +458,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void enumValid(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -499,7 +484,7 @@ public interface Paths {
      * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse(UriColor enumPath);
+    Observable<ServiceResponse<Void>> enumValidWithServiceResponseAsync(UriColor enumPath);
 
     /**
      * Get null (should throw on the client before the request is sent on wire).
@@ -508,7 +493,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void enumNull(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -535,7 +519,7 @@ public interface Paths {
      * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse(UriColor enumPath);
+    Observable<ServiceResponse<Void>> enumNullWithServiceResponseAsync(UriColor enumPath);
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
@@ -544,7 +528,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void byteMultiByte(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -571,14 +554,13 @@ public interface Paths {
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse(byte[] bytePath);
+    Observable<ServiceResponse<Void>> byteMultiByteWithServiceResponseAsync(byte[] bytePath);
 
     /**
      * Get '' as byte array.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void byteEmpty() throws ErrorException, IOException;
 
@@ -602,7 +584,7 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> byteEmptyWithServiceResponseAsync();
 
     /**
      * Get null as byte array (should throw).
@@ -611,7 +593,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void byteNull(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -638,14 +619,13 @@ public interface Paths {
      * @param bytePath null as byte array (should throw)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse(byte[] bytePath);
+    Observable<ServiceResponse<Void>> byteNullWithServiceResponseAsync(byte[] bytePath);
 
     /**
      * Get '2012-01-01' as date.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateValid() throws ErrorException, IOException;
 
@@ -669,7 +649,7 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> dateValidWithServiceResponseAsync();
 
     /**
      * Get null as date - this should throw or be unusable on the client side, depending on date representation.
@@ -678,7 +658,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateNull(LocalDate datePath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -705,14 +684,13 @@ public interface Paths {
      * @param datePath null as date (should throw)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse(LocalDate datePath);
+    Observable<ServiceResponse<Void>> dateNullWithServiceResponseAsync(LocalDate datePath);
 
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateTimeValid() throws ErrorException, IOException;
 
@@ -736,7 +714,7 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> dateTimeValidWithServiceResponseAsync();
 
     /**
      * Get null as date-time, should be disallowed or throw depending on representation of date-time.
@@ -745,7 +723,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateTimeNull(DateTime dateTimePath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -772,7 +749,7 @@ public interface Paths {
      * @param dateTimePath null as date-time
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse(DateTime dateTimePath);
+    Observable<ServiceResponse<Void>> dateTimeNullWithServiceResponseAsync(DateTime dateTimePath);
 
     /**
      * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
@@ -781,7 +758,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void base64Url(byte[] base64UrlPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -808,7 +784,7 @@ public interface Paths {
      * @param base64UrlPath base64url encoded value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> base64UrlAsyncWithServiceResponse(byte[] base64UrlPath);
+    Observable<ServiceResponse<Void>> base64UrlWithServiceResponseAsync(byte[] base64UrlPath);
 
     /**
      * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
@@ -817,7 +793,6 @@ public interface Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayCsvInPath(List<String> arrayPath) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -844,7 +819,7 @@ public interface Paths {
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayCsvInPathAsyncWithServiceResponse(List<String> arrayPath);
+    Observable<ServiceResponse<Void>> arrayCsvInPathWithServiceResponseAsync(List<String> arrayPath);
 
     /**
      * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
@@ -852,7 +827,6 @@ public interface Paths {
      * @param unixTimeUrlPath Unix time encoded value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void unixTimeUrl(DateTime unixTimeUrlPath) throws ErrorException, IOException;
 
@@ -879,6 +853,6 @@ public interface Paths {
      * @param unixTimeUrlPath Unix time encoded value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> unixTimeUrlAsyncWithServiceResponse(DateTime unixTimeUrlPath);
+    Observable<ServiceResponse<Void>> unixTimeUrlWithServiceResponseAsync(DateTime unixTimeUrlPath);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/Paths.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/Paths.java
@@ -33,7 +33,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getBooleanTrue() throws ErrorException, IOException;
+    void getBooleanTrue() throws ErrorException, IOException;
 
     /**
      * Get true Boolean value on path.
@@ -48,7 +48,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanTrueAsync();
+    Observable<Void> getBooleanTrueAsync();
+
+    /**
+     * Get true Boolean value on path.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getBooleanTrueAsyncWithServiceResponse();
 
     /**
      * Get false Boolean value on path.
@@ -57,7 +64,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getBooleanFalse() throws ErrorException, IOException;
+    void getBooleanFalse() throws ErrorException, IOException;
 
     /**
      * Get false Boolean value on path.
@@ -72,7 +79,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanFalseAsync();
+    Observable<Void> getBooleanFalseAsync();
+
+    /**
+     * Get false Boolean value on path.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getBooleanFalseAsyncWithServiceResponse();
 
     /**
      * Get '1000000' integer value.
@@ -81,7 +95,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getIntOneMillion() throws ErrorException, IOException;
+    void getIntOneMillion() throws ErrorException, IOException;
 
     /**
      * Get '1000000' integer value.
@@ -96,7 +110,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntOneMillionAsync();
+    Observable<Void> getIntOneMillionAsync();
+
+    /**
+     * Get '1000000' integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getIntOneMillionAsyncWithServiceResponse();
 
     /**
      * Get '-1000000' integer value.
@@ -105,7 +126,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getIntNegativeOneMillion() throws ErrorException, IOException;
+    void getIntNegativeOneMillion() throws ErrorException, IOException;
 
     /**
      * Get '-1000000' integer value.
@@ -120,7 +141,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsync();
+    Observable<Void> getIntNegativeOneMillionAsync();
+
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsyncWithServiceResponse();
 
     /**
      * Get '10000000000' 64 bit integer value.
@@ -129,7 +157,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getTenBillion() throws ErrorException, IOException;
+    void getTenBillion() throws ErrorException, IOException;
 
     /**
      * Get '10000000000' 64 bit integer value.
@@ -144,7 +172,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getTenBillionAsync();
+    Observable<Void> getTenBillionAsync();
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getTenBillionAsyncWithServiceResponse();
 
     /**
      * Get '-10000000000' 64 bit integer value.
@@ -153,7 +188,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getNegativeTenBillion() throws ErrorException, IOException;
+    void getNegativeTenBillion() throws ErrorException, IOException;
 
     /**
      * Get '-10000000000' 64 bit integer value.
@@ -168,7 +203,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getNegativeTenBillionAsync();
+    Observable<Void> getNegativeTenBillionAsync();
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getNegativeTenBillionAsyncWithServiceResponse();
 
     /**
      * Get '1.034E+20' numeric value.
@@ -177,7 +219,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> floatScientificPositive() throws ErrorException, IOException;
+    void floatScientificPositive() throws ErrorException, IOException;
 
     /**
      * Get '1.034E+20' numeric value.
@@ -192,7 +234,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatScientificPositiveAsync();
+    Observable<Void> floatScientificPositiveAsync();
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> floatScientificPositiveAsyncWithServiceResponse();
 
     /**
      * Get '-1.034E-20' numeric value.
@@ -201,7 +250,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> floatScientificNegative() throws ErrorException, IOException;
+    void floatScientificNegative() throws ErrorException, IOException;
 
     /**
      * Get '-1.034E-20' numeric value.
@@ -216,7 +265,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatScientificNegativeAsync();
+    Observable<Void> floatScientificNegativeAsync();
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> floatScientificNegativeAsyncWithServiceResponse();
 
     /**
      * Get '9999999.999' numeric value.
@@ -225,7 +281,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> doubleDecimalPositive() throws ErrorException, IOException;
+    void doubleDecimalPositive() throws ErrorException, IOException;
 
     /**
      * Get '9999999.999' numeric value.
@@ -240,7 +296,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleDecimalPositiveAsync();
+    Observable<Void> doubleDecimalPositiveAsync();
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> doubleDecimalPositiveAsyncWithServiceResponse();
 
     /**
      * Get '-9999999.999' numeric value.
@@ -249,7 +312,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> doubleDecimalNegative() throws ErrorException, IOException;
+    void doubleDecimalNegative() throws ErrorException, IOException;
 
     /**
      * Get '-9999999.999' numeric value.
@@ -264,7 +327,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleDecimalNegativeAsync();
+    Observable<Void> doubleDecimalNegativeAsync();
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> doubleDecimalNegativeAsyncWithServiceResponse();
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
@@ -273,7 +343,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringUnicode() throws ErrorException, IOException;
+    void stringUnicode() throws ErrorException, IOException;
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
@@ -288,7 +358,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringUnicodeAsync();
+    Observable<Void> stringUnicodeAsync();
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringUnicodeAsyncWithServiceResponse();
 
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
@@ -297,7 +374,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringUrlEncoded() throws ErrorException, IOException;
+    void stringUrlEncoded() throws ErrorException, IOException;
 
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
@@ -312,7 +389,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringUrlEncodedAsync();
+    Observable<Void> stringUrlEncodedAsync();
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringUrlEncodedAsyncWithServiceResponse();
 
     /**
      * Get ''.
@@ -321,7 +405,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringEmpty() throws ErrorException, IOException;
+    void stringEmpty() throws ErrorException, IOException;
 
     /**
      * Get ''.
@@ -336,7 +420,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringEmptyAsync();
+    Observable<Void> stringEmptyAsync();
+
+    /**
+     * Get ''.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringEmptyAsyncWithServiceResponse();
 
     /**
      * Get null (should throw).
@@ -347,7 +438,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringNull(String stringPath) throws ErrorException, IOException, IllegalArgumentException;
+    void stringNull(String stringPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get null (should throw).
@@ -364,7 +455,15 @@ public interface Paths {
      * @param stringPath null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringNullAsync(String stringPath);
+    Observable<Void> stringNullAsync(String stringPath);
+
+    /**
+     * Get null (should throw).
+     *
+     * @param stringPath null string value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse(String stringPath);
 
     /**
      * Get using uri with 'green color' in path parameter.
@@ -375,7 +474,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> enumValid(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException;
+    void enumValid(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get using uri with 'green color' in path parameter.
@@ -392,7 +491,15 @@ public interface Paths {
      * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumValidAsync(UriColor enumPath);
+    Observable<Void> enumValidAsync(UriColor enumPath);
+
+    /**
+     * Get using uri with 'green color' in path parameter.
+     *
+     * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse(UriColor enumPath);
 
     /**
      * Get null (should throw on the client before the request is sent on wire).
@@ -403,7 +510,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> enumNull(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException;
+    void enumNull(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get null (should throw on the client before the request is sent on wire).
@@ -420,7 +527,15 @@ public interface Paths {
      * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumNullAsync(UriColor enumPath);
+    Observable<Void> enumNullAsync(UriColor enumPath);
+
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     *
+     * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse(UriColor enumPath);
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
@@ -431,7 +546,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> byteMultiByte(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException;
+    void byteMultiByte(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
@@ -448,7 +563,15 @@ public interface Paths {
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteMultiByteAsync(byte[] bytePath);
+    Observable<Void> byteMultiByteAsync(byte[] bytePath);
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse(byte[] bytePath);
 
     /**
      * Get '' as byte array.
@@ -457,7 +580,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> byteEmpty() throws ErrorException, IOException;
+    void byteEmpty() throws ErrorException, IOException;
 
     /**
      * Get '' as byte array.
@@ -472,7 +595,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteEmptyAsync();
+    Observable<Void> byteEmptyAsync();
+
+    /**
+     * Get '' as byte array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> byteEmptyAsyncWithServiceResponse();
 
     /**
      * Get null as byte array (should throw).
@@ -483,7 +613,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> byteNull(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException;
+    void byteNull(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get null as byte array (should throw).
@@ -500,7 +630,15 @@ public interface Paths {
      * @param bytePath null as byte array (should throw)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteNullAsync(byte[] bytePath);
+    Observable<Void> byteNullAsync(byte[] bytePath);
+
+    /**
+     * Get null as byte array (should throw).
+     *
+     * @param bytePath null as byte array (should throw)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse(byte[] bytePath);
 
     /**
      * Get '2012-01-01' as date.
@@ -509,7 +647,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateValid() throws ErrorException, IOException;
+    void dateValid() throws ErrorException, IOException;
 
     /**
      * Get '2012-01-01' as date.
@@ -524,7 +662,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateValidAsync();
+    Observable<Void> dateValidAsync();
+
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateValidAsyncWithServiceResponse();
 
     /**
      * Get null as date - this should throw or be unusable on the client side, depending on date representation.
@@ -535,7 +680,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateNull(LocalDate datePath) throws ErrorException, IOException, IllegalArgumentException;
+    void dateNull(LocalDate datePath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get null as date - this should throw or be unusable on the client side, depending on date representation.
@@ -552,7 +697,15 @@ public interface Paths {
      * @param datePath null as date (should throw)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateNullAsync(LocalDate datePath);
+    Observable<Void> dateNullAsync(LocalDate datePath);
+
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     *
+     * @param datePath null as date (should throw)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse(LocalDate datePath);
 
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
@@ -561,7 +714,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateTimeValid() throws ErrorException, IOException;
+    void dateTimeValid() throws ErrorException, IOException;
 
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
@@ -576,7 +729,14 @@ public interface Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeValidAsync();
+    Observable<Void> dateTimeValidAsync();
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateTimeValidAsyncWithServiceResponse();
 
     /**
      * Get null as date-time, should be disallowed or throw depending on representation of date-time.
@@ -587,7 +747,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateTimeNull(DateTime dateTimePath) throws ErrorException, IOException, IllegalArgumentException;
+    void dateTimeNull(DateTime dateTimePath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get null as date-time, should be disallowed or throw depending on representation of date-time.
@@ -604,7 +764,15 @@ public interface Paths {
      * @param dateTimePath null as date-time
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeNullAsync(DateTime dateTimePath);
+    Observable<Void> dateTimeNullAsync(DateTime dateTimePath);
+
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     *
+     * @param dateTimePath null as date-time
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse(DateTime dateTimePath);
 
     /**
      * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
@@ -615,7 +783,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> base64Url(byte[] base64UrlPath) throws ErrorException, IOException, IllegalArgumentException;
+    void base64Url(byte[] base64UrlPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
@@ -632,7 +800,15 @@ public interface Paths {
      * @param base64UrlPath base64url encoded value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> base64UrlAsync(byte[] base64UrlPath);
+    Observable<Void> base64UrlAsync(byte[] base64UrlPath);
+
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     *
+     * @param base64UrlPath base64url encoded value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> base64UrlAsyncWithServiceResponse(byte[] base64UrlPath);
 
     /**
      * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
@@ -643,7 +819,7 @@ public interface Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayCsvInPath(List<String> arrayPath) throws ErrorException, IOException, IllegalArgumentException;
+    void arrayCsvInPath(List<String> arrayPath) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
@@ -660,7 +836,15 @@ public interface Paths {
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayCsvInPathAsync(List<String> arrayPath);
+    Observable<Void> arrayCsvInPathAsync(List<String> arrayPath);
+
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayCsvInPathAsyncWithServiceResponse(List<String> arrayPath);
 
     /**
      * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
@@ -670,7 +854,7 @@ public interface Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> unixTimeUrl(DateTime unixTimeUrlPath) throws ErrorException, IOException;
+    void unixTimeUrl(DateTime unixTimeUrlPath) throws ErrorException, IOException;
 
     /**
      * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
@@ -687,6 +871,14 @@ public interface Paths {
      * @param unixTimeUrlPath Unix time encoded value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> unixTimeUrlAsync(DateTime unixTimeUrlPath);
+    Observable<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath);
+
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     *
+     * @param unixTimeUrlPath Unix time encoded value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> unixTimeUrlAsyncWithServiceResponse(DateTime unixTimeUrlPath);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/Queries.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/Queries.java
@@ -31,7 +31,6 @@ public interface Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getBooleanTrue() throws ErrorException, IOException;
 
@@ -55,14 +54,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanTrueAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getBooleanTrueWithServiceResponseAsync();
 
     /**
      * Get false Boolean value on path.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getBooleanFalse() throws ErrorException, IOException;
 
@@ -86,14 +84,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanFalseAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getBooleanFalseWithServiceResponseAsync();
 
     /**
      * Get null Boolean value on query (query string should be absent).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getBooleanNull() throws ErrorException, IOException;
 
@@ -108,7 +105,6 @@ public interface Queries {
     /**
      * Get null Boolean value on query (query string should be absent).
      *
-     * @param boolQuery null boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getBooleanNullAsync();
@@ -116,17 +112,15 @@ public interface Queries {
     /**
      * Get null Boolean value on query (query string should be absent).
      *
-     * @param boolQuery null boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getBooleanNullWithServiceResponseAsync();
     /**
      * Get null Boolean value on query (query string should be absent).
      *
      * @param boolQuery null boolean value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getBooleanNull(Boolean boolQuery) throws ErrorException, IOException;
 
@@ -153,14 +147,13 @@ public interface Queries {
      * @param boolQuery null boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanNullAsyncWithServiceResponse(Boolean boolQuery);
+    Observable<ServiceResponse<Void>> getBooleanNullWithServiceResponseAsync(Boolean boolQuery);
 
     /**
      * Get '1000000' integer value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getIntOneMillion() throws ErrorException, IOException;
 
@@ -184,14 +177,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntOneMillionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getIntOneMillionWithServiceResponseAsync();
 
     /**
      * Get '-1000000' integer value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getIntNegativeOneMillion() throws ErrorException, IOException;
 
@@ -215,14 +207,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getIntNegativeOneMillionWithServiceResponseAsync();
 
     /**
      * Get null integer value (no query parameter).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getIntNull() throws ErrorException, IOException;
 
@@ -237,7 +228,6 @@ public interface Queries {
     /**
      * Get null integer value (no query parameter).
      *
-     * @param intQuery null integer value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getIntNullAsync();
@@ -245,17 +235,15 @@ public interface Queries {
     /**
      * Get null integer value (no query parameter).
      *
-     * @param intQuery null integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getIntNullWithServiceResponseAsync();
     /**
      * Get null integer value (no query parameter).
      *
      * @param intQuery null integer value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getIntNull(Integer intQuery) throws ErrorException, IOException;
 
@@ -282,14 +270,13 @@ public interface Queries {
      * @param intQuery null integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntNullAsyncWithServiceResponse(Integer intQuery);
+    Observable<ServiceResponse<Void>> getIntNullWithServiceResponseAsync(Integer intQuery);
 
     /**
      * Get '10000000000' 64 bit integer value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getTenBillion() throws ErrorException, IOException;
 
@@ -313,14 +300,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getTenBillionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getTenBillionWithServiceResponseAsync();
 
     /**
      * Get '-10000000000' 64 bit integer value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getNegativeTenBillion() throws ErrorException, IOException;
 
@@ -344,14 +330,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getNegativeTenBillionAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getNegativeTenBillionWithServiceResponseAsync();
 
     /**
      * Get 'null 64 bit integer value (no query param in uri).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getLongNull() throws ErrorException, IOException;
 
@@ -366,7 +351,6 @@ public interface Queries {
     /**
      * Get 'null 64 bit integer value (no query param in uri).
      *
-     * @param longQuery null 64 bit integer value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> getLongNullAsync();
@@ -374,17 +358,15 @@ public interface Queries {
     /**
      * Get 'null 64 bit integer value (no query param in uri).
      *
-     * @param longQuery null 64 bit integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getLongNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getLongNullWithServiceResponseAsync();
     /**
      * Get 'null 64 bit integer value (no query param in uri).
      *
      * @param longQuery null 64 bit integer value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getLongNull(Long longQuery) throws ErrorException, IOException;
 
@@ -411,14 +393,13 @@ public interface Queries {
      * @param longQuery null 64 bit integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getLongNullAsyncWithServiceResponse(Long longQuery);
+    Observable<ServiceResponse<Void>> getLongNullWithServiceResponseAsync(Long longQuery);
 
     /**
      * Get '1.034E+20' numeric value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void floatScientificPositive() throws ErrorException, IOException;
 
@@ -442,14 +423,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatScientificPositiveAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> floatScientificPositiveWithServiceResponseAsync();
 
     /**
      * Get '-1.034E-20' numeric value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void floatScientificNegative() throws ErrorException, IOException;
 
@@ -473,14 +453,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatScientificNegativeAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> floatScientificNegativeWithServiceResponseAsync();
 
     /**
      * Get null numeric value (no query parameter).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void floatNull() throws ErrorException, IOException;
 
@@ -495,7 +474,6 @@ public interface Queries {
     /**
      * Get null numeric value (no query parameter).
      *
-     * @param floatQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> floatNullAsync();
@@ -503,17 +481,15 @@ public interface Queries {
     /**
      * Get null numeric value (no query parameter).
      *
-     * @param floatQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> floatNullWithServiceResponseAsync();
     /**
      * Get null numeric value (no query parameter).
      *
      * @param floatQuery null numeric value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void floatNull(Double floatQuery) throws ErrorException, IOException;
 
@@ -540,14 +516,13 @@ public interface Queries {
      * @param floatQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatNullAsyncWithServiceResponse(Double floatQuery);
+    Observable<ServiceResponse<Void>> floatNullWithServiceResponseAsync(Double floatQuery);
 
     /**
      * Get '9999999.999' numeric value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void doubleDecimalPositive() throws ErrorException, IOException;
 
@@ -571,14 +546,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleDecimalPositiveAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> doubleDecimalPositiveWithServiceResponseAsync();
 
     /**
      * Get '-9999999.999' numeric value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void doubleDecimalNegative() throws ErrorException, IOException;
 
@@ -602,14 +576,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleDecimalNegativeAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> doubleDecimalNegativeWithServiceResponseAsync();
 
     /**
      * Get null numeric value (no query parameter).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void doubleNull() throws ErrorException, IOException;
 
@@ -624,7 +597,6 @@ public interface Queries {
     /**
      * Get null numeric value (no query parameter).
      *
-     * @param doubleQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> doubleNullAsync();
@@ -632,17 +604,15 @@ public interface Queries {
     /**
      * Get null numeric value (no query parameter).
      *
-     * @param doubleQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> doubleNullWithServiceResponseAsync();
     /**
      * Get null numeric value (no query parameter).
      *
      * @param doubleQuery null numeric value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void doubleNull(Double doubleQuery) throws ErrorException, IOException;
 
@@ -669,14 +639,13 @@ public interface Queries {
      * @param doubleQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleNullAsyncWithServiceResponse(Double doubleQuery);
+    Observable<ServiceResponse<Void>> doubleNullWithServiceResponseAsync(Double doubleQuery);
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringUnicode() throws ErrorException, IOException;
 
@@ -700,14 +669,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringUnicodeAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> stringUnicodeWithServiceResponseAsync();
 
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringUrlEncoded() throws ErrorException, IOException;
 
@@ -731,14 +699,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringUrlEncodedAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> stringUrlEncodedWithServiceResponseAsync();
 
     /**
      * Get ''.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringEmpty() throws ErrorException, IOException;
 
@@ -762,14 +729,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> stringEmptyWithServiceResponseAsync();
 
     /**
      * Get null (no query parameter in url).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringNull() throws ErrorException, IOException;
 
@@ -784,7 +750,6 @@ public interface Queries {
     /**
      * Get null (no query parameter in url).
      *
-     * @param stringQuery null string value
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> stringNullAsync();
@@ -792,17 +757,15 @@ public interface Queries {
     /**
      * Get null (no query parameter in url).
      *
-     * @param stringQuery null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> stringNullWithServiceResponseAsync();
     /**
      * Get null (no query parameter in url).
      *
      * @param stringQuery null string value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void stringNull(String stringQuery) throws ErrorException, IOException;
 
@@ -829,14 +792,13 @@ public interface Queries {
      * @param stringQuery null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse(String stringQuery);
+    Observable<ServiceResponse<Void>> stringNullWithServiceResponseAsync(String stringQuery);
 
     /**
      * Get using uri with query parameter 'green color'.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void enumValid() throws ErrorException, IOException;
 
@@ -851,7 +813,6 @@ public interface Queries {
     /**
      * Get using uri with query parameter 'green color'.
      *
-     * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> enumValidAsync();
@@ -859,17 +820,15 @@ public interface Queries {
     /**
      * Get using uri with query parameter 'green color'.
      *
-     * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> enumValidWithServiceResponseAsync();
     /**
      * Get using uri with query parameter 'green color'.
      *
      * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void enumValid(UriColor enumQuery) throws ErrorException, IOException;
 
@@ -896,14 +855,13 @@ public interface Queries {
      * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse(UriColor enumQuery);
+    Observable<ServiceResponse<Void>> enumValidWithServiceResponseAsync(UriColor enumQuery);
 
     /**
      * Get null (no query parameter in url).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void enumNull() throws ErrorException, IOException;
 
@@ -918,7 +876,6 @@ public interface Queries {
     /**
      * Get null (no query parameter in url).
      *
-     * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> enumNullAsync();
@@ -926,17 +883,15 @@ public interface Queries {
     /**
      * Get null (no query parameter in url).
      *
-     * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> enumNullWithServiceResponseAsync();
     /**
      * Get null (no query parameter in url).
      *
      * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void enumNull(UriColor enumQuery) throws ErrorException, IOException;
 
@@ -963,14 +918,13 @@ public interface Queries {
      * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse(UriColor enumQuery);
+    Observable<ServiceResponse<Void>> enumNullWithServiceResponseAsync(UriColor enumQuery);
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void byteMultiByte() throws ErrorException, IOException;
 
@@ -985,7 +939,6 @@ public interface Queries {
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
-     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> byteMultiByteAsync();
@@ -993,17 +946,15 @@ public interface Queries {
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
-     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> byteMultiByteWithServiceResponseAsync();
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
      * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void byteMultiByte(byte[] byteQuery) throws ErrorException, IOException;
 
@@ -1030,14 +981,13 @@ public interface Queries {
      * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse(byte[] byteQuery);
+    Observable<ServiceResponse<Void>> byteMultiByteWithServiceResponseAsync(byte[] byteQuery);
 
     /**
      * Get '' as byte array.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void byteEmpty() throws ErrorException, IOException;
 
@@ -1061,14 +1011,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> byteEmptyWithServiceResponseAsync();
 
     /**
      * Get null as byte array (no query parameters in uri).
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void byteNull() throws ErrorException, IOException;
 
@@ -1083,7 +1032,6 @@ public interface Queries {
     /**
      * Get null as byte array (no query parameters in uri).
      *
-     * @param byteQuery null as byte array (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> byteNullAsync();
@@ -1091,17 +1039,15 @@ public interface Queries {
     /**
      * Get null as byte array (no query parameters in uri).
      *
-     * @param byteQuery null as byte array (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> byteNullWithServiceResponseAsync();
     /**
      * Get null as byte array (no query parameters in uri).
      *
      * @param byteQuery null as byte array (no query parameters in uri)
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void byteNull(byte[] byteQuery) throws ErrorException, IOException;
 
@@ -1128,14 +1074,13 @@ public interface Queries {
      * @param byteQuery null as byte array (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse(byte[] byteQuery);
+    Observable<ServiceResponse<Void>> byteNullWithServiceResponseAsync(byte[] byteQuery);
 
     /**
      * Get '2012-01-01' as date.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateValid() throws ErrorException, IOException;
 
@@ -1159,14 +1104,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> dateValidWithServiceResponseAsync();
 
     /**
      * Get null as date - this should result in no query parameters in uri.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateNull() throws ErrorException, IOException;
 
@@ -1181,7 +1125,6 @@ public interface Queries {
     /**
      * Get null as date - this should result in no query parameters in uri.
      *
-     * @param dateQuery null as date (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> dateNullAsync();
@@ -1189,17 +1132,15 @@ public interface Queries {
     /**
      * Get null as date - this should result in no query parameters in uri.
      *
-     * @param dateQuery null as date (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> dateNullWithServiceResponseAsync();
     /**
      * Get null as date - this should result in no query parameters in uri.
      *
      * @param dateQuery null as date (no query parameters in uri)
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateNull(LocalDate dateQuery) throws ErrorException, IOException;
 
@@ -1226,14 +1167,13 @@ public interface Queries {
      * @param dateQuery null as date (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse(LocalDate dateQuery);
+    Observable<ServiceResponse<Void>> dateNullWithServiceResponseAsync(LocalDate dateQuery);
 
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateTimeValid() throws ErrorException, IOException;
 
@@ -1257,14 +1197,13 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> dateTimeValidWithServiceResponseAsync();
 
     /**
      * Get null as date-time, should result in no query parameters in uri.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateTimeNull() throws ErrorException, IOException;
 
@@ -1279,7 +1218,6 @@ public interface Queries {
     /**
      * Get null as date-time, should result in no query parameters in uri.
      *
-     * @param dateTimeQuery null as date-time (no query parameters)
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> dateTimeNullAsync();
@@ -1287,17 +1225,15 @@ public interface Queries {
     /**
      * Get null as date-time, should result in no query parameters in uri.
      *
-     * @param dateTimeQuery null as date-time (no query parameters)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> dateTimeNullWithServiceResponseAsync();
     /**
      * Get null as date-time, should result in no query parameters in uri.
      *
      * @param dateTimeQuery null as date-time (no query parameters)
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void dateTimeNull(DateTime dateTimeQuery) throws ErrorException, IOException;
 
@@ -1324,14 +1260,13 @@ public interface Queries {
      * @param dateTimeQuery null as date-time (no query parameters)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse(DateTime dateTimeQuery);
+    Observable<ServiceResponse<Void>> dateTimeNullWithServiceResponseAsync(DateTime dateTimeQuery);
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringCsvValid() throws ErrorException, IOException;
 
@@ -1346,7 +1281,6 @@ public interface Queries {
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
      *
-     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> arrayStringCsvValidAsync();
@@ -1354,17 +1288,15 @@ public interface Queries {
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
      *
-     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> arrayStringCsvValidWithServiceResponseAsync();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringCsvValid(List<String> arrayQuery) throws ErrorException, IOException;
 
@@ -1391,14 +1323,13 @@ public interface Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvValidAsyncWithServiceResponse(List<String> arrayQuery);
+    Observable<ServiceResponse<Void>> arrayStringCsvValidWithServiceResponseAsync(List<String> arrayQuery);
 
     /**
      * Get a null array of string using the csv-array format.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringCsvNull() throws ErrorException, IOException;
 
@@ -1413,7 +1344,6 @@ public interface Queries {
     /**
      * Get a null array of string using the csv-array format.
      *
-     * @param arrayQuery a null array of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> arrayStringCsvNullAsync();
@@ -1421,17 +1351,15 @@ public interface Queries {
     /**
      * Get a null array of string using the csv-array format.
      *
-     * @param arrayQuery a null array of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvNullAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> arrayStringCsvNullWithServiceResponseAsync();
     /**
      * Get a null array of string using the csv-array format.
      *
      * @param arrayQuery a null array of string using the csv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringCsvNull(List<String> arrayQuery) throws ErrorException, IOException;
 
@@ -1458,14 +1386,13 @@ public interface Queries {
      * @param arrayQuery a null array of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvNullAsyncWithServiceResponse(List<String> arrayQuery);
+    Observable<ServiceResponse<Void>> arrayStringCsvNullWithServiceResponseAsync(List<String> arrayQuery);
 
     /**
      * Get an empty array [] of string using the csv-array format.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringCsvEmpty() throws ErrorException, IOException;
 
@@ -1480,7 +1407,6 @@ public interface Queries {
     /**
      * Get an empty array [] of string using the csv-array format.
      *
-     * @param arrayQuery an empty array [] of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> arrayStringCsvEmptyAsync();
@@ -1488,17 +1414,15 @@ public interface Queries {
     /**
      * Get an empty array [] of string using the csv-array format.
      *
-     * @param arrayQuery an empty array [] of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> arrayStringCsvEmptyWithServiceResponseAsync();
     /**
      * Get an empty array [] of string using the csv-array format.
      *
      * @param arrayQuery an empty array [] of string using the csv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringCsvEmpty(List<String> arrayQuery) throws ErrorException, IOException;
 
@@ -1525,14 +1449,13 @@ public interface Queries {
      * @param arrayQuery an empty array [] of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsyncWithServiceResponse(List<String> arrayQuery);
+    Observable<ServiceResponse<Void>> arrayStringCsvEmptyWithServiceResponseAsync(List<String> arrayQuery);
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringSsvValid() throws ErrorException, IOException;
 
@@ -1547,7 +1470,6 @@ public interface Queries {
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
      *
-     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> arrayStringSsvValidAsync();
@@ -1555,17 +1477,15 @@ public interface Queries {
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
      *
-     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringSsvValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> arrayStringSsvValidWithServiceResponseAsync();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringSsvValid(List<String> arrayQuery) throws ErrorException, IOException;
 
@@ -1592,14 +1512,13 @@ public interface Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringSsvValidAsyncWithServiceResponse(List<String> arrayQuery);
+    Observable<ServiceResponse<Void>> arrayStringSsvValidWithServiceResponseAsync(List<String> arrayQuery);
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringTsvValid() throws ErrorException, IOException;
 
@@ -1614,7 +1533,6 @@ public interface Queries {
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
      *
-     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> arrayStringTsvValidAsync();
@@ -1622,17 +1540,15 @@ public interface Queries {
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
      *
-     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringTsvValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> arrayStringTsvValidWithServiceResponseAsync();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringTsvValid(List<String> arrayQuery) throws ErrorException, IOException;
 
@@ -1659,14 +1575,13 @@ public interface Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringTsvValidAsyncWithServiceResponse(List<String> arrayQuery);
+    Observable<ServiceResponse<Void>> arrayStringTsvValidWithServiceResponseAsync(List<String> arrayQuery);
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringPipesValid() throws ErrorException, IOException;
 
@@ -1681,7 +1596,6 @@ public interface Queries {
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
      *
-     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @return the {@link ServiceResponse} object if successful.
      */
     Observable<Void> arrayStringPipesValidAsync();
@@ -1689,17 +1603,15 @@ public interface Queries {
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
      *
-     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringPipesValidAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> arrayStringPipesValidWithServiceResponseAsync();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void arrayStringPipesValid(List<String> arrayQuery) throws ErrorException, IOException;
 
@@ -1726,6 +1638,6 @@ public interface Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringPipesValidAsyncWithServiceResponse(List<String> arrayQuery);
+    Observable<ServiceResponse<Void>> arrayStringPipesValidWithServiceResponseAsync(List<String> arrayQuery);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/Queries.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/Queries.java
@@ -33,7 +33,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getBooleanTrue() throws ErrorException, IOException;
+    void getBooleanTrue() throws ErrorException, IOException;
 
     /**
      * Get true Boolean value on path.
@@ -48,7 +48,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanTrueAsync();
+    Observable<Void> getBooleanTrueAsync();
+
+    /**
+     * Get true Boolean value on path.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getBooleanTrueAsyncWithServiceResponse();
 
     /**
      * Get false Boolean value on path.
@@ -57,7 +64,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getBooleanFalse() throws ErrorException, IOException;
+    void getBooleanFalse() throws ErrorException, IOException;
 
     /**
      * Get false Boolean value on path.
@@ -72,7 +79,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanFalseAsync();
+    Observable<Void> getBooleanFalseAsync();
+
+    /**
+     * Get false Boolean value on path.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getBooleanFalseAsyncWithServiceResponse();
 
     /**
      * Get null Boolean value on query (query string should be absent).
@@ -81,7 +95,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getBooleanNull() throws ErrorException, IOException;
+    void getBooleanNull() throws ErrorException, IOException;
 
     /**
      * Get null Boolean value on query (query string should be absent).
@@ -90,6 +104,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getBooleanNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @param boolQuery null boolean value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getBooleanNullAsync();
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @param boolQuery null boolean value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getBooleanNullAsyncWithServiceResponse();
     /**
      * Get null Boolean value on query (query string should be absent).
      *
@@ -98,7 +128,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getBooleanNull(Boolean boolQuery) throws ErrorException, IOException;
+    void getBooleanNull(Boolean boolQuery) throws ErrorException, IOException;
 
     /**
      * Get null Boolean value on query (query string should be absent).
@@ -115,7 +145,15 @@ public interface Queries {
      * @param boolQuery null boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getBooleanNullAsync(Boolean boolQuery);
+    Observable<Void> getBooleanNullAsync(Boolean boolQuery);
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @param boolQuery null boolean value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getBooleanNullAsyncWithServiceResponse(Boolean boolQuery);
 
     /**
      * Get '1000000' integer value.
@@ -124,7 +162,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getIntOneMillion() throws ErrorException, IOException;
+    void getIntOneMillion() throws ErrorException, IOException;
 
     /**
      * Get '1000000' integer value.
@@ -139,7 +177,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntOneMillionAsync();
+    Observable<Void> getIntOneMillionAsync();
+
+    /**
+     * Get '1000000' integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getIntOneMillionAsyncWithServiceResponse();
 
     /**
      * Get '-1000000' integer value.
@@ -148,7 +193,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getIntNegativeOneMillion() throws ErrorException, IOException;
+    void getIntNegativeOneMillion() throws ErrorException, IOException;
 
     /**
      * Get '-1000000' integer value.
@@ -163,7 +208,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsync();
+    Observable<Void> getIntNegativeOneMillionAsync();
+
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsyncWithServiceResponse();
 
     /**
      * Get null integer value (no query parameter).
@@ -172,7 +224,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getIntNull() throws ErrorException, IOException;
+    void getIntNull() throws ErrorException, IOException;
 
     /**
      * Get null integer value (no query parameter).
@@ -181,6 +233,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getIntNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @param intQuery null integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getIntNullAsync();
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @param intQuery null integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getIntNullAsyncWithServiceResponse();
     /**
      * Get null integer value (no query parameter).
      *
@@ -189,7 +257,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getIntNull(Integer intQuery) throws ErrorException, IOException;
+    void getIntNull(Integer intQuery) throws ErrorException, IOException;
 
     /**
      * Get null integer value (no query parameter).
@@ -206,7 +274,15 @@ public interface Queries {
      * @param intQuery null integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getIntNullAsync(Integer intQuery);
+    Observable<Void> getIntNullAsync(Integer intQuery);
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @param intQuery null integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getIntNullAsyncWithServiceResponse(Integer intQuery);
 
     /**
      * Get '10000000000' 64 bit integer value.
@@ -215,7 +291,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getTenBillion() throws ErrorException, IOException;
+    void getTenBillion() throws ErrorException, IOException;
 
     /**
      * Get '10000000000' 64 bit integer value.
@@ -230,7 +306,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getTenBillionAsync();
+    Observable<Void> getTenBillionAsync();
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getTenBillionAsyncWithServiceResponse();
 
     /**
      * Get '-10000000000' 64 bit integer value.
@@ -239,7 +322,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getNegativeTenBillion() throws ErrorException, IOException;
+    void getNegativeTenBillion() throws ErrorException, IOException;
 
     /**
      * Get '-10000000000' 64 bit integer value.
@@ -254,7 +337,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getNegativeTenBillionAsync();
+    Observable<Void> getNegativeTenBillionAsync();
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getNegativeTenBillionAsyncWithServiceResponse();
 
     /**
      * Get 'null 64 bit integer value (no query param in uri).
@@ -263,7 +353,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getLongNull() throws ErrorException, IOException;
+    void getLongNull() throws ErrorException, IOException;
 
     /**
      * Get 'null 64 bit integer value (no query param in uri).
@@ -272,6 +362,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> getLongNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @param longQuery null 64 bit integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> getLongNullAsync();
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @param longQuery null 64 bit integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getLongNullAsyncWithServiceResponse();
     /**
      * Get 'null 64 bit integer value (no query param in uri).
      *
@@ -280,7 +386,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getLongNull(Long longQuery) throws ErrorException, IOException;
+    void getLongNull(Long longQuery) throws ErrorException, IOException;
 
     /**
      * Get 'null 64 bit integer value (no query param in uri).
@@ -297,7 +403,15 @@ public interface Queries {
      * @param longQuery null 64 bit integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getLongNullAsync(Long longQuery);
+    Observable<Void> getLongNullAsync(Long longQuery);
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @param longQuery null 64 bit integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getLongNullAsyncWithServiceResponse(Long longQuery);
 
     /**
      * Get '1.034E+20' numeric value.
@@ -306,7 +420,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> floatScientificPositive() throws ErrorException, IOException;
+    void floatScientificPositive() throws ErrorException, IOException;
 
     /**
      * Get '1.034E+20' numeric value.
@@ -321,7 +435,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatScientificPositiveAsync();
+    Observable<Void> floatScientificPositiveAsync();
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> floatScientificPositiveAsyncWithServiceResponse();
 
     /**
      * Get '-1.034E-20' numeric value.
@@ -330,7 +451,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> floatScientificNegative() throws ErrorException, IOException;
+    void floatScientificNegative() throws ErrorException, IOException;
 
     /**
      * Get '-1.034E-20' numeric value.
@@ -345,7 +466,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatScientificNegativeAsync();
+    Observable<Void> floatScientificNegativeAsync();
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> floatScientificNegativeAsyncWithServiceResponse();
 
     /**
      * Get null numeric value (no query parameter).
@@ -354,7 +482,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> floatNull() throws ErrorException, IOException;
+    void floatNull() throws ErrorException, IOException;
 
     /**
      * Get null numeric value (no query parameter).
@@ -363,6 +491,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> floatNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param floatQuery null numeric value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> floatNullAsync();
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param floatQuery null numeric value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> floatNullAsyncWithServiceResponse();
     /**
      * Get null numeric value (no query parameter).
      *
@@ -371,7 +515,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> floatNull(Double floatQuery) throws ErrorException, IOException;
+    void floatNull(Double floatQuery) throws ErrorException, IOException;
 
     /**
      * Get null numeric value (no query parameter).
@@ -388,7 +532,15 @@ public interface Queries {
      * @param floatQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> floatNullAsync(Double floatQuery);
+    Observable<Void> floatNullAsync(Double floatQuery);
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param floatQuery null numeric value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> floatNullAsyncWithServiceResponse(Double floatQuery);
 
     /**
      * Get '9999999.999' numeric value.
@@ -397,7 +549,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> doubleDecimalPositive() throws ErrorException, IOException;
+    void doubleDecimalPositive() throws ErrorException, IOException;
 
     /**
      * Get '9999999.999' numeric value.
@@ -412,7 +564,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleDecimalPositiveAsync();
+    Observable<Void> doubleDecimalPositiveAsync();
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> doubleDecimalPositiveAsyncWithServiceResponse();
 
     /**
      * Get '-9999999.999' numeric value.
@@ -421,7 +580,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> doubleDecimalNegative() throws ErrorException, IOException;
+    void doubleDecimalNegative() throws ErrorException, IOException;
 
     /**
      * Get '-9999999.999' numeric value.
@@ -436,7 +595,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleDecimalNegativeAsync();
+    Observable<Void> doubleDecimalNegativeAsync();
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> doubleDecimalNegativeAsyncWithServiceResponse();
 
     /**
      * Get null numeric value (no query parameter).
@@ -445,7 +611,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> doubleNull() throws ErrorException, IOException;
+    void doubleNull() throws ErrorException, IOException;
 
     /**
      * Get null numeric value (no query parameter).
@@ -454,6 +620,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> doubleNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param doubleQuery null numeric value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> doubleNullAsync();
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param doubleQuery null numeric value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> doubleNullAsyncWithServiceResponse();
     /**
      * Get null numeric value (no query parameter).
      *
@@ -462,7 +644,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> doubleNull(Double doubleQuery) throws ErrorException, IOException;
+    void doubleNull(Double doubleQuery) throws ErrorException, IOException;
 
     /**
      * Get null numeric value (no query parameter).
@@ -479,7 +661,15 @@ public interface Queries {
      * @param doubleQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> doubleNullAsync(Double doubleQuery);
+    Observable<Void> doubleNullAsync(Double doubleQuery);
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param doubleQuery null numeric value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> doubleNullAsyncWithServiceResponse(Double doubleQuery);
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
@@ -488,7 +678,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringUnicode() throws ErrorException, IOException;
+    void stringUnicode() throws ErrorException, IOException;
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
@@ -503,7 +693,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringUnicodeAsync();
+    Observable<Void> stringUnicodeAsync();
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringUnicodeAsyncWithServiceResponse();
 
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
@@ -512,7 +709,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringUrlEncoded() throws ErrorException, IOException;
+    void stringUrlEncoded() throws ErrorException, IOException;
 
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
@@ -527,7 +724,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringUrlEncodedAsync();
+    Observable<Void> stringUrlEncodedAsync();
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringUrlEncodedAsyncWithServiceResponse();
 
     /**
      * Get ''.
@@ -536,7 +740,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringEmpty() throws ErrorException, IOException;
+    void stringEmpty() throws ErrorException, IOException;
 
     /**
      * Get ''.
@@ -551,7 +755,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringEmptyAsync();
+    Observable<Void> stringEmptyAsync();
+
+    /**
+     * Get ''.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringEmptyAsyncWithServiceResponse();
 
     /**
      * Get null (no query parameter in url).
@@ -560,7 +771,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringNull() throws ErrorException, IOException;
+    void stringNull() throws ErrorException, IOException;
 
     /**
      * Get null (no query parameter in url).
@@ -569,6 +780,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> stringNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param stringQuery null string value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> stringNullAsync();
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param stringQuery null string value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse();
     /**
      * Get null (no query parameter in url).
      *
@@ -577,7 +804,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> stringNull(String stringQuery) throws ErrorException, IOException;
+    void stringNull(String stringQuery) throws ErrorException, IOException;
 
     /**
      * Get null (no query parameter in url).
@@ -594,7 +821,15 @@ public interface Queries {
      * @param stringQuery null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> stringNullAsync(String stringQuery);
+    Observable<Void> stringNullAsync(String stringQuery);
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param stringQuery null string value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse(String stringQuery);
 
     /**
      * Get using uri with query parameter 'green color'.
@@ -603,7 +838,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> enumValid() throws ErrorException, IOException;
+    void enumValid() throws ErrorException, IOException;
 
     /**
      * Get using uri with query parameter 'green color'.
@@ -612,6 +847,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> enumValidAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> enumValidAsync();
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse();
     /**
      * Get using uri with query parameter 'green color'.
      *
@@ -620,7 +871,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> enumValid(UriColor enumQuery) throws ErrorException, IOException;
+    void enumValid(UriColor enumQuery) throws ErrorException, IOException;
 
     /**
      * Get using uri with query parameter 'green color'.
@@ -637,7 +888,15 @@ public interface Queries {
      * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumValidAsync(UriColor enumQuery);
+    Observable<Void> enumValidAsync(UriColor enumQuery);
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse(UriColor enumQuery);
 
     /**
      * Get null (no query parameter in url).
@@ -646,7 +905,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> enumNull() throws ErrorException, IOException;
+    void enumNull() throws ErrorException, IOException;
 
     /**
      * Get null (no query parameter in url).
@@ -655,6 +914,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> enumNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> enumNullAsync();
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse();
     /**
      * Get null (no query parameter in url).
      *
@@ -663,7 +938,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> enumNull(UriColor enumQuery) throws ErrorException, IOException;
+    void enumNull(UriColor enumQuery) throws ErrorException, IOException;
 
     /**
      * Get null (no query parameter in url).
@@ -680,7 +955,15 @@ public interface Queries {
      * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> enumNullAsync(UriColor enumQuery);
+    Observable<Void> enumNullAsync(UriColor enumQuery);
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse(UriColor enumQuery);
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
@@ -689,7 +972,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> byteMultiByte() throws ErrorException, IOException;
+    void byteMultiByte() throws ErrorException, IOException;
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
@@ -698,6 +981,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> byteMultiByteAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> byteMultiByteAsync();
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse();
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
@@ -706,7 +1005,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> byteMultiByte(byte[] byteQuery) throws ErrorException, IOException;
+    void byteMultiByte(byte[] byteQuery) throws ErrorException, IOException;
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
@@ -723,7 +1022,15 @@ public interface Queries {
      * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteMultiByteAsync(byte[] byteQuery);
+    Observable<Void> byteMultiByteAsync(byte[] byteQuery);
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse(byte[] byteQuery);
 
     /**
      * Get '' as byte array.
@@ -732,7 +1039,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> byteEmpty() throws ErrorException, IOException;
+    void byteEmpty() throws ErrorException, IOException;
 
     /**
      * Get '' as byte array.
@@ -747,7 +1054,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteEmptyAsync();
+    Observable<Void> byteEmptyAsync();
+
+    /**
+     * Get '' as byte array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> byteEmptyAsyncWithServiceResponse();
 
     /**
      * Get null as byte array (no query parameters in uri).
@@ -756,7 +1070,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> byteNull() throws ErrorException, IOException;
+    void byteNull() throws ErrorException, IOException;
 
     /**
      * Get null as byte array (no query parameters in uri).
@@ -765,6 +1079,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> byteNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @param byteQuery null as byte array (no query parameters in uri)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> byteNullAsync();
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @param byteQuery null as byte array (no query parameters in uri)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse();
     /**
      * Get null as byte array (no query parameters in uri).
      *
@@ -773,7 +1103,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> byteNull(byte[] byteQuery) throws ErrorException, IOException;
+    void byteNull(byte[] byteQuery) throws ErrorException, IOException;
 
     /**
      * Get null as byte array (no query parameters in uri).
@@ -790,7 +1120,15 @@ public interface Queries {
      * @param byteQuery null as byte array (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> byteNullAsync(byte[] byteQuery);
+    Observable<Void> byteNullAsync(byte[] byteQuery);
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @param byteQuery null as byte array (no query parameters in uri)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse(byte[] byteQuery);
 
     /**
      * Get '2012-01-01' as date.
@@ -799,7 +1137,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateValid() throws ErrorException, IOException;
+    void dateValid() throws ErrorException, IOException;
 
     /**
      * Get '2012-01-01' as date.
@@ -814,7 +1152,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateValidAsync();
+    Observable<Void> dateValidAsync();
+
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateValidAsyncWithServiceResponse();
 
     /**
      * Get null as date - this should result in no query parameters in uri.
@@ -823,7 +1168,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateNull() throws ErrorException, IOException;
+    void dateNull() throws ErrorException, IOException;
 
     /**
      * Get null as date - this should result in no query parameters in uri.
@@ -832,6 +1177,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> dateNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @param dateQuery null as date (no query parameters in uri)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> dateNullAsync();
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @param dateQuery null as date (no query parameters in uri)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse();
     /**
      * Get null as date - this should result in no query parameters in uri.
      *
@@ -840,7 +1201,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateNull(LocalDate dateQuery) throws ErrorException, IOException;
+    void dateNull(LocalDate dateQuery) throws ErrorException, IOException;
 
     /**
      * Get null as date - this should result in no query parameters in uri.
@@ -857,7 +1218,15 @@ public interface Queries {
      * @param dateQuery null as date (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateNullAsync(LocalDate dateQuery);
+    Observable<Void> dateNullAsync(LocalDate dateQuery);
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @param dateQuery null as date (no query parameters in uri)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse(LocalDate dateQuery);
 
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
@@ -866,7 +1235,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateTimeValid() throws ErrorException, IOException;
+    void dateTimeValid() throws ErrorException, IOException;
 
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
@@ -881,7 +1250,14 @@ public interface Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeValidAsync();
+    Observable<Void> dateTimeValidAsync();
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateTimeValidAsyncWithServiceResponse();
 
     /**
      * Get null as date-time, should result in no query parameters in uri.
@@ -890,7 +1266,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateTimeNull() throws ErrorException, IOException;
+    void dateTimeNull() throws ErrorException, IOException;
 
     /**
      * Get null as date-time, should result in no query parameters in uri.
@@ -899,6 +1275,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> dateTimeNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @param dateTimeQuery null as date-time (no query parameters)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> dateTimeNullAsync();
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @param dateTimeQuery null as date-time (no query parameters)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse();
     /**
      * Get null as date-time, should result in no query parameters in uri.
      *
@@ -907,7 +1299,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> dateTimeNull(DateTime dateTimeQuery) throws ErrorException, IOException;
+    void dateTimeNull(DateTime dateTimeQuery) throws ErrorException, IOException;
 
     /**
      * Get null as date-time, should result in no query parameters in uri.
@@ -924,7 +1316,15 @@ public interface Queries {
      * @param dateTimeQuery null as date-time (no query parameters)
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> dateTimeNullAsync(DateTime dateTimeQuery);
+    Observable<Void> dateTimeNullAsync(DateTime dateTimeQuery);
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @param dateTimeQuery null as date-time (no query parameters)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse(DateTime dateTimeQuery);
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
@@ -933,7 +1333,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringCsvValid() throws ErrorException, IOException;
+    void arrayStringCsvValid() throws ErrorException, IOException;
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
@@ -942,6 +1342,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> arrayStringCsvValidAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> arrayStringCsvValidAsync();
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringCsvValidAsyncWithServiceResponse();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
      *
@@ -950,7 +1366,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringCsvValid(List<String> arrayQuery) throws ErrorException, IOException;
+    void arrayStringCsvValid(List<String> arrayQuery) throws ErrorException, IOException;
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
@@ -967,7 +1383,15 @@ public interface Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvValidAsync(List<String> arrayQuery);
+    Observable<Void> arrayStringCsvValidAsync(List<String> arrayQuery);
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringCsvValidAsyncWithServiceResponse(List<String> arrayQuery);
 
     /**
      * Get a null array of string using the csv-array format.
@@ -976,7 +1400,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringCsvNull() throws ErrorException, IOException;
+    void arrayStringCsvNull() throws ErrorException, IOException;
 
     /**
      * Get a null array of string using the csv-array format.
@@ -985,6 +1409,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> arrayStringCsvNullAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @param arrayQuery a null array of string using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> arrayStringCsvNullAsync();
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @param arrayQuery a null array of string using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringCsvNullAsyncWithServiceResponse();
     /**
      * Get a null array of string using the csv-array format.
      *
@@ -993,7 +1433,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringCsvNull(List<String> arrayQuery) throws ErrorException, IOException;
+    void arrayStringCsvNull(List<String> arrayQuery) throws ErrorException, IOException;
 
     /**
      * Get a null array of string using the csv-array format.
@@ -1010,7 +1450,15 @@ public interface Queries {
      * @param arrayQuery a null array of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvNullAsync(List<String> arrayQuery);
+    Observable<Void> arrayStringCsvNullAsync(List<String> arrayQuery);
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @param arrayQuery a null array of string using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringCsvNullAsyncWithServiceResponse(List<String> arrayQuery);
 
     /**
      * Get an empty array [] of string using the csv-array format.
@@ -1019,7 +1467,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringCsvEmpty() throws ErrorException, IOException;
+    void arrayStringCsvEmpty() throws ErrorException, IOException;
 
     /**
      * Get an empty array [] of string using the csv-array format.
@@ -1028,6 +1476,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> arrayStringCsvEmptyAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> arrayStringCsvEmptyAsync();
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsyncWithServiceResponse();
     /**
      * Get an empty array [] of string using the csv-array format.
      *
@@ -1036,7 +1500,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringCsvEmpty(List<String> arrayQuery) throws ErrorException, IOException;
+    void arrayStringCsvEmpty(List<String> arrayQuery) throws ErrorException, IOException;
 
     /**
      * Get an empty array [] of string using the csv-array format.
@@ -1053,7 +1517,15 @@ public interface Queries {
      * @param arrayQuery an empty array [] of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsync(List<String> arrayQuery);
+    Observable<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery);
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsyncWithServiceResponse(List<String> arrayQuery);
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
@@ -1062,7 +1534,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringSsvValid() throws ErrorException, IOException;
+    void arrayStringSsvValid() throws ErrorException, IOException;
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
@@ -1071,6 +1543,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> arrayStringSsvValidAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> arrayStringSsvValidAsync();
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringSsvValidAsyncWithServiceResponse();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
      *
@@ -1079,7 +1567,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringSsvValid(List<String> arrayQuery) throws ErrorException, IOException;
+    void arrayStringSsvValid(List<String> arrayQuery) throws ErrorException, IOException;
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
@@ -1096,7 +1584,15 @@ public interface Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringSsvValidAsync(List<String> arrayQuery);
+    Observable<Void> arrayStringSsvValidAsync(List<String> arrayQuery);
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringSsvValidAsyncWithServiceResponse(List<String> arrayQuery);
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
@@ -1105,7 +1601,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringTsvValid() throws ErrorException, IOException;
+    void arrayStringTsvValid() throws ErrorException, IOException;
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
@@ -1114,6 +1610,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> arrayStringTsvValidAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> arrayStringTsvValidAsync();
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringTsvValidAsyncWithServiceResponse();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
      *
@@ -1122,7 +1634,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringTsvValid(List<String> arrayQuery) throws ErrorException, IOException;
+    void arrayStringTsvValid(List<String> arrayQuery) throws ErrorException, IOException;
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
@@ -1139,7 +1651,15 @@ public interface Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringTsvValidAsync(List<String> arrayQuery);
+    Observable<Void> arrayStringTsvValidAsync(List<String> arrayQuery);
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringTsvValidAsyncWithServiceResponse(List<String> arrayQuery);
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
@@ -1148,7 +1668,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringPipesValid() throws ErrorException, IOException;
+    void arrayStringPipesValid() throws ErrorException, IOException;
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
@@ -1157,6 +1677,22 @@ public interface Queries {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Void> arrayStringPipesValidAsync(final ServiceCallback<Void> serviceCallback);
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<Void> arrayStringPipesValidAsync();
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringPipesValidAsyncWithServiceResponse();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
      *
@@ -1165,7 +1701,7 @@ public interface Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> arrayStringPipesValid(List<String> arrayQuery) throws ErrorException, IOException;
+    void arrayStringPipesValid(List<String> arrayQuery) throws ErrorException, IOException;
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
@@ -1182,6 +1718,14 @@ public interface Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> arrayStringPipesValidAsync(List<String> arrayQuery);
+    Observable<Void> arrayStringPipesValidAsync(List<String> arrayQuery);
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> arrayStringPipesValidAsyncWithServiceResponse(List<String> arrayQuery);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/PathItemsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/PathItemsImpl.java
@@ -82,8 +82,8 @@ public final class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getAllWithValues(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
-        return getAllWithValuesAsync(localStringPath, pathItemStringPath).toBlocking().single();
+    public void getAllWithValues(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
+        getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -95,7 +95,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getAllWithValuesAsync(localStringPath, pathItemStringPath), serviceCallback);
+        return ServiceCall.create(getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath), serviceCallback);
     }
 
     /**
@@ -105,7 +105,23 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getAllWithValuesAsync(String localStringPath, String pathItemStringPath) {
+    public Observable<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath) {
+        return getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getAllWithValuesAsyncWithServiceResponse(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -143,8 +159,8 @@ public final class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getAllWithValues(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
-        return getAllWithValuesAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().single();
+    public void getAllWithValues(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
+        getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -158,7 +174,23 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getAllWithValuesAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
+        return ServiceCall.create(getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -170,7 +202,7 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Observable<ServiceResponse<Void>> getAllWithValuesAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -211,8 +243,8 @@ public final class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getGlobalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
-        return getGlobalQueryNullAsync(localStringPath, pathItemStringPath).toBlocking().single();
+    public void getGlobalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
+        getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -224,7 +256,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getGlobalQueryNullAsync(localStringPath, pathItemStringPath), serviceCallback);
+        return ServiceCall.create(getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath), serviceCallback);
     }
 
     /**
@@ -234,7 +266,23 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath) {
+    public Observable<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath) {
+        return getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getGlobalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -272,8 +320,8 @@ public final class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getGlobalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
-        return getGlobalQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().single();
+    public void getGlobalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
+        getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -287,7 +335,23 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getGlobalQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
+        return ServiceCall.create(getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -299,7 +363,7 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Observable<ServiceResponse<Void>> getGlobalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -340,8 +404,8 @@ public final class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
-        return getGlobalAndLocalQueryNullAsync(localStringPath, pathItemStringPath).toBlocking().single();
+    public void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
+        getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -353,7 +417,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getGlobalAndLocalQueryNullAsync(localStringPath, pathItemStringPath), serviceCallback);
+        return ServiceCall.create(getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath), serviceCallback);
     }
 
     /**
@@ -363,7 +427,23 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath) {
+    public Observable<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath) {
+        return getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -401,8 +481,8 @@ public final class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
-        return getGlobalAndLocalQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().single();
+    public void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
+        getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -416,7 +496,23 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getGlobalAndLocalQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
+        return ServiceCall.create(getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
+    }
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -428,7 +524,7 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -469,8 +565,8 @@ public final class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
-        return getLocalPathItemQueryNullAsync(localStringPath, pathItemStringPath).toBlocking().single();
+    public void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
+        getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -482,7 +578,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getLocalPathItemQueryNullAsync(localStringPath, pathItemStringPath), serviceCallback);
+        return ServiceCall.create(getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath), serviceCallback);
     }
 
     /**
@@ -492,7 +588,23 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath) {
+    public Observable<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath) {
+        return getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -530,8 +642,8 @@ public final class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
-        return getLocalPathItemQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().single();
+    public void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
+        getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -545,7 +657,23 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getLocalPathItemQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
+        return ServiceCall.create(getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -557,7 +685,7 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringQuery should contain value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/PathItemsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/PathItemsImpl.java
@@ -80,10 +80,9 @@ public final class PathItemsImpl implements PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getAllWithValues(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
-        getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
+        getAllWithValuesWithServiceResponseAsync(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -95,7 +94,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath), serviceCallback);
+        return ServiceCall.create(getAllWithValuesWithServiceResponseAsync(localStringPath, pathItemStringPath), serviceCallback);
     }
 
     /**
@@ -106,12 +105,12 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath) {
-        return getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return getAllWithValuesWithServiceResponseAsync(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -121,7 +120,7 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getAllWithValuesAsyncWithServiceResponse(String localStringPath, String pathItemStringPath) {
+    public Observable<ServiceResponse<Void>> getAllWithValuesWithServiceResponseAsync(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -157,10 +156,9 @@ public final class PathItemsImpl implements PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getAllWithValues(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
-        getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
+        getAllWithValuesWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -174,23 +172,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
-    }
-
-    /**
-     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
-     *
-     * @param localStringPath should contain value 'localStringPath'
-     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
-        return getAllWithValuesAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(getAllWithValuesWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
     }
 
     /**
@@ -202,7 +184,25 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getAllWithValuesAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Observable<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getAllWithValuesWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getAllWithValuesWithServiceResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -241,10 +241,9 @@ public final class PathItemsImpl implements PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getGlobalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
-        getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
+        getGlobalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -256,7 +255,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath), serviceCallback);
+        return ServiceCall.create(getGlobalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath), serviceCallback);
     }
 
     /**
@@ -267,12 +266,12 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath) {
-        return getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return getGlobalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -282,7 +281,7 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getGlobalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath) {
+    public Observable<ServiceResponse<Void>> getGlobalQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -318,10 +317,9 @@ public final class PathItemsImpl implements PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getGlobalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
-        getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
+        getGlobalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -335,23 +333,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
-    }
-
-    /**
-     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
-     *
-     * @param localStringPath should contain value 'localStringPath'
-     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
-        return getGlobalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(getGlobalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
     }
 
     /**
@@ -363,7 +345,25 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getGlobalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Observable<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getGlobalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getGlobalQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -402,10 +402,9 @@ public final class PathItemsImpl implements PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
-        getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
+        getGlobalAndLocalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -417,7 +416,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath), serviceCallback);
+        return ServiceCall.create(getGlobalAndLocalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath), serviceCallback);
     }
 
     /**
@@ -428,12 +427,12 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath) {
-        return getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return getGlobalAndLocalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -443,7 +442,7 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath) {
+    public Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -479,10 +478,9 @@ public final class PathItemsImpl implements PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
-        getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
+        getGlobalAndLocalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -496,23 +494,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
-    }
-
-    /**
-     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
-     *
-     * @param localStringPath should contain value 'localStringPath'
-     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
-        return getGlobalAndLocalQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(getGlobalAndLocalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
     }
 
     /**
@@ -524,7 +506,25 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Observable<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getGlobalAndLocalQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain null value
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getGlobalAndLocalQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -563,10 +563,9 @@ public final class PathItemsImpl implements PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath) throws ErrorException, IOException, IllegalArgumentException {
-        getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
+        getLocalPathItemQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -578,7 +577,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath), serviceCallback);
+        return ServiceCall.create(getLocalPathItemQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath), serviceCallback);
     }
 
     /**
@@ -589,12 +588,12 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath) {
-        return getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return getLocalPathItemQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -604,7 +603,7 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath) {
+    public Observable<ServiceResponse<Void>> getLocalPathItemQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -640,10 +639,9 @@ public final class PathItemsImpl implements PathItems {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) throws ErrorException, IOException, IllegalArgumentException {
-        getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath).toBlocking().single().getBody();
+        getLocalPathItemQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -657,23 +655,7 @@ public final class PathItemsImpl implements PathItems {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
-    }
-
-    /**
-     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
-     *
-     * @param localStringPath should contain value 'localStringPath'
-     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
-        return getLocalPathItemQueryNullAsyncWithServiceResponse(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(getLocalPathItemQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
     }
 
     /**
@@ -685,7 +667,25 @@ public final class PathItemsImpl implements PathItems {
      * @param pathItemStringQuery should contain value null
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getLocalPathItemQueryNullAsyncWithServiceResponse(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Observable<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getLocalPathItemQueryNullWithServiceResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value null
+     * @param pathItemStringQuery should contain value null
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getLocalPathItemQueryNullWithServiceResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/PathsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/PathsImpl.java
@@ -173,10 +173,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getBooleanTrue() throws ErrorException, IOException {
-        getBooleanTrueAsyncWithServiceResponse().toBlocking().single().getBody();
+        getBooleanTrueWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -186,7 +185,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanTrueAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanTrueAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanTrueWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -195,12 +194,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getBooleanTrueAsync() {
-        return getBooleanTrueAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getBooleanTrueWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -208,7 +207,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanTrueAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getBooleanTrueWithServiceResponseAsync() {
         final boolean boolPath = true;
         return service.getBooleanTrue(boolPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -236,10 +235,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getBooleanFalse() throws ErrorException, IOException {
-        getBooleanFalseAsyncWithServiceResponse().toBlocking().single().getBody();
+        getBooleanFalseWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -249,7 +247,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanFalseAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanFalseAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanFalseWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -258,12 +256,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getBooleanFalseAsync() {
-        return getBooleanFalseAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getBooleanFalseWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -271,7 +269,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanFalseAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getBooleanFalseWithServiceResponseAsync() {
         final boolean boolPath = false;
         return service.getBooleanFalse(boolPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -299,10 +297,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getIntOneMillion() throws ErrorException, IOException {
-        getIntOneMillionAsyncWithServiceResponse().toBlocking().single().getBody();
+        getIntOneMillionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -312,7 +309,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntOneMillionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntOneMillionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -321,12 +318,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getIntOneMillionAsync() {
-        return getIntOneMillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getIntOneMillionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -334,7 +331,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntOneMillionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getIntOneMillionWithServiceResponseAsync() {
         final int intPath = 1000000;
         return service.getIntOneMillion(intPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -362,10 +359,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getIntNegativeOneMillion() throws ErrorException, IOException {
-        getIntNegativeOneMillionAsyncWithServiceResponse().toBlocking().single().getBody();
+        getIntNegativeOneMillionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -375,7 +371,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntNegativeOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntNegativeOneMillionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntNegativeOneMillionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -384,12 +380,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getIntNegativeOneMillionAsync() {
-        return getIntNegativeOneMillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getIntNegativeOneMillionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -397,7 +393,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getIntNegativeOneMillionWithServiceResponseAsync() {
         final int intPath = -1000000;
         return service.getIntNegativeOneMillion(intPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -425,10 +421,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getTenBillion() throws ErrorException, IOException {
-        getTenBillionAsyncWithServiceResponse().toBlocking().single().getBody();
+        getTenBillionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -438,7 +433,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getTenBillionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getTenBillionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -447,12 +442,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getTenBillionAsync() {
-        return getTenBillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getTenBillionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -460,7 +455,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getTenBillionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getTenBillionWithServiceResponseAsync() {
         final long longPath = 10000000000L;
         return service.getTenBillion(longPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -488,10 +483,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getNegativeTenBillion() throws ErrorException, IOException {
-        getNegativeTenBillionAsyncWithServiceResponse().toBlocking().single().getBody();
+        getNegativeTenBillionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -501,7 +495,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getNegativeTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getNegativeTenBillionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNegativeTenBillionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -510,12 +504,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getNegativeTenBillionAsync() {
-        return getNegativeTenBillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getNegativeTenBillionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -523,7 +517,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getNegativeTenBillionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getNegativeTenBillionWithServiceResponseAsync() {
         final long longPath = -10000000000L;
         return service.getNegativeTenBillion(longPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -551,10 +545,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void floatScientificPositive() throws ErrorException, IOException {
-        floatScientificPositiveAsyncWithServiceResponse().toBlocking().single().getBody();
+        floatScientificPositiveWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -564,7 +557,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatScientificPositiveAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatScientificPositiveAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(floatScientificPositiveWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -573,12 +566,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> floatScientificPositiveAsync() {
-        return floatScientificPositiveAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return floatScientificPositiveWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -586,7 +579,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatScientificPositiveAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> floatScientificPositiveWithServiceResponseAsync() {
         final double floatPath = 1.034E+20;
         return service.floatScientificPositive(floatPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -614,10 +607,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void floatScientificNegative() throws ErrorException, IOException {
-        floatScientificNegativeAsyncWithServiceResponse().toBlocking().single().getBody();
+        floatScientificNegativeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -627,7 +619,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatScientificNegativeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatScientificNegativeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(floatScientificNegativeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -636,12 +628,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> floatScientificNegativeAsync() {
-        return floatScientificNegativeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return floatScientificNegativeWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -649,7 +641,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatScientificNegativeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> floatScientificNegativeWithServiceResponseAsync() {
         final double floatPath = -1.034E-20;
         return service.floatScientificNegative(floatPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -677,10 +669,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void doubleDecimalPositive() throws ErrorException, IOException {
-        doubleDecimalPositiveAsyncWithServiceResponse().toBlocking().single().getBody();
+        doubleDecimalPositiveWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -690,7 +681,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleDecimalPositiveAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleDecimalPositiveAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(doubleDecimalPositiveWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -699,12 +690,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> doubleDecimalPositiveAsync() {
-        return doubleDecimalPositiveAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return doubleDecimalPositiveWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -712,7 +703,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleDecimalPositiveAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> doubleDecimalPositiveWithServiceResponseAsync() {
         final double doublePath = 9999999.999;
         return service.doubleDecimalPositive(doublePath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -740,10 +731,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void doubleDecimalNegative() throws ErrorException, IOException {
-        doubleDecimalNegativeAsyncWithServiceResponse().toBlocking().single().getBody();
+        doubleDecimalNegativeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -753,7 +743,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleDecimalNegativeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleDecimalNegativeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(doubleDecimalNegativeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -762,12 +752,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> doubleDecimalNegativeAsync() {
-        return doubleDecimalNegativeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return doubleDecimalNegativeWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -775,7 +765,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleDecimalNegativeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> doubleDecimalNegativeWithServiceResponseAsync() {
         final double doublePath = -9999999.999;
         return service.doubleDecimalNegative(doublePath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -803,10 +793,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringUnicode() throws ErrorException, IOException {
-        stringUnicodeAsyncWithServiceResponse().toBlocking().single().getBody();
+        stringUnicodeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -816,7 +805,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringUnicodeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringUnicodeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(stringUnicodeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -825,12 +814,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> stringUnicodeAsync() {
-        return stringUnicodeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return stringUnicodeWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -838,7 +827,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringUnicodeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> stringUnicodeWithServiceResponseAsync() {
         final String stringPath = "啊齄丂狛狜隣郎隣兀﨩";
         return service.stringUnicode(stringPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -866,10 +855,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringUrlEncoded() throws ErrorException, IOException {
-        stringUrlEncodedAsyncWithServiceResponse().toBlocking().single().getBody();
+        stringUrlEncodedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -879,7 +867,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringUrlEncodedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringUrlEncodedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(stringUrlEncodedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -888,12 +876,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> stringUrlEncodedAsync() {
-        return stringUrlEncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return stringUrlEncodedWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -901,7 +889,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringUrlEncodedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> stringUrlEncodedWithServiceResponseAsync() {
         final String stringPath = "begin!*'();:@ &=+$,/?#[]end";
         return service.stringUrlEncoded(stringPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -929,10 +917,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringEmpty() throws ErrorException, IOException {
-        stringEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        stringEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -942,7 +929,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(stringEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -951,12 +938,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> stringEmptyAsync() {
-        return stringEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return stringEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -964,7 +951,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> stringEmptyWithServiceResponseAsync() {
         final String stringPath = "";
         return service.stringEmpty(stringPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -994,10 +981,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringNull(String stringPath) throws ErrorException, IOException, IllegalArgumentException {
-        stringNullAsyncWithServiceResponse(stringPath).toBlocking().single().getBody();
+        stringNullWithServiceResponseAsync(stringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1008,7 +994,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringNullAsync(String stringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringNullAsyncWithServiceResponse(stringPath), serviceCallback);
+        return ServiceCall.create(stringNullWithServiceResponseAsync(stringPath), serviceCallback);
     }
 
     /**
@@ -1018,12 +1004,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> stringNullAsync(String stringPath) {
-        return stringNullAsyncWithServiceResponse(stringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return stringNullWithServiceResponseAsync(stringPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1032,7 +1018,7 @@ public final class PathsImpl implements Paths {
      * @param stringPath null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse(String stringPath) {
+    public Observable<ServiceResponse<Void>> stringNullWithServiceResponseAsync(String stringPath) {
         if (stringPath == null) {
             throw new IllegalArgumentException("Parameter stringPath is required and cannot be null.");
         }
@@ -1064,10 +1050,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void enumValid(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException {
-        enumValidAsyncWithServiceResponse(enumPath).toBlocking().single().getBody();
+        enumValidWithServiceResponseAsync(enumPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1078,7 +1063,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumValidAsync(UriColor enumPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumValidAsyncWithServiceResponse(enumPath), serviceCallback);
+        return ServiceCall.create(enumValidWithServiceResponseAsync(enumPath), serviceCallback);
     }
 
     /**
@@ -1088,12 +1073,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> enumValidAsync(UriColor enumPath) {
-        return enumValidAsyncWithServiceResponse(enumPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return enumValidWithServiceResponseAsync(enumPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1102,7 +1087,7 @@ public final class PathsImpl implements Paths {
      * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse(UriColor enumPath) {
+    public Observable<ServiceResponse<Void>> enumValidWithServiceResponseAsync(UriColor enumPath) {
         if (enumPath == null) {
             throw new IllegalArgumentException("Parameter enumPath is required and cannot be null.");
         }
@@ -1134,10 +1119,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void enumNull(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException {
-        enumNullAsyncWithServiceResponse(enumPath).toBlocking().single().getBody();
+        enumNullWithServiceResponseAsync(enumPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1148,7 +1132,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumNullAsync(UriColor enumPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumNullAsyncWithServiceResponse(enumPath), serviceCallback);
+        return ServiceCall.create(enumNullWithServiceResponseAsync(enumPath), serviceCallback);
     }
 
     /**
@@ -1158,12 +1142,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> enumNullAsync(UriColor enumPath) {
-        return enumNullAsyncWithServiceResponse(enumPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return enumNullWithServiceResponseAsync(enumPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1172,7 +1156,7 @@ public final class PathsImpl implements Paths {
      * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse(UriColor enumPath) {
+    public Observable<ServiceResponse<Void>> enumNullWithServiceResponseAsync(UriColor enumPath) {
         if (enumPath == null) {
             throw new IllegalArgumentException("Parameter enumPath is required and cannot be null.");
         }
@@ -1204,10 +1188,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void byteMultiByte(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException {
-        byteMultiByteAsyncWithServiceResponse(bytePath).toBlocking().single().getBody();
+        byteMultiByteWithServiceResponseAsync(bytePath).toBlocking().single().getBody();
     }
 
     /**
@@ -1218,7 +1201,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteMultiByteAsync(byte[] bytePath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteMultiByteAsyncWithServiceResponse(bytePath), serviceCallback);
+        return ServiceCall.create(byteMultiByteWithServiceResponseAsync(bytePath), serviceCallback);
     }
 
     /**
@@ -1228,12 +1211,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> byteMultiByteAsync(byte[] bytePath) {
-        return byteMultiByteAsyncWithServiceResponse(bytePath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return byteMultiByteWithServiceResponseAsync(bytePath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1242,7 +1225,7 @@ public final class PathsImpl implements Paths {
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse(byte[] bytePath) {
+    public Observable<ServiceResponse<Void>> byteMultiByteWithServiceResponseAsync(byte[] bytePath) {
         if (bytePath == null) {
             throw new IllegalArgumentException("Parameter bytePath is required and cannot be null.");
         }
@@ -1273,10 +1256,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void byteEmpty() throws ErrorException, IOException {
-        byteEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        byteEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1286,7 +1268,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(byteEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1295,12 +1277,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> byteEmptyAsync() {
-        return byteEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return byteEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1308,7 +1290,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> byteEmptyWithServiceResponseAsync() {
         final byte[] bytePath = "".getBytes();
         String bytePathConverted = Base64.encodeBase64String(bytePath);
         return service.byteEmpty(bytePathConverted)
@@ -1339,10 +1321,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void byteNull(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException {
-        byteNullAsyncWithServiceResponse(bytePath).toBlocking().single().getBody();
+        byteNullWithServiceResponseAsync(bytePath).toBlocking().single().getBody();
     }
 
     /**
@@ -1353,7 +1334,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteNullAsync(byte[] bytePath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteNullAsyncWithServiceResponse(bytePath), serviceCallback);
+        return ServiceCall.create(byteNullWithServiceResponseAsync(bytePath), serviceCallback);
     }
 
     /**
@@ -1363,12 +1344,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> byteNullAsync(byte[] bytePath) {
-        return byteNullAsyncWithServiceResponse(bytePath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return byteNullWithServiceResponseAsync(bytePath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1377,7 +1358,7 @@ public final class PathsImpl implements Paths {
      * @param bytePath null as byte array (should throw)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse(byte[] bytePath) {
+    public Observable<ServiceResponse<Void>> byteNullWithServiceResponseAsync(byte[] bytePath) {
         if (bytePath == null) {
             throw new IllegalArgumentException("Parameter bytePath is required and cannot be null.");
         }
@@ -1408,10 +1389,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateValid() throws ErrorException, IOException {
-        dateValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        dateValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1421,7 +1401,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(dateValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1430,12 +1410,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> dateValidAsync() {
-        return dateValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return dateValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1443,7 +1423,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> dateValidWithServiceResponseAsync() {
         final LocalDate datePath = LocalDate.parse("2012-01-01");
         return service.dateValid(datePath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1473,10 +1453,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateNull(LocalDate datePath) throws ErrorException, IOException, IllegalArgumentException {
-        dateNullAsyncWithServiceResponse(datePath).toBlocking().single().getBody();
+        dateNullWithServiceResponseAsync(datePath).toBlocking().single().getBody();
     }
 
     /**
@@ -1487,7 +1466,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateNullAsync(LocalDate datePath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateNullAsyncWithServiceResponse(datePath), serviceCallback);
+        return ServiceCall.create(dateNullWithServiceResponseAsync(datePath), serviceCallback);
     }
 
     /**
@@ -1497,12 +1476,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> dateNullAsync(LocalDate datePath) {
-        return dateNullAsyncWithServiceResponse(datePath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return dateNullWithServiceResponseAsync(datePath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1511,7 +1490,7 @@ public final class PathsImpl implements Paths {
      * @param datePath null as date (should throw)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse(LocalDate datePath) {
+    public Observable<ServiceResponse<Void>> dateNullWithServiceResponseAsync(LocalDate datePath) {
         if (datePath == null) {
             throw new IllegalArgumentException("Parameter datePath is required and cannot be null.");
         }
@@ -1541,10 +1520,9 @@ public final class PathsImpl implements Paths {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateTimeValid() throws ErrorException, IOException {
-        dateTimeValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        dateTimeValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1554,7 +1532,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(dateTimeValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1563,12 +1541,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> dateTimeValidAsync() {
-        return dateTimeValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return dateTimeValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1576,7 +1554,7 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> dateTimeValidWithServiceResponseAsync() {
         final DateTime dateTimePath = DateTime.parse("2012-01-01T01:01:01Z");
         return service.dateTimeValid(dateTimePath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1606,10 +1584,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateTimeNull(DateTime dateTimePath) throws ErrorException, IOException, IllegalArgumentException {
-        dateTimeNullAsyncWithServiceResponse(dateTimePath).toBlocking().single().getBody();
+        dateTimeNullWithServiceResponseAsync(dateTimePath).toBlocking().single().getBody();
     }
 
     /**
@@ -1620,7 +1597,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeNullAsync(DateTime dateTimePath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeNullAsyncWithServiceResponse(dateTimePath), serviceCallback);
+        return ServiceCall.create(dateTimeNullWithServiceResponseAsync(dateTimePath), serviceCallback);
     }
 
     /**
@@ -1630,12 +1607,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> dateTimeNullAsync(DateTime dateTimePath) {
-        return dateTimeNullAsyncWithServiceResponse(dateTimePath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return dateTimeNullWithServiceResponseAsync(dateTimePath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1644,7 +1621,7 @@ public final class PathsImpl implements Paths {
      * @param dateTimePath null as date-time
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse(DateTime dateTimePath) {
+    public Observable<ServiceResponse<Void>> dateTimeNullWithServiceResponseAsync(DateTime dateTimePath) {
         if (dateTimePath == null) {
             throw new IllegalArgumentException("Parameter dateTimePath is required and cannot be null.");
         }
@@ -1676,10 +1653,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void base64Url(byte[] base64UrlPath) throws ErrorException, IOException, IllegalArgumentException {
-        base64UrlAsyncWithServiceResponse(base64UrlPath).toBlocking().single().getBody();
+        base64UrlWithServiceResponseAsync(base64UrlPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1690,7 +1666,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> base64UrlAsync(byte[] base64UrlPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(base64UrlAsyncWithServiceResponse(base64UrlPath), serviceCallback);
+        return ServiceCall.create(base64UrlWithServiceResponseAsync(base64UrlPath), serviceCallback);
     }
 
     /**
@@ -1700,12 +1676,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> base64UrlAsync(byte[] base64UrlPath) {
-        return base64UrlAsyncWithServiceResponse(base64UrlPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return base64UrlWithServiceResponseAsync(base64UrlPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1714,7 +1690,7 @@ public final class PathsImpl implements Paths {
      * @param base64UrlPath base64url encoded value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> base64UrlAsyncWithServiceResponse(byte[] base64UrlPath) {
+    public Observable<ServiceResponse<Void>> base64UrlWithServiceResponseAsync(byte[] base64UrlPath) {
         if (base64UrlPath == null) {
             throw new IllegalArgumentException("Parameter base64UrlPath is required and cannot be null.");
         }
@@ -1747,10 +1723,9 @@ public final class PathsImpl implements Paths {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayCsvInPath(List<String> arrayPath) throws ErrorException, IOException, IllegalArgumentException {
-        arrayCsvInPathAsyncWithServiceResponse(arrayPath).toBlocking().single().getBody();
+        arrayCsvInPathWithServiceResponseAsync(arrayPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1761,7 +1736,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayCsvInPathAsync(List<String> arrayPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayCsvInPathAsyncWithServiceResponse(arrayPath), serviceCallback);
+        return ServiceCall.create(arrayCsvInPathWithServiceResponseAsync(arrayPath), serviceCallback);
     }
 
     /**
@@ -1771,12 +1746,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> arrayCsvInPathAsync(List<String> arrayPath) {
-        return arrayCsvInPathAsyncWithServiceResponse(arrayPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return arrayCsvInPathWithServiceResponseAsync(arrayPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1785,7 +1760,7 @@ public final class PathsImpl implements Paths {
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayCsvInPathAsyncWithServiceResponse(List<String> arrayPath) {
+    public Observable<ServiceResponse<Void>> arrayCsvInPathWithServiceResponseAsync(List<String> arrayPath) {
         if (arrayPath == null) {
             throw new IllegalArgumentException("Parameter arrayPath is required and cannot be null.");
         }
@@ -1818,10 +1793,9 @@ public final class PathsImpl implements Paths {
      * @param unixTimeUrlPath Unix time encoded value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void unixTimeUrl(DateTime unixTimeUrlPath) throws ErrorException, IOException {
-        unixTimeUrlAsyncWithServiceResponse(unixTimeUrlPath).toBlocking().single().getBody();
+        unixTimeUrlWithServiceResponseAsync(unixTimeUrlPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1832,7 +1806,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(unixTimeUrlAsyncWithServiceResponse(unixTimeUrlPath), serviceCallback);
+        return ServiceCall.create(unixTimeUrlWithServiceResponseAsync(unixTimeUrlPath), serviceCallback);
     }
 
     /**
@@ -1842,12 +1816,12 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath) {
-        return unixTimeUrlAsyncWithServiceResponse(unixTimeUrlPath).map(new Func1<ServiceResponse<Void>, Void>() {
+        return unixTimeUrlWithServiceResponseAsync(unixTimeUrlPath).map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1856,7 +1830,7 @@ public final class PathsImpl implements Paths {
      * @param unixTimeUrlPath Unix time encoded value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> unixTimeUrlAsyncWithServiceResponse(DateTime unixTimeUrlPath) {
+    public Observable<ServiceResponse<Void>> unixTimeUrlWithServiceResponseAsync(DateTime unixTimeUrlPath) {
         Long unixTimeUrlPathConverted = unixTimeUrlPath.toDateTime(DateTimeZone.UTC).getMillis() / 1000;
         return service.unixTimeUrl(unixTimeUrlPathConverted)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/PathsImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/PathsImpl.java
@@ -175,8 +175,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getBooleanTrue() throws ErrorException, IOException {
-        return getBooleanTrueAsync().toBlocking().single();
+    public void getBooleanTrue() throws ErrorException, IOException {
+        getBooleanTrueAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -186,7 +186,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanTrueAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanTrueAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanTrueAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -194,7 +194,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanTrueAsync() {
+    public Observable<Void> getBooleanTrueAsync() {
+        return getBooleanTrueAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get true Boolean value on path.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getBooleanTrueAsyncWithServiceResponse() {
         final boolean boolPath = true;
         return service.getBooleanTrue(boolPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -224,8 +238,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getBooleanFalse() throws ErrorException, IOException {
-        return getBooleanFalseAsync().toBlocking().single();
+    public void getBooleanFalse() throws ErrorException, IOException {
+        getBooleanFalseAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -235,7 +249,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanFalseAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanFalseAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanFalseAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -243,7 +257,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanFalseAsync() {
+    public Observable<Void> getBooleanFalseAsync() {
+        return getBooleanFalseAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get false Boolean value on path.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getBooleanFalseAsyncWithServiceResponse() {
         final boolean boolPath = false;
         return service.getBooleanFalse(boolPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -273,8 +301,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getIntOneMillion() throws ErrorException, IOException {
-        return getIntOneMillionAsync().toBlocking().single();
+    public void getIntOneMillion() throws ErrorException, IOException {
+        getIntOneMillionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -284,7 +312,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntOneMillionAsync(), serviceCallback);
+        return ServiceCall.create(getIntOneMillionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -292,7 +320,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntOneMillionAsync() {
+    public Observable<Void> getIntOneMillionAsync() {
+        return getIntOneMillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '1000000' integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getIntOneMillionAsyncWithServiceResponse() {
         final int intPath = 1000000;
         return service.getIntOneMillion(intPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -322,8 +364,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getIntNegativeOneMillion() throws ErrorException, IOException {
-        return getIntNegativeOneMillionAsync().toBlocking().single();
+    public void getIntNegativeOneMillion() throws ErrorException, IOException {
+        getIntNegativeOneMillionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -333,7 +375,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntNegativeOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntNegativeOneMillionAsync(), serviceCallback);
+        return ServiceCall.create(getIntNegativeOneMillionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -341,7 +383,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsync() {
+    public Observable<Void> getIntNegativeOneMillionAsync() {
+        return getIntNegativeOneMillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsyncWithServiceResponse() {
         final int intPath = -1000000;
         return service.getIntNegativeOneMillion(intPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -371,8 +427,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getTenBillion() throws ErrorException, IOException {
-        return getTenBillionAsync().toBlocking().single();
+    public void getTenBillion() throws ErrorException, IOException {
+        getTenBillionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -382,7 +438,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getTenBillionAsync(), serviceCallback);
+        return ServiceCall.create(getTenBillionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -390,7 +446,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getTenBillionAsync() {
+    public Observable<Void> getTenBillionAsync() {
+        return getTenBillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getTenBillionAsyncWithServiceResponse() {
         final long longPath = 10000000000L;
         return service.getTenBillion(longPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -420,8 +490,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getNegativeTenBillion() throws ErrorException, IOException {
-        return getNegativeTenBillionAsync().toBlocking().single();
+    public void getNegativeTenBillion() throws ErrorException, IOException {
+        getNegativeTenBillionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -431,7 +501,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getNegativeTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getNegativeTenBillionAsync(), serviceCallback);
+        return ServiceCall.create(getNegativeTenBillionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -439,7 +509,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getNegativeTenBillionAsync() {
+    public Observable<Void> getNegativeTenBillionAsync() {
+        return getNegativeTenBillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getNegativeTenBillionAsyncWithServiceResponse() {
         final long longPath = -10000000000L;
         return service.getNegativeTenBillion(longPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -469,8 +553,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> floatScientificPositive() throws ErrorException, IOException {
-        return floatScientificPositiveAsync().toBlocking().single();
+    public void floatScientificPositive() throws ErrorException, IOException {
+        floatScientificPositiveAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -480,7 +564,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatScientificPositiveAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatScientificPositiveAsync(), serviceCallback);
+        return ServiceCall.create(floatScientificPositiveAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -488,7 +572,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatScientificPositiveAsync() {
+    public Observable<Void> floatScientificPositiveAsync() {
+        return floatScientificPositiveAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> floatScientificPositiveAsyncWithServiceResponse() {
         final double floatPath = 1.034E+20;
         return service.floatScientificPositive(floatPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -518,8 +616,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> floatScientificNegative() throws ErrorException, IOException {
-        return floatScientificNegativeAsync().toBlocking().single();
+    public void floatScientificNegative() throws ErrorException, IOException {
+        floatScientificNegativeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -529,7 +627,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatScientificNegativeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatScientificNegativeAsync(), serviceCallback);
+        return ServiceCall.create(floatScientificNegativeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -537,7 +635,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatScientificNegativeAsync() {
+    public Observable<Void> floatScientificNegativeAsync() {
+        return floatScientificNegativeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> floatScientificNegativeAsyncWithServiceResponse() {
         final double floatPath = -1.034E-20;
         return service.floatScientificNegative(floatPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -567,8 +679,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> doubleDecimalPositive() throws ErrorException, IOException {
-        return doubleDecimalPositiveAsync().toBlocking().single();
+    public void doubleDecimalPositive() throws ErrorException, IOException {
+        doubleDecimalPositiveAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -578,7 +690,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleDecimalPositiveAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleDecimalPositiveAsync(), serviceCallback);
+        return ServiceCall.create(doubleDecimalPositiveAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -586,7 +698,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleDecimalPositiveAsync() {
+    public Observable<Void> doubleDecimalPositiveAsync() {
+        return doubleDecimalPositiveAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> doubleDecimalPositiveAsyncWithServiceResponse() {
         final double doublePath = 9999999.999;
         return service.doubleDecimalPositive(doublePath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -616,8 +742,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> doubleDecimalNegative() throws ErrorException, IOException {
-        return doubleDecimalNegativeAsync().toBlocking().single();
+    public void doubleDecimalNegative() throws ErrorException, IOException {
+        doubleDecimalNegativeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -627,7 +753,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleDecimalNegativeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleDecimalNegativeAsync(), serviceCallback);
+        return ServiceCall.create(doubleDecimalNegativeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -635,7 +761,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleDecimalNegativeAsync() {
+    public Observable<Void> doubleDecimalNegativeAsync() {
+        return doubleDecimalNegativeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> doubleDecimalNegativeAsyncWithServiceResponse() {
         final double doublePath = -9999999.999;
         return service.doubleDecimalNegative(doublePath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -665,8 +805,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringUnicode() throws ErrorException, IOException {
-        return stringUnicodeAsync().toBlocking().single();
+    public void stringUnicode() throws ErrorException, IOException {
+        stringUnicodeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -676,7 +816,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringUnicodeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringUnicodeAsync(), serviceCallback);
+        return ServiceCall.create(stringUnicodeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -684,7 +824,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringUnicodeAsync() {
+    public Observable<Void> stringUnicodeAsync() {
+        return stringUnicodeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringUnicodeAsyncWithServiceResponse() {
         final String stringPath = "啊齄丂狛狜隣郎隣兀﨩";
         return service.stringUnicode(stringPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -714,8 +868,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringUrlEncoded() throws ErrorException, IOException {
-        return stringUrlEncodedAsync().toBlocking().single();
+    public void stringUrlEncoded() throws ErrorException, IOException {
+        stringUrlEncodedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -725,7 +879,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringUrlEncodedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringUrlEncodedAsync(), serviceCallback);
+        return ServiceCall.create(stringUrlEncodedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -733,7 +887,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringUrlEncodedAsync() {
+    public Observable<Void> stringUrlEncodedAsync() {
+        return stringUrlEncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringUrlEncodedAsyncWithServiceResponse() {
         final String stringPath = "begin!*'();:@ &=+$,/?#[]end";
         return service.stringUrlEncoded(stringPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -763,8 +931,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringEmpty() throws ErrorException, IOException {
-        return stringEmptyAsync().toBlocking().single();
+    public void stringEmpty() throws ErrorException, IOException {
+        stringEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -774,7 +942,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringEmptyAsync(), serviceCallback);
+        return ServiceCall.create(stringEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -782,7 +950,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringEmptyAsync() {
+    public Observable<Void> stringEmptyAsync() {
+        return stringEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get ''.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringEmptyAsyncWithServiceResponse() {
         final String stringPath = "";
         return service.stringEmpty(stringPath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -814,8 +996,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringNull(String stringPath) throws ErrorException, IOException, IllegalArgumentException {
-        return stringNullAsync(stringPath).toBlocking().single();
+    public void stringNull(String stringPath) throws ErrorException, IOException, IllegalArgumentException {
+        stringNullAsyncWithServiceResponse(stringPath).toBlocking().single().getBody();
     }
 
     /**
@@ -826,7 +1008,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringNullAsync(String stringPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringNullAsync(stringPath), serviceCallback);
+        return ServiceCall.create(stringNullAsyncWithServiceResponse(stringPath), serviceCallback);
     }
 
     /**
@@ -835,7 +1017,22 @@ public final class PathsImpl implements Paths {
      * @param stringPath null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringNullAsync(String stringPath) {
+    public Observable<Void> stringNullAsync(String stringPath) {
+        return stringNullAsyncWithServiceResponse(stringPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null (should throw).
+     *
+     * @param stringPath null string value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse(String stringPath) {
         if (stringPath == null) {
             throw new IllegalArgumentException("Parameter stringPath is required and cannot be null.");
         }
@@ -869,8 +1066,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> enumValid(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException {
-        return enumValidAsync(enumPath).toBlocking().single();
+    public void enumValid(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException {
+        enumValidAsyncWithServiceResponse(enumPath).toBlocking().single().getBody();
     }
 
     /**
@@ -881,7 +1078,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumValidAsync(UriColor enumPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumValidAsync(enumPath), serviceCallback);
+        return ServiceCall.create(enumValidAsyncWithServiceResponse(enumPath), serviceCallback);
     }
 
     /**
@@ -890,7 +1087,22 @@ public final class PathsImpl implements Paths {
      * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumValidAsync(UriColor enumPath) {
+    public Observable<Void> enumValidAsync(UriColor enumPath) {
+        return enumValidAsyncWithServiceResponse(enumPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get using uri with 'green color' in path parameter.
+     *
+     * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse(UriColor enumPath) {
         if (enumPath == null) {
             throw new IllegalArgumentException("Parameter enumPath is required and cannot be null.");
         }
@@ -924,8 +1136,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> enumNull(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException {
-        return enumNullAsync(enumPath).toBlocking().single();
+    public void enumNull(UriColor enumPath) throws ErrorException, IOException, IllegalArgumentException {
+        enumNullAsyncWithServiceResponse(enumPath).toBlocking().single().getBody();
     }
 
     /**
@@ -936,7 +1148,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumNullAsync(UriColor enumPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumNullAsync(enumPath), serviceCallback);
+        return ServiceCall.create(enumNullAsyncWithServiceResponse(enumPath), serviceCallback);
     }
 
     /**
@@ -945,7 +1157,22 @@ public final class PathsImpl implements Paths {
      * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumNullAsync(UriColor enumPath) {
+    public Observable<Void> enumNullAsync(UriColor enumPath) {
+        return enumNullAsyncWithServiceResponse(enumPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     *
+     * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse(UriColor enumPath) {
         if (enumPath == null) {
             throw new IllegalArgumentException("Parameter enumPath is required and cannot be null.");
         }
@@ -979,8 +1206,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> byteMultiByte(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException {
-        return byteMultiByteAsync(bytePath).toBlocking().single();
+    public void byteMultiByte(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException {
+        byteMultiByteAsyncWithServiceResponse(bytePath).toBlocking().single().getBody();
     }
 
     /**
@@ -991,7 +1218,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteMultiByteAsync(byte[] bytePath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteMultiByteAsync(bytePath), serviceCallback);
+        return ServiceCall.create(byteMultiByteAsyncWithServiceResponse(bytePath), serviceCallback);
     }
 
     /**
@@ -1000,7 +1227,22 @@ public final class PathsImpl implements Paths {
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteMultiByteAsync(byte[] bytePath) {
+    public Observable<Void> byteMultiByteAsync(byte[] bytePath) {
+        return byteMultiByteAsyncWithServiceResponse(bytePath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse(byte[] bytePath) {
         if (bytePath == null) {
             throw new IllegalArgumentException("Parameter bytePath is required and cannot be null.");
         }
@@ -1033,8 +1275,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> byteEmpty() throws ErrorException, IOException {
-        return byteEmptyAsync().toBlocking().single();
+    public void byteEmpty() throws ErrorException, IOException {
+        byteEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1044,7 +1286,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteEmptyAsync(), serviceCallback);
+        return ServiceCall.create(byteEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1052,7 +1294,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteEmptyAsync() {
+    public Observable<Void> byteEmptyAsync() {
+        return byteEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '' as byte array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> byteEmptyAsyncWithServiceResponse() {
         final byte[] bytePath = "".getBytes();
         String bytePathConverted = Base64.encodeBase64String(bytePath);
         return service.byteEmpty(bytePathConverted)
@@ -1085,8 +1341,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> byteNull(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException {
-        return byteNullAsync(bytePath).toBlocking().single();
+    public void byteNull(byte[] bytePath) throws ErrorException, IOException, IllegalArgumentException {
+        byteNullAsyncWithServiceResponse(bytePath).toBlocking().single().getBody();
     }
 
     /**
@@ -1097,7 +1353,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteNullAsync(byte[] bytePath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteNullAsync(bytePath), serviceCallback);
+        return ServiceCall.create(byteNullAsyncWithServiceResponse(bytePath), serviceCallback);
     }
 
     /**
@@ -1106,7 +1362,22 @@ public final class PathsImpl implements Paths {
      * @param bytePath null as byte array (should throw)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteNullAsync(byte[] bytePath) {
+    public Observable<Void> byteNullAsync(byte[] bytePath) {
+        return byteNullAsyncWithServiceResponse(bytePath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null as byte array (should throw).
+     *
+     * @param bytePath null as byte array (should throw)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse(byte[] bytePath) {
         if (bytePath == null) {
             throw new IllegalArgumentException("Parameter bytePath is required and cannot be null.");
         }
@@ -1139,8 +1410,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateValid() throws ErrorException, IOException {
-        return dateValidAsync().toBlocking().single();
+    public void dateValid() throws ErrorException, IOException {
+        dateValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1150,7 +1421,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateValidAsync(), serviceCallback);
+        return ServiceCall.create(dateValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1158,7 +1429,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateValidAsync() {
+    public Observable<Void> dateValidAsync() {
+        return dateValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateValidAsyncWithServiceResponse() {
         final LocalDate datePath = LocalDate.parse("2012-01-01");
         return service.dateValid(datePath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1190,8 +1475,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateNull(LocalDate datePath) throws ErrorException, IOException, IllegalArgumentException {
-        return dateNullAsync(datePath).toBlocking().single();
+    public void dateNull(LocalDate datePath) throws ErrorException, IOException, IllegalArgumentException {
+        dateNullAsyncWithServiceResponse(datePath).toBlocking().single().getBody();
     }
 
     /**
@@ -1202,7 +1487,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateNullAsync(LocalDate datePath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateNullAsync(datePath), serviceCallback);
+        return ServiceCall.create(dateNullAsyncWithServiceResponse(datePath), serviceCallback);
     }
 
     /**
@@ -1211,7 +1496,22 @@ public final class PathsImpl implements Paths {
      * @param datePath null as date (should throw)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateNullAsync(LocalDate datePath) {
+    public Observable<Void> dateNullAsync(LocalDate datePath) {
+        return dateNullAsyncWithServiceResponse(datePath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     *
+     * @param datePath null as date (should throw)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse(LocalDate datePath) {
         if (datePath == null) {
             throw new IllegalArgumentException("Parameter datePath is required and cannot be null.");
         }
@@ -1243,8 +1543,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateTimeValid() throws ErrorException, IOException {
-        return dateTimeValidAsync().toBlocking().single();
+    public void dateTimeValid() throws ErrorException, IOException {
+        dateTimeValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1254,7 +1554,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeValidAsync(), serviceCallback);
+        return ServiceCall.create(dateTimeValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1262,7 +1562,21 @@ public final class PathsImpl implements Paths {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeValidAsync() {
+    public Observable<Void> dateTimeValidAsync() {
+        return dateTimeValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateTimeValidAsyncWithServiceResponse() {
         final DateTime dateTimePath = DateTime.parse("2012-01-01T01:01:01Z");
         return service.dateTimeValid(dateTimePath)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1294,8 +1608,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateTimeNull(DateTime dateTimePath) throws ErrorException, IOException, IllegalArgumentException {
-        return dateTimeNullAsync(dateTimePath).toBlocking().single();
+    public void dateTimeNull(DateTime dateTimePath) throws ErrorException, IOException, IllegalArgumentException {
+        dateTimeNullAsyncWithServiceResponse(dateTimePath).toBlocking().single().getBody();
     }
 
     /**
@@ -1306,7 +1620,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeNullAsync(DateTime dateTimePath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeNullAsync(dateTimePath), serviceCallback);
+        return ServiceCall.create(dateTimeNullAsyncWithServiceResponse(dateTimePath), serviceCallback);
     }
 
     /**
@@ -1315,7 +1629,22 @@ public final class PathsImpl implements Paths {
      * @param dateTimePath null as date-time
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeNullAsync(DateTime dateTimePath) {
+    public Observable<Void> dateTimeNullAsync(DateTime dateTimePath) {
+        return dateTimeNullAsyncWithServiceResponse(dateTimePath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     *
+     * @param dateTimePath null as date-time
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse(DateTime dateTimePath) {
         if (dateTimePath == null) {
             throw new IllegalArgumentException("Parameter dateTimePath is required and cannot be null.");
         }
@@ -1349,8 +1678,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> base64Url(byte[] base64UrlPath) throws ErrorException, IOException, IllegalArgumentException {
-        return base64UrlAsync(base64UrlPath).toBlocking().single();
+    public void base64Url(byte[] base64UrlPath) throws ErrorException, IOException, IllegalArgumentException {
+        base64UrlAsyncWithServiceResponse(base64UrlPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1361,7 +1690,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> base64UrlAsync(byte[] base64UrlPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(base64UrlAsync(base64UrlPath), serviceCallback);
+        return ServiceCall.create(base64UrlAsyncWithServiceResponse(base64UrlPath), serviceCallback);
     }
 
     /**
@@ -1370,7 +1699,22 @@ public final class PathsImpl implements Paths {
      * @param base64UrlPath base64url encoded value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> base64UrlAsync(byte[] base64UrlPath) {
+    public Observable<Void> base64UrlAsync(byte[] base64UrlPath) {
+        return base64UrlAsyncWithServiceResponse(base64UrlPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     *
+     * @param base64UrlPath base64url encoded value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> base64UrlAsyncWithServiceResponse(byte[] base64UrlPath) {
         if (base64UrlPath == null) {
             throw new IllegalArgumentException("Parameter base64UrlPath is required and cannot be null.");
         }
@@ -1405,8 +1749,8 @@ public final class PathsImpl implements Paths {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayCsvInPath(List<String> arrayPath) throws ErrorException, IOException, IllegalArgumentException {
-        return arrayCsvInPathAsync(arrayPath).toBlocking().single();
+    public void arrayCsvInPath(List<String> arrayPath) throws ErrorException, IOException, IllegalArgumentException {
+        arrayCsvInPathAsyncWithServiceResponse(arrayPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1417,7 +1761,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayCsvInPathAsync(List<String> arrayPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayCsvInPathAsync(arrayPath), serviceCallback);
+        return ServiceCall.create(arrayCsvInPathAsyncWithServiceResponse(arrayPath), serviceCallback);
     }
 
     /**
@@ -1426,7 +1770,22 @@ public final class PathsImpl implements Paths {
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayCsvInPathAsync(List<String> arrayPath) {
+    public Observable<Void> arrayCsvInPathAsync(List<String> arrayPath) {
+        return arrayCsvInPathAsyncWithServiceResponse(arrayPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayCsvInPathAsyncWithServiceResponse(List<String> arrayPath) {
         if (arrayPath == null) {
             throw new IllegalArgumentException("Parameter arrayPath is required and cannot be null.");
         }
@@ -1461,8 +1820,8 @@ public final class PathsImpl implements Paths {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> unixTimeUrl(DateTime unixTimeUrlPath) throws ErrorException, IOException {
-        return unixTimeUrlAsync(unixTimeUrlPath).toBlocking().single();
+    public void unixTimeUrl(DateTime unixTimeUrlPath) throws ErrorException, IOException {
+        unixTimeUrlAsyncWithServiceResponse(unixTimeUrlPath).toBlocking().single().getBody();
     }
 
     /**
@@ -1473,7 +1832,7 @@ public final class PathsImpl implements Paths {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(unixTimeUrlAsync(unixTimeUrlPath), serviceCallback);
+        return ServiceCall.create(unixTimeUrlAsyncWithServiceResponse(unixTimeUrlPath), serviceCallback);
     }
 
     /**
@@ -1482,7 +1841,22 @@ public final class PathsImpl implements Paths {
      * @param unixTimeUrlPath Unix time encoded value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> unixTimeUrlAsync(DateTime unixTimeUrlPath) {
+    public Observable<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath) {
+        return unixTimeUrlAsyncWithServiceResponse(unixTimeUrlPath).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     *
+     * @param unixTimeUrlPath Unix time encoded value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> unixTimeUrlAsyncWithServiceResponse(DateTime unixTimeUrlPath) {
         Long unixTimeUrlPathConverted = unixTimeUrlPath.toDateTime(DateTimeZone.UTC).getMillis() / 1000;
         return service.unixTimeUrl(unixTimeUrlPathConverted)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/QueriesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/QueriesImpl.java
@@ -205,8 +205,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getBooleanTrue() throws ErrorException, IOException {
-        return getBooleanTrueAsync().toBlocking().single();
+    public void getBooleanTrue() throws ErrorException, IOException {
+        getBooleanTrueAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -216,7 +216,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanTrueAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanTrueAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanTrueAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -224,7 +224,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanTrueAsync() {
+    public Observable<Void> getBooleanTrueAsync() {
+        return getBooleanTrueAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get true Boolean value on path.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getBooleanTrueAsyncWithServiceResponse() {
         final boolean boolQuery = true;
         return service.getBooleanTrue(boolQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -254,8 +268,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getBooleanFalse() throws ErrorException, IOException {
-        return getBooleanFalseAsync().toBlocking().single();
+    public void getBooleanFalse() throws ErrorException, IOException {
+        getBooleanFalseAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -265,7 +279,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanFalseAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanFalseAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanFalseAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -273,7 +287,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanFalseAsync() {
+    public Observable<Void> getBooleanFalseAsync() {
+        return getBooleanFalseAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get false Boolean value on path.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getBooleanFalseAsyncWithServiceResponse() {
         final boolean boolQuery = false;
         return service.getBooleanFalse(boolQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -303,8 +331,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getBooleanNull() throws ErrorException, IOException {
-        return getBooleanNullAsync().toBlocking().single();
+    public void getBooleanNull() throws ErrorException, IOException {
+        getBooleanNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -314,7 +342,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanNullAsync(), serviceCallback);
+        return ServiceCall.create(getBooleanNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -322,7 +350,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanNullAsync() {
+    public Observable<Void> getBooleanNullAsync() {
+        return getBooleanNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getBooleanNullAsyncWithServiceResponse() {
         final Boolean boolQuery = null;
         return service.getBooleanNull(boolQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -346,8 +388,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getBooleanNull(Boolean boolQuery) throws ErrorException, IOException {
-        return getBooleanNullAsync(boolQuery).toBlocking().single();
+    public void getBooleanNull(Boolean boolQuery) throws ErrorException, IOException {
+        getBooleanNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -358,7 +400,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanNullAsync(Boolean boolQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanNullAsync(boolQuery), serviceCallback);
+        return ServiceCall.create(getBooleanNullAsyncWithServiceResponse(boolQuery), serviceCallback);
+    }
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getBooleanNullAsync(Boolean boolQuery) {
+        return getBooleanNullAsyncWithServiceResponse(boolQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -367,7 +423,7 @@ public final class QueriesImpl implements Queries {
      * @param boolQuery null boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanNullAsync(Boolean boolQuery) {
+    public Observable<ServiceResponse<Void>> getBooleanNullAsyncWithServiceResponse(Boolean boolQuery) {
         return service.getBooleanNull(boolQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -396,8 +452,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getIntOneMillion() throws ErrorException, IOException {
-        return getIntOneMillionAsync().toBlocking().single();
+    public void getIntOneMillion() throws ErrorException, IOException {
+        getIntOneMillionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -407,7 +463,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntOneMillionAsync(), serviceCallback);
+        return ServiceCall.create(getIntOneMillionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -415,7 +471,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntOneMillionAsync() {
+    public Observable<Void> getIntOneMillionAsync() {
+        return getIntOneMillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '1000000' integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getIntOneMillionAsyncWithServiceResponse() {
         final int intQuery = 1000000;
         return service.getIntOneMillion(intQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -445,8 +515,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getIntNegativeOneMillion() throws ErrorException, IOException {
-        return getIntNegativeOneMillionAsync().toBlocking().single();
+    public void getIntNegativeOneMillion() throws ErrorException, IOException {
+        getIntNegativeOneMillionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -456,7 +526,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntNegativeOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntNegativeOneMillionAsync(), serviceCallback);
+        return ServiceCall.create(getIntNegativeOneMillionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -464,7 +534,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsync() {
+    public Observable<Void> getIntNegativeOneMillionAsync() {
+        return getIntNegativeOneMillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsyncWithServiceResponse() {
         final int intQuery = -1000000;
         return service.getIntNegativeOneMillion(intQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -494,8 +578,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getIntNull() throws ErrorException, IOException {
-        return getIntNullAsync().toBlocking().single();
+    public void getIntNull() throws ErrorException, IOException {
+        getIntNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -505,7 +589,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntNullAsync(), serviceCallback);
+        return ServiceCall.create(getIntNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -513,7 +597,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntNullAsync() {
+    public Observable<Void> getIntNullAsync() {
+        return getIntNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getIntNullAsyncWithServiceResponse() {
         final Integer intQuery = null;
         return service.getIntNull(intQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -537,8 +635,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getIntNull(Integer intQuery) throws ErrorException, IOException {
-        return getIntNullAsync(intQuery).toBlocking().single();
+    public void getIntNull(Integer intQuery) throws ErrorException, IOException {
+        getIntNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -549,7 +647,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntNullAsync(Integer intQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntNullAsync(intQuery), serviceCallback);
+        return ServiceCall.create(getIntNullAsyncWithServiceResponse(intQuery), serviceCallback);
+    }
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getIntNullAsync(Integer intQuery) {
+        return getIntNullAsyncWithServiceResponse(intQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -558,7 +670,7 @@ public final class QueriesImpl implements Queries {
      * @param intQuery null integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntNullAsync(Integer intQuery) {
+    public Observable<ServiceResponse<Void>> getIntNullAsyncWithServiceResponse(Integer intQuery) {
         return service.getIntNull(intQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -587,8 +699,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getTenBillion() throws ErrorException, IOException {
-        return getTenBillionAsync().toBlocking().single();
+    public void getTenBillion() throws ErrorException, IOException {
+        getTenBillionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -598,7 +710,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getTenBillionAsync(), serviceCallback);
+        return ServiceCall.create(getTenBillionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -606,7 +718,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getTenBillionAsync() {
+    public Observable<Void> getTenBillionAsync() {
+        return getTenBillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getTenBillionAsyncWithServiceResponse() {
         final long longQuery = 10000000000L;
         return service.getTenBillion(longQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -636,8 +762,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getNegativeTenBillion() throws ErrorException, IOException {
-        return getNegativeTenBillionAsync().toBlocking().single();
+    public void getNegativeTenBillion() throws ErrorException, IOException {
+        getNegativeTenBillionAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -647,7 +773,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getNegativeTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getNegativeTenBillionAsync(), serviceCallback);
+        return ServiceCall.create(getNegativeTenBillionAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -655,7 +781,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getNegativeTenBillionAsync() {
+    public Observable<Void> getNegativeTenBillionAsync() {
+        return getNegativeTenBillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getNegativeTenBillionAsyncWithServiceResponse() {
         final long longQuery = -10000000000L;
         return service.getNegativeTenBillion(longQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -685,8 +825,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getLongNull() throws ErrorException, IOException {
-        return getLongNullAsync().toBlocking().single();
+    public void getLongNull() throws ErrorException, IOException {
+        getLongNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -696,7 +836,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getLongNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getLongNullAsync(), serviceCallback);
+        return ServiceCall.create(getLongNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -704,7 +844,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getLongNullAsync() {
+    public Observable<Void> getLongNullAsync() {
+        return getLongNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getLongNullAsyncWithServiceResponse() {
         final Long longQuery = null;
         return service.getLongNull(longQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -728,8 +882,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getLongNull(Long longQuery) throws ErrorException, IOException {
-        return getLongNullAsync(longQuery).toBlocking().single();
+    public void getLongNull(Long longQuery) throws ErrorException, IOException {
+        getLongNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -740,7 +894,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getLongNullAsync(Long longQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getLongNullAsync(longQuery), serviceCallback);
+        return ServiceCall.create(getLongNullAsyncWithServiceResponse(longQuery), serviceCallback);
+    }
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> getLongNullAsync(Long longQuery) {
+        return getLongNullAsyncWithServiceResponse(longQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -749,7 +917,7 @@ public final class QueriesImpl implements Queries {
      * @param longQuery null 64 bit integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getLongNullAsync(Long longQuery) {
+    public Observable<ServiceResponse<Void>> getLongNullAsyncWithServiceResponse(Long longQuery) {
         return service.getLongNull(longQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -778,8 +946,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> floatScientificPositive() throws ErrorException, IOException {
-        return floatScientificPositiveAsync().toBlocking().single();
+    public void floatScientificPositive() throws ErrorException, IOException {
+        floatScientificPositiveAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -789,7 +957,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatScientificPositiveAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatScientificPositiveAsync(), serviceCallback);
+        return ServiceCall.create(floatScientificPositiveAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -797,7 +965,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatScientificPositiveAsync() {
+    public Observable<Void> floatScientificPositiveAsync() {
+        return floatScientificPositiveAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> floatScientificPositiveAsyncWithServiceResponse() {
         final double floatQuery = 1.034E+20;
         return service.floatScientificPositive(floatQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -827,8 +1009,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> floatScientificNegative() throws ErrorException, IOException {
-        return floatScientificNegativeAsync().toBlocking().single();
+    public void floatScientificNegative() throws ErrorException, IOException {
+        floatScientificNegativeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -838,7 +1020,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatScientificNegativeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatScientificNegativeAsync(), serviceCallback);
+        return ServiceCall.create(floatScientificNegativeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -846,7 +1028,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatScientificNegativeAsync() {
+    public Observable<Void> floatScientificNegativeAsync() {
+        return floatScientificNegativeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> floatScientificNegativeAsyncWithServiceResponse() {
         final double floatQuery = -1.034E-20;
         return service.floatScientificNegative(floatQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -876,8 +1072,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> floatNull() throws ErrorException, IOException {
-        return floatNullAsync().toBlocking().single();
+    public void floatNull() throws ErrorException, IOException {
+        floatNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -887,7 +1083,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatNullAsync(), serviceCallback);
+        return ServiceCall.create(floatNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -895,7 +1091,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatNullAsync() {
+    public Observable<Void> floatNullAsync() {
+        return floatNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> floatNullAsyncWithServiceResponse() {
         final Double floatQuery = null;
         return service.floatNull(floatQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -919,8 +1129,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> floatNull(Double floatQuery) throws ErrorException, IOException {
-        return floatNullAsync(floatQuery).toBlocking().single();
+    public void floatNull(Double floatQuery) throws ErrorException, IOException {
+        floatNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -931,7 +1141,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatNullAsync(Double floatQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatNullAsync(floatQuery), serviceCallback);
+        return ServiceCall.create(floatNullAsyncWithServiceResponse(floatQuery), serviceCallback);
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> floatNullAsync(Double floatQuery) {
+        return floatNullAsyncWithServiceResponse(floatQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -940,7 +1164,7 @@ public final class QueriesImpl implements Queries {
      * @param floatQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatNullAsync(Double floatQuery) {
+    public Observable<ServiceResponse<Void>> floatNullAsyncWithServiceResponse(Double floatQuery) {
         return service.floatNull(floatQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -969,8 +1193,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> doubleDecimalPositive() throws ErrorException, IOException {
-        return doubleDecimalPositiveAsync().toBlocking().single();
+    public void doubleDecimalPositive() throws ErrorException, IOException {
+        doubleDecimalPositiveAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -980,7 +1204,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleDecimalPositiveAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleDecimalPositiveAsync(), serviceCallback);
+        return ServiceCall.create(doubleDecimalPositiveAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -988,7 +1212,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleDecimalPositiveAsync() {
+    public Observable<Void> doubleDecimalPositiveAsync() {
+        return doubleDecimalPositiveAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> doubleDecimalPositiveAsyncWithServiceResponse() {
         final double doubleQuery = 9999999.999;
         return service.doubleDecimalPositive(doubleQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1018,8 +1256,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> doubleDecimalNegative() throws ErrorException, IOException {
-        return doubleDecimalNegativeAsync().toBlocking().single();
+    public void doubleDecimalNegative() throws ErrorException, IOException {
+        doubleDecimalNegativeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1029,7 +1267,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleDecimalNegativeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleDecimalNegativeAsync(), serviceCallback);
+        return ServiceCall.create(doubleDecimalNegativeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1037,7 +1275,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleDecimalNegativeAsync() {
+    public Observable<Void> doubleDecimalNegativeAsync() {
+        return doubleDecimalNegativeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> doubleDecimalNegativeAsyncWithServiceResponse() {
         final double doubleQuery = -9999999.999;
         return service.doubleDecimalNegative(doubleQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1067,8 +1319,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> doubleNull() throws ErrorException, IOException {
-        return doubleNullAsync().toBlocking().single();
+    public void doubleNull() throws ErrorException, IOException {
+        doubleNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1078,7 +1330,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleNullAsync(), serviceCallback);
+        return ServiceCall.create(doubleNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1086,7 +1338,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleNullAsync() {
+    public Observable<Void> doubleNullAsync() {
+        return doubleNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> doubleNullAsyncWithServiceResponse() {
         final Double doubleQuery = null;
         return service.doubleNull(doubleQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1110,8 +1376,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> doubleNull(Double doubleQuery) throws ErrorException, IOException {
-        return doubleNullAsync(doubleQuery).toBlocking().single();
+    public void doubleNull(Double doubleQuery) throws ErrorException, IOException {
+        doubleNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1122,7 +1388,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleNullAsync(Double doubleQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleNullAsync(doubleQuery), serviceCallback);
+        return ServiceCall.create(doubleNullAsyncWithServiceResponse(doubleQuery), serviceCallback);
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> doubleNullAsync(Double doubleQuery) {
+        return doubleNullAsyncWithServiceResponse(doubleQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1131,7 +1411,7 @@ public final class QueriesImpl implements Queries {
      * @param doubleQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleNullAsync(Double doubleQuery) {
+    public Observable<ServiceResponse<Void>> doubleNullAsyncWithServiceResponse(Double doubleQuery) {
         return service.doubleNull(doubleQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1160,8 +1440,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringUnicode() throws ErrorException, IOException {
-        return stringUnicodeAsync().toBlocking().single();
+    public void stringUnicode() throws ErrorException, IOException {
+        stringUnicodeAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1171,7 +1451,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringUnicodeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringUnicodeAsync(), serviceCallback);
+        return ServiceCall.create(stringUnicodeAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1179,7 +1459,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringUnicodeAsync() {
+    public Observable<Void> stringUnicodeAsync() {
+        return stringUnicodeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringUnicodeAsyncWithServiceResponse() {
         final String stringQuery = "啊齄丂狛狜隣郎隣兀﨩";
         return service.stringUnicode(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1209,8 +1503,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringUrlEncoded() throws ErrorException, IOException {
-        return stringUrlEncodedAsync().toBlocking().single();
+    public void stringUrlEncoded() throws ErrorException, IOException {
+        stringUrlEncodedAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1220,7 +1514,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringUrlEncodedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringUrlEncodedAsync(), serviceCallback);
+        return ServiceCall.create(stringUrlEncodedAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1228,7 +1522,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringUrlEncodedAsync() {
+    public Observable<Void> stringUrlEncodedAsync() {
+        return stringUrlEncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringUrlEncodedAsyncWithServiceResponse() {
         final String stringQuery = "begin!*'();:@ &=+$,/?#[]end";
         return service.stringUrlEncoded(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1258,8 +1566,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringEmpty() throws ErrorException, IOException {
-        return stringEmptyAsync().toBlocking().single();
+    public void stringEmpty() throws ErrorException, IOException {
+        stringEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1269,7 +1577,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringEmptyAsync(), serviceCallback);
+        return ServiceCall.create(stringEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1277,7 +1585,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringEmptyAsync() {
+    public Observable<Void> stringEmptyAsync() {
+        return stringEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get ''.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringEmptyAsyncWithServiceResponse() {
         final String stringQuery = "";
         return service.stringEmpty(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1307,8 +1629,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringNull() throws ErrorException, IOException {
-        return stringNullAsync().toBlocking().single();
+    public void stringNull() throws ErrorException, IOException {
+        stringNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1318,7 +1640,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringNullAsync(), serviceCallback);
+        return ServiceCall.create(stringNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1326,7 +1648,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringNullAsync() {
+    public Observable<Void> stringNullAsync() {
+        return stringNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse() {
         final String stringQuery = null;
         return service.stringNull(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1350,8 +1686,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> stringNull(String stringQuery) throws ErrorException, IOException {
-        return stringNullAsync(stringQuery).toBlocking().single();
+    public void stringNull(String stringQuery) throws ErrorException, IOException {
+        stringNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1362,7 +1698,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringNullAsync(String stringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringNullAsync(stringQuery), serviceCallback);
+        return ServiceCall.create(stringNullAsyncWithServiceResponse(stringQuery), serviceCallback);
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> stringNullAsync(String stringQuery) {
+        return stringNullAsyncWithServiceResponse(stringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1371,7 +1721,7 @@ public final class QueriesImpl implements Queries {
      * @param stringQuery null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringNullAsync(String stringQuery) {
+    public Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse(String stringQuery) {
         return service.stringNull(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1400,8 +1750,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> enumValid() throws ErrorException, IOException {
-        return enumValidAsync().toBlocking().single();
+    public void enumValid() throws ErrorException, IOException {
+        enumValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1411,7 +1761,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumValidAsync(), serviceCallback);
+        return ServiceCall.create(enumValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1419,7 +1769,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumValidAsync() {
+    public Observable<Void> enumValidAsync() {
+        return enumValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse() {
         final UriColor enumQuery = null;
         return service.enumValid(enumQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1443,8 +1807,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> enumValid(UriColor enumQuery) throws ErrorException, IOException {
-        return enumValidAsync(enumQuery).toBlocking().single();
+    public void enumValid(UriColor enumQuery) throws ErrorException, IOException {
+        enumValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1455,7 +1819,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumValidAsync(UriColor enumQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumValidAsync(enumQuery), serviceCallback);
+        return ServiceCall.create(enumValidAsyncWithServiceResponse(enumQuery), serviceCallback);
+    }
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> enumValidAsync(UriColor enumQuery) {
+        return enumValidAsyncWithServiceResponse(enumQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1464,7 +1842,7 @@ public final class QueriesImpl implements Queries {
      * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumValidAsync(UriColor enumQuery) {
+    public Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse(UriColor enumQuery) {
         return service.enumValid(enumQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1493,8 +1871,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> enumNull() throws ErrorException, IOException {
-        return enumNullAsync().toBlocking().single();
+    public void enumNull() throws ErrorException, IOException {
+        enumNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1504,7 +1882,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumNullAsync(), serviceCallback);
+        return ServiceCall.create(enumNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1512,7 +1890,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumNullAsync() {
+    public Observable<Void> enumNullAsync() {
+        return enumNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse() {
         final UriColor enumQuery = null;
         return service.enumNull(enumQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1536,8 +1928,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> enumNull(UriColor enumQuery) throws ErrorException, IOException {
-        return enumNullAsync(enumQuery).toBlocking().single();
+    public void enumNull(UriColor enumQuery) throws ErrorException, IOException {
+        enumNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1548,7 +1940,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumNullAsync(UriColor enumQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumNullAsync(enumQuery), serviceCallback);
+        return ServiceCall.create(enumNullAsyncWithServiceResponse(enumQuery), serviceCallback);
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> enumNullAsync(UriColor enumQuery) {
+        return enumNullAsyncWithServiceResponse(enumQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1557,7 +1963,7 @@ public final class QueriesImpl implements Queries {
      * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumNullAsync(UriColor enumQuery) {
+    public Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse(UriColor enumQuery) {
         return service.enumNull(enumQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1586,8 +1992,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> byteMultiByte() throws ErrorException, IOException {
-        return byteMultiByteAsync().toBlocking().single();
+    public void byteMultiByte() throws ErrorException, IOException {
+        byteMultiByteAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1597,7 +2003,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteMultiByteAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteMultiByteAsync(), serviceCallback);
+        return ServiceCall.create(byteMultiByteAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1605,7 +2011,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteMultiByteAsync() {
+    public Observable<Void> byteMultiByteAsync() {
+        return byteMultiByteAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse() {
         final byte[] byteQuery = new byte[0];
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteMultiByte(byteQueryConverted)
@@ -1630,8 +2050,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> byteMultiByte(byte[] byteQuery) throws ErrorException, IOException {
-        return byteMultiByteAsync(byteQuery).toBlocking().single();
+    public void byteMultiByte(byte[] byteQuery) throws ErrorException, IOException {
+        byteMultiByteAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1642,7 +2062,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteMultiByteAsync(byte[] byteQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteMultiByteAsync(byteQuery), serviceCallback);
+        return ServiceCall.create(byteMultiByteAsyncWithServiceResponse(byteQuery), serviceCallback);
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> byteMultiByteAsync(byte[] byteQuery) {
+        return byteMultiByteAsyncWithServiceResponse(byteQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1651,7 +2085,7 @@ public final class QueriesImpl implements Queries {
      * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteMultiByteAsync(byte[] byteQuery) {
+    public Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse(byte[] byteQuery) {
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteMultiByte(byteQueryConverted)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1681,8 +2115,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> byteEmpty() throws ErrorException, IOException {
-        return byteEmptyAsync().toBlocking().single();
+    public void byteEmpty() throws ErrorException, IOException {
+        byteEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1692,7 +2126,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteEmptyAsync(), serviceCallback);
+        return ServiceCall.create(byteEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1700,7 +2134,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteEmptyAsync() {
+    public Observable<Void> byteEmptyAsync() {
+        return byteEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '' as byte array.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> byteEmptyAsyncWithServiceResponse() {
         final byte[] byteQuery = "".getBytes();
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteEmpty(byteQueryConverted)
@@ -1731,8 +2179,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> byteNull() throws ErrorException, IOException {
-        return byteNullAsync().toBlocking().single();
+    public void byteNull() throws ErrorException, IOException {
+        byteNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1742,7 +2190,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteNullAsync(), serviceCallback);
+        return ServiceCall.create(byteNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1750,7 +2198,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteNullAsync() {
+    public Observable<Void> byteNullAsync() {
+        return byteNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse() {
         final byte[] byteQuery = new byte[0];
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteNull(byteQueryConverted)
@@ -1775,8 +2237,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> byteNull(byte[] byteQuery) throws ErrorException, IOException {
-        return byteNullAsync(byteQuery).toBlocking().single();
+    public void byteNull(byte[] byteQuery) throws ErrorException, IOException {
+        byteNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1787,7 +2249,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteNullAsync(byte[] byteQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteNullAsync(byteQuery), serviceCallback);
+        return ServiceCall.create(byteNullAsyncWithServiceResponse(byteQuery), serviceCallback);
+    }
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> byteNullAsync(byte[] byteQuery) {
+        return byteNullAsyncWithServiceResponse(byteQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1796,7 +2272,7 @@ public final class QueriesImpl implements Queries {
      * @param byteQuery null as byte array (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteNullAsync(byte[] byteQuery) {
+    public Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse(byte[] byteQuery) {
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteNull(byteQueryConverted)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1826,8 +2302,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateValid() throws ErrorException, IOException {
-        return dateValidAsync().toBlocking().single();
+    public void dateValid() throws ErrorException, IOException {
+        dateValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1837,7 +2313,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateValidAsync(), serviceCallback);
+        return ServiceCall.create(dateValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1845,7 +2321,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateValidAsync() {
+    public Observable<Void> dateValidAsync() {
+        return dateValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateValidAsyncWithServiceResponse() {
         final LocalDate dateQuery = LocalDate.parse("2012-01-01");
         return service.dateValid(dateQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1875,8 +2365,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateNull() throws ErrorException, IOException {
-        return dateNullAsync().toBlocking().single();
+    public void dateNull() throws ErrorException, IOException {
+        dateNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1886,7 +2376,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateNullAsync(), serviceCallback);
+        return ServiceCall.create(dateNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1894,7 +2384,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateNullAsync() {
+    public Observable<Void> dateNullAsync() {
+        return dateNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse() {
         final LocalDate dateQuery = null;
         return service.dateNull(dateQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1918,8 +2422,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateNull(LocalDate dateQuery) throws ErrorException, IOException {
-        return dateNullAsync(dateQuery).toBlocking().single();
+    public void dateNull(LocalDate dateQuery) throws ErrorException, IOException {
+        dateNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1930,7 +2434,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateNullAsync(LocalDate dateQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateNullAsync(dateQuery), serviceCallback);
+        return ServiceCall.create(dateNullAsyncWithServiceResponse(dateQuery), serviceCallback);
+    }
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> dateNullAsync(LocalDate dateQuery) {
+        return dateNullAsyncWithServiceResponse(dateQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -1939,7 +2457,7 @@ public final class QueriesImpl implements Queries {
      * @param dateQuery null as date (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateNullAsync(LocalDate dateQuery) {
+    public Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse(LocalDate dateQuery) {
         return service.dateNull(dateQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1968,8 +2486,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateTimeValid() throws ErrorException, IOException {
-        return dateTimeValidAsync().toBlocking().single();
+    public void dateTimeValid() throws ErrorException, IOException {
+        dateTimeValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -1979,7 +2497,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeValidAsync(), serviceCallback);
+        return ServiceCall.create(dateTimeValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -1987,7 +2505,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeValidAsync() {
+    public Observable<Void> dateTimeValidAsync() {
+        return dateTimeValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateTimeValidAsyncWithServiceResponse() {
         final DateTime dateTimeQuery = DateTime.parse("2012-01-01T01:01:01Z");
         return service.dateTimeValid(dateTimeQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2017,8 +2549,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateTimeNull() throws ErrorException, IOException {
-        return dateTimeNullAsync().toBlocking().single();
+    public void dateTimeNull() throws ErrorException, IOException {
+        dateTimeNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2028,7 +2560,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeNullAsync(), serviceCallback);
+        return ServiceCall.create(dateTimeNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2036,7 +2568,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeNullAsync() {
+    public Observable<Void> dateTimeNullAsync() {
+        return dateTimeNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse() {
         final DateTime dateTimeQuery = null;
         return service.dateTimeNull(dateTimeQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2060,8 +2606,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> dateTimeNull(DateTime dateTimeQuery) throws ErrorException, IOException {
-        return dateTimeNullAsync(dateTimeQuery).toBlocking().single();
+    public void dateTimeNull(DateTime dateTimeQuery) throws ErrorException, IOException {
+        dateTimeNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2072,7 +2618,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeNullAsync(DateTime dateTimeQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeNullAsync(dateTimeQuery), serviceCallback);
+        return ServiceCall.create(dateTimeNullAsyncWithServiceResponse(dateTimeQuery), serviceCallback);
+    }
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> dateTimeNullAsync(DateTime dateTimeQuery) {
+        return dateTimeNullAsyncWithServiceResponse(dateTimeQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2081,7 +2641,7 @@ public final class QueriesImpl implements Queries {
      * @param dateTimeQuery null as date-time (no query parameters)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeNullAsync(DateTime dateTimeQuery) {
+    public Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse(DateTime dateTimeQuery) {
         return service.dateTimeNull(dateTimeQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -2110,8 +2670,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringCsvValid() throws ErrorException, IOException {
-        return arrayStringCsvValidAsync().toBlocking().single();
+    public void arrayStringCsvValid() throws ErrorException, IOException {
+        arrayStringCsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2121,7 +2681,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvValidAsync(), serviceCallback);
+        return ServiceCall.create(arrayStringCsvValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2129,7 +2689,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvValidAsync() {
+    public Observable<Void> arrayStringCsvValidAsync() {
+        return arrayStringCsvValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringCsvValidAsyncWithServiceResponse() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvValid(arrayQueryConverted)
@@ -2154,8 +2728,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringCsvValid(List<String> arrayQuery) throws ErrorException, IOException {
-        return arrayStringCsvValidAsync(arrayQuery).toBlocking().single();
+    public void arrayStringCsvValid(List<String> arrayQuery) throws ErrorException, IOException {
+        arrayStringCsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2166,7 +2740,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvValidAsync(arrayQuery), serviceCallback);
+        return ServiceCall.create(arrayStringCsvValidAsyncWithServiceResponse(arrayQuery), serviceCallback);
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> arrayStringCsvValidAsync(List<String> arrayQuery) {
+        return arrayStringCsvValidAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2175,7 +2763,7 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvValidAsync(List<String> arrayQuery) {
+    public Observable<ServiceResponse<Void>> arrayStringCsvValidAsyncWithServiceResponse(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvValid(arrayQueryConverted)
@@ -2206,8 +2794,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringCsvNull() throws ErrorException, IOException {
-        return arrayStringCsvNullAsync().toBlocking().single();
+    public void arrayStringCsvNull() throws ErrorException, IOException {
+        arrayStringCsvNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2217,7 +2805,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvNullAsync(), serviceCallback);
+        return ServiceCall.create(arrayStringCsvNullAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2225,7 +2813,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvNullAsync() {
+    public Observable<Void> arrayStringCsvNullAsync() {
+        return arrayStringCsvNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringCsvNullAsyncWithServiceResponse() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvNull(arrayQueryConverted)
@@ -2250,8 +2852,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringCsvNull(List<String> arrayQuery) throws ErrorException, IOException {
-        return arrayStringCsvNullAsync(arrayQuery).toBlocking().single();
+    public void arrayStringCsvNull(List<String> arrayQuery) throws ErrorException, IOException {
+        arrayStringCsvNullAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2262,7 +2864,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvNullAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvNullAsync(arrayQuery), serviceCallback);
+        return ServiceCall.create(arrayStringCsvNullAsyncWithServiceResponse(arrayQuery), serviceCallback);
+    }
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> arrayStringCsvNullAsync(List<String> arrayQuery) {
+        return arrayStringCsvNullAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2271,7 +2887,7 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery a null array of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvNullAsync(List<String> arrayQuery) {
+    public Observable<ServiceResponse<Void>> arrayStringCsvNullAsyncWithServiceResponse(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvNull(arrayQueryConverted)
@@ -2302,8 +2918,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringCsvEmpty() throws ErrorException, IOException {
-        return arrayStringCsvEmptyAsync().toBlocking().single();
+    public void arrayStringCsvEmpty() throws ErrorException, IOException {
+        arrayStringCsvEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2313,7 +2929,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvEmptyAsync(), serviceCallback);
+        return ServiceCall.create(arrayStringCsvEmptyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2321,7 +2937,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsync() {
+    public Observable<Void> arrayStringCsvEmptyAsync() {
+        return arrayStringCsvEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsyncWithServiceResponse() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvEmpty(arrayQueryConverted)
@@ -2346,8 +2976,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringCsvEmpty(List<String> arrayQuery) throws ErrorException, IOException {
-        return arrayStringCsvEmptyAsync(arrayQuery).toBlocking().single();
+    public void arrayStringCsvEmpty(List<String> arrayQuery) throws ErrorException, IOException {
+        arrayStringCsvEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2358,7 +2988,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvEmptyAsync(arrayQuery), serviceCallback);
+        return ServiceCall.create(arrayStringCsvEmptyAsyncWithServiceResponse(arrayQuery), serviceCallback);
+    }
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery) {
+        return arrayStringCsvEmptyAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2367,7 +3011,7 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an empty array [] of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsync(List<String> arrayQuery) {
+    public Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsyncWithServiceResponse(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvEmpty(arrayQueryConverted)
@@ -2398,8 +3042,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringSsvValid() throws ErrorException, IOException {
-        return arrayStringSsvValidAsync().toBlocking().single();
+    public void arrayStringSsvValid() throws ErrorException, IOException {
+        arrayStringSsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2409,7 +3053,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringSsvValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringSsvValidAsync(), serviceCallback);
+        return ServiceCall.create(arrayStringSsvValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2417,7 +3061,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringSsvValidAsync() {
+    public Observable<Void> arrayStringSsvValidAsync() {
+        return arrayStringSsvValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringSsvValidAsyncWithServiceResponse() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.SSV);
         return service.arrayStringSsvValid(arrayQueryConverted)
@@ -2442,8 +3100,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringSsvValid(List<String> arrayQuery) throws ErrorException, IOException {
-        return arrayStringSsvValidAsync(arrayQuery).toBlocking().single();
+    public void arrayStringSsvValid(List<String> arrayQuery) throws ErrorException, IOException {
+        arrayStringSsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2454,7 +3112,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringSsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringSsvValidAsync(arrayQuery), serviceCallback);
+        return ServiceCall.create(arrayStringSsvValidAsyncWithServiceResponse(arrayQuery), serviceCallback);
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> arrayStringSsvValidAsync(List<String> arrayQuery) {
+        return arrayStringSsvValidAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2463,7 +3135,7 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringSsvValidAsync(List<String> arrayQuery) {
+    public Observable<ServiceResponse<Void>> arrayStringSsvValidAsyncWithServiceResponse(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.SSV);
         return service.arrayStringSsvValid(arrayQueryConverted)
@@ -2494,8 +3166,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringTsvValid() throws ErrorException, IOException {
-        return arrayStringTsvValidAsync().toBlocking().single();
+    public void arrayStringTsvValid() throws ErrorException, IOException {
+        arrayStringTsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2505,7 +3177,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringTsvValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringTsvValidAsync(), serviceCallback);
+        return ServiceCall.create(arrayStringTsvValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2513,7 +3185,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringTsvValidAsync() {
+    public Observable<Void> arrayStringTsvValidAsync() {
+        return arrayStringTsvValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringTsvValidAsyncWithServiceResponse() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.TSV);
         return service.arrayStringTsvValid(arrayQueryConverted)
@@ -2538,8 +3224,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringTsvValid(List<String> arrayQuery) throws ErrorException, IOException {
-        return arrayStringTsvValidAsync(arrayQuery).toBlocking().single();
+    public void arrayStringTsvValid(List<String> arrayQuery) throws ErrorException, IOException {
+        arrayStringTsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2550,7 +3236,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringTsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringTsvValidAsync(arrayQuery), serviceCallback);
+        return ServiceCall.create(arrayStringTsvValidAsyncWithServiceResponse(arrayQuery), serviceCallback);
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> arrayStringTsvValidAsync(List<String> arrayQuery) {
+        return arrayStringTsvValidAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2559,7 +3259,7 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringTsvValidAsync(List<String> arrayQuery) {
+    public Observable<ServiceResponse<Void>> arrayStringTsvValidAsyncWithServiceResponse(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.TSV);
         return service.arrayStringTsvValid(arrayQueryConverted)
@@ -2590,8 +3290,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringPipesValid() throws ErrorException, IOException {
-        return arrayStringPipesValidAsync().toBlocking().single();
+    public void arrayStringPipesValid() throws ErrorException, IOException {
+        arrayStringPipesValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2601,7 +3301,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringPipesValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringPipesValidAsync(), serviceCallback);
+        return ServiceCall.create(arrayStringPipesValidAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
@@ -2609,7 +3309,21 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringPipesValidAsync() {
+    public Observable<Void> arrayStringPipesValidAsync() {
+        return arrayStringPipesValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringPipesValidAsyncWithServiceResponse() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.PIPES);
         return service.arrayStringPipesValid(arrayQueryConverted)
@@ -2634,8 +3348,8 @@ public final class QueriesImpl implements Queries {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> arrayStringPipesValid(List<String> arrayQuery) throws ErrorException, IOException {
-        return arrayStringPipesValidAsync(arrayQuery).toBlocking().single();
+    public void arrayStringPipesValid(List<String> arrayQuery) throws ErrorException, IOException {
+        arrayStringPipesValidAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -2646,7 +3360,21 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringPipesValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringPipesValidAsync(arrayQuery), serviceCallback);
+        return ServiceCall.create(arrayStringPipesValidAsyncWithServiceResponse(arrayQuery), serviceCallback);
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<Void> arrayStringPipesValidAsync(List<String> arrayQuery) {
+        return arrayStringPipesValidAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -2655,7 +3383,7 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringPipesValidAsync(List<String> arrayQuery) {
+    public Observable<ServiceResponse<Void>> arrayStringPipesValidAsyncWithServiceResponse(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.PIPES);
         return service.arrayStringPipesValid(arrayQueryConverted)

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/QueriesImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/url/implementation/QueriesImpl.java
@@ -203,10 +203,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getBooleanTrue() throws ErrorException, IOException {
-        getBooleanTrueAsyncWithServiceResponse().toBlocking().single().getBody();
+        getBooleanTrueWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -216,7 +215,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanTrueAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanTrueAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanTrueWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -225,12 +224,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getBooleanTrueAsync() {
-        return getBooleanTrueAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getBooleanTrueWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -238,7 +237,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanTrueAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getBooleanTrueWithServiceResponseAsync() {
         final boolean boolQuery = true;
         return service.getBooleanTrue(boolQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -266,10 +265,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getBooleanFalse() throws ErrorException, IOException {
-        getBooleanFalseAsyncWithServiceResponse().toBlocking().single().getBody();
+        getBooleanFalseWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -279,7 +277,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanFalseAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanFalseAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanFalseWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -288,12 +286,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getBooleanFalseAsync() {
-        return getBooleanFalseAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getBooleanFalseWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -301,7 +299,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanFalseAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getBooleanFalseWithServiceResponseAsync() {
         final boolean boolQuery = false;
         return service.getBooleanFalse(boolQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -329,10 +327,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getBooleanNull() throws ErrorException, IOException {
-        getBooleanNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        getBooleanNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -342,7 +339,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getBooleanNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -351,12 +348,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getBooleanNullAsync() {
-        return getBooleanNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getBooleanNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -364,7 +361,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getBooleanNullWithServiceResponseAsync() {
         final Boolean boolQuery = null;
         return service.getBooleanNull(boolQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -386,10 +383,9 @@ public final class QueriesImpl implements Queries {
      * @param boolQuery null boolean value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getBooleanNull(Boolean boolQuery) throws ErrorException, IOException {
-        getBooleanNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        getBooleanNullWithServiceResponseAsync(boolQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -400,21 +396,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getBooleanNullAsync(Boolean boolQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getBooleanNullAsyncWithServiceResponse(boolQuery), serviceCallback);
-    }
-
-    /**
-     * Get null Boolean value on query (query string should be absent).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> getBooleanNullAsync(Boolean boolQuery) {
-        return getBooleanNullAsyncWithServiceResponse(boolQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(getBooleanNullWithServiceResponseAsync(boolQuery), serviceCallback);
     }
 
     /**
@@ -423,7 +405,22 @@ public final class QueriesImpl implements Queries {
      * @param boolQuery null boolean value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getBooleanNullAsyncWithServiceResponse(Boolean boolQuery) {
+    public Observable<Void> getBooleanNullAsync(Boolean boolQuery) {
+        return getBooleanNullWithServiceResponseAsync(boolQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @param boolQuery null boolean value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getBooleanNullWithServiceResponseAsync(Boolean boolQuery) {
         return service.getBooleanNull(boolQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -450,10 +447,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getIntOneMillion() throws ErrorException, IOException {
-        getIntOneMillionAsyncWithServiceResponse().toBlocking().single().getBody();
+        getIntOneMillionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -463,7 +459,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntOneMillionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntOneMillionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -472,12 +468,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getIntOneMillionAsync() {
-        return getIntOneMillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getIntOneMillionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -485,7 +481,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntOneMillionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getIntOneMillionWithServiceResponseAsync() {
         final int intQuery = 1000000;
         return service.getIntOneMillion(intQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -513,10 +509,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getIntNegativeOneMillion() throws ErrorException, IOException {
-        getIntNegativeOneMillionAsyncWithServiceResponse().toBlocking().single().getBody();
+        getIntNegativeOneMillionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -526,7 +521,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntNegativeOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntNegativeOneMillionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntNegativeOneMillionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -535,12 +530,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getIntNegativeOneMillionAsync() {
-        return getIntNegativeOneMillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getIntNegativeOneMillionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -548,7 +543,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntNegativeOneMillionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getIntNegativeOneMillionWithServiceResponseAsync() {
         final int intQuery = -1000000;
         return service.getIntNegativeOneMillion(intQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -576,10 +571,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getIntNull() throws ErrorException, IOException {
-        getIntNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        getIntNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -589,7 +583,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getIntNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -598,12 +592,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getIntNullAsync() {
-        return getIntNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getIntNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -611,7 +605,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getIntNullWithServiceResponseAsync() {
         final Integer intQuery = null;
         return service.getIntNull(intQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -633,10 +627,9 @@ public final class QueriesImpl implements Queries {
      * @param intQuery null integer value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getIntNull(Integer intQuery) throws ErrorException, IOException {
-        getIntNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        getIntNullWithServiceResponseAsync(intQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -647,21 +640,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getIntNullAsync(Integer intQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getIntNullAsyncWithServiceResponse(intQuery), serviceCallback);
-    }
-
-    /**
-     * Get null integer value (no query parameter).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> getIntNullAsync(Integer intQuery) {
-        return getIntNullAsyncWithServiceResponse(intQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(getIntNullWithServiceResponseAsync(intQuery), serviceCallback);
     }
 
     /**
@@ -670,7 +649,22 @@ public final class QueriesImpl implements Queries {
      * @param intQuery null integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getIntNullAsyncWithServiceResponse(Integer intQuery) {
+    public Observable<Void> getIntNullAsync(Integer intQuery) {
+        return getIntNullWithServiceResponseAsync(intQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @param intQuery null integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getIntNullWithServiceResponseAsync(Integer intQuery) {
         return service.getIntNull(intQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -697,10 +691,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getTenBillion() throws ErrorException, IOException {
-        getTenBillionAsyncWithServiceResponse().toBlocking().single().getBody();
+        getTenBillionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -710,7 +703,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getTenBillionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getTenBillionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -719,12 +712,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getTenBillionAsync() {
-        return getTenBillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getTenBillionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -732,7 +725,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getTenBillionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getTenBillionWithServiceResponseAsync() {
         final long longQuery = 10000000000L;
         return service.getTenBillion(longQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -760,10 +753,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getNegativeTenBillion() throws ErrorException, IOException {
-        getNegativeTenBillionAsyncWithServiceResponse().toBlocking().single().getBody();
+        getNegativeTenBillionWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -773,7 +765,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getNegativeTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getNegativeTenBillionAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getNegativeTenBillionWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -782,12 +774,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getNegativeTenBillionAsync() {
-        return getNegativeTenBillionAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getNegativeTenBillionWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -795,7 +787,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getNegativeTenBillionAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getNegativeTenBillionWithServiceResponseAsync() {
         final long longQuery = -10000000000L;
         return service.getNegativeTenBillion(longQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -823,10 +815,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getLongNull() throws ErrorException, IOException {
-        getLongNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        getLongNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -836,7 +827,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getLongNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getLongNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getLongNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -845,12 +836,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getLongNullAsync() {
-        return getLongNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getLongNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -858,7 +849,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getLongNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getLongNullWithServiceResponseAsync() {
         final Long longQuery = null;
         return service.getLongNull(longQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -880,10 +871,9 @@ public final class QueriesImpl implements Queries {
      * @param longQuery null 64 bit integer value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getLongNull(Long longQuery) throws ErrorException, IOException {
-        getLongNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        getLongNullWithServiceResponseAsync(longQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -894,21 +884,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getLongNullAsync(Long longQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getLongNullAsyncWithServiceResponse(longQuery), serviceCallback);
-    }
-
-    /**
-     * Get 'null 64 bit integer value (no query param in uri).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> getLongNullAsync(Long longQuery) {
-        return getLongNullAsyncWithServiceResponse(longQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(getLongNullWithServiceResponseAsync(longQuery), serviceCallback);
     }
 
     /**
@@ -917,7 +893,22 @@ public final class QueriesImpl implements Queries {
      * @param longQuery null 64 bit integer value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getLongNullAsyncWithServiceResponse(Long longQuery) {
+    public Observable<Void> getLongNullAsync(Long longQuery) {
+        return getLongNullWithServiceResponseAsync(longQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @param longQuery null 64 bit integer value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getLongNullWithServiceResponseAsync(Long longQuery) {
         return service.getLongNull(longQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -944,10 +935,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void floatScientificPositive() throws ErrorException, IOException {
-        floatScientificPositiveAsyncWithServiceResponse().toBlocking().single().getBody();
+        floatScientificPositiveWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -957,7 +947,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatScientificPositiveAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatScientificPositiveAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(floatScientificPositiveWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -966,12 +956,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> floatScientificPositiveAsync() {
-        return floatScientificPositiveAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return floatScientificPositiveWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -979,7 +969,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatScientificPositiveAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> floatScientificPositiveWithServiceResponseAsync() {
         final double floatQuery = 1.034E+20;
         return service.floatScientificPositive(floatQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1007,10 +997,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void floatScientificNegative() throws ErrorException, IOException {
-        floatScientificNegativeAsyncWithServiceResponse().toBlocking().single().getBody();
+        floatScientificNegativeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1020,7 +1009,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatScientificNegativeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatScientificNegativeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(floatScientificNegativeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1029,12 +1018,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> floatScientificNegativeAsync() {
-        return floatScientificNegativeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return floatScientificNegativeWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1042,7 +1031,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatScientificNegativeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> floatScientificNegativeWithServiceResponseAsync() {
         final double floatQuery = -1.034E-20;
         return service.floatScientificNegative(floatQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1070,10 +1059,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void floatNull() throws ErrorException, IOException {
-        floatNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        floatNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1083,7 +1071,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(floatNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1092,12 +1080,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> floatNullAsync() {
-        return floatNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return floatNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1105,7 +1093,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> floatNullWithServiceResponseAsync() {
         final Double floatQuery = null;
         return service.floatNull(floatQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1127,10 +1115,9 @@ public final class QueriesImpl implements Queries {
      * @param floatQuery null numeric value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void floatNull(Double floatQuery) throws ErrorException, IOException {
-        floatNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        floatNullWithServiceResponseAsync(floatQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -1141,21 +1128,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> floatNullAsync(Double floatQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(floatNullAsyncWithServiceResponse(floatQuery), serviceCallback);
-    }
-
-    /**
-     * Get null numeric value (no query parameter).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> floatNullAsync(Double floatQuery) {
-        return floatNullAsyncWithServiceResponse(floatQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(floatNullWithServiceResponseAsync(floatQuery), serviceCallback);
     }
 
     /**
@@ -1164,7 +1137,22 @@ public final class QueriesImpl implements Queries {
      * @param floatQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> floatNullAsyncWithServiceResponse(Double floatQuery) {
+    public Observable<Void> floatNullAsync(Double floatQuery) {
+        return floatNullWithServiceResponseAsync(floatQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param floatQuery null numeric value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> floatNullWithServiceResponseAsync(Double floatQuery) {
         return service.floatNull(floatQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1191,10 +1179,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void doubleDecimalPositive() throws ErrorException, IOException {
-        doubleDecimalPositiveAsyncWithServiceResponse().toBlocking().single().getBody();
+        doubleDecimalPositiveWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1204,7 +1191,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleDecimalPositiveAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleDecimalPositiveAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(doubleDecimalPositiveWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1213,12 +1200,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> doubleDecimalPositiveAsync() {
-        return doubleDecimalPositiveAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return doubleDecimalPositiveWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1226,7 +1213,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleDecimalPositiveAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> doubleDecimalPositiveWithServiceResponseAsync() {
         final double doubleQuery = 9999999.999;
         return service.doubleDecimalPositive(doubleQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1254,10 +1241,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void doubleDecimalNegative() throws ErrorException, IOException {
-        doubleDecimalNegativeAsyncWithServiceResponse().toBlocking().single().getBody();
+        doubleDecimalNegativeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1267,7 +1253,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleDecimalNegativeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleDecimalNegativeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(doubleDecimalNegativeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1276,12 +1262,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> doubleDecimalNegativeAsync() {
-        return doubleDecimalNegativeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return doubleDecimalNegativeWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1289,7 +1275,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleDecimalNegativeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> doubleDecimalNegativeWithServiceResponseAsync() {
         final double doubleQuery = -9999999.999;
         return service.doubleDecimalNegative(doubleQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1317,10 +1303,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void doubleNull() throws ErrorException, IOException {
-        doubleNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        doubleNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1330,7 +1315,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(doubleNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1339,12 +1324,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> doubleNullAsync() {
-        return doubleNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return doubleNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1352,7 +1337,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> doubleNullWithServiceResponseAsync() {
         final Double doubleQuery = null;
         return service.doubleNull(doubleQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1374,10 +1359,9 @@ public final class QueriesImpl implements Queries {
      * @param doubleQuery null numeric value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void doubleNull(Double doubleQuery) throws ErrorException, IOException {
-        doubleNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        doubleNullWithServiceResponseAsync(doubleQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -1388,21 +1372,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> doubleNullAsync(Double doubleQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(doubleNullAsyncWithServiceResponse(doubleQuery), serviceCallback);
-    }
-
-    /**
-     * Get null numeric value (no query parameter).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> doubleNullAsync(Double doubleQuery) {
-        return doubleNullAsyncWithServiceResponse(doubleQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(doubleNullWithServiceResponseAsync(doubleQuery), serviceCallback);
     }
 
     /**
@@ -1411,7 +1381,22 @@ public final class QueriesImpl implements Queries {
      * @param doubleQuery null numeric value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> doubleNullAsyncWithServiceResponse(Double doubleQuery) {
+    public Observable<Void> doubleNullAsync(Double doubleQuery) {
+        return doubleNullWithServiceResponseAsync(doubleQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param doubleQuery null numeric value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> doubleNullWithServiceResponseAsync(Double doubleQuery) {
         return service.doubleNull(doubleQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1438,10 +1423,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringUnicode() throws ErrorException, IOException {
-        stringUnicodeAsyncWithServiceResponse().toBlocking().single().getBody();
+        stringUnicodeWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1451,7 +1435,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringUnicodeAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringUnicodeAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(stringUnicodeWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1460,12 +1444,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> stringUnicodeAsync() {
-        return stringUnicodeAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return stringUnicodeWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1473,7 +1457,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringUnicodeAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> stringUnicodeWithServiceResponseAsync() {
         final String stringQuery = "啊齄丂狛狜隣郎隣兀﨩";
         return service.stringUnicode(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1501,10 +1485,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringUrlEncoded() throws ErrorException, IOException {
-        stringUrlEncodedAsyncWithServiceResponse().toBlocking().single().getBody();
+        stringUrlEncodedWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1514,7 +1497,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringUrlEncodedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringUrlEncodedAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(stringUrlEncodedWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1523,12 +1506,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> stringUrlEncodedAsync() {
-        return stringUrlEncodedAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return stringUrlEncodedWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1536,7 +1519,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringUrlEncodedAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> stringUrlEncodedWithServiceResponseAsync() {
         final String stringQuery = "begin!*'();:@ &=+$,/?#[]end";
         return service.stringUrlEncoded(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1564,10 +1547,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringEmpty() throws ErrorException, IOException {
-        stringEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        stringEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1577,7 +1559,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(stringEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1586,12 +1568,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> stringEmptyAsync() {
-        return stringEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return stringEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1599,7 +1581,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> stringEmptyWithServiceResponseAsync() {
         final String stringQuery = "";
         return service.stringEmpty(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1627,10 +1609,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringNull() throws ErrorException, IOException {
-        stringNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        stringNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1640,7 +1621,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(stringNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1649,12 +1630,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> stringNullAsync() {
-        return stringNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return stringNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1662,7 +1643,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> stringNullWithServiceResponseAsync() {
         final String stringQuery = null;
         return service.stringNull(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1684,10 +1665,9 @@ public final class QueriesImpl implements Queries {
      * @param stringQuery null string value
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void stringNull(String stringQuery) throws ErrorException, IOException {
-        stringNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        stringNullWithServiceResponseAsync(stringQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -1698,21 +1678,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> stringNullAsync(String stringQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(stringNullAsyncWithServiceResponse(stringQuery), serviceCallback);
-    }
-
-    /**
-     * Get null (no query parameter in url).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> stringNullAsync(String stringQuery) {
-        return stringNullAsyncWithServiceResponse(stringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(stringNullWithServiceResponseAsync(stringQuery), serviceCallback);
     }
 
     /**
@@ -1721,7 +1687,22 @@ public final class QueriesImpl implements Queries {
      * @param stringQuery null string value
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> stringNullAsyncWithServiceResponse(String stringQuery) {
+    public Observable<Void> stringNullAsync(String stringQuery) {
+        return stringNullWithServiceResponseAsync(stringQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param stringQuery null string value
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> stringNullWithServiceResponseAsync(String stringQuery) {
         return service.stringNull(stringQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1748,10 +1729,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void enumValid() throws ErrorException, IOException {
-        enumValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        enumValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1761,7 +1741,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(enumValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1770,12 +1750,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> enumValidAsync() {
-        return enumValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return enumValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1783,7 +1763,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> enumValidWithServiceResponseAsync() {
         final UriColor enumQuery = null;
         return service.enumValid(enumQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1805,10 +1785,9 @@ public final class QueriesImpl implements Queries {
      * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void enumValid(UriColor enumQuery) throws ErrorException, IOException {
-        enumValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        enumValidWithServiceResponseAsync(enumQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -1819,21 +1798,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumValidAsync(UriColor enumQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumValidAsyncWithServiceResponse(enumQuery), serviceCallback);
-    }
-
-    /**
-     * Get using uri with query parameter 'green color'.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> enumValidAsync(UriColor enumQuery) {
-        return enumValidAsyncWithServiceResponse(enumQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(enumValidWithServiceResponseAsync(enumQuery), serviceCallback);
     }
 
     /**
@@ -1842,7 +1807,22 @@ public final class QueriesImpl implements Queries {
      * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumValidAsyncWithServiceResponse(UriColor enumQuery) {
+    public Observable<Void> enumValidAsync(UriColor enumQuery) {
+        return enumValidWithServiceResponseAsync(enumQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> enumValidWithServiceResponseAsync(UriColor enumQuery) {
         return service.enumValid(enumQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1869,10 +1849,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void enumNull() throws ErrorException, IOException {
-        enumNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        enumNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -1882,7 +1861,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(enumNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -1891,12 +1870,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> enumNullAsync() {
-        return enumNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return enumNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -1904,7 +1883,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> enumNullWithServiceResponseAsync() {
         final UriColor enumQuery = null;
         return service.enumNull(enumQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -1926,10 +1905,9 @@ public final class QueriesImpl implements Queries {
      * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void enumNull(UriColor enumQuery) throws ErrorException, IOException {
-        enumNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        enumNullWithServiceResponseAsync(enumQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -1940,21 +1918,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> enumNullAsync(UriColor enumQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(enumNullAsyncWithServiceResponse(enumQuery), serviceCallback);
-    }
-
-    /**
-     * Get null (no query parameter in url).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> enumNullAsync(UriColor enumQuery) {
-        return enumNullAsyncWithServiceResponse(enumQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(enumNullWithServiceResponseAsync(enumQuery), serviceCallback);
     }
 
     /**
@@ -1963,7 +1927,22 @@ public final class QueriesImpl implements Queries {
      * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> enumNullAsyncWithServiceResponse(UriColor enumQuery) {
+    public Observable<Void> enumNullAsync(UriColor enumQuery) {
+        return enumNullWithServiceResponseAsync(enumQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> enumNullWithServiceResponseAsync(UriColor enumQuery) {
         return service.enumNull(enumQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -1990,10 +1969,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void byteMultiByte() throws ErrorException, IOException {
-        byteMultiByteAsyncWithServiceResponse().toBlocking().single().getBody();
+        byteMultiByteWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2003,7 +1981,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteMultiByteAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteMultiByteAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(byteMultiByteWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2012,12 +1990,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> byteMultiByteAsync() {
-        return byteMultiByteAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return byteMultiByteWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2025,7 +2003,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> byteMultiByteWithServiceResponseAsync() {
         final byte[] byteQuery = new byte[0];
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteMultiByte(byteQueryConverted)
@@ -2048,10 +2026,9 @@ public final class QueriesImpl implements Queries {
      * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void byteMultiByte(byte[] byteQuery) throws ErrorException, IOException {
-        byteMultiByteAsyncWithServiceResponse().toBlocking().single().getBody();
+        byteMultiByteWithServiceResponseAsync(byteQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -2062,21 +2039,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteMultiByteAsync(byte[] byteQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteMultiByteAsyncWithServiceResponse(byteQuery), serviceCallback);
-    }
-
-    /**
-     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> byteMultiByteAsync(byte[] byteQuery) {
-        return byteMultiByteAsyncWithServiceResponse(byteQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(byteMultiByteWithServiceResponseAsync(byteQuery), serviceCallback);
     }
 
     /**
@@ -2085,7 +2048,22 @@ public final class QueriesImpl implements Queries {
      * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteMultiByteAsyncWithServiceResponse(byte[] byteQuery) {
+    public Observable<Void> byteMultiByteAsync(byte[] byteQuery) {
+        return byteMultiByteWithServiceResponseAsync(byteQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> byteMultiByteWithServiceResponseAsync(byte[] byteQuery) {
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteMultiByte(byteQueryConverted)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2113,10 +2091,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void byteEmpty() throws ErrorException, IOException {
-        byteEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        byteEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2126,7 +2103,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(byteEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2135,12 +2112,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> byteEmptyAsync() {
-        return byteEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return byteEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2148,7 +2125,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> byteEmptyWithServiceResponseAsync() {
         final byte[] byteQuery = "".getBytes();
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteEmpty(byteQueryConverted)
@@ -2177,10 +2154,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void byteNull() throws ErrorException, IOException {
-        byteNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        byteNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2190,7 +2166,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(byteNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2199,12 +2175,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> byteNullAsync() {
-        return byteNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return byteNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2212,7 +2188,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> byteNullWithServiceResponseAsync() {
         final byte[] byteQuery = new byte[0];
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteNull(byteQueryConverted)
@@ -2235,10 +2211,9 @@ public final class QueriesImpl implements Queries {
      * @param byteQuery null as byte array (no query parameters in uri)
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void byteNull(byte[] byteQuery) throws ErrorException, IOException {
-        byteNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        byteNullWithServiceResponseAsync(byteQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -2249,21 +2224,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> byteNullAsync(byte[] byteQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(byteNullAsyncWithServiceResponse(byteQuery), serviceCallback);
-    }
-
-    /**
-     * Get null as byte array (no query parameters in uri).
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> byteNullAsync(byte[] byteQuery) {
-        return byteNullAsyncWithServiceResponse(byteQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(byteNullWithServiceResponseAsync(byteQuery), serviceCallback);
     }
 
     /**
@@ -2272,7 +2233,22 @@ public final class QueriesImpl implements Queries {
      * @param byteQuery null as byte array (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> byteNullAsyncWithServiceResponse(byte[] byteQuery) {
+    public Observable<Void> byteNullAsync(byte[] byteQuery) {
+        return byteNullWithServiceResponseAsync(byteQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @param byteQuery null as byte array (no query parameters in uri)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> byteNullWithServiceResponseAsync(byte[] byteQuery) {
         String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteNull(byteQueryConverted)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2300,10 +2276,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateValid() throws ErrorException, IOException {
-        dateValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        dateValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2313,7 +2288,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(dateValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2322,12 +2297,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> dateValidAsync() {
-        return dateValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return dateValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2335,7 +2310,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> dateValidWithServiceResponseAsync() {
         final LocalDate dateQuery = LocalDate.parse("2012-01-01");
         return service.dateValid(dateQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2363,10 +2338,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateNull() throws ErrorException, IOException {
-        dateNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        dateNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2376,7 +2350,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(dateNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2385,12 +2359,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> dateNullAsync() {
-        return dateNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return dateNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2398,7 +2372,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> dateNullWithServiceResponseAsync() {
         final LocalDate dateQuery = null;
         return service.dateNull(dateQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2420,10 +2394,9 @@ public final class QueriesImpl implements Queries {
      * @param dateQuery null as date (no query parameters in uri)
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateNull(LocalDate dateQuery) throws ErrorException, IOException {
-        dateNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        dateNullWithServiceResponseAsync(dateQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -2434,21 +2407,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateNullAsync(LocalDate dateQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateNullAsyncWithServiceResponse(dateQuery), serviceCallback);
-    }
-
-    /**
-     * Get null as date - this should result in no query parameters in uri.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> dateNullAsync(LocalDate dateQuery) {
-        return dateNullAsyncWithServiceResponse(dateQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(dateNullWithServiceResponseAsync(dateQuery), serviceCallback);
     }
 
     /**
@@ -2457,7 +2416,22 @@ public final class QueriesImpl implements Queries {
      * @param dateQuery null as date (no query parameters in uri)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateNullAsyncWithServiceResponse(LocalDate dateQuery) {
+    public Observable<Void> dateNullAsync(LocalDate dateQuery) {
+        return dateNullWithServiceResponseAsync(dateQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @param dateQuery null as date (no query parameters in uri)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateNullWithServiceResponseAsync(LocalDate dateQuery) {
         return service.dateNull(dateQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -2484,10 +2458,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateTimeValid() throws ErrorException, IOException {
-        dateTimeValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        dateTimeValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2497,7 +2470,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(dateTimeValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2506,12 +2479,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> dateTimeValidAsync() {
-        return dateTimeValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return dateTimeValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2519,7 +2492,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> dateTimeValidWithServiceResponseAsync() {
         final DateTime dateTimeQuery = DateTime.parse("2012-01-01T01:01:01Z");
         return service.dateTimeValid(dateTimeQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2547,10 +2520,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateTimeNull() throws ErrorException, IOException {
-        dateTimeNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        dateTimeNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2560,7 +2532,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(dateTimeNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2569,12 +2541,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> dateTimeNullAsync() {
-        return dateTimeNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return dateTimeNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2582,7 +2554,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> dateTimeNullWithServiceResponseAsync() {
         final DateTime dateTimeQuery = null;
         return service.dateTimeNull(dateTimeQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -2604,10 +2576,9 @@ public final class QueriesImpl implements Queries {
      * @param dateTimeQuery null as date-time (no query parameters)
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void dateTimeNull(DateTime dateTimeQuery) throws ErrorException, IOException {
-        dateTimeNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        dateTimeNullWithServiceResponseAsync(dateTimeQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -2618,21 +2589,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> dateTimeNullAsync(DateTime dateTimeQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(dateTimeNullAsyncWithServiceResponse(dateTimeQuery), serviceCallback);
-    }
-
-    /**
-     * Get null as date-time, should result in no query parameters in uri.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> dateTimeNullAsync(DateTime dateTimeQuery) {
-        return dateTimeNullAsyncWithServiceResponse(dateTimeQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(dateTimeNullWithServiceResponseAsync(dateTimeQuery), serviceCallback);
     }
 
     /**
@@ -2641,7 +2598,22 @@ public final class QueriesImpl implements Queries {
      * @param dateTimeQuery null as date-time (no query parameters)
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> dateTimeNullAsyncWithServiceResponse(DateTime dateTimeQuery) {
+    public Observable<Void> dateTimeNullAsync(DateTime dateTimeQuery) {
+        return dateTimeNullWithServiceResponseAsync(dateTimeQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @param dateTimeQuery null as date-time (no query parameters)
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> dateTimeNullWithServiceResponseAsync(DateTime dateTimeQuery) {
         return service.dateTimeNull(dateTimeQuery)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
                 @Override
@@ -2668,10 +2640,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringCsvValid() throws ErrorException, IOException {
-        arrayStringCsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringCsvValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2681,7 +2652,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(arrayStringCsvValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2690,12 +2661,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> arrayStringCsvValidAsync() {
-        return arrayStringCsvValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return arrayStringCsvValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2703,7 +2674,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> arrayStringCsvValidWithServiceResponseAsync() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvValid(arrayQueryConverted)
@@ -2726,10 +2697,9 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringCsvValid(List<String> arrayQuery) throws ErrorException, IOException {
-        arrayStringCsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringCsvValidWithServiceResponseAsync(arrayQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -2740,21 +2710,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvValidAsyncWithServiceResponse(arrayQuery), serviceCallback);
-    }
-
-    /**
-     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> arrayStringCsvValidAsync(List<String> arrayQuery) {
-        return arrayStringCsvValidAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(arrayStringCsvValidWithServiceResponseAsync(arrayQuery), serviceCallback);
     }
 
     /**
@@ -2763,7 +2719,22 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvValidAsyncWithServiceResponse(List<String> arrayQuery) {
+    public Observable<Void> arrayStringCsvValidAsync(List<String> arrayQuery) {
+        return arrayStringCsvValidWithServiceResponseAsync(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringCsvValidWithServiceResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvValid(arrayQueryConverted)
@@ -2792,10 +2763,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringCsvNull() throws ErrorException, IOException {
-        arrayStringCsvNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringCsvNullWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2805,7 +2775,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvNullAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvNullAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(arrayStringCsvNullWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2814,12 +2784,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> arrayStringCsvNullAsync() {
-        return arrayStringCsvNullAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return arrayStringCsvNullWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2827,7 +2797,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvNullAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> arrayStringCsvNullWithServiceResponseAsync() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvNull(arrayQueryConverted)
@@ -2850,10 +2820,9 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery a null array of string using the csv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringCsvNull(List<String> arrayQuery) throws ErrorException, IOException {
-        arrayStringCsvNullAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringCsvNullWithServiceResponseAsync(arrayQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -2864,21 +2833,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvNullAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvNullAsyncWithServiceResponse(arrayQuery), serviceCallback);
-    }
-
-    /**
-     * Get a null array of string using the csv-array format.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> arrayStringCsvNullAsync(List<String> arrayQuery) {
-        return arrayStringCsvNullAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(arrayStringCsvNullWithServiceResponseAsync(arrayQuery), serviceCallback);
     }
 
     /**
@@ -2887,7 +2842,22 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery a null array of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvNullAsyncWithServiceResponse(List<String> arrayQuery) {
+    public Observable<Void> arrayStringCsvNullAsync(List<String> arrayQuery) {
+        return arrayStringCsvNullWithServiceResponseAsync(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @param arrayQuery a null array of string using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringCsvNullWithServiceResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvNull(arrayQueryConverted)
@@ -2916,10 +2886,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringCsvEmpty() throws ErrorException, IOException {
-        arrayStringCsvEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringCsvEmptyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -2929,7 +2898,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvEmptyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvEmptyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(arrayStringCsvEmptyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -2938,12 +2907,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> arrayStringCsvEmptyAsync() {
-        return arrayStringCsvEmptyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return arrayStringCsvEmptyWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -2951,7 +2920,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> arrayStringCsvEmptyWithServiceResponseAsync() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvEmpty(arrayQueryConverted)
@@ -2974,10 +2943,9 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an empty array [] of string using the csv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringCsvEmpty(List<String> arrayQuery) throws ErrorException, IOException {
-        arrayStringCsvEmptyAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringCsvEmptyWithServiceResponseAsync(arrayQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -2988,21 +2956,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringCsvEmptyAsyncWithServiceResponse(arrayQuery), serviceCallback);
-    }
-
-    /**
-     * Get an empty array [] of string using the csv-array format.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery) {
-        return arrayStringCsvEmptyAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(arrayStringCsvEmptyWithServiceResponseAsync(arrayQuery), serviceCallback);
     }
 
     /**
@@ -3011,7 +2965,22 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an empty array [] of string using the csv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringCsvEmptyAsyncWithServiceResponse(List<String> arrayQuery) {
+    public Observable<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery) {
+        return arrayStringCsvEmptyWithServiceResponseAsync(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the csv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringCsvEmptyWithServiceResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvEmpty(arrayQueryConverted)
@@ -3040,10 +3009,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringSsvValid() throws ErrorException, IOException {
-        arrayStringSsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringSsvValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3053,7 +3021,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringSsvValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringSsvValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(arrayStringSsvValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3062,12 +3030,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> arrayStringSsvValidAsync() {
-        return arrayStringSsvValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return arrayStringSsvValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3075,7 +3043,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringSsvValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> arrayStringSsvValidWithServiceResponseAsync() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.SSV);
         return service.arrayStringSsvValid(arrayQueryConverted)
@@ -3098,10 +3066,9 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringSsvValid(List<String> arrayQuery) throws ErrorException, IOException {
-        arrayStringSsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringSsvValidWithServiceResponseAsync(arrayQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -3112,21 +3079,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringSsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringSsvValidAsyncWithServiceResponse(arrayQuery), serviceCallback);
-    }
-
-    /**
-     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> arrayStringSsvValidAsync(List<String> arrayQuery) {
-        return arrayStringSsvValidAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(arrayStringSsvValidWithServiceResponseAsync(arrayQuery), serviceCallback);
     }
 
     /**
@@ -3135,7 +3088,22 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringSsvValidAsyncWithServiceResponse(List<String> arrayQuery) {
+    public Observable<Void> arrayStringSsvValidAsync(List<String> arrayQuery) {
+        return arrayStringSsvValidWithServiceResponseAsync(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringSsvValidWithServiceResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.SSV);
         return service.arrayStringSsvValid(arrayQueryConverted)
@@ -3164,10 +3132,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringTsvValid() throws ErrorException, IOException {
-        arrayStringTsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringTsvValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3177,7 +3144,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringTsvValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringTsvValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(arrayStringTsvValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3186,12 +3153,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> arrayStringTsvValidAsync() {
-        return arrayStringTsvValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return arrayStringTsvValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3199,7 +3166,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringTsvValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> arrayStringTsvValidWithServiceResponseAsync() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.TSV);
         return service.arrayStringTsvValid(arrayQueryConverted)
@@ -3222,10 +3189,9 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringTsvValid(List<String> arrayQuery) throws ErrorException, IOException {
-        arrayStringTsvValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringTsvValidWithServiceResponseAsync(arrayQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -3236,21 +3202,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringTsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringTsvValidAsyncWithServiceResponse(arrayQuery), serviceCallback);
-    }
-
-    /**
-     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> arrayStringTsvValidAsync(List<String> arrayQuery) {
-        return arrayStringTsvValidAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(arrayStringTsvValidWithServiceResponseAsync(arrayQuery), serviceCallback);
     }
 
     /**
@@ -3259,7 +3211,22 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringTsvValidAsyncWithServiceResponse(List<String> arrayQuery) {
+    public Observable<Void> arrayStringTsvValidAsync(List<String> arrayQuery) {
+        return arrayStringTsvValidWithServiceResponseAsync(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringTsvValidWithServiceResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.TSV);
         return service.arrayStringTsvValid(arrayQueryConverted)
@@ -3288,10 +3255,9 @@ public final class QueriesImpl implements Queries {
      *
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringPipesValid() throws ErrorException, IOException {
-        arrayStringPipesValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringPipesValidWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -3301,7 +3267,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringPipesValidAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringPipesValidAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(arrayStringPipesValidWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -3310,12 +3276,12 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> arrayStringPipesValidAsync() {
-        return arrayStringPipesValidAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return arrayStringPipesValidWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -3323,7 +3289,7 @@ public final class QueriesImpl implements Queries {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringPipesValidAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> arrayStringPipesValidWithServiceResponseAsync() {
         final List<String> arrayQuery = null;
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.PIPES);
         return service.arrayStringPipesValid(arrayQueryConverted)
@@ -3346,10 +3312,9 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void arrayStringPipesValid(List<String> arrayQuery) throws ErrorException, IOException {
-        arrayStringPipesValidAsyncWithServiceResponse().toBlocking().single().getBody();
+        arrayStringPipesValidWithServiceResponseAsync(arrayQuery).toBlocking().single().getBody();
     }
 
     /**
@@ -3360,21 +3325,7 @@ public final class QueriesImpl implements Queries {
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> arrayStringPipesValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(arrayStringPipesValidAsyncWithServiceResponse(arrayQuery), serviceCallback);
-    }
-
-    /**
-     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
-     *
-     * @return the {@link ServiceResponse} object if successful.
-     */
-    public Observable<Void> arrayStringPipesValidAsync(List<String> arrayQuery) {
-        return arrayStringPipesValidAsyncWithServiceResponse(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
-            @Override
-            public Void call(ServiceResponse<Void> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(arrayStringPipesValidWithServiceResponseAsync(arrayQuery), serviceCallback);
     }
 
     /**
@@ -3383,7 +3334,22 @@ public final class QueriesImpl implements Queries {
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> arrayStringPipesValidAsyncWithServiceResponse(List<String> arrayQuery) {
+    public Observable<Void> arrayStringPipesValidAsync(List<String> arrayQuery) {
+        return arrayStringPipesValidWithServiceResponseAsync(arrayQuery).map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> arrayStringPipesValidWithServiceResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
         String arrayQueryConverted = this.client.mapperAdapter().serializeList(arrayQuery, CollectionFormat.PIPES);
         return service.arrayStringPipesValid(arrayQueryConverted)

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
@@ -68,7 +68,7 @@ public interface AutoRestValidationTest {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> validationOfMethodParameters(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException;
+    Product validationOfMethodParameters(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Validates input parameters on the method. See swagger for details.
@@ -87,7 +87,16 @@ public interface AutoRestValidationTest {
      * @param id Required int multiple of 10 from 100 to 1000.
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> validationOfMethodParametersAsync(String resourceGroupName, int id);
+    Observable<Product> validationOfMethodParametersAsync(String resourceGroupName, int id);
+
+    /**
+     * Validates input parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> validationOfMethodParametersAsyncWithServiceResponse(String resourceGroupName, int id);
 
     /**
      * Validates body parameters on the method. See swagger for details.
@@ -99,7 +108,7 @@ public interface AutoRestValidationTest {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> validationOfBody(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException;
+    Product validationOfBody(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Validates body parameters on the method. See swagger for details.
@@ -110,6 +119,26 @@ public interface AutoRestValidationTest {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> validationOfBodyAsync(String resourceGroupName, int id, final ServiceCallback<Product> serviceCallback);
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param body the Product value
+     * @return the observable to the Product object
+     */
+    Observable<Product> validationOfBodyAsync(String resourceGroupName, int id);
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param body the Product value
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> validationOfBodyAsyncWithServiceResponse(String resourceGroupName, int id);
     /**
      * Validates body parameters on the method. See swagger for details.
      *
@@ -121,7 +150,7 @@ public interface AutoRestValidationTest {
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> validationOfBody(String resourceGroupName, int id, Product body) throws ErrorException, IOException, IllegalArgumentException;
+    Product validationOfBody(String resourceGroupName, int id, Product body) throws ErrorException, IOException, IllegalArgumentException;
 
     /**
      * Validates body parameters on the method. See swagger for details.
@@ -142,7 +171,17 @@ public interface AutoRestValidationTest {
      * @param body the Product value
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> validationOfBodyAsync(String resourceGroupName, int id, Product body);
+    Observable<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body);
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param body the Product value
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> validationOfBodyAsyncWithServiceResponse(String resourceGroupName, int id, Product body);
 
     /**
      *
@@ -150,7 +189,7 @@ public interface AutoRestValidationTest {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    ServiceResponse<Void> getWithConstantInPath() throws ServiceException, IOException;
+    void getWithConstantInPath() throws ServiceException, IOException;
 
     /**
      *
@@ -163,7 +202,13 @@ public interface AutoRestValidationTest {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getWithConstantInPathAsync();
+    Observable<Void> getWithConstantInPathAsync();
+
+    /**
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    Observable<ServiceResponse<Void>> getWithConstantInPathAsyncWithServiceResponse();
 
     /**
      *
@@ -171,7 +216,7 @@ public interface AutoRestValidationTest {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> postWithConstantInBody() throws ServiceException, IOException;
+    Product postWithConstantInBody() throws ServiceException, IOException;
 
     /**
      *
@@ -179,6 +224,20 @@ public interface AutoRestValidationTest {
      * @return the {@link ServiceCall} object
      */
     ServiceCall<Product> postWithConstantInBodyAsync(final ServiceCallback<Product> serviceCallback);
+
+    /**
+     *
+     * @param body the Product value
+     * @return the observable to the Product object
+     */
+    Observable<Product> postWithConstantInBodyAsync();
+
+    /**
+     *
+     * @param body the Product value
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> postWithConstantInBodyAsyncWithServiceResponse();
     /**
      *
      * @param body the Product value
@@ -186,7 +245,7 @@ public interface AutoRestValidationTest {
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    ServiceResponse<Product> postWithConstantInBody(Product body) throws ServiceException, IOException;
+    Product postWithConstantInBody(Product body) throws ServiceException, IOException;
 
     /**
      *
@@ -201,6 +260,13 @@ public interface AutoRestValidationTest {
      * @param body the Product value
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> postWithConstantInBodyAsync(Product body);
+    Observable<Product> postWithConstantInBodyAsync(Product body);
+
+    /**
+     *
+     * @param body the Product value
+     * @return the observable to the Product object
+     */
+    Observable<ServiceResponse<Product>> postWithConstantInBodyAsyncWithServiceResponse(Product body);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
@@ -66,7 +66,7 @@ public interface AutoRestValidationTest {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product validationOfMethodParameters(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -96,7 +96,7 @@ public interface AutoRestValidationTest {
      * @param id Required int multiple of 10 from 100 to 1000.
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> validationOfMethodParametersAsyncWithServiceResponse(String resourceGroupName, int id);
+    Observable<ServiceResponse<Product>> validationOfMethodParametersWithServiceResponseAsync(String resourceGroupName, int id);
 
     /**
      * Validates body parameters on the method. See swagger for details.
@@ -106,7 +106,7 @@ public interface AutoRestValidationTest {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product validationOfBody(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -125,7 +125,6 @@ public interface AutoRestValidationTest {
      *
      * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
      * @param id Required int multiple of 10 from 100 to 1000.
-     * @param body the Product value
      * @return the observable to the Product object
      */
     Observable<Product> validationOfBodyAsync(String resourceGroupName, int id);
@@ -135,10 +134,9 @@ public interface AutoRestValidationTest {
      *
      * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
      * @param id Required int multiple of 10 from 100 to 1000.
-     * @param body the Product value
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> validationOfBodyAsyncWithServiceResponse(String resourceGroupName, int id);
+    Observable<ServiceResponse<Product>> validationOfBodyWithServiceResponseAsync(String resourceGroupName, int id);
     /**
      * Validates body parameters on the method. See swagger for details.
      *
@@ -148,7 +146,7 @@ public interface AutoRestValidationTest {
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product validationOfBody(String resourceGroupName, int id, Product body) throws ErrorException, IOException, IllegalArgumentException;
 
@@ -181,13 +179,12 @@ public interface AutoRestValidationTest {
      * @param body the Product value
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> validationOfBodyAsyncWithServiceResponse(String resourceGroupName, int id, Product body);
+    Observable<ServiceResponse<Product>> validationOfBodyWithServiceResponseAsync(String resourceGroupName, int id, Product body);
 
     /**
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     void getWithConstantInPath() throws ServiceException, IOException;
 
@@ -208,13 +205,13 @@ public interface AutoRestValidationTest {
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    Observable<ServiceResponse<Void>> getWithConstantInPathAsyncWithServiceResponse();
+    Observable<ServiceResponse<Void>> getWithConstantInPathWithServiceResponseAsync();
 
     /**
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product postWithConstantInBody() throws ServiceException, IOException;
 
@@ -227,23 +224,21 @@ public interface AutoRestValidationTest {
 
     /**
      *
-     * @param body the Product value
      * @return the observable to the Product object
      */
     Observable<Product> postWithConstantInBodyAsync();
 
     /**
      *
-     * @param body the Product value
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> postWithConstantInBodyAsyncWithServiceResponse();
+    Observable<ServiceResponse<Product>> postWithConstantInBodyWithServiceResponseAsync();
     /**
      *
      * @param body the Product value
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     Product postWithConstantInBody(Product body) throws ServiceException, IOException;
 
@@ -267,6 +262,6 @@ public interface AutoRestValidationTest {
      * @param body the Product value
      * @return the observable to the Product object
      */
-    Observable<ServiceResponse<Product>> postWithConstantInBodyAsyncWithServiceResponse(Product body);
+    Observable<ServiceResponse<Product>> postWithConstantInBodyWithServiceResponseAsync(Product body);
 
 }

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
@@ -170,10 +170,10 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     public Product validationOfMethodParameters(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException {
-        return validationOfMethodParametersAsyncWithServiceResponse(resourceGroupName, id).toBlocking().single().getBody();
+        return validationOfMethodParametersWithServiceResponseAsync(resourceGroupName, id).toBlocking().single().getBody();
     }
 
     /**
@@ -185,7 +185,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> validationOfMethodParametersAsync(String resourceGroupName, int id, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(validationOfMethodParametersAsyncWithServiceResponse(resourceGroupName, id), serviceCallback);
+        return ServiceCall.create(validationOfMethodParametersWithServiceResponseAsync(resourceGroupName, id), serviceCallback);
     }
 
     /**
@@ -196,12 +196,12 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the observable to the Product object
      */
     public Observable<Product> validationOfMethodParametersAsync(String resourceGroupName, int id) {
-        return validationOfMethodParametersAsyncWithServiceResponse(resourceGroupName, id).map(new Func1<ServiceResponse<Product>, Product>() {
+        return validationOfMethodParametersWithServiceResponseAsync(resourceGroupName, id).map(new Func1<ServiceResponse<Product>, Product>() {
             @Override
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -211,7 +211,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param id Required int multiple of 10 from 100 to 1000.
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> validationOfMethodParametersAsyncWithServiceResponse(String resourceGroupName, int id) {
+    public Observable<ServiceResponse<Product>> validationOfMethodParametersWithServiceResponseAsync(String resourceGroupName, int id) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -250,10 +250,10 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     public Product validationOfBody(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException {
-        return validationOfBodyAsyncWithServiceResponse(resourceGroupName, id).toBlocking().single().getBody();
+        return validationOfBodyWithServiceResponseAsync(resourceGroupName, id).toBlocking().single().getBody();
     }
 
     /**
@@ -265,7 +265,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> validationOfBodyAsync(String resourceGroupName, int id, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(validationOfBodyAsyncWithServiceResponse(resourceGroupName, id), serviceCallback);
+        return ServiceCall.create(validationOfBodyWithServiceResponseAsync(resourceGroupName, id), serviceCallback);
     }
 
     /**
@@ -276,12 +276,12 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the observable to the Product object
      */
     public Observable<Product> validationOfBodyAsync(String resourceGroupName, int id) {
-        return validationOfBodyAsyncWithServiceResponse(resourceGroupName, id).map(new Func1<ServiceResponse<Product>, Product>() {
+        return validationOfBodyWithServiceResponseAsync(resourceGroupName, id).map(new Func1<ServiceResponse<Product>, Product>() {
             @Override
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
@@ -291,7 +291,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param id Required int multiple of 10 from 100 to 1000.
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> validationOfBodyAsyncWithServiceResponse(String resourceGroupName, int id) {
+    public Observable<ServiceResponse<Product>> validationOfBodyWithServiceResponseAsync(String resourceGroupName, int id) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -325,10 +325,10 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws ErrorException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
      * @throws IllegalArgumentException exception thrown from invalid parameters
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     public Product validationOfBody(String resourceGroupName, int id, Product body) throws ErrorException, IOException, IllegalArgumentException {
-        return validationOfBodyAsyncWithServiceResponse(resourceGroupName, id).toBlocking().single().getBody();
+        return validationOfBodyWithServiceResponseAsync(resourceGroupName, id, body).toBlocking().single().getBody();
     }
 
     /**
@@ -341,23 +341,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(validationOfBodyAsyncWithServiceResponse(resourceGroupName, id, body), serviceCallback);
-    }
-
-    /**
-     * Validates body parameters on the method. See swagger for details.
-     *
-     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
-     * @param id Required int multiple of 10 from 100 to 1000.
-     * @return the observable to the Product object
-     */
-    public Observable<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body) {
-        return validationOfBodyAsyncWithServiceResponse(resourceGroupName, id, body).map(new Func1<ServiceResponse<Product>, Product>() {
-            @Override
-            public Product call(ServiceResponse<Product> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(validationOfBodyWithServiceResponseAsync(resourceGroupName, id, body), serviceCallback);
     }
 
     /**
@@ -368,7 +352,24 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param body the Product value
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> validationOfBodyAsyncWithServiceResponse(String resourceGroupName, int id, Product body) {
+    public Observable<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body) {
+        return validationOfBodyWithServiceResponseAsync(resourceGroupName, id, body).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param body the Product value
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> validationOfBodyWithServiceResponseAsync(String resourceGroupName, int id, Product body) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -404,10 +405,9 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the {@link ServiceResponse} object if successful.
      */
     public void getWithConstantInPath() throws ServiceException, IOException {
-        getWithConstantInPathAsyncWithServiceResponse().toBlocking().single().getBody();
+        getWithConstantInPathWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -416,7 +416,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getWithConstantInPathAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getWithConstantInPathAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(getWithConstantInPathWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -424,19 +424,19 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceResponse} object if successful.
      */
     public Observable<Void> getWithConstantInPathAsync() {
-        return getWithConstantInPathAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+        return getWithConstantInPathWithServiceResponseAsync().map(new Func1<ServiceResponse<Void>, Void>() {
             @Override
             public Void call(ServiceResponse<Void> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getWithConstantInPathAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Void>> getWithConstantInPathWithServiceResponseAsync() {
         final String constantParam = "constant";
         return service.getWithConstantInPath(constantParam)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -462,10 +462,10 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      *
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     public Product postWithConstantInBody() throws ServiceException, IOException {
-        return postWithConstantInBodyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return postWithConstantInBodyWithServiceResponseAsync().toBlocking().single().getBody();
     }
 
     /**
@@ -474,7 +474,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> postWithConstantInBodyAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(postWithConstantInBodyAsyncWithServiceResponse(), serviceCallback);
+        return ServiceCall.create(postWithConstantInBodyWithServiceResponseAsync(), serviceCallback);
     }
 
     /**
@@ -482,19 +482,19 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the observable to the Product object
      */
     public Observable<Product> postWithConstantInBodyAsync() {
-        return postWithConstantInBodyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Product>, Product>() {
+        return postWithConstantInBodyWithServiceResponseAsync().map(new Func1<ServiceResponse<Product>, Product>() {
             @Override
             public Product call(ServiceResponse<Product> response) {
                 return response.getBody();
             }
-        }); 
+        });
     }
 
     /**
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> postWithConstantInBodyAsyncWithServiceResponse() {
+    public Observable<ServiceResponse<Product>> postWithConstantInBodyWithServiceResponseAsync() {
         final String constantParam = "constant";
         final Product body = null;
         return service.postWithConstantInBody(constantParam, body)
@@ -516,10 +516,10 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param body the Product value
      * @throws ServiceException exception thrown from REST call
      * @throws IOException exception thrown from serialization/deserialization
-     * @return the Product object wrapped in {@link ServiceResponse} if successful.
+     * @return the Product object if successful.
      */
     public Product postWithConstantInBody(Product body) throws ServiceException, IOException {
-        return postWithConstantInBodyAsyncWithServiceResponse().toBlocking().single().getBody();
+        return postWithConstantInBodyWithServiceResponseAsync(body).toBlocking().single().getBody();
     }
 
     /**
@@ -529,20 +529,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> postWithConstantInBodyAsync(Product body, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(postWithConstantInBodyAsyncWithServiceResponse(body), serviceCallback);
-    }
-
-    /**
-     *
-     * @return the observable to the Product object
-     */
-    public Observable<Product> postWithConstantInBodyAsync(Product body) {
-        return postWithConstantInBodyAsyncWithServiceResponse(body).map(new Func1<ServiceResponse<Product>, Product>() {
-            @Override
-            public Product call(ServiceResponse<Product> response) {
-                return response.getBody();
-            }
-        }); 
+        return ServiceCall.create(postWithConstantInBodyWithServiceResponseAsync(body), serviceCallback);
     }
 
     /**
@@ -550,7 +537,21 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param body the Product value
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> postWithConstantInBodyAsyncWithServiceResponse(Product body) {
+    public Observable<Product> postWithConstantInBodyAsync(Product body) {
+        return postWithConstantInBodyWithServiceResponseAsync(body).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        });
+    }
+
+    /**
+     *
+     * @param body the Product value
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> postWithConstantInBodyWithServiceResponseAsync(Product body) {
         Validator.validate(body);
         final String constantParam = "constant";
         return service.postWithConstantInBody(constantParam, body)

--- a/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
+++ b/src/generator/AutoRest.Java.Tests/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
@@ -172,8 +172,8 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Product> validationOfMethodParameters(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException {
-        return validationOfMethodParametersAsync(resourceGroupName, id).toBlocking().single();
+    public Product validationOfMethodParameters(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException {
+        return validationOfMethodParametersAsyncWithServiceResponse(resourceGroupName, id).toBlocking().single().getBody();
     }
 
     /**
@@ -185,7 +185,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> validationOfMethodParametersAsync(String resourceGroupName, int id, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(validationOfMethodParametersAsync(resourceGroupName, id), serviceCallback);
+        return ServiceCall.create(validationOfMethodParametersAsyncWithServiceResponse(resourceGroupName, id), serviceCallback);
     }
 
     /**
@@ -195,7 +195,23 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param id Required int multiple of 10 from 100 to 1000.
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> validationOfMethodParametersAsync(String resourceGroupName, int id) {
+    public Observable<Product> validationOfMethodParametersAsync(String resourceGroupName, int id) {
+        return validationOfMethodParametersAsyncWithServiceResponse(resourceGroupName, id).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Validates input parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> validationOfMethodParametersAsyncWithServiceResponse(String resourceGroupName, int id) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -236,8 +252,8 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Product> validationOfBody(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException {
-        return validationOfBodyAsync(resourceGroupName, id).toBlocking().single();
+    public Product validationOfBody(String resourceGroupName, int id) throws ErrorException, IOException, IllegalArgumentException {
+        return validationOfBodyAsyncWithServiceResponse(resourceGroupName, id).toBlocking().single().getBody();
     }
 
     /**
@@ -249,7 +265,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> validationOfBodyAsync(String resourceGroupName, int id, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(validationOfBodyAsync(resourceGroupName, id), serviceCallback);
+        return ServiceCall.create(validationOfBodyAsyncWithServiceResponse(resourceGroupName, id), serviceCallback);
     }
 
     /**
@@ -259,7 +275,23 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param id Required int multiple of 10 from 100 to 1000.
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> validationOfBodyAsync(String resourceGroupName, int id) {
+    public Observable<Product> validationOfBodyAsync(String resourceGroupName, int id) {
+        return validationOfBodyAsyncWithServiceResponse(resourceGroupName, id).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> validationOfBodyAsyncWithServiceResponse(String resourceGroupName, int id) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -295,8 +327,8 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws IllegalArgumentException exception thrown from invalid parameters
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Product> validationOfBody(String resourceGroupName, int id, Product body) throws ErrorException, IOException, IllegalArgumentException {
-        return validationOfBodyAsync(resourceGroupName, id, body).toBlocking().single();
+    public Product validationOfBody(String resourceGroupName, int id, Product body) throws ErrorException, IOException, IllegalArgumentException {
+        return validationOfBodyAsyncWithServiceResponse(resourceGroupName, id).toBlocking().single().getBody();
     }
 
     /**
@@ -309,7 +341,23 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(validationOfBodyAsync(resourceGroupName, id, body), serviceCallback);
+        return ServiceCall.create(validationOfBodyAsyncWithServiceResponse(resourceGroupName, id, body), serviceCallback);
+    }
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @return the observable to the Product object
+     */
+    public Observable<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body) {
+        return validationOfBodyAsyncWithServiceResponse(resourceGroupName, id, body).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -320,7 +368,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param body the Product value
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> validationOfBodyAsync(String resourceGroupName, int id, Product body) {
+    public Observable<ServiceResponse<Product>> validationOfBodyAsyncWithServiceResponse(String resourceGroupName, int id, Product body) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -358,8 +406,8 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws IOException exception thrown from serialization/deserialization
      * @return the {@link ServiceResponse} object if successful.
      */
-    public ServiceResponse<Void> getWithConstantInPath() throws ServiceException, IOException {
-        return getWithConstantInPathAsync().toBlocking().single();
+    public void getWithConstantInPath() throws ServiceException, IOException {
+        getWithConstantInPathAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -368,14 +416,27 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Void> getWithConstantInPathAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceCall.create(getWithConstantInPathAsync(), serviceCallback);
+        return ServiceCall.create(getWithConstantInPathAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
      *
      * @return the {@link ServiceResponse} object if successful.
      */
-    public Observable<ServiceResponse<Void>> getWithConstantInPathAsync() {
+    public Observable<Void> getWithConstantInPathAsync() {
+        return getWithConstantInPathAsyncWithServiceResponse().map(new Func1<ServiceResponse<Void>, Void>() {
+            @Override
+            public Void call(ServiceResponse<Void> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     *
+     * @return the {@link ServiceResponse} object if successful.
+     */
+    public Observable<ServiceResponse<Void>> getWithConstantInPathAsyncWithServiceResponse() {
         final String constantParam = "constant";
         return service.getWithConstantInPath(constantParam)
             .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<Void>>>() {
@@ -403,8 +464,8 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Product> postWithConstantInBody() throws ServiceException, IOException {
-        return postWithConstantInBodyAsync().toBlocking().single();
+    public Product postWithConstantInBody() throws ServiceException, IOException {
+        return postWithConstantInBodyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -413,14 +474,27 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> postWithConstantInBodyAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(postWithConstantInBodyAsync(), serviceCallback);
+        return ServiceCall.create(postWithConstantInBodyAsyncWithServiceResponse(), serviceCallback);
     }
 
     /**
      *
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> postWithConstantInBodyAsync() {
+    public Observable<Product> postWithConstantInBodyAsync() {
+        return postWithConstantInBodyAsyncWithServiceResponse().map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
+    }
+
+    /**
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<ServiceResponse<Product>> postWithConstantInBodyAsyncWithServiceResponse() {
         final String constantParam = "constant";
         final Product body = null;
         return service.postWithConstantInBody(constantParam, body)
@@ -444,8 +518,8 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @throws IOException exception thrown from serialization/deserialization
      * @return the Product object wrapped in {@link ServiceResponse} if successful.
      */
-    public ServiceResponse<Product> postWithConstantInBody(Product body) throws ServiceException, IOException {
-        return postWithConstantInBodyAsync(body).toBlocking().single();
+    public Product postWithConstantInBody(Product body) throws ServiceException, IOException {
+        return postWithConstantInBodyAsyncWithServiceResponse().toBlocking().single().getBody();
     }
 
     /**
@@ -455,7 +529,20 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @return the {@link ServiceCall} object
      */
     public ServiceCall<Product> postWithConstantInBodyAsync(Product body, final ServiceCallback<Product> serviceCallback) {
-        return ServiceCall.create(postWithConstantInBodyAsync(body), serviceCallback);
+        return ServiceCall.create(postWithConstantInBodyAsyncWithServiceResponse(body), serviceCallback);
+    }
+
+    /**
+     *
+     * @return the observable to the Product object
+     */
+    public Observable<Product> postWithConstantInBodyAsync(Product body) {
+        return postWithConstantInBodyAsyncWithServiceResponse(body).map(new Func1<ServiceResponse<Product>, Product>() {
+            @Override
+            public Product call(ServiceResponse<Product> response) {
+                return response.getBody();
+            }
+        }); 
     }
 
     /**
@@ -463,7 +550,7 @@ public final class AutoRestValidationTestImpl extends ServiceClient implements A
      * @param body the Product value
      * @return the observable to the Product object
      */
-    public Observable<ServiceResponse<Product>> postWithConstantInBodyAsync(Product body) {
+    public Observable<ServiceResponse<Product>> postWithConstantInBodyAsyncWithServiceResponse(Product body) {
         Validator.validate(body);
         final String constantParam = "constant";
         return service.postWithConstantInBody(constantParam, body)

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyarray/ArrayTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyarray/ArrayTests.java
@@ -29,13 +29,13 @@ public class ArrayTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.arrays().getNull().getBody());
+        Assert.assertNull(client.arrays().getNull());
     }
 
     @Test
     public void getInvalid() throws Exception {
         try {
-            List<Integer> result = client.arrays().getInvalid().getBody();
+            List<Integer> result = client.arrays().getInvalid();
             Assert.assertTrue(false);
         } catch (RuntimeException exception) {
             // expected
@@ -45,7 +45,7 @@ public class ArrayTests {
 
     @Test
     public void getEmpty() throws Exception {
-        List<Integer> result = client.arrays().getEmpty().getBody();
+        List<Integer> result = client.arrays().getEmpty();
         Assert.assertEquals(0, result.size());
     }
 
@@ -56,7 +56,7 @@ public class ArrayTests {
 
     @Test
     public void getBooleanTfft() throws Exception {
-        List<Boolean> result = client.arrays().getBooleanTfft().getBody();
+        List<Boolean> result = client.arrays().getBooleanTfft();
         Object[] exected = new Boolean[] {true, false, false, true};
         Assert.assertArrayEquals(exected, result.toArray());
     }
@@ -69,7 +69,7 @@ public class ArrayTests {
     @Test
     public void getBooleanInvalidNull() throws Exception {
         try {
-            List<Boolean> result = client.arrays().getBooleanInvalidNull().getBody();
+            List<Boolean> result = client.arrays().getBooleanInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -79,7 +79,7 @@ public class ArrayTests {
     @Test
     public void getBooleanInvalidString() throws Exception {
         try {
-            List<Boolean> result = client.arrays().getBooleanInvalidString().getBody();
+            List<Boolean> result = client.arrays().getBooleanInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("only \"true\" or \"false\" recognized"));
@@ -88,7 +88,7 @@ public class ArrayTests {
 
     @Test
     public void getIntegerValid() throws Exception {
-        List<Integer> result = client.arrays().getIntegerValid().getBody();
+        List<Integer> result = client.arrays().getIntegerValid();
         Object[] expected = new Integer[] {1, -1, 3, 300};
         Assert.assertArrayEquals(expected, result.toArray());
     }
@@ -101,7 +101,7 @@ public class ArrayTests {
     @Test
     public void getIntInvalidNull() throws Exception {
         try {
-            List<Integer> result = client.arrays().getIntInvalidNull().getBody();
+            List<Integer> result = client.arrays().getIntInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -111,7 +111,7 @@ public class ArrayTests {
     @Test
     public void getIntInvalidString() throws Exception {
         try {
-            List<Integer> result = client.arrays().getIntInvalidString().getBody();
+            List<Integer> result = client.arrays().getIntInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("not a valid Integer value"));
@@ -120,7 +120,7 @@ public class ArrayTests {
 
     @Test
     public void getLongValid() throws Exception {
-        List<Long> result = client.arrays().getLongValid().getBody();
+        List<Long> result = client.arrays().getLongValid();
         Object[] expected = new Long[] {1L, -1L, 3L, 300L};
         Assert.assertArrayEquals(expected, result.toArray());
     }
@@ -133,7 +133,7 @@ public class ArrayTests {
     @Test
     public void getLongInvalidNull() throws Exception {
         try {
-            List<Long> result = client.arrays().getLongInvalidNull().getBody();
+            List<Long> result = client.arrays().getLongInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -143,7 +143,7 @@ public class ArrayTests {
     @Test
     public void getLongInvalidString() throws Exception {
         try {
-            List<Long> result = client.arrays().getLongInvalidString().getBody();
+            List<Long> result = client.arrays().getLongInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("not a valid Long value"));
@@ -152,7 +152,7 @@ public class ArrayTests {
 
     @Test
     public void getFloatValid() throws Exception {
-        List<Double> result = client.arrays().getFloatValid().getBody();
+        List<Double> result = client.arrays().getFloatValid();
         Object[] expected = new Double[] {0d, -0.01, -1.2e20};
         Assert.assertArrayEquals(expected, result.toArray());
     }
@@ -165,7 +165,7 @@ public class ArrayTests {
     @Test
     public void getFloatInvalidNull() throws Exception {
         try {
-            List<Double> result = client.arrays().getFloatInvalidNull().getBody();
+            List<Double> result = client.arrays().getFloatInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -175,7 +175,7 @@ public class ArrayTests {
     @Test
     public void getFloatInvalidString() throws Exception {
         try {
-            List<Double> result = client.arrays().getFloatInvalidString().getBody();
+            List<Double> result = client.arrays().getFloatInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("not a valid Double value"));
@@ -184,7 +184,7 @@ public class ArrayTests {
 
     @Test
     public void getDoubleValid() throws Exception {
-        List<Double> result = client.arrays().getDoubleValid().getBody();
+        List<Double> result = client.arrays().getDoubleValid();
         Object[] expected = new Double[] {0d, -0.01, -1.2e20};
         Assert.assertArrayEquals(expected, result.toArray());
     }
@@ -197,7 +197,7 @@ public class ArrayTests {
     @Test
     public void getDoubleInvalidNull() throws Exception {
         try {
-            List<Double> result = client.arrays().getDoubleInvalidNull().getBody();
+            List<Double> result = client.arrays().getDoubleInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -207,7 +207,7 @@ public class ArrayTests {
     @Test
     public void getDoubleInvalidString() throws Exception {
         try {
-            List<Double> result = client.arrays().getDoubleInvalidString().getBody();
+            List<Double> result = client.arrays().getDoubleInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("not a valid Double value"));
@@ -216,7 +216,7 @@ public class ArrayTests {
 
     @Test
     public void getStringValid() throws Exception {
-        List<String> result = client.arrays().getStringValid().getBody();
+        List<String> result = client.arrays().getStringValid();
         Object[] expected = new String[] {"foo1", "foo2", "foo3"};
         Assert.assertArrayEquals(expected, result.toArray());
     }
@@ -229,7 +229,7 @@ public class ArrayTests {
     @Test
     public void getStringWithNull() throws Exception {
         try {
-            List<String> result = client.arrays().getStringWithNull().getBody();
+            List<String> result = client.arrays().getStringWithNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -239,7 +239,7 @@ public class ArrayTests {
     @Test
     public void getStringWithInvalid() throws Exception {
         try {
-            List<String> result = client.arrays().getStringWithInvalid().getBody();
+            List<String> result = client.arrays().getStringWithInvalid();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("InvalidFormatException"));
@@ -248,7 +248,7 @@ public class ArrayTests {
 
     @Test
     public void getUuidValid() throws Exception {
-        List<UUID> result = client.arrays().getUuidValid().getBody();
+        List<UUID> result = client.arrays().getUuidValid();
         Object[] expected = new UUID[] {UUID.fromString("6dcc7237-45fe-45c4-8a6b-3a8a3f625652"),
                                          UUID.fromString("d1399005-30f7-40d6-8da6-dd7c89ad34db"),
                                          UUID.fromString("f42f6aa1-a5bc-4ddf-907e-5f915de43205")};
@@ -264,7 +264,7 @@ public class ArrayTests {
     @Test
     public void getUuidInvalidChars() throws Exception {
         try {
-            List<UUID> result = client.arrays().getUuidInvalidChars().getBody();
+            List<UUID> result = client.arrays().getUuidInvalidChars();
             Assert.fail();
         } catch (RuntimeException ex) {
             // expected
@@ -273,7 +273,7 @@ public class ArrayTests {
     }
     @Test
     public void getDateValid() throws Exception {
-        List<LocalDate> result = client.arrays().getDateValid().getBody();
+        List<LocalDate> result = client.arrays().getDateValid();
         Object[] expected = new LocalDate[] {
                 new LocalDate(2000, 12, 1),
                 new LocalDate(1980, 1, 2),
@@ -294,7 +294,7 @@ public class ArrayTests {
     @Test
     public void getDateInvalidNull() throws Exception {
         try {
-            List<LocalDate> result = client.arrays().getDateInvalidNull().getBody();
+            List<LocalDate> result = client.arrays().getDateInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -304,7 +304,7 @@ public class ArrayTests {
     @Test
     public void getDateInvalidString() throws Exception {
         try {
-            List<LocalDate> result = client.arrays().getDateInvalidChars().getBody();
+            List<LocalDate> result = client.arrays().getDateInvalidChars();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Invalid format: \"date\""));
@@ -313,7 +313,7 @@ public class ArrayTests {
 
     @Test
     public void getDateTimeValid() throws Exception {
-        List<DateTime> result = client.arrays().getDateTimeValid().getBody();
+        List<DateTime> result = client.arrays().getDateTimeValid();
         Object[] expected = new DateTime[] {
                 new DateTime(2000, 12, 1, 0, 0, 1, DateTimeZone.UTC),
                 new DateTime(1980, 1, 2, 0, 11, 35, DateTimeZone.UTC),
@@ -334,7 +334,7 @@ public class ArrayTests {
     @Test
     public void getDateTimeInvalidNull() throws Exception {
         try {
-            List<DateTime> result = client.arrays().getDateTimeInvalidNull().getBody();
+            List<DateTime> result = client.arrays().getDateTimeInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -344,7 +344,7 @@ public class ArrayTests {
     @Test
     public void getDateTimeInvalidString() throws Exception {
         try {
-            List<DateTime> result = client.arrays().getDateTimeInvalidChars().getBody();
+            List<DateTime> result = client.arrays().getDateTimeInvalidChars();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Invalid format: \"date-time\""));
@@ -353,7 +353,7 @@ public class ArrayTests {
 
     @Test
     public void getDateTimeRfc1123Valid() throws Exception {
-        List<DateTime> result = client.arrays().getDateTimeRfc1123Valid().getBody();
+        List<DateTime> result = client.arrays().getDateTimeRfc1123Valid();
         Object[] expected = new DateTime[] {
                 new DateTime(2000, 12, 1, 0, 0, 1, DateTimeZone.UTC),
                 new DateTime(1980, 1, 2, 0, 11, 35, DateTimeZone.UTC),
@@ -373,7 +373,7 @@ public class ArrayTests {
 
     @Test
     public void getDurationValid() throws Exception {
-        List<Period> result = client.arrays().getDurationValid().getBody();
+        List<Period> result = client.arrays().getDurationValid();
         Object[] expected = new Period[] {
                 new Period(0, 0, 0, 123, 22, 14, 12, 11),
                 new Period(0, 0, 0, 5, 1, 0, 0, 0)
@@ -390,7 +390,7 @@ public class ArrayTests {
 
     @Test
     public void getByteValid() throws Exception {
-        List<byte[]> result = client.arrays().getByteValid().getBody();
+        List<byte[]> result = client.arrays().getByteValid();
         Object[] expected = new byte[][] {
                 new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFA},
                 new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03},
@@ -411,7 +411,7 @@ public class ArrayTests {
     @Test
     public void getByteInvalidNull() throws Exception {
         try {
-            List<byte[]> result = client.arrays().getByteInvalidNull().getBody();
+            List<byte[]> result = client.arrays().getByteInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -420,7 +420,7 @@ public class ArrayTests {
 
     @Test
     public void getBase64Url() throws Exception {
-        List<byte[]> result = client.arrays().getBase64Url().getBody();
+        List<byte[]> result = client.arrays().getBase64Url();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals("a string that gets encoded with base64url", new String(result.get(0)));
         Assert.assertEquals("test string", new String(result.get(1)));
@@ -430,7 +430,7 @@ public class ArrayTests {
     @Test
     public void getComplexNull() throws Exception {
         try {
-            List<Product> result = client.arrays().getComplexNull().getBody();
+            List<Product> result = client.arrays().getComplexNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -439,27 +439,27 @@ public class ArrayTests {
 
     @Test
     public void getComplexEmpty() throws Exception {
-        List<Product> result = client.arrays().getComplexEmpty().getBody();
+        List<Product> result = client.arrays().getComplexEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getComplexItemNull() throws Exception {
-        List<Product> result = client.arrays().getComplexItemNull().getBody();
+        List<Product> result = client.arrays().getComplexItemNull();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get(1));
     }
 
     @Test
     public void getComplexItemEmpty() throws Exception {
-        List<Product> result = client.arrays().getComplexItemEmpty().getBody();
+        List<Product> result = client.arrays().getComplexItemEmpty();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get(1).stringProperty());
     }
 
     @Test
     public void getComplexValid() throws Exception {
-        List<Product> result = client.arrays().getComplexValid().getBody();
+        List<Product> result = client.arrays().getComplexValid();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals(5, result.get(2).integer().intValue());
         Assert.assertEquals("6", result.get(2).stringProperty());
@@ -486,7 +486,7 @@ public class ArrayTests {
     @Test
     public void getArrayNull() throws Exception {
         try {
-            List<List<String>> result = client.arrays().getArrayNull().getBody();
+            List<List<String>> result = client.arrays().getArrayNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -495,27 +495,27 @@ public class ArrayTests {
 
     @Test
     public void getArrayEmpty() throws Exception {
-        List<List<String>> result = client.arrays().getArrayEmpty().getBody();
+        List<List<String>> result = client.arrays().getArrayEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getArrayItemNull() throws Exception {
-        List<List<String>> result = client.arrays().getArrayItemNull().getBody();
+        List<List<String>> result = client.arrays().getArrayItemNull();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get(1));
     }
 
     @Test
     public void getArrayItemEmpty() throws Exception {
-        List<List<String>> result = client.arrays().getArrayItemEmpty().getBody();
+        List<List<String>> result = client.arrays().getArrayItemEmpty();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals(0, result.get(1).size());
     }
 
     @Test
     public void getArrayValid() throws Exception {
-        List<List<String>> result = client.arrays().getArrayValid().getBody();
+        List<List<String>> result = client.arrays().getArrayValid();
         Assert.assertArrayEquals(new String[]{"1", "2", "3"}, result.get(0).toArray());
         Assert.assertArrayEquals(new String[]{"4", "5", "6"}, result.get(1).toArray());
         Assert.assertArrayEquals(new String[] {"7", "8", "9"}, result.get(2).toArray());
@@ -533,7 +533,7 @@ public class ArrayTests {
     @Test
     public void getDictionaryNull() throws Exception {
         try {
-            List<Map<String, String>> result = client.arrays().getDictionaryNull().getBody();
+            List<Map<String, String>> result = client.arrays().getDictionaryNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -542,27 +542,27 @@ public class ArrayTests {
 
     @Test
     public void getDictionaryEmpty() throws Exception {
-        List<Map<String, String>> result = client.arrays().getDictionaryEmpty().getBody();
+        List<Map<String, String>> result = client.arrays().getDictionaryEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getDictionaryItemNull() throws Exception {
-        List<Map<String, String>> result = client.arrays().getDictionaryItemNull().getBody();
+        List<Map<String, String>> result = client.arrays().getDictionaryItemNull();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get(1));
     }
 
     @Test
     public void getDictionaryItemEmpty() throws Exception {
-        List<Map<String, String>> result = client.arrays().getDictionaryItemEmpty().getBody();
+        List<Map<String, String>> result = client.arrays().getDictionaryItemEmpty();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals(0, result.get(1).size());
     }
 
     @Test
     public void getDictionaryValid() throws Exception {
-        List<Map<String, String>> result = client.arrays().getDictionaryValid().getBody();
+        List<Map<String, String>> result = client.arrays().getDictionaryValid();
         Assert.assertEquals("seven", result.get(2).get("7"));
         Assert.assertEquals("five", result.get(1).get("5"));
         Assert.assertEquals("three", result.get(0).get("3"));

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyboolean/BoolTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyboolean/BoolTests.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 
 import fixtures.bodyboolean.implementation.AutoRestBoolTestServiceImpl;
 
+import static org.junit.Assert.fail;
+
 public class BoolTests {
     private static AutoRestBoolTestService client;
 
@@ -18,7 +20,12 @@ public class BoolTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.bools().getNull().getBody());
+        try {
+            client.bools().getNull();
+            fail();
+        } catch (NullPointerException e) {
+            // expected
+        }
     }
 
     @Test
@@ -34,13 +41,13 @@ public class BoolTests {
 
     @Test
     public void getTrue() throws Exception {
-        boolean result = client.bools().getTrue().getBody();
+        boolean result = client.bools().getTrue();
         Assert.assertTrue(result);
     }
 
     @Test
     public void getFalse() throws Exception {
-        boolean result = client.bools().getFalse().getBody();
+        boolean result = client.bools().getFalse();
         Assert.assertFalse(result);
     }
 

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodybyte/ByteOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodybyte/ByteOperationsTests.java
@@ -17,18 +17,18 @@ public class ByteOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.bytes().getNull().getBody());
+        Assert.assertNull(client.bytes().getNull());
     }
 
     @Test
     public void getEmpty() throws Exception {
-        byte[] result = client.bytes().getEmpty().getBody();
+        byte[] result = client.bytes().getEmpty();
         Assert.assertEquals(0, result.length);
     }
 
     @Test
     public void getNonAscii() throws Exception {
-        byte[] result = client.bytes().getNonAscii().getBody();
+        byte[] result = client.bytes().getNonAscii();
         byte[] expected = new byte[] {
                 (byte) 0xff, (byte) 0xfe, (byte) 0xfd, (byte) 0xfc, (byte) 0xfb,
                 (byte) 0xfa, (byte) 0xf9, (byte) 0xf8, (byte) 0xf7, (byte) 0xf6

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/ArrayTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/ArrayTests.java
@@ -19,7 +19,7 @@ public class ArrayTests {
 
     @Test
     public void getValid() throws Exception {
-        ArrayWrapper result = client.arrays().getValid().getBody();
+        ArrayWrapper result = client.arrays().getValid();
         Assert.assertEquals(5, result.array().size());
         Assert.assertEquals("&S#$(*Y", result.array().get(3));
     }
@@ -33,7 +33,7 @@ public class ArrayTests {
 
     @Test
     public void getEmpty() throws Exception {
-        ArrayWrapper result = client.arrays().getEmpty().getBody();
+        ArrayWrapper result = client.arrays().getEmpty();
         Assert.assertEquals(0, result.array().size());
     }
 
@@ -46,7 +46,7 @@ public class ArrayTests {
 
     @Test
     public void getNotProvided() throws Exception {
-        ArrayWrapper result = client.arrays().getNotProvided().getBody();
+        ArrayWrapper result = client.arrays().getNotProvided();
         Assert.assertNull(result.array());
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/BasicOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/BasicOperationsTests.java
@@ -26,7 +26,7 @@ public class BasicOperationsTests {
 
     @Test
     public void getValid() throws Exception {
-        Basic result = client.basics().getValid().getBody();
+        Basic result = client.basics().getValid();
         Assert.assertEquals(2, result.id().intValue());
         Assert.assertEquals("abc", result.name());
         Assert.assertEquals(CMYKColors.YELLOW, result.color());
@@ -54,18 +54,18 @@ public class BasicOperationsTests {
 
     @Test
     public void getEmpty() throws Exception {
-        Basic result = client.basics().getEmpty().getBody();
+        Basic result = client.basics().getEmpty();
         Assert.assertNull(result.name());
     }
 
     @Test
     public void getNull() throws Exception {
-        Basic result = client.basics().getNull().getBody();
+        Basic result = client.basics().getNull();
         Assert.assertNull(result.name());
     }
 
     @Test
     public void getNotProvided() throws Exception {
-        Assert.assertNull(client.basics().getNotProvided().getBody());
+        Assert.assertNull(client.basics().getNotProvided());
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/DictionaryTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/DictionaryTests.java
@@ -20,7 +20,7 @@ public class DictionaryTests {
 
     @Test
     public void getValid() throws Exception {
-        DictionaryWrapper result = client.dictionarys().getValid().getBody();
+        DictionaryWrapper result = client.dictionarys().getValid();
         Assert.assertEquals(5, result.defaultProgram().size());
         Assert.assertEquals("", result.defaultProgram().get("exe"));
         Assert.assertEquals(null, result.defaultProgram().get(""));
@@ -41,7 +41,7 @@ public class DictionaryTests {
 
     @Test
     public void getEmpty() throws Exception {
-        DictionaryWrapper result = client.dictionarys().getEmpty().getBody();
+        DictionaryWrapper result = client.dictionarys().getEmpty();
         Assert.assertEquals(0, result.defaultProgram().size());
     }
 
@@ -54,13 +54,13 @@ public class DictionaryTests {
 
     @Test
     public void getNull() throws Exception {
-        DictionaryWrapper result = client.dictionarys().getNull().getBody();
+        DictionaryWrapper result = client.dictionarys().getNull();
         Assert.assertNull(result.defaultProgram());
     }
 
     @Test
     public void getNotProvided() throws Exception {
-        DictionaryWrapper result = client.dictionarys().getNotProvided().getBody();
+        DictionaryWrapper result = client.dictionarys().getNotProvided();
         Assert.assertNull(result.defaultProgram());
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/InheritanceTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/InheritanceTests.java
@@ -19,7 +19,7 @@ public class InheritanceTests {
 
     @Test
     public void getValid() throws Exception {
-        Siamese result = client.inheritances().getValid().getBody();
+        Siamese result = client.inheritances().getValid();
         Assert.assertEquals("persian", result.breed());
         Assert.assertEquals("green", result.color());
         Assert.assertEquals(2, result.id().intValue());

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/PolymorphismTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/PolymorphismTests.java
@@ -25,7 +25,7 @@ public class PolymorphismTests {
 
     @Test
     public void getValid() throws Exception {
-        Fish result = client.polymorphisms().getValid().getBody();
+        Fish result = client.polymorphisms().getValid();
         Assert.assertEquals(Salmon.class, result.getClass());
         Salmon salmon = (Salmon) result;
         Assert.assertEquals("alaska", salmon.location());

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/PolymorphismrecursiveTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/PolymorphismrecursiveTests.java
@@ -23,7 +23,7 @@ public class PolymorphismrecursiveTests {
 
     @Test
     public void getValid() throws Exception {
-        Fish result = client.polymorphicrecursives().getValid().getBody();
+        Fish result = client.polymorphicrecursives().getValid();
         Salmon salmon = (Salmon) result;
         Shark sib1 = (Shark) (salmon.siblings().get(0));
         Salmon sib2 = (Salmon) (sib1.siblings().get(0));

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/PrimitiveTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/PrimitiveTests.java
@@ -31,7 +31,7 @@ public class PrimitiveTests {
 
     @Test
     public void getInt() throws Exception {
-        IntWrapper result = client.primitives().getInt().getBody();
+        IntWrapper result = client.primitives().getInt();
         Assert.assertEquals(Integer.valueOf(-1), result.field1());
         Assert.assertEquals(Integer.valueOf(2), result.field2());
     }
@@ -46,7 +46,7 @@ public class PrimitiveTests {
 
     @Test
     public void getLong() throws Exception {
-        LongWrapper result = client.primitives().getLong().getBody();
+        LongWrapper result = client.primitives().getLong();
         Assert.assertEquals(Long.valueOf(1099511627775L), result.field1());
         Assert.assertEquals(Long.valueOf(-999511627788L), result.field2());
     }
@@ -61,7 +61,7 @@ public class PrimitiveTests {
 
     @Test
     public void getFloat() throws Exception {
-        FloatWrapper result = client.primitives().getFloat().getBody();
+        FloatWrapper result = client.primitives().getFloat();
         Assert.assertEquals(1.05, result.field1(), 0f);
         Assert.assertEquals(-0.003, result.field2(), 0f);
     }
@@ -76,7 +76,7 @@ public class PrimitiveTests {
 
     @Test
     public void getDouble() throws Exception {
-        DoubleWrapper result = client.primitives().getDouble().getBody();
+        DoubleWrapper result = client.primitives().getDouble();
         Assert.assertEquals(3e-100, result.field1(), 0f);
         Assert.assertEquals(-0.000000000000000000000000000000000000000000000000000000005,
                 result.field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose(),
@@ -93,7 +93,7 @@ public class PrimitiveTests {
 
     @Test
     public void getBool() throws Exception {
-        BooleanWrapper result = client.primitives().getBool().getBody();
+        BooleanWrapper result = client.primitives().getBool();
         Assert.assertEquals(true, result.fieldTrue());
         Assert.assertEquals(false, result.fieldFalse());
     }
@@ -108,7 +108,7 @@ public class PrimitiveTests {
 
     @Test
     public void getString() throws Exception {
-        StringWrapper result = client.primitives().getString().getBody();
+        StringWrapper result = client.primitives().getString();
         Assert.assertEquals("goodrequest", result.field());
         Assert.assertEquals("", result.empty());
         Assert.assertEquals(null, result.nullProperty());
@@ -124,7 +124,7 @@ public class PrimitiveTests {
 
     @Test
     public void getDate() throws Exception {
-        DateWrapper result = client.primitives().getDate().getBody();
+        DateWrapper result = client.primitives().getDate();
         Assert.assertEquals(new LocalDate(1, 1, 1), result.field());
         Assert.assertEquals(new LocalDate(2016, 2, 29), result.leap());
     }
@@ -139,7 +139,7 @@ public class PrimitiveTests {
 
     @Test
     public void getDateTime() throws Exception {
-        DatetimeWrapper result = client.primitives().getDateTime().getBody();
+        DatetimeWrapper result = client.primitives().getDateTime();
         Assert.assertEquals(new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC), result.field());
         Assert.assertEquals(new DateTime(2015, 5, 18, 18, 38, 0, DateTimeZone.UTC), result.now());
     }
@@ -154,7 +154,7 @@ public class PrimitiveTests {
 
     @Test
     public void getDateTimeRfc1123() throws Exception {
-        Datetimerfc1123Wrapper result = client.primitives().getDateTimeRfc1123().getBody();
+        Datetimerfc1123Wrapper result = client.primitives().getDateTimeRfc1123();
         Assert.assertEquals(new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC), result.field());
         Assert.assertEquals(new DateTime(2015, 5, 18, 11, 38, 0, DateTimeZone.UTC), result.now());
     }
@@ -169,7 +169,7 @@ public class PrimitiveTests {
 
     @Test
     public void getDuration() throws Exception {
-        DurationWrapper result = client.primitives().getDuration().getBody();
+        DurationWrapper result = client.primitives().getDuration();
         Assert.assertEquals(new Period(0, 0, 0, 123, 22, 14, 12, 11), result.field());
     }
 
@@ -182,7 +182,7 @@ public class PrimitiveTests {
 
     @Test
     public void getByte() throws Exception {
-        ByteWrapper result = client.primitives().getByte().getBody();
+        ByteWrapper result = client.primitives().getByte();
         byte[] expected = new byte[] {
                 (byte) 255, (byte) 254, (byte) 253, (byte) 252, (byte) 0,
                 (byte) 250, (byte) 249, (byte) 248, (byte) 247, (byte) 246

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/ReadonlypropertyTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodycomplex/ReadonlypropertyTests.java
@@ -1,9 +1,10 @@
 package fixtures.bodycomplex;
 
-import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceImpl;
-import fixtures.bodycomplex.models.ReadonlyObj;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceImpl;
+import fixtures.bodycomplex.models.ReadonlyObj;
 
 public class ReadonlypropertyTests {
     private static AutoRestComplexTestService client;
@@ -15,7 +16,7 @@ public class ReadonlypropertyTests {
 
     @Test
     public void putReadOnlyPropertyValid() throws Exception {
-        ReadonlyObj o = client.readonlypropertys().getValid().getBody();
-        client.readonlypropertys().putValid(o).getResponse().code();
+        ReadonlyObj o = client.readonlypropertys().getValid();
+        client.readonlypropertys().putValid(o);
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodydate/DateOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodydate/DateOperationsTests.java
@@ -21,7 +21,7 @@ public class DateOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.dates().getNull().getBody());
+        Assert.assertNull(client.dates().getNull());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class DateOperationsTests {
     @Test
     public void getMaxDate() throws Exception {
         LocalDate expected = new LocalDate(9999, 12, 31);
-        LocalDate result = client.dates().getMaxDate().getBody();
+        LocalDate result = client.dates().getMaxDate();
         Assert.assertEquals(expected, result);
     }
 
@@ -79,7 +79,7 @@ public class DateOperationsTests {
     @Test
     public void getMinDate() throws Exception {
         LocalDate expected = new LocalDate(1, 1, 1);
-        LocalDate result = client.dates().getMinDate().getBody();
+        LocalDate result = client.dates().getMinDate();
         Assert.assertEquals(expected, result);
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodydatetime/DatetimeOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodydatetime/DatetimeOperationsTests.java
@@ -19,7 +19,7 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.datetimes().getNull().getBody());
+        Assert.assertNull(client.datetimes().getNull());
     }
 
     @Test
@@ -35,7 +35,7 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getOverflowDate() throws Exception {
-        DateTime result = client.datetimes().getOverflow().getBody();
+        DateTime result = client.datetimes().getOverflow();
         // 9999-12-31T23:59:59.999-14:000
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeZone.forOffsetHours(-14));
         expected = expected.toDateTime(DateTimeZone.UTC);
@@ -61,14 +61,14 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getUtcLowercaseMaxDateTime() throws Exception {
-        DateTime result = client.datetimes().getUtcLowercaseMaxDateTime().getBody();
+        DateTime result = client.datetimes().getUtcLowercaseMaxDateTime();
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void getUtcUppercaseMaxDateTime() throws Exception {
-        DateTime result = client.datetimes().getUtcUppercaseMaxDateTime().getBody();
+        DateTime result = client.datetimes().getUtcUppercaseMaxDateTime();
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -81,14 +81,14 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getLocalPositiveOffsetLowercaseMaxDateTime() throws Exception {
-        DateTime result = client.datetimes().getLocalPositiveOffsetLowercaseMaxDateTime().getBody();
+        DateTime result = client.datetimes().getLocalPositiveOffsetLowercaseMaxDateTime();
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeZone.forOffsetHours(14)).toDateTime(DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void getLocalPositiveOffsetUppercaseMaxDateTime() throws Exception {
-        DateTime result = client.datetimes().getLocalPositiveOffsetUppercaseMaxDateTime().getBody();
+        DateTime result = client.datetimes().getLocalPositiveOffsetUppercaseMaxDateTime();
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeZone.forOffsetHours(14)).toDateTime(DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -101,14 +101,14 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getLocalNegativeOffsetLowercaseMaxDateTime() throws Exception {
-        DateTime result = client.datetimes().getLocalNegativeOffsetLowercaseMaxDateTime().getBody();
+        DateTime result = client.datetimes().getLocalNegativeOffsetLowercaseMaxDateTime();
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeZone.forOffsetHours(-14)).toDateTime(DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void getLocalNegativeOffsetUppercaseMaxDateTime() throws Exception {
-        DateTime result = client.datetimes().getLocalNegativeOffsetUppercaseMaxDateTime().getBody();
+        DateTime result = client.datetimes().getLocalNegativeOffsetUppercaseMaxDateTime();
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeZone.forOffsetHours(-14)).toDateTime(DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -121,7 +121,7 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getUtcMinDateTime() throws Exception {
-        DateTime result = client.datetimes().getUtcMinDateTime().getBody();
+        DateTime result = client.datetimes().getUtcMinDateTime();
         DateTime expected = new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -134,7 +134,7 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getLocalPositiveOffsetMinDateTime() throws Exception {
-        DateTime result = client.datetimes().getLocalPositiveOffsetMinDateTime().getBody();
+        DateTime result = client.datetimes().getLocalPositiveOffsetMinDateTime();
         DateTime expected = new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeZone.forOffsetHours(14)).toDateTime(DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -147,7 +147,7 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getLocalNegativeOffsetMinDateTime() throws Exception {
-        DateTime result = client.datetimes().getLocalNegativeOffsetMinDateTime().getBody();
+        DateTime result = client.datetimes().getLocalNegativeOffsetMinDateTime();
         DateTime expected = new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeZone.forOffsetHours(-14)).toDateTime(DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodydatetimerfc1123/DateTimeRfc1123OperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodydatetimerfc1123/DateTimeRfc1123OperationsTests.java
@@ -20,7 +20,7 @@ public class DateTimeRfc1123OperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.datetimerfc1123s().getNull().getBody());
+        Assert.assertNull(client.datetimerfc1123s().getNull());
     }
 
     @Test
@@ -36,7 +36,7 @@ public class DateTimeRfc1123OperationsTests {
 
     @Test
     public void getOverflowDate() throws Exception {
-        DateTime result = client.datetimerfc1123s().getOverflow().getBody();
+        DateTime result = client.datetimerfc1123s().getOverflow();
         DateTime expected = new DateTime(10000, 1, 1, 00, 00, 00, 0, DateTimeZone.UTC);
         expected = expected.toDateTime(DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
@@ -61,14 +61,14 @@ public class DateTimeRfc1123OperationsTests {
 
     @Test
     public void getUtcLowercaseMaxDateTime() throws Exception {
-        DateTime result = client.datetimerfc1123s().getUtcLowercaseMaxDateTime().getBody();
+        DateTime result = client.datetimerfc1123s().getUtcLowercaseMaxDateTime();
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 0, DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void getUtcUppercaseMaxDateTime() throws Exception {
-        DateTime result = client.datetimerfc1123s().getUtcUppercaseMaxDateTime().getBody();
+        DateTime result = client.datetimerfc1123s().getUtcUppercaseMaxDateTime();
         DateTime expected = new DateTime(9999, 12, 31, 23, 59, 59, 0, DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -81,7 +81,7 @@ public class DateTimeRfc1123OperationsTests {
 
     @Test
     public void getUtcMinDateTime() throws Exception {
-        DateTime result = client.datetimerfc1123s().getUtcMinDateTime().getBody();
+        DateTime result = client.datetimerfc1123s().getUtcMinDateTime();
         DateTime expected = new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
         Assert.assertEquals(expected, result);
     }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodydictionary/DictionaryTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodydictionary/DictionaryTests.java
@@ -28,7 +28,7 @@ public class DictionaryTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.dictionarys().getNull().getBody());
+        Assert.assertNull(client.dictionarys().getNull());
     }
 
     @Test
@@ -44,7 +44,7 @@ public class DictionaryTests {
 
     @Test
     public void getEmpty() throws Exception {
-        Map<String, Integer> result = client.dictionarys().getEmpty().getBody();
+        Map<String, Integer> result = client.dictionarys().getEmpty();
         Assert.assertEquals(0, result.keySet().size());
     }
 
@@ -55,7 +55,7 @@ public class DictionaryTests {
 
     @Test
     public void getNullValue() throws Exception {
-        Map<String, String> result = client.dictionarys().getNullValue().getBody();
+        Map<String, String> result = client.dictionarys().getNullValue();
         Assert.assertNull(result.get("key1"));
     }
 
@@ -72,13 +72,13 @@ public class DictionaryTests {
 
     @Test
     public void getEmptyStringKey() throws Exception {
-        Map<String, String> result = client.dictionarys().getEmptyStringKey().getBody();
+        Map<String, String> result = client.dictionarys().getEmptyStringKey();
         Assert.assertEquals("val1", result.get(""));
     }
 
     @Test
     public void getBooleanTfft() throws Exception {
-        Map<String, Boolean>  result = client.dictionarys().getBooleanTfft().getBody();
+        Map<String, Boolean>  result = client.dictionarys().getBooleanTfft();
         Map<String, Boolean> expected = new HashMap<String, Boolean>();
         expected.put("0", true);
         expected.put("1", false);
@@ -99,14 +99,14 @@ public class DictionaryTests {
 
     @Test
     public void getBooleanInvalidNull() throws Exception {
-        Map<String, Boolean> result = client.dictionarys().getBooleanInvalidNull().getBody();
+        Map<String, Boolean> result = client.dictionarys().getBooleanInvalidNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getBooleanInvalidString() throws Exception {
         try {
-            Map<String, Boolean> result = client.dictionarys().getBooleanInvalidString().getBody();
+            Map<String, Boolean> result = client.dictionarys().getBooleanInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("only \"true\" or \"false\" recognized"));
@@ -115,7 +115,7 @@ public class DictionaryTests {
 
     @Test
     public void getIntegerValid() throws Exception {
-        Map<String, Integer> result = client.dictionarys().getIntegerValid().getBody();
+        Map<String, Integer> result = client.dictionarys().getIntegerValid();
         Map<String, Integer> expected = new HashMap<String, Integer>();
         expected.put("0", 1);
         expected.put("1", -1);
@@ -136,14 +136,14 @@ public class DictionaryTests {
 
     @Test
     public void getIntInvalidNull() throws Exception {
-        Map<String, Integer> result = client.dictionarys().getIntInvalidNull().getBody();
+        Map<String, Integer> result = client.dictionarys().getIntInvalidNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getIntInvalidString() throws Exception {
         try {
-            Map<String, Integer> result = client.dictionarys().getIntInvalidString().getBody();
+            Map<String, Integer> result = client.dictionarys().getIntInvalidString();
             fail();
         } catch (RuntimeException ex) {
             // expected
@@ -153,7 +153,7 @@ public class DictionaryTests {
 
     @Test
     public void getLongValid() throws Exception {
-        Map<String, Long> result = client.dictionarys().getLongValid().getBody();
+        Map<String, Long> result = client.dictionarys().getLongValid();
         HashMap<String, Long> expected = new HashMap<String, Long>();
         expected.put("0", 1L);
         expected.put("1", -1L);
@@ -174,14 +174,14 @@ public class DictionaryTests {
 
     @Test
     public void getLongInvalidNull() throws Exception {
-        Map<String, Long> result = client.dictionarys().getLongInvalidNull().getBody();
+        Map<String, Long> result = client.dictionarys().getLongInvalidNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getLongInvalidString() throws Exception {
         try {
-            Map<String, Long> result = client.dictionarys().getLongInvalidString().getBody();
+            Map<String, Long> result = client.dictionarys().getLongInvalidString();
             fail();
         } catch (RuntimeException ex) {
             // expected
@@ -191,7 +191,7 @@ public class DictionaryTests {
 
     @Test
     public void getFloatValid() throws Exception {
-        Map<String, Double> result = client.dictionarys().getFloatValid().getBody();
+        Map<String, Double> result = client.dictionarys().getFloatValid();
         Map<String, Double> expected = new HashMap<String, Double>();
         expected.put("0", 0d);
         expected.put("1", -0.01d);
@@ -210,14 +210,14 @@ public class DictionaryTests {
 
     @Test
     public void getFloatInvalidNull() throws Exception {
-        Map<String, Double> result = client.dictionarys().getFloatInvalidNull().getBody();
+        Map<String, Double> result = client.dictionarys().getFloatInvalidNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getFloatInvalidString() throws Exception {
         try {
-            Map<String, Double> result = client.dictionarys().getFloatInvalidString().getBody();
+            Map<String, Double> result = client.dictionarys().getFloatInvalidString();
             fail();
         } catch (RuntimeException ex) {
             // expected
@@ -227,7 +227,7 @@ public class DictionaryTests {
 
     @Test
     public void getDoubleValid() throws Exception {
-        Map<String, Double> result = client.dictionarys().getDoubleValid().getBody();
+        Map<String, Double> result = client.dictionarys().getDoubleValid();
         Map<String, Double> expected = new HashMap<String, Double>();
         expected.put("0", 0d);
         expected.put("1", -0.01d);
@@ -247,14 +247,14 @@ public class DictionaryTests {
 
     @Test
     public void getDoubleInvalidNull() throws Exception {
-        Map<String, Double> result = client.dictionarys().getDoubleInvalidNull().getBody();
+        Map<String, Double> result = client.dictionarys().getDoubleInvalidNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getDoubleInvalidString() throws Exception {
         try {
-            Map<String, Double> result = client.dictionarys().getDoubleInvalidString().getBody();
+            Map<String, Double> result = client.dictionarys().getDoubleInvalidString();
             fail();
         } catch (RuntimeException ex) {
             // expected
@@ -264,7 +264,7 @@ public class DictionaryTests {
 
     @Test
     public void getStringValid() throws Exception {
-        Map<String, String> result = client.dictionarys().getStringValid().getBody();
+        Map<String, String> result = client.dictionarys().getStringValid();
         Map<String, String> expected = new HashMap<String, String>();
         expected.put("0", "foo1");
         expected.put("1", "foo2");
@@ -283,19 +283,19 @@ public class DictionaryTests {
 
     @Test
     public void getStringWithNull() throws Exception {
-        Map<String, String> result = client.dictionarys().getStringWithNull().getBody();
+        Map<String, String> result = client.dictionarys().getStringWithNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getStringWithInvalid() throws Exception {
-        Map<String, String> result = client.dictionarys().getStringWithInvalid().getBody();
+        Map<String, String> result = client.dictionarys().getStringWithInvalid();
         Assert.assertEquals("123", result.get("1"));
     }
 
     @Test
     public void getDateValid() throws Exception {
-        Map<String, LocalDate> result = client.dictionarys().getDateValid().getBody();
+        Map<String, LocalDate> result = client.dictionarys().getDateValid();
         Map<String, LocalDate> expected = new HashMap<String, LocalDate>();
         expected.put("0", new LocalDate(2000, 12, 1));
         expected.put("1", new LocalDate(1980, 1, 2));
@@ -314,14 +314,14 @@ public class DictionaryTests {
 
     @Test
     public void getDateInvalidNull() throws Exception {
-        Map<String, LocalDate> result = client.dictionarys().getDateInvalidNull().getBody();
+        Map<String, LocalDate> result = client.dictionarys().getDateInvalidNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getDateInvalidString() throws Exception {
         try {
-            Map<String, LocalDate> result = client.dictionarys().getDateInvalidChars().getBody();
+            Map<String, LocalDate> result = client.dictionarys().getDateInvalidChars();
             fail();
         } catch (RuntimeException ex) {
             // expected
@@ -331,7 +331,7 @@ public class DictionaryTests {
 
     @Test
     public void getDateTimeValid() throws Exception {
-        Map<String, DateTime> result = client.dictionarys().getDateTimeValid().getBody();
+        Map<String, DateTime> result = client.dictionarys().getDateTimeValid();
         Map<String, DateTime> expected = new HashMap<String, DateTime>();
         expected.put("0", new DateTime(2000, 12, 1, 0, 0, 1, DateTimeZone.UTC));
         expected.put("1", new DateTime(1980, 1, 2, 0, 11, 35, DateTimeZone.forOffsetHours(1))
@@ -352,14 +352,14 @@ public class DictionaryTests {
 
     @Test
     public void getDateTimeInvalidNull() throws Exception {
-        Map<String, DateTime> result = client.dictionarys().getDateTimeInvalidNull().getBody();
+        Map<String, DateTime> result = client.dictionarys().getDateTimeInvalidNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getDateTimeInvalidString() throws Exception {
         try {
-            Map<String, DateTime> result = client.dictionarys().getDateTimeInvalidChars().getBody();
+            Map<String, DateTime> result = client.dictionarys().getDateTimeInvalidChars();
             fail();
         } catch (RuntimeException ex) {
             // expected
@@ -369,7 +369,7 @@ public class DictionaryTests {
 
     @Test
     public void getDateTimeRfc1123Valid() throws Exception {
-        Map<String, DateTime> result = client.dictionarys().getDateTimeRfc1123Valid().getBody();
+        Map<String, DateTime> result = client.dictionarys().getDateTimeRfc1123Valid();
         Map<String, DateTime> expected = new HashMap<String, DateTime>();
         expected.put("0", new DateTime(2000, 12, 1, 0, 0, 1, DateTimeZone.UTC));
         expected.put("1", new DateTime(1980, 1, 2, 0, 11, 35, DateTimeZone.UTC));
@@ -388,7 +388,7 @@ public class DictionaryTests {
 
     @Test
     public void getDurationValid() throws Exception {
-        Map<String, Period> result = client.dictionarys().getDurationValid().getBody();
+        Map<String, Period> result = client.dictionarys().getDurationValid();
         Map<String, Period> expected = new HashMap<String, Period>();
         expected.put("0", new Period(0, 0, 0, 123, 22, 14, 12, 11));
         expected.put("1", new Period(0, 0, 0, 5, 1, 0, 0, 0));
@@ -405,7 +405,7 @@ public class DictionaryTests {
 
     @Test
     public void getByteValid() throws Exception {
-        Map<String, byte[]> result = client.dictionarys().getByteValid().getBody();
+        Map<String, byte[]> result = client.dictionarys().getByteValid();
         Map<String, byte[]> expected = new HashMap<String, byte[]>();
         expected.put("0", new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFA});
         expected.put("1", new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03});
@@ -426,13 +426,13 @@ public class DictionaryTests {
 
     @Test
     public void getByteInvalidNull() throws Exception {
-        Map<String, byte[]> result = client.dictionarys().getByteInvalidNull().getBody();
+        Map<String, byte[]> result = client.dictionarys().getByteInvalidNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getBase64Url() throws Exception {
-        Map<String, byte[]> result = client.dictionarys().getBase64Url().getBody();
+        Map<String, byte[]> result = client.dictionarys().getBase64Url();
         Assert.assertEquals("a string that gets encoded with base64url", new String(result.get("0")));
         Assert.assertEquals("test string", new String(result.get("1")));
         Assert.assertEquals("Lorem ipsum", new String(result.get("2")));
@@ -440,26 +440,26 @@ public class DictionaryTests {
 
     @Test
     public void getComplexNull() throws Exception {
-        Map<String, Widget> result = client.dictionarys().getComplexNull().getBody();
+        Map<String, Widget> result = client.dictionarys().getComplexNull();
         Assert.assertNull(result);
     }
 
     @Test
     public void getComplexEmpty() throws Exception {
-        Map<String, Widget> result = client.dictionarys().getComplexEmpty().getBody();
+        Map<String, Widget> result = client.dictionarys().getComplexEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getComplexItemNull() throws Exception {
-        Map<String, Widget> result = client.dictionarys().getComplexItemNull().getBody();
+        Map<String, Widget> result = client.dictionarys().getComplexItemNull();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getComplexItemEmpty() throws Exception {
-        Map<String, Widget> result = client.dictionarys().getComplexItemEmpty().getBody();
+        Map<String, Widget> result = client.dictionarys().getComplexItemEmpty();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get("1").integer());
         Assert.assertNull(result.get("1").stringProperty());
@@ -467,7 +467,7 @@ public class DictionaryTests {
 
     @Test
     public void getComplexValid() throws Exception {
-        Map<String, Widget> result = client.dictionarys().getComplexValid().getBody();
+        Map<String, Widget> result = client.dictionarys().getComplexValid();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals(1, result.get("0").integer().intValue());
         Assert.assertEquals("4", result.get("1").stringProperty());
@@ -493,31 +493,31 @@ public class DictionaryTests {
 
     @Test
     public void getArrayNull() throws Exception {
-        Map<String, List<String>> result = client.dictionarys().getArrayNull().getBody();
+        Map<String, List<String>> result = client.dictionarys().getArrayNull();
         Assert.assertNull(result);
     }
 
     @Test
     public void getArrayEmpty() throws Exception {
-        Map<String, List<String>> result = client.dictionarys().getArrayEmpty().getBody();
+        Map<String, List<String>> result = client.dictionarys().getArrayEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getArrayItemNull() throws Exception {
-        Map<String, List<String>> result = client.dictionarys().getArrayItemNull().getBody();
+        Map<String, List<String>> result = client.dictionarys().getArrayItemNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getArrayItemEmpty() throws Exception {
-        Map<String, List<String>> result = client.dictionarys().getArrayItemEmpty().getBody();
+        Map<String, List<String>> result = client.dictionarys().getArrayItemEmpty();
         Assert.assertEquals(0, result.get("1").size());
     }
 
     @Test
     public void getArrayValid() throws  Exception {
-        Map<String, List<String>> result = client.dictionarys().getArrayValid().getBody();
+        Map<String, List<String>> result = client.dictionarys().getArrayValid();
         Assert.assertArrayEquals(new String[] {"1", "2", "3" }, result.get("0").toArray());
         Assert.assertArrayEquals(new String[] {"4", "5", "6" }, result.get("1").toArray());
         Assert.assertArrayEquals(new String[] {"7", "8", "9" }, result.get("2").toArray());
@@ -534,30 +534,30 @@ public class DictionaryTests {
 
     @Test
     public void getDictionaryNull() throws Exception {
-        Assert.assertNull(client.dictionarys().getDictionaryNull().getBody());
+        Assert.assertNull(client.dictionarys().getDictionaryNull());
     }
 
     @Test
     public void getDictionaryEmpty() throws Exception {
-        Map<String, Map<String, String>> result = client.dictionarys().getDictionaryEmpty().getBody();
+        Map<String, Map<String, String>> result = client.dictionarys().getDictionaryEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getDictionaryItemNull() throws Exception {
-        Map<String, Map<String, String>> result = client.dictionarys().getDictionaryItemNull().getBody();
+        Map<String, Map<String, String>> result = client.dictionarys().getDictionaryItemNull();
         Assert.assertNull(result.get("1"));
     }
 
     @Test
     public void getDictionaryItemEmpty() throws Exception {
-        Map<String, Map<String, String>> result = client.dictionarys().getDictionaryItemEmpty().getBody();
+        Map<String, Map<String, String>> result = client.dictionarys().getDictionaryItemEmpty();
         Assert.assertEquals(0, result.get("1").size());
     }
 
     @Test
     public void getDictionaryValid() throws  Exception {
-        Map<String, Map<String, String>> result = client.dictionarys().getDictionaryValid().getBody();
+        Map<String, Map<String, String>> result = client.dictionarys().getDictionaryValid();
         Map<String, String> map1 = new HashMap<String, String>();
         map1.put("1", "one");
         map1.put("2", "two");

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyduration/DurationOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyduration/DurationOperationsTests.java
@@ -18,7 +18,7 @@ public class DurationOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.durations().getNull().getBody());
+        Assert.assertNull(client.durations().getNull());
     }
 
     @Test

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyfile/FilesTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyfile/FilesTests.java
@@ -1,7 +1,5 @@
 package fixtures.bodyfile;
 
-import com.microsoft.rest.ServiceResponse;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -31,11 +29,11 @@ public class FilesTests {
         ClassLoader classLoader = getClass().getClassLoader();
         try (InputStream file = classLoader.getResourceAsStream("sample.png")) {
             byte[] actual = client.files().getFileAsync()
-                .map(new Func1<ServiceResponse<InputStream>, byte[]>() {
+                .map(new Func1<InputStream, byte[]>() {
                     @Override
-                    public byte[] call(ServiceResponse<InputStream> inputStreamServiceResponse) {
+                    public byte[] call(InputStream inputStreamServiceResponse) {
                         try {
-                            return IOUtils.toByteArray(inputStreamServiceResponse.getBody());
+                            return IOUtils.toByteArray(inputStreamServiceResponse);
                         } catch (IOException e) {
                             throw Exceptions.propagate(e);
                         }
@@ -50,11 +48,11 @@ public class FilesTests {
     public void getLargeFile() throws Exception {
         final long streamSize = 3000L * 1024L * 1024L;
         long skipped = client.files().getFileLargeAsync()
-            .map(new Func1<ServiceResponse<InputStream>, Long>() {
+            .map(new Func1<InputStream, Long>() {
                 @Override
-                public Long call(ServiceResponse<InputStream> inputStreamServiceResponse) {
+                public Long call(InputStream inputStreamServiceResponse) {
                     try {
-                        return inputStreamServiceResponse.getBody().skip(streamSize);
+                        return inputStreamServiceResponse.skip(streamSize);
                     } catch (IOException e) {
                         throw Exceptions.propagate(e);
                     }
@@ -65,7 +63,7 @@ public class FilesTests {
 
     @Test
     public void getEmptyFile() throws Exception {
-        try (InputStream result = client.files().getEmptyFile().getBody()) {
+        try (InputStream result = client.files().getEmptyFile()) {
             byte[] actual = IOUtils.toByteArray(result);
             Assert.assertEquals(0, actual.length);
         }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyformdata/FormdataTests.java
@@ -1,7 +1,5 @@
 package fixtures.bodyformdata;
 
-import com.microsoft.rest.ServiceResponse;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -28,7 +26,7 @@ public class FormdataTests {
         InputStream stream = classLoader.getResourceAsStream("upload.txt");
         byte[] bytes = IOUtils.toByteArray(stream);
         stream.close();
-        InputStream result = client.formdatas().uploadFile(bytes, "sample.png").getBody();
+        InputStream result = client.formdatas().uploadFile(bytes, "sample.png");
         try {
             Assert.assertEquals(new String(bytes), IOUtils.toString(result));
         } finally {
@@ -43,11 +41,11 @@ public class FormdataTests {
             byte[] bytes = IOUtils.toByteArray(stream);
             stream.close();
             byte[] actual = client.formdatas().uploadFileViaBodyAsync(bytes)
-                    .map(new Func1<ServiceResponse<InputStream>, byte[]>() {
+                    .map(new Func1<InputStream, byte[]>() {
                         @Override
-                        public byte[] call(ServiceResponse<InputStream> inputStreamServiceResponse) {
+                        public byte[] call(InputStream inputStreamServiceResponse) {
                             try {
-                                return IOUtils.toByteArray(inputStreamServiceResponse.getBody());
+                                return IOUtils.toByteArray(inputStreamServiceResponse);
                             } catch (IOException e) {
                                 throw Exceptions.propagate(e);
                             }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyinteger/IntOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodyinteger/IntOperationsTests.java
@@ -2,7 +2,6 @@ package fixtures.bodyinteger;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.microsoft.rest.ServiceCallback;
-import com.microsoft.rest.ServiceResponse;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -30,12 +29,17 @@ public class IntOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.ints().getNull().getBody());
+        try {
+            client.ints().getNull();
+            fail();
+        } catch (NullPointerException e) {
+            // expected
+        }
     }
 
     @Test
     public void getNullAsync() throws Exception {
-        Observable.from(client.ints().getNullAsync(null)).subscribe(new Subscriber<ServiceResponse<Integer>>() {
+        Observable.from(client.ints().getNullAsync(null)).subscribe(new Subscriber<Integer>() {
             @Override
             public void onCompleted() {
                 System.out.println("completed");
@@ -47,8 +51,8 @@ public class IntOperationsTests {
             }
 
             @Override
-            public void onNext(ServiceResponse<Integer> integerServiceResponse) {
-                System.out.println(integerServiceResponse.getBody());
+            public void onNext(Integer integerServiceResponse) {
+                System.out.println(integerServiceResponse);
             }
         });
         System.out.println("checkpoint");
@@ -87,7 +91,7 @@ public class IntOperationsTests {
     @Test
     public void getOverflowInt64() throws Exception {
         try {
-            long value = client.ints().getOverflowInt64().getBody();
+            long value = client.ints().getOverflowInt64();
             Assert.assertEquals(Long.MAX_VALUE, value);
         } catch (Exception exception) {
             Assert.assertEquals(JsonParseException.class, exception.getCause().getClass());
@@ -97,7 +101,7 @@ public class IntOperationsTests {
     @Test
     public void getUnderflowInt64() throws Exception {
         try {
-            long value = client.ints().getUnderflowInt64().getBody();
+            long value = client.ints().getUnderflowInt64();
             Assert.assertEquals(Long.MIN_VALUE, value);
         } catch (Exception exception) {
             Assert.assertEquals(JsonParseException.class, exception.getCause().getClass());
@@ -112,8 +116,7 @@ public class IntOperationsTests {
             }
 
             @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
+            public void success(Void response) {
                 lock.countDown();
             }
         });
@@ -128,8 +131,7 @@ public class IntOperationsTests {
             }
 
             @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
+            public void success(Void response) {
                 lock.countDown();
             }
         });
@@ -144,8 +146,7 @@ public class IntOperationsTests {
             }
 
             @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
+            public void success(Void response) {
                 lock.countDown();
             }
         });
@@ -160,8 +161,7 @@ public class IntOperationsTests {
             }
 
             @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
+            public void success(Void response) {
                 lock.countDown();
             }
         });
@@ -170,7 +170,7 @@ public class IntOperationsTests {
 
     @Test
     public void getUnixTime() throws Exception {
-        DateTime result = client.ints().getUnixTime().getBody();
+        DateTime result = client.ints().getUnixTime();
         Assert.assertEquals(new DateTime(2016, 4, 13, 0, 0, 0, DateTimeZone.UTC), result);
     }
 
@@ -191,7 +191,7 @@ public class IntOperationsTests {
 
     @Test
     public void getNullUnixTime() throws Exception {
-        DateTime result = client.ints().getNullUnixTime().getBody();
+        DateTime result = client.ints().getNullUnixTime();
         Assert.assertNull(result);
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodynumber/NumberTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodynumber/NumberTests.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 
 import fixtures.bodynumber.implementation.AutoRestNumberTestServiceImpl;
 
+import static org.junit.Assert.fail;
+
 public class NumberTests {
     private static AutoRestNumberTestService client;
 
@@ -17,7 +19,12 @@ public class NumberTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.numbers().getNull().getBody());
+        try {
+            client.numbers().getNull();
+            fail();
+        } catch (NullPointerException e) {
+            // expected
+        }
     }
 
     @Test
@@ -54,13 +61,13 @@ public class NumberTests {
 
     @Test
     public void getBigFloat() throws Exception {
-        double result = client.numbers().getBigFloat().getBody();
+        double result = client.numbers().getBigFloat();
         Assert.assertEquals(3.402823e+20, result, 0.0f);
     }
 
     @Test
     public void getBigDouble() throws Exception {
-        double result = client.numbers().getBigDouble().getBody();
+        double result = client.numbers().getBigDouble();
         Assert.assertEquals(2.5976931e+101, result, 0.0f);
     }
 
@@ -71,7 +78,7 @@ public class NumberTests {
 
     @Test
     public void getBigDoublePositiveDecimal() throws Exception {
-        double result = client.numbers().getBigDoublePositiveDecimal().getBody();
+        double result = client.numbers().getBigDoublePositiveDecimal();
         Assert.assertEquals(99999999.99, result, 0.0f);
     }
 
@@ -82,7 +89,7 @@ public class NumberTests {
 
     @Test
     public void getBigDoubleNegativeDecimal() throws Exception {
-        double result = client.numbers().getBigDoubleNegativeDecimal().getBody();
+        double result = client.numbers().getBigDoubleNegativeDecimal();
         Assert.assertEquals(-99999999.99, result, 0.0f);
     }
 
@@ -93,7 +100,7 @@ public class NumberTests {
 
     @Test
     public void getSmallFloat() throws Exception {
-        double result = client.numbers().getSmallFloat().getBody();
+        double result = client.numbers().getSmallFloat();
         Assert.assertEquals(3.402823e-20, result, 0.0f);
     }
 
@@ -104,7 +111,7 @@ public class NumberTests {
 
     @Test
     public void getSmallDouble() throws Exception {
-        double result = client.numbers().getSmallDouble().getBody();
+        double result = client.numbers().getSmallDouble();
         Assert.assertEquals(2.5976931e-101, result, 0.0f);
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodystring/EnumOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodystring/EnumOperationsTests.java
@@ -19,7 +19,7 @@ public class EnumOperationsTests {
 
     @Test
     public void getNotExpandable() throws Exception {
-        Colors result = client.enums().getNotExpandable().getBody();
+        Colors result = client.enums().getNotExpandable();
         Assert.assertEquals(Colors.RED_COLOR, result);
     }
 

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodystring/StringOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/bodystring/StringOperationsTests.java
@@ -2,7 +2,6 @@ package fixtures.bodystring;
 
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceException;
-import com.microsoft.rest.ServiceResponse;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -24,7 +23,7 @@ public class StringOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.strings().getNull().getBody());
+        Assert.assertNull(client.strings().getNull());
     }
 
     @Test
@@ -39,7 +38,7 @@ public class StringOperationsTests {
 
     @Test
     public void getEmpty() throws Exception {
-        String result = client.strings().getEmpty().getBody();
+        String result = client.strings().getEmpty();
         Assert.assertEquals("", result);
     }
 
@@ -51,8 +50,7 @@ public class StringOperationsTests {
             }
 
             @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
+            public void success(Void response) {
                 lock.countDown();
             }
         });
@@ -61,7 +59,7 @@ public class StringOperationsTests {
 
     @Test
     public void getMbcs() throws Exception {
-        String result = client.strings().getMbcs().getBody();
+        String result = client.strings().getMbcs();
         String expected = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑ\uE7C7ɡ〇〾⿻⺁\uE843䜣\uE864€";
         Assert.assertEquals(expected, result);
     }
@@ -74,7 +72,7 @@ public class StringOperationsTests {
 
     @Test
     public void getWhitespace() throws Exception {
-        String result = client.strings().getWhitespace().getBody();
+        String result = client.strings().getWhitespace();
         Assert.assertEquals("    Now is the time for all good men to come to the aid of their country    ", result);
     }
 
@@ -95,19 +93,19 @@ public class StringOperationsTests {
 
     @Test
     public void getBase64Encoded() throws Exception {
-        byte[] result = client.strings().getBase64Encoded().getBody();
+        byte[] result = client.strings().getBase64Encoded();
         Assert.assertEquals("a string that gets encoded with base64", new String(result));
     }
 
     @Test
     public void getBase64UrlEncoded() throws Exception {
-        byte[] result = client.strings().getBase64UrlEncoded().getBody();
+        byte[] result = client.strings().getBase64UrlEncoded();
         Assert.assertEquals("a string that gets encoded with base64url", new String(result));
     }
 
     @Test
     public void getNullBase64UrlEncoded() throws Exception {
-        byte[] result = client.strings().getNullBase64UrlEncoded().getBody();
+        byte[] result = client.strings().getNullBase64UrlEncoded();
         Assert.assertNull(result);
     }
 

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/custombaseuri/CustomBaseUriTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/custombaseuri/CustomBaseUriTests.java
@@ -28,7 +28,7 @@ public class CustomBaseUriTests {
     @Test
     public void getEmptyWithValidCustomUri() throws Exception {
         client.withHost("host:3000");
-        Assert.assertTrue(client.paths().getEmpty("local").getResponse().isSuccessful());
+        client.paths().getEmpty("local");
     }
 
     @Test
@@ -102,7 +102,7 @@ public class CustomBaseUriTests {
             @Override
             public void run() {
                 try {
-                    Assert.assertTrue(client1.paths().getEmpty("local").getResponse().isSuccessful());
+                    client1.paths().getEmpty("local");
                     latch.countDown();
                 } catch (Exception ex) {
                     fail();

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/custombaseurimoreoptions/CustomBaseUriMoreOptionsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/custombaseurimoreoptions/CustomBaseUriMoreOptionsTests.java
@@ -1,6 +1,5 @@
 package fixtures.custombaseurimoreoptions;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -24,6 +23,6 @@ public class CustomBaseUriMoreOptionsTests {
     @Test
     public void getEmpty() throws Exception {
         client.withDnsSuffix("host:3000");
-        Assert.assertTrue(client.paths().getEmpty("http://lo", "cal", "key1", "v1").getResponse().isSuccessful());
+        client.paths().getEmpty("http://lo", "cal", "key1", "v1");
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/header/HeaderOperationsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/header/HeaderOperationsTests.java
@@ -1,7 +1,6 @@
 package fixtures.header;
 
-import com.microsoft.rest.ServiceCallback;
-import com.microsoft.rest.ServiceResponse;
+import com.microsoft.rest.ServiceResponseWithHeaders;
 
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
@@ -20,7 +19,22 @@ import java.util.concurrent.TimeUnit;
 import fixtures.header.implementation.AutoRestSwaggerBATHeaderServiceImpl;
 import fixtures.header.models.ErrorException;
 import fixtures.header.models.GreyscaleColors;
+import fixtures.header.models.HeaderResponseBoolHeaders;
+import fixtures.header.models.HeaderResponseByteHeaders;
+import fixtures.header.models.HeaderResponseDateHeaders;
+import fixtures.header.models.HeaderResponseDatetimeHeaders;
+import fixtures.header.models.HeaderResponseDatetimeRfc1123Headers;
+import fixtures.header.models.HeaderResponseDoubleHeaders;
+import fixtures.header.models.HeaderResponseDurationHeaders;
+import fixtures.header.models.HeaderResponseEnumHeaders;
+import fixtures.header.models.HeaderResponseExistingKeyHeaders;
+import fixtures.header.models.HeaderResponseFloatHeaders;
+import fixtures.header.models.HeaderResponseIntegerHeaders;
+import fixtures.header.models.HeaderResponseLongHeaders;
+import fixtures.header.models.HeaderResponseProtectedKeyHeaders;
+import fixtures.header.models.HeaderResponseStringHeaders;
 import okhttp3.Headers;
+import rx.functions.Action1;
 
 import static org.junit.Assert.fail;
 
@@ -41,21 +55,22 @@ public class HeaderOperationsTests {
     @Test
     public void responseExistingKey() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseExistingKeyAsync(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("User-Agent") != null) {
-                    Assert.assertEquals("overwrite", headers.get("User-Agent"));
-                    lock.countDown();
+        client.headers().responseExistingKeyWithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("User-Agent") != null) {
+                        Assert.assertEquals("overwrite", headers.get("User-Agent"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -71,21 +86,22 @@ public class HeaderOperationsTests {
     @Test
     public void responseProtectedKey() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseProtectedKeyAsync(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("Content-Type") != null) {
-                    Assert.assertTrue(headers.get("Content-Type").contains("text/html"));
-                    lock.countDown();
+        client.headers().responseProtectedKeyWithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("Content-Type") != null) {
+                        Assert.assertTrue(headers.get("Content-Type").contains("text/html"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -98,38 +114,40 @@ public class HeaderOperationsTests {
     @Test
     public void responseInteger() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseIntegerAsync("positive", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("1", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseIntegerWithServiceResponseAsync("positive")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("1", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseIntegerAsync("negative", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("-2", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseIntegerWithServiceResponseAsync("negative")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("-2", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -142,38 +160,40 @@ public class HeaderOperationsTests {
     @Test
     public void responseLong() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseLongAsync("positive", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("105", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseLongWithServiceResponseAsync("positive")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("105", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseLongAsync("negative", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("-2", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseLongWithServiceResponseAsync("negative")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("-2", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -186,38 +206,40 @@ public class HeaderOperationsTests {
     @Test
     public void responseFloat() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseFloatAsync("positive", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("0.07", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseFloatWithServiceResponseAsync("positive")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("0.07", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseFloatAsync("negative", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("-3", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseFloatWithServiceResponseAsync("negative")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("-3", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -230,38 +252,40 @@ public class HeaderOperationsTests {
     @Test
     public void responseDouble() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseDoubleAsync("positive", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("7e+120", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseDoubleWithServiceResponseAsync("positive")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("7e+120", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseDoubleAsync("negative", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("-3", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseDoubleWithServiceResponseAsync("negative")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("-3", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -274,38 +298,40 @@ public class HeaderOperationsTests {
     @Test
     public void responseBool() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseBoolAsync("true", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("true", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseBoolWithServiceResponseAsync("true")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("true", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseBoolAsync("false", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("false", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseBoolWithServiceResponseAsync("false")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("false", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -319,55 +345,58 @@ public class HeaderOperationsTests {
     @Test
     public void responseString() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseStringAsync("valid", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("The quick brown fox jumps over the lazy dog", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseStringWithServiceResponseAsync("valid")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("The quick brown fox jumps over the lazy dog", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseStringAsync("null", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("null", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseStringWithServiceResponseAsync("null")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("null", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseStringAsync("empty", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseStringWithServiceResponseAsync("empty")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -380,38 +409,40 @@ public class HeaderOperationsTests {
     @Test
     public void responseDate() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseDateAsync("valid", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("2010-01-01", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseDateWithServiceResponseAsync("valid")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("2010-01-01", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseDateAsync("min", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("0001-01-01", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseDateWithServiceResponseAsync("min")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("0001-01-01", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -423,21 +454,22 @@ public class HeaderOperationsTests {
     @Test
     public void responseDuration() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseDurationAsync("valid", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("P123DT22H14M12.011S", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseDurationWithServiceResponseAsync("valid")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("P123DT22H14M12.011S", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -450,40 +482,41 @@ public class HeaderOperationsTests {
     @Test
     public void responseDatetimeRfc1123() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseDatetimeRfc1123Async("valid", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("Fri, 01 Jan 2010 12:34:56 GMT", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseDatetimeRfc1123WithServiceResponseAsync("valid")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("Fri, 01 Jan 2010 12:34:56 GMT", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(100000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseDatetimeRfc1123Async("min", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
+        client.headers().responseDatetimeRfc1123WithServiceResponseAsync("min")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("Mon, 01 Jan 0001 00:00:00 GMT", headers.get("value"));
+                        lock.countDown();
 
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("Mon, 01 Jan 0001 00:00:00 GMT", headers.get("value"));
-                    lock.countDown();
-
+                    }
                 }
-
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -496,38 +529,40 @@ public class HeaderOperationsTests {
     @Test
     public void responseDatetime() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseDatetimeAsync("valid", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("2010-01-01T12:34:56Z", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseDatetimeWithServiceResponseAsync("valid")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("2010-01-01T12:34:56Z", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseDatetimeAsync("min", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("0001-01-01T00:00:00Z", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseDatetimeWithServiceResponseAsync("min")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("0001-01-01T00:00:00Z", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -539,23 +574,24 @@ public class HeaderOperationsTests {
     @Test
     public void responseByte() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseByteAsync("valid", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    byte[] value = Base64.decodeBase64(headers.get("value"));
-                    String actual = new String(value, Charset.forName("UTF-8"));
-                    Assert.assertEquals("啊齄丂狛狜隣郎隣兀﨩", actual);
-                    lock.countDown();
+        client.headers().responseByteWithServiceResponseAsync("valid")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        byte[] value = Base64.decodeBase64(headers.get("value"));
+                        String actual = new String(value, Charset.forName("UTF-8"));
+                        Assert.assertEquals("啊齄丂狛狜隣郎隣兀﨩", actual);
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -568,38 +604,40 @@ public class HeaderOperationsTests {
     @Test
     public void responseEnum() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseEnumAsync("valid", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("GREY", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseEnumWithServiceResponseAsync("valid")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("GREY", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseEnumAsync("null", new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Headers headers = response.getResponse().headers();
-                if (headers.get("value") != null) {
-                    Assert.assertEquals("", headers.get("value"));
-                    lock.countDown();
+        client.headers().responseEnumWithServiceResponseAsync("null")
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders> response) {
+                    Headers headers = response.getResponse().headers();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("", headers.get("value"));
+                        lock.countDown();
+                    }
                 }
-            }
-        });
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/http/HttpRedirectsTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/http/HttpRedirectsTests.java
@@ -1,7 +1,7 @@
 package fixtures.http;
 
-import com.microsoft.rest.ServiceCallback;
-import com.microsoft.rest.ServiceResponse;
+import com.microsoft.rest.ServiceResponseWithHeaders;
+
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -12,8 +12,22 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import fixtures.http.implementation.AutoRestHttpInfrastructureTestServiceImpl;
-
-import static org.junit.Assert.fail;
+import fixtures.http.models.HttpRedirectsDelete307Headers;
+import fixtures.http.models.HttpRedirectsGet300Headers;
+import fixtures.http.models.HttpRedirectsGet301Headers;
+import fixtures.http.models.HttpRedirectsGet302Headers;
+import fixtures.http.models.HttpRedirectsGet307Headers;
+import fixtures.http.models.HttpRedirectsHead300Headers;
+import fixtures.http.models.HttpRedirectsHead301Headers;
+import fixtures.http.models.HttpRedirectsHead302Headers;
+import fixtures.http.models.HttpRedirectsHead307Headers;
+import fixtures.http.models.HttpRedirectsPatch302Headers;
+import fixtures.http.models.HttpRedirectsPatch307Headers;
+import fixtures.http.models.HttpRedirectsPost303Headers;
+import fixtures.http.models.HttpRedirectsPost307Headers;
+import fixtures.http.models.HttpRedirectsPut301Headers;
+import fixtures.http.models.HttpRedirectsPut307Headers;
+import rx.functions.Action1;
 
 public class HttpRedirectsTests {
     private static AutoRestHttpInfrastructureTestService client;
@@ -26,258 +40,198 @@ public class HttpRedirectsTests {
 
     @Test
     public void head300() throws Exception {
-        client.httpRedirects().head300Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getHeadResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().head300WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead300Headers> response) {
+                    Assert.assertEquals(200, response.getHeadResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(100000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void get300() throws Exception {
-        client.httpRedirects().get300Async(new ServiceCallback<List<String>>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<List<String>> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().get300WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<List<String>, HttpRedirectsGet300Headers> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void head301() throws Exception {
-        client.httpRedirects().head301Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getHeadResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().head301WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead301Headers> response) {
+                    Assert.assertEquals(200, response.getHeadResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void get301() throws Exception {
-        client.httpRedirects().get301Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().get301WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet301Headers> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     @Ignore("Not supported yet")
     public void put301() throws Exception {
-        client.httpRedirects().put301Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(301, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().put301WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut301Headers> response) {
+                    Assert.assertEquals(301, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void head302() throws Exception {
-        client.httpRedirects().head302Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getHeadResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().head302WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead302Headers> response) {
+                    Assert.assertEquals(200, response.getHeadResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void get302() throws Exception {
-        client.httpRedirects().get302Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().get302WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet302Headers> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     @Ignore("Not supported yet")
     public void patch302() throws Exception {
-        client.httpRedirects().patch302Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(302, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().patch302WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch302Headers> response) {
+                    Assert.assertEquals(302, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void post303() throws Exception {
-        client.httpRedirects().post303Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().post303WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost303Headers> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void head307() throws Exception {
-        client.httpRedirects().head307Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getHeadResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().head307WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsHead307Headers> response) {
+                    Assert.assertEquals(200, response.getHeadResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void get307() throws Exception {
-        client.httpRedirects().get307Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().get307WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsGet307Headers> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void put307() throws Exception {
-        client.httpRedirects().put307Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(307, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().put307WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsPut307Headers> response) {
+                    Assert.assertEquals(307, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void patch307() throws Exception {
-        client.httpRedirects().patch307Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(307, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().patch307WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsPatch307Headers> response) {
+                    Assert.assertEquals(307, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void post307() throws Exception {
-        client.httpRedirects().post307Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(307, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().post307WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsPost307Headers> response) {
+                    Assert.assertEquals(307, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void delete307() throws Exception {
-        client.httpRedirects().delete307Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(307, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRedirects().delete307WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers>>() {
+                @Override
+                public void call(ServiceResponseWithHeaders<Void, HttpRedirectsDelete307Headers> response) {
+                    Assert.assertEquals(307, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/http/HttpRetryTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/http/HttpRetryTests.java
@@ -1,7 +1,7 @@
 package fixtures.http;
 
-import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceResponse;
+
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -10,8 +10,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import fixtures.http.implementation.AutoRestHttpInfrastructureTestServiceImpl;
-
-import static org.junit.Assert.fail;
+import rx.functions.Action1;
 
 public class HttpRetryTests {
     private static AutoRestHttpInfrastructureTestService client;
@@ -24,137 +23,105 @@ public class HttpRetryTests {
 
     @Test
     public void head408() throws Exception {
-        client.httpRetrys().head408Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getHeadResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRetrys().head408WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(200, response.getHeadResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void put500() throws Exception {
-        client.httpRetrys().put500Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRetrys().put500WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void patch500() throws Exception {
-        client.httpRetrys().patch500Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRetrys().patch500WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void get502() throws Exception {
-        client.httpRetrys().get502Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRetrys().get502WithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(50000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void post503() throws Exception {
-        client.httpRetrys().post503Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRetrys().post503WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void delete503() throws Exception {
-        client.httpRetrys().delete503Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRetrys().delete503WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void put504() throws Exception {
-        client.httpRetrys().put504Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRetrys().put504WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void patch504() throws Exception {
-        client.httpRetrys().patch504Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.httpRetrys().patch504WithServiceResponseAsync(true)
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(200, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/http/HttpSuccessTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/http/HttpSuccessTests.java
@@ -1,18 +1,11 @@
 package fixtures.http;
 
-import com.microsoft.rest.ServiceCall;
-import com.microsoft.rest.ServiceCallback;
-import com.microsoft.rest.ServiceResponse;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import fixtures.http.implementation.AutoRestHttpInfrastructureTestServiceImpl;
-
-import static org.junit.Assert.fail;
 
 public class HttpSuccessTests {
     private static AutoRestHttpInfrastructureTestService client;
@@ -25,296 +18,91 @@ public class HttpSuccessTests {
 
     @Test
     public void head200() throws Exception {
-        ServiceCall<Void> serviceCall = client.httpSuccess().head200Async(null);
-        Assert.assertEquals(200, serviceCall.get().getHeadResponse().code());
+        client.httpSuccess().head200();
     }
 
     @Test
     public void get200() throws Exception {
-        client.httpSuccess().get200Async(new ServiceCallback<Boolean>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Boolean> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().get200();
     }
 
     @Test
     public void put200() throws Exception {
-        client.httpSuccess().put200Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().put200(true);
     }
 
     @Test
     public void patch200() throws Exception {
-        client.httpSuccess().patch200Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().patch200(true);
     }
 
     @Test
     public void post200() throws Exception {
-        client.httpSuccess().post200Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().post200(true);
     }
 
     @Test
     public void delete200() throws Exception {
-        client.httpSuccess().delete200Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(200, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().delete200(true);
     }
 
     @Test
     public void put201() throws Exception {
-        client.httpSuccess().put201Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(201, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().put201(true);
     }
 
     @Test
     public void post201() throws Exception {
-        client.httpSuccess().post201Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(201, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().post201(true);
     }
 
     @Test
     public void put202() throws Exception {
-        client.httpSuccess().put202Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(202, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().put202(true);
     }
 
     @Test
     public void patch202() throws Exception {
-        client.httpSuccess().patch202Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(202, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().patch202(true);
     }
 
     @Test
     public void post202() throws Exception {
-        client.httpSuccess().post202Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(202, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().post202(true);
     }
 
     @Test
     public void delete202() throws Exception {
-        client.httpSuccess().delete202Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(202, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().delete202(true);
     }
 
     @Test
     public void head204() throws Exception {
-        client.httpSuccess().head204Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(204, response.getHeadResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().head204();
     }
 
     @Test
     public void put204() throws Exception {
-        client.httpSuccess().put204Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(204, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().put204(true);
     }
 
     @Test
     public void patch204() throws Exception {
-        client.httpSuccess().patch204Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(204, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().patch204(true);
     }
 
     @Test
     public void post204() throws Exception {
-        client.httpSuccess().post204Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(204, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().post204(true);
     }
 
     @Test
     public void delete204() throws Exception {
-        client.httpSuccess().delete204Async(true, new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(204, response.getResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().delete204(true);
     }
 
     @Test
     public void head404() throws Exception {
-        client.httpSuccess().head404Async(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(404, response.getHeadResponse().code());
-                lock.countDown();
-            }
-        });
-        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        client.httpSuccess().head404();
     }
 }

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/http/MultipleResponsesTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/http/MultipleResponsesTests.java
@@ -1,6 +1,5 @@
 package fixtures.http;
 
-import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceException;
 import com.microsoft.rest.ServiceResponse;
 
@@ -18,6 +17,7 @@ import fixtures.http.models.D;
 import fixtures.http.models.Error;
 import fixtures.http.models.ErrorException;
 import fixtures.http.models.MyException;
+import rx.functions.Action1;
 
 import static org.junit.Assert.fail;
 
@@ -32,14 +32,14 @@ public class MultipleResponsesTests {
 
     @Test
     public void get200Model204NoModelDefaultError200Valid() throws Exception {
-        A result = client.multipleResponses().get200Model204NoModelDefaultError200Valid().getBody();
+        A result = client.multipleResponses().get200Model204NoModelDefaultError200Valid();
         Assert.assertEquals(A.class, result.getClass());
         Assert.assertEquals("200", result.statusCode());
     }
 
     @Test
     public void get200Model204NoModelDefaultError204Valid() throws Exception {
-        A result = client.multipleResponses().get200Model204NoModelDefaultError204Valid().getBody();
+        A result = client.multipleResponses().get200Model204NoModelDefaultError204Valid();
         Assert.assertNull(result);
     }
 
@@ -56,7 +56,7 @@ public class MultipleResponsesTests {
     @Test
     public void get200Model204NoModelDefaultError202None() throws Exception {
         try {
-            A result = client.multipleResponses().get200Model204NoModelDefaultError202None().getBody();
+            A result = client.multipleResponses().get200Model204NoModelDefaultError202None();
         } catch (ErrorException ex) {
             Assert.assertEquals(202, ex.getResponse().code());
         }
@@ -74,13 +74,13 @@ public class MultipleResponsesTests {
 
     @Test
     public void get200Model201ModelDefaultError200Valid() throws Exception {
-        A result = client.multipleResponses().get200Model201ModelDefaultError200Valid().getBody();
+        A result = client.multipleResponses().get200Model201ModelDefaultError200Valid();
         Assert.assertEquals("200", result.statusCode());
     }
 
     @Test
     public void get200Model201ModelDefaultError201Valid() throws Exception {
-        A result = client.multipleResponses().get200Model201ModelDefaultError201Valid().getBody();
+        A result = client.multipleResponses().get200Model201ModelDefaultError201Valid();
         Assert.assertEquals("201", result.statusCode());
     }
 
@@ -91,30 +91,28 @@ public class MultipleResponsesTests {
             fail();
         } catch (ErrorException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
-            Error model = client.mapperAdapter().getObjectMapper().convertValue(
-                    ex.getBody(), Error.class);
-            Assert.assertEquals(400, model.status().intValue());
-            Assert.assertEquals("client error", model.message());
+            Assert.assertEquals(400, ex.getBody().status().intValue());
+            Assert.assertEquals("client error", ex.getBody().message());
         }
     }
 
     @Test
     public void get200ModelA201ModelC404ModelDDefaultError200Valid() throws Exception {
-        Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError200Valid().getBody();
+        Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError200Valid();
         A actual = (A) result;
         Assert.assertEquals("200", actual.statusCode());
     }
 
     @Test
     public void get200ModelA201ModelC404ModelDDefaultError201Valid() throws Exception {
-        Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError201Valid().getBody();
+        Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError201Valid();
         C actual = (C) result;
         Assert.assertEquals("201", actual.httpCode());
     }
 
     @Test
     public void get200ModelA201ModelC404ModelDDefaultError404Valid() throws Exception {
-        Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError404Valid().getBody();
+        Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError404Valid();
         D actual = (D) result;
         Assert.assertEquals("404", actual.httpStatusCode());
     }
@@ -126,8 +124,7 @@ public class MultipleResponsesTests {
             fail();
         } catch (ErrorException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
-            Error model = client.mapperAdapter().getObjectMapper().convertValue(
-                    ex.getBody(), Error.class);
+            Error model = ex.getBody();
             Assert.assertEquals(400, model.status().intValue());
             Assert.assertEquals("client error", model.message());
         }
@@ -135,35 +132,27 @@ public class MultipleResponsesTests {
 
     @Test
     public void get202None204NoneDefaultError202None() throws Exception {
-        client.multipleResponses().get202None204NoneDefaultError202NoneAsync(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(202, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.multipleResponses().get202None204NoneDefaultError202NoneWithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(202, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void get202None204NoneDefaultError204None() throws Exception {
-        client.multipleResponses().get202None204NoneDefaultError204NoneAsync(new ServiceCallback<Void>() {
-            @Override
-            public void failure(Throwable t) {
-                fail();
-            }
-
-            @Override
-            public void success(ServiceResponse<Void> response) {
-                Assert.assertEquals(204, response.getResponse().code());
-                lock.countDown();
-            }
-        });
+        client.multipleResponses().get202None204NoneDefaultError204NoneWithServiceResponseAsync()
+            .subscribe(new Action1<ServiceResponse<Void>>() {
+                @Override
+                public void call(ServiceResponse<Void> response) {
+                    Assert.assertEquals(204, response.getResponse().code());
+                    lock.countDown();
+                }
+            });
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
@@ -174,8 +163,7 @@ public class MultipleResponsesTests {
             fail();
         } catch (ErrorException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
-            Error model = client.mapperAdapter().getObjectMapper().convertValue(
-                    ex.getBody(), Error.class);
+            Error model = ex.getBody();
             Assert.assertEquals(400, model.status().intValue());
             Assert.assertEquals("client error", model.message());
         }
@@ -213,13 +201,13 @@ public class MultipleResponsesTests {
 
     @Test
     public void getDefaultModelA200Valid() throws Exception {
-        A result = client.multipleResponses().getDefaultModelA200Valid().getBody();
+        A result = client.multipleResponses().getDefaultModelA200Valid();
         Assert.assertEquals("200", result.statusCode());
     }
 
     @Test
     public void getDefaultModelA200None() throws Exception {
-        A result = client.multipleResponses().getDefaultModelA200None().getBody();
+        A result = client.multipleResponses().getDefaultModelA200None();
         Assert.assertNull(result);
     }
 
@@ -230,9 +218,7 @@ public class MultipleResponsesTests {
             fail();
         } catch (MyException ex) {
             Assert.assertEquals(400, ex.getResponse().code());
-            A model = client.mapperAdapter().getObjectMapper().convertValue(
-                    ex.getBody(), A.class);
-            Assert.assertEquals("400", model.statusCode());
+            Assert.assertEquals("400", ex.getBody().statusCode());
         }
     }
 
@@ -278,19 +264,19 @@ public class MultipleResponsesTests {
 
     @Test
     public void get200ModelA200None() throws Exception {
-        A result = client.multipleResponses().get200ModelA200None().getBody();
+        A result = client.multipleResponses().get200ModelA200None();
         Assert.assertNull(result);
     }
 
     @Test
     public void get200ModelA200Valid() throws Exception {
-        A result = client.multipleResponses().get200ModelA200Valid().getBody();
+        A result = client.multipleResponses().get200ModelA200Valid();
         Assert.assertEquals("200", result.statusCode());
     }
 
     @Test
     public void get200ModelA200Invalid() throws Exception {
-        Assert.assertEquals(null, client.multipleResponses().get200ModelA200Invalid().getBody().statusCode());
+        Assert.assertEquals(null, client.multipleResponses().get200ModelA200Invalid().statusCode());
     }
 
     @Test

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/modelflattening/ModelFlatteningTests.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/modelflattening/ModelFlatteningTests.java
@@ -1,7 +1,5 @@
 package fixtures.modelflattening;
 
-import com.microsoft.rest.ServiceResponse;
-
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,7 +26,7 @@ public class ModelFlatteningTests {
 
     @Test
     public void getArray() throws Exception {
-        List<FlattenedProduct> result = client.getArray().getBody();
+        List<FlattenedProduct> result = client.getArray();
         Assert.assertEquals(3, result.size());
         // Resource 1
         Assert.assertEquals("1", result.get(0).id());
@@ -62,13 +60,12 @@ public class ModelFlatteningTests {
         FlattenedProduct product1 = new FlattenedProduct();
         product1.withLocation("Building 44");
         body.add(product1);
-        ServiceResponse<Void> response = client.putArray(body);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.putArray(body);
     }
 
     @Test
     public void getDictionary() throws Exception {
-        Map<String, FlattenedProduct> result = client.getDictionary().getBody();
+        Map<String, FlattenedProduct> result = client.getDictionary();
         Assert.assertEquals(3, result.size());
         // Resource 1
         Assert.assertEquals("1", result.get("Product1").id());
@@ -106,13 +103,12 @@ public class ModelFlatteningTests {
         product1.withPname("Product2");
         product1.withFlattenedProductType("Flat");
         body.put("Resource2", product1);
-        ServiceResponse<Void> response = client.putDictionary(body);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.putDictionary(body);
     }
 
     @Test
     public void getResourceCollection() throws Exception {
-        ResourceCollection resultResource = client.getResourceCollection().getBody();
+        ResourceCollection resultResource = client.getResourceCollection();
         //Dictionaryofresources
         Assert.assertEquals(3, resultResource.dictionaryofresources().size());
         // Resource 1
@@ -191,8 +187,7 @@ public class ModelFlatteningTests {
         pr.withFlattenedProductType("Flat");
         complexObj.withProductresource(pr);
 
-        ServiceResponse<Void> response = client.putResourceCollection(complexObj);
-        Assert.assertEquals(200, response.getResponse().code());
+        client.putResourceCollection(complexObj);
     }
 
     @Test
@@ -205,7 +200,7 @@ public class ModelFlatteningTests {
         simpleProduct.withOdatavalue("http://foo");
         simpleProduct.withGenericValue("https://generic");
 
-        SimpleProduct product = client.putSimpleProduct(simpleProduct).getBody();
+        SimpleProduct product = client.putSimpleProduct(simpleProduct);
         assertSimpleProductEquals(simpleProduct, product);
     }
 
@@ -236,7 +231,7 @@ public class ModelFlatteningTests {
         flattenParameterGroup.withOdatavalue("http://foo");
         flattenParameterGroup.withName("groupproduct");
 
-        SimpleProduct product = client.putSimpleProductWithGrouping(flattenParameterGroup).getBody();
+        SimpleProduct product = client.putSimpleProductWithGrouping(flattenParameterGroup);
         assertSimpleProductEquals(simpleProduct, product);
     }
 

--- a/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/report/CoverageReporter.java
+++ b/src/generator/AutoRest.Java.Tests/src/test/java/fixtures/report/CoverageReporter.java
@@ -12,7 +12,7 @@ public final class CoverageReporter {
     private CoverageReporter() { }
 
     public static void main(String[] args) throws Exception {
-        Map<String, Integer> report = client.getReport().getBody();
+        Map<String, Integer> report = client.getReport();
 
         // Body cannot be null
         report.put("putStringNull", 1);

--- a/src/generator/AutoRest.Java/Templates/MethodInterfaceTemplate.cshtml
+++ b/src/generator/AutoRest.Java/Templates/MethodInterfaceTemplate.cshtml
@@ -32,7 +32,7 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-@Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString;
+@Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString;
 @EmptyLine
 /**
 @if (!string.IsNullOrEmpty(Model.Summary))
@@ -52,6 +52,56 @@ else
  * @@return the {@@link ServiceCall} object
  */
 ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclarationWithCallback);
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
+}
+@if (Model.ReturnType.Body != null)
+{
+@: * @@return the observable to the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+}
+ */
+Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration);
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
+}
+@if (Model.ReturnType.Body != null)
+{
+@: * @@return the observable to the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+}
+ */
+Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)AsyncWithServiceResponse(@Model.MethodRequiredParameterDeclaration);
 </text>
 }
 /**
@@ -81,7 +131,7 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-@Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString;
+@Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString;
 @EmptyLine
 /**
 @if (!string.IsNullOrEmpty(Model.Summary))
@@ -125,4 +175,29 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)Async(@Model.MethodParameterDeclaration);
+Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterString> @(Model.Name)Async(@Model.MethodParameterDeclaration);
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
+}
+@if (Model.ReturnType.Body != null)
+{
+@: * @@return the observable to the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+}
+ */
+Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)AsyncWithServiceResponse(@Model.MethodParameterDeclaration);

--- a/src/generator/AutoRest.Java/Templates/MethodInterfaceTemplate.cshtml
+++ b/src/generator/AutoRest.Java/Templates/MethodInterfaceTemplate.cshtml
@@ -25,11 +25,7 @@
 }
 @if (Model.ReturnType.Body != null)
 {
-@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object wrapped in {@@link @Model.ReturnTypeModel.ClientResponseType} if successful.
-}
-else
-{
-@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object if successful.
 }
  */
 @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString;
@@ -63,7 +59,7 @@ ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(Model.Na
 @: * @Model.Description.EscapeXmlComment().Period()
 }
  *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
 {
 @: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
 }
@@ -88,7 +84,7 @@ Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterString> @(Model
 @: * @Model.Description.EscapeXmlComment().Period()
 }
  *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
 {
 @: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
 }
@@ -101,7 +97,7 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)AsyncWithServiceResponse(@Model.MethodRequiredParameterDeclaration);
+Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterDeclaration);
 </text>
 }
 /**
@@ -124,11 +120,7 @@ Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> 
 }
 @if (Model.ReturnType.Body != null)
 {
-@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object wrapped in {@@link @Model.ReturnTypeModel.ClientResponseType} if successful.
-}
-else
-{
-@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object if successful.
 }
  */
 @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString;
@@ -200,4 +192,4 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)AsyncWithServiceResponse(@Model.MethodParameterDeclaration);
+Observable<@Model.ReturnTypeModel.ServiceResponseGenericParameterStringWrapped> @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterDeclaration);

--- a/src/generator/AutoRest.Java/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Java/Templates/MethodTemplate.cshtml
@@ -91,7 +91,7 @@ public Observable<@Model.ReturnTypeModel.GenericBodyClientTypeString> @(Model.Na
         public @Model.ReturnTypeModel.GenericBodyClientTypeString call(@Model.ReturnTypeModel.ClientResponseTypeString response) {
             return response.getBody();
         }
-    }); 
+    });
 }
 @EmptyLine
 /**
@@ -189,11 +189,11 @@ public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)
 public @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString {
 @if (@Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name == "void")
 {
-@:    @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().single().getBody();
+@:    @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation).toBlocking().single().getBody();
 }
 else
 {
-@:    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().single().getBody();
+@:    return @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation).toBlocking().single().getBody();
 }
 }
 @EmptyLine
@@ -228,7 +228,7 @@ public ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(M
 @: * @Model.Description.EscapeXmlComment().Period()
 }
  *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
 {
 @: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
 }
@@ -247,7 +247,7 @@ public Observable<@Model.ReturnTypeModel.GenericBodyClientTypeString> @(Model.Na
         public @Model.ReturnTypeModel.GenericBodyClientTypeString call(@Model.ReturnTypeModel.ClientResponseTypeString response) {
             return response.getBody();
         }
-    }); 
+    });
 }
 @EmptyLine
 /**

--- a/src/generator/AutoRest.Java/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Java/Templates/MethodTemplate.cshtml
@@ -27,15 +27,18 @@
 }
 @if (Model.ReturnType.Body != null)
 {
-@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object wrapped in {@@link @Model.ReturnTypeModel.ClientResponseType} if successful.
+@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object if successful.
+}
+ */
+public @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString {
+@if (@Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name == "void")
+{
+@:    @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().single().getBody();
 }
 else
 {
-@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+@:    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().single().getBody();
 }
- */
-public @Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.MethodRequiredParameterDeclaration) throws @Model.ExceptionString {
-    return @(Model.Name)Async(@Model.MethodRequiredParameterInvocation).toBlocking().single();
 }
 @EmptyLine
 /**
@@ -56,7 +59,7 @@ public @Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.Meth
  * @@return the {@@link ServiceCall} object
  */
 public ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclarationWithCallback) {
-    return ServiceCall.@(Model.ServiceCallFactoryMethod)(@(Model.Name)Async(@Model.MethodRequiredParameterInvocation), serviceCallback);
+    return ServiceCall.@(Model.ServiceCallFactoryMethod)(@(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation), serviceCallback);
 }
 @EmptyLine
 /**
@@ -82,7 +85,39 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration) {
+public Observable<@Model.ReturnTypeModel.GenericBodyClientTypeString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration) {
+    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).map(new Func1<@Model.ReturnTypeModel.ClientResponseTypeString, @Model.ReturnTypeModel.GenericBodyClientTypeString>() {
+        @@Override
+        public @Model.ReturnTypeModel.GenericBodyClientTypeString call(@Model.ReturnTypeModel.ClientResponseTypeString response) {
+            return response.getBody();
+        }
+    }); 
+}
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
+}
+@if (Model.ReturnType.Body != null)
+{
+@: * @@return the observable to the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+}
+ */
+public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterDeclaration) {
 @foreach (var param in Model.RequiredNullableParameters)
 {
 @:    if (@param.Name == null) {
@@ -148,15 +183,18 @@ public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)
 }
 @if (Model.ReturnType.Body != null)
 {
-@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object wrapped in {@@link @Model.ReturnTypeModel.ClientResponseType} if successful.
+@: * @@return the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object if successful.
+}
+ */
+public @Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString {
+@if (@Model.ReturnTypeModel.BodyClientType.ResponseVariant.Name == "void")
+{
+@:    @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().single().getBody();
 }
 else
 {
-@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+@:    return @(Model.Name)WithServiceResponseAsync(@Model.MethodRequiredParameterInvocation).toBlocking().single().getBody();
 }
- */
-public @Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.MethodParameterDeclaration) throws @Model.ExceptionString {
-    return @(Model.Name)Async(@Model.MethodParameterInvocation).toBlocking().single();
 }
 @EmptyLine
 /**
@@ -177,7 +215,39 @@ public @Model.ReturnTypeModel.ClientResponseTypeString @(Model.Name)(@Model.Meth
  * @@return the {@@link ServiceCall} object
  */
 public ServiceCall<@Model.ReturnTypeModel.ServiceCallGenericParameterString> @(Model.Name)Async(@Model.MethodParameterDeclarationWithCallback) {
-    return ServiceCall.@(Model.ServiceCallFactoryMethod)(@(Model.Name)Async(@Model.MethodParameterInvocation), serviceCallback);
+    return ServiceCall.@(Model.ServiceCallFactoryMethod)(@(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation), serviceCallback);
+}
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.Type.ToString() + " value" : param.Documentation).EscapeXmlComment().Trim())
+}
+@if (Model.ReturnType.Body != null)
+{
+@: * @@return the observable to the @Model.ReturnTypeModel.BodyClientType.Name.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
+}
+ */
+public Observable<@Model.ReturnTypeModel.GenericBodyClientTypeString> @(Model.Name)Async(@Model.MethodParameterDeclaration) {
+    return @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterInvocation).map(new Func1<@Model.ReturnTypeModel.ClientResponseTypeString, @Model.ReturnTypeModel.GenericBodyClientTypeString>() {
+        @@Override
+        public @Model.ReturnTypeModel.GenericBodyClientTypeString call(@Model.ReturnTypeModel.ClientResponseTypeString response) {
+            return response.getBody();
+        }
+    }); 
 }
 @EmptyLine
 /**
@@ -203,7 +273,7 @@ else
 @: * @@return the {@@link @Model.ReturnTypeModel.ClientResponseType} object if successful.
 }
  */
-public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)Async(@Model.MethodParameterDeclaration) {
+public Observable<@Model.ReturnTypeModel.ClientResponseTypeString> @(Model.Name)WithServiceResponseAsync(@Model.MethodParameterDeclaration) {
 @foreach (var param in Model.RequiredNullableParameters)
 {
 @:    if (@param.Name == null) {

--- a/src/generator/AutoRest.Java/TypeModels/ResponseModel.cs
+++ b/src/generator/AutoRest.Java/TypeModels/ResponseModel.cs
@@ -51,7 +51,7 @@ namespace AutoRest.Java.TypeModels
             }
         }
 
-        public ITypeModel BodyClientType
+        public virtual ITypeModel BodyClientType
         {
             get
             {


### PR DESCRIPTION
Used to be
```java
ServiceResponse<Foo> getFoo();
Future<ServiceResponse<Foo>> getFooAsync(Callback<ServiceResponse<Foo>> cb);
Observable<ServiceResponse<Foo>> getFooAsync();
```
Now it's
```java
Foo getFoo();
Future<Foo> getFooAsync(Callback<Foo> cb);
Observable<Foo> getFooAsync();
Observable<ServiceResponse<Foo>> getFooWithServiceResponse();
```