### PR TITLE
Supporting relative $ref paths in Swagger files

### DIFF
--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -61,6 +61,30 @@ Licensed under the MIT License. See License.txt in the project root for license 
         /// </summary>
         public IFileSystem FileSystem { get; set; }
 
+        private Uri _inputFolder = null;
+        /// <summary>
+        /// Gets the Uri for the path to the folder that contains the input specification file.
+        /// </summary>
+        public Uri InputFolder
+        {
+            get
+            {
+                if (_inputFolder == null)
+                {
+                    var isBasePathUri = Uri.IsWellFormedUriString(Input, UriKind.Absolute);
+                    if (isBasePathUri)
+                    {
+                        _inputFolder = new Uri(new Uri(Input), ".");
+                    }
+                    else
+                    {
+                        _inputFolder = new Uri(Path.Combine(Directory.GetParent(Input).FullName, "."));
+                    }
+                }
+                return _inputFolder;
+            }
+        }
+
         /// <summary>
         /// Custom provider specific settings.
         /// </summary>
@@ -241,7 +265,7 @@ Licensed under the MIT License. See License.txt in the project root for license 
         [SettingsAlias("cgs")]
         [SettingsInfo("The path for a json file containing code generation settings.")]
         public string CodeGenSettings { get; set; }
-        
+
         /// <summary>
         /// The input validation severity level that will prevent code generation
         /// </summary>
@@ -369,14 +393,14 @@ Licensed under the MIT License. See License.txt in the project root for license 
                                 var elementType = property.PropertyType.GetElementType();
                                 if (elementType == typeof(string))
                                 {
-                                    var stringArray = ((JArray) setting.Value).Children().
+                                    var stringArray = ((JArray)setting.Value).Children().
                                     Select(
                                         c => c.ToString())
                                     .ToArray();
-  
+
                                     property.SetValue(entityToPopulate, stringArray);
                                 }
-                                else if (elementType == typeof (int))
+                                else if (elementType == typeof(int))
                                 {
                                     var intValues = ((JArray)setting.Value).Children().
                                          Select(c => (int)Convert.ChangeType(c, elementType, CultureInfo.InvariantCulture))
@@ -404,7 +428,7 @@ Licensed under the MIT License. See License.txt in the project root for license 
 
         public void Validate()
         {
-            foreach (PropertyInfo property in (typeof (Settings)).GetProperties())
+            foreach (PropertyInfo property in (typeof(Settings)).GetProperties())
             {
                 // If property value is not set - throw exception.
                 var doc = property.GetCustomAttributes<SettingsInfoAttribute>().FirstOrDefault();

--- a/src/core/AutoRest.Core/Utilities/FileSystem.cs
+++ b/src/core/AutoRest.Core/Utilities/FileSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -12,6 +13,28 @@ namespace AutoRest.Core.Utilities
         public void WriteFile(string path, string contents)
         {
             File.WriteAllText(path, contents, Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Returns whether or not that <paramref name="path"/> is an absolute URI or rooted path
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static bool IsCompletePath(string path)
+            => Path.IsPathRooted(path) || Uri.IsWellFormedUriString(path, UriKind.Absolute);
+
+        /// <summary>
+        /// Roots the <paramref name="relativePath"/> using the <paramref name="rootPath"/>
+        /// Works whether the <paramref name="rootPath"/> is an absolute URI (e.g. https://contoso.com/swaggers)
+        /// or a rooted local URI (e.g. C:/swaggers/)
+        /// </summary>
+        /// <param name="rootPath"></param>
+        /// <param name="relativePath"></param>
+        /// <returns></returns>
+        public static string MakePathRooted(Uri rootPath, string relativePath)
+        {
+            var combined = new Uri(rootPath, relativePath);
+            return combined.IsAbsoluteUri ? combined.AbsoluteUri : combined.LocalPath;
         }
 
         public string ReadFileAsText(string path)

--- a/src/modeler/AutoRest.CompositeSwagger/CompositeSwaggerModeler.cs
+++ b/src/modeler/AutoRest.CompositeSwagger/CompositeSwaggerModeler.cs
@@ -53,31 +53,14 @@ namespace AutoRest.CompositeSwagger
                 throw ErrorManager.CreateError(Resources.InfoSectionMissing);
             }
 
-            //Ensure all the docs are absolute paths
-            string basePath;
-            var isBasePathUri = Uri.IsWellFormedUriString(Settings.Input, UriKind.Absolute);
-            if (isBasePathUri)
-            {
-                basePath = new Uri(new Uri(Settings.Input), ".").ToString();
-            }
-            else
-            {
-                basePath = Directory.GetParent(Settings.Input).FullName;
-            }
+            // Ensure all the docs are absolute URIs or rooted paths
             for (var i = 0; i < compositeSwaggerModel.Documents.Count; i++)
             {
-                if (!(Path.IsPathRooted(compositeSwaggerModel.Documents[i]) ||
-                    Uri.IsWellFormedUriString(compositeSwaggerModel.Documents[i], UriKind.Absolute)))
+                var compositeDocument = compositeSwaggerModel.Documents[i];
+                if (!FileSystem.IsCompletePath(compositeDocument))
                 {
-                    var tempPath = Path.Combine(basePath, compositeSwaggerModel.Documents[i]);
-                    if (isBasePathUri)
-                    {
-                        compositeSwaggerModel.Documents[i] = new Uri(tempPath).AbsoluteUri;
-                    }
-                    else
-                    {
-                        compositeSwaggerModel.Documents[i] = Path.GetFullPath(tempPath);
-                    }
+                    // Otherwise, root it from the current path
+                    compositeSwaggerModel.Documents[i] = FileSystem.MakePathRooted(Settings.InputFolder, compositeDocument);
                 }
             }
 
@@ -148,7 +131,7 @@ namespace AutoRest.CompositeSwagger
             }
 
             // Merge
-            if(compositeClient.BaseUrl == null)
+            if (compositeClient.BaseUrl == null)
             {
                 compositeClient.BaseUrl = subClient.BaseUrl;
             }
@@ -316,7 +299,7 @@ namespace AutoRest.CompositeSwagger
         /// <returns></returns>
         public override IEnumerable<ComparisonMessage> Compare()
         {
-            throw new NotImplementedException("Version comparison of compositions. Please run the comparison on individual specifications" );
+            throw new NotImplementedException("Version comparison of compositions. Please run the comparison on individual specifications");
         }
     }
 }

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-external-ref-no-definitions.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-external-ref-no-definitions.json
@@ -48,13 +48,13 @@
           "200": {
             "description": "A list of caches",
             "schema": {
-              "$ref": "./Swagger/swagger-external-def.json#/definitions/Product"
+              "$ref": "./swagger-external-def.json#/definitions/Product"
             }
           },
           "default": {
             "description": "Unexpected error",
             "schema": {
-              "$ref": "./Swagger/swagger-external-def.json#/definitions/Error"
+              "$ref": "./swagger-external-def.json#/definitions/Error"
             }
           }
         }
@@ -96,7 +96,7 @@
           "default": {
             "description": "Unexpected error",
             "schema": {
-              "$ref": "./Swagger/swagger-external-def.json#/definitions/Error"
+              "$ref": "./swagger-external-def.json#/definitions/Error"
             }
           }
         }

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-external-ref.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/swagger-external-ref.json
@@ -48,7 +48,7 @@
           "200": {
             "description": "A list of caches",
             "schema": {
-              "$ref": "./Swagger/swagger-external-def.json#/definitions/Product"
+              "$ref": "./swagger-external-def.json#/definitions/Product"
             }
           },
           "201": {
@@ -60,7 +60,7 @@
           "default": {
             "description": "Unexpected error",
             "schema": {
-              "$ref": "./Swagger/swagger-external-def.json#/definitions/Error"
+              "$ref": "./swagger-external-def.json#/definitions/Error"
             }
           }
         }
@@ -97,12 +97,12 @@
         ],
         "responses": {
           "204": {
-            "description": "A list of caches",
+            "description": "A list of caches"
           },
           "default": {
             "description": "Unexpected error",
             "schema": {
-              "$ref": "./Swagger/swagger-external-def.json#/definitions/Error"
+              "$ref": "./swagger-external-def.json#/definitions/Error"
             }
           }
         }
@@ -111,14 +111,14 @@
   },
   "definitions": {
     "ChildProduct": {
-      "AllOf": [ { "$ref": "./Swagger/swagger-external-def.json#/definitions/Product" } ],
+      "AllOf": [ { "$ref": "./swagger-external-def.json#/definitions/Product" } ],
       "properties": {
         "size": {
           "type": "integer",
           "description": "product size"
         },
         "parentProduct": {
-          "$ref": "./Swagger/swagger-external-def.json#/definitions/Product"
+          "$ref": "./swagger-external-def.json#/definitions/Product"
         }
       }
     }

--- a/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
+++ b/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
@@ -259,6 +259,12 @@ namespace AutoRest.Swagger
                 string[] splitReference = reference.Split(new[] { '#' }, StringSplitOptions.RemoveEmptyEntries);
                 Debug.Assert(splitReference.Length == 2);
                 string filePath = splitReference[0];
+                // Make sure the filePath is either an absolute uri, or a rooted path
+                if (!FileSystem.IsCompletePath(filePath))
+                {
+                    // Otherwise, root it from the current path
+                    filePath = FileSystem.MakePathRooted(Settings.InputFolder, filePath);
+                }
                 string externalDefinition = Settings.FileSystem.ReadFileAsText(filePath);
                 ServiceDefinition external = SwaggerParser.Parse(externalDefinition);
                 external.Definitions.ForEach(d => ServiceDefinition.Definitions[d.Key] = d.Value);


### PR DESCRIPTION
Currently, a $ref that refers to an external file with a relative path will try to resolve from the directory of AutoRest.exe, not the input Swagger file. This PR changes this behavior so that the files resolve from the input file.

- Re-using code that correctly resolves relative composite swagger file document paths
- Refactoring this code to put it in Settings and FileSystem.cs (see commit #2)
- Also fixing existing tests that validate the current (wrong) behavior

Note: This PR is a step in the right direction. It doesn't yet support multiple levels of $ref relative paths (e.g. Input spec has an absolute ref to spec A on the internet -> Spec A has a relative $ref to spec B -> This logic will try to use the folder of the Input spec file to fully resolve the $ref to spec B). This is because we don't store the file path of a file once we deserialize it. Therefore we don't have that path when we're resolving external $refs. I'm submitting this PR since it supports the most common scenario with relative $ref and it gets us closer to solving the more complicated scenario.