### PR TITLE
Fixing TestResults dir path

### DIFF
--- a/src/dev/TestServer/server/app.js
+++ b/src/dev/TestServer/server/app.js
@@ -44,7 +44,7 @@ var app = express();
 var now = new Date();
 var logFileName = 'AccTestServer-' + now.getHours() +
     now.getMinutes() + now.getSeconds() + '.log';
-var testResultDir = path.join(__dirname, '../../../TestResults');
+var testResultDir = path.join(__dirname, '../../../../TestResults');
 if (!fs.existsSync(testResultDir)) {
   fs.mkdirSync(testResultDir);
 }


### PR DESCRIPTION
Creating the TestResults directory under root dir like build.proj does

@fearthecowboy 