### PR TITLE
Changed Constants.HttpVerbs to Constants.HttpConstants.HttpVerbs in r…

### DIFF
--- a/src/client/NodeJS/ms-rest/lib/requestPipeline.js
+++ b/src/client/NodeJS/ms-rest/lib/requestPipeline.js
@@ -9,7 +9,7 @@ var duplexer = require('duplexer');
 var _ = require('underscore');
 var Constants = require('./constants');
 
-var HttpVerbs = Constants.HttpVerbs;
+var HttpVerbs = Constants.HttpConstants.HttpVerbs;
 
 //
 // Request pipelines are functions that allow you to


### PR DESCRIPTION
…equestPipe.js.

HttpVerbs is undefined because HttpVerbs is under Constants.HttpConstants. See below:

var Constants: {
    HTTP: string;
    HTTPS: string;
    HTTP_PROXY: string;
    HTTPS_PROXY: string;
    HttpConstants: {
        HttpVerbs: {
            PUT: string;
            GET: string;
            DELETE: string;
            POST: string;
            MERGE: string;
            HEAD: string;
            PATCH: string;
        };
    };
    HeaderConstants: {
        AUTHORIZATION: string;
        AUTHORIZATION_SCHEME: string;
    };
}