### PR TITLE
[Ruby] Correctly parse and use query parameters provided in nextlink format

### DIFF
--- a/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_request.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_request.rb
@@ -76,9 +76,9 @@ module MsRest
             faraday.response :logger, nil, { :bodies => logging == 'full' }
           end
         end
-        
+
         @connection.run_request(:"#{method}", build_path, body, {'User-Agent' => user_agent}.merge(headers)) do |req|
-          req.params = query_params.reject{|_, v| v.nil?} unless query_params.nil?
+          req.params = req.params.merge(query_params.reject{|_, v| v.nil?}) unless query_params.nil?
           yield(req) if block_given?
         end
       end

--- a/src/dev/TestServer/server/routes/paging.js
+++ b/src/dev/TestServer/server/routes/paging.js
@@ -143,6 +143,27 @@ var paging = function(coverage) {
     }
   });
 
+  router.get('/multiple/fragmentwithgrouping/:tenant', function(req, res, next) {
+    if(req.query.api_version != "1.6" || req.params.tenant != "test_user") {
+      res.status(400).end("Required path and query parameters are not present");
+    }
+    else {
+      res.status(200).end('{ "values": [ {"properties":{"id" : 1, "name": "product"}} ], "odata.nextLink": "next?page=2"}');
+    }
+  });
+
+  router.get('/multiple/fragmentwithgrouping/:tenant/next', function(req, res, next) {
+    if(req.query.api_version != "1.6" || req.params.tenant != "test_user") {
+      res.status(400).end("Required path and query parameters are not present");
+    }
+    else if(req.query.page < 10) {
+      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.query.page + ', "name": "product"}} ], "odata.nextLink": "next?page=' + ++req.query.page + '"}');
+    }
+    else {
+      res.status(200).end('{"values": [ {"properties":{"id" : ' + req.query.page + ', "name": "product"}} ]}');
+    }
+  });
+
   /*** NEGATIVE TESTS HERE ***/
   router.get('/single/failure', function(req, res, next) {
     coverage["PagingSingleFailure"]++;

--- a/src/dev/TestServer/swagger/paging.json
+++ b/src/dev/TestServer/swagger/paging.json
@@ -315,6 +315,46 @@
           }
         }
       }
+    },
+    "/paging/multiple/fragmentwithgrouping/{tenant}": {
+      "get": {
+        "x-ms-pageable": { "nextLinkName": "odata.nextLink", "itemName": "values", "operationName": "Paging_nextFragmentWithGrouping" },
+        "operationId": "Paging_getMultiplePagesFragmentWithGroupingNextLink",
+        "description": "A paging operation that doesn't return a full URL, just a fragment with parameters grouped",
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Sets the api version to use.",
+            "x-ms-parameter-grouping": {
+              "name": "custom-parameter-group"
+            }
+          },
+          {
+            "name": "tenant",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Sets the tenant to use.",
+            "x-ms-parameter-grouping": {
+              "name": "custom-parameter-group"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paging response with a fragment nextLink",
+            "schema": {
+              "$ref": "#/definitions/OdataProductResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
     }
   },
   "x-ms-paths": {
@@ -337,6 +377,54 @@
             "required": true,
             "type": "string",
             "description": "Sets the tenant to use."
+          },
+          {
+            "name": "nextLink",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Next link for list operation.",
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paging response with a fragment nextLink",
+            "schema": {
+              "$ref": "#/definitions/OdataProductResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}": {
+      "get": {
+        "x-ms-pageable": { "nextLinkName": "odata.nextLink", "itemName": "values", "operationName": "Paging_nextFragmentWithGrouping" },
+        "operationId": "Paging_nextFragmentWithGrouping",
+        "description": "A paging operation that doesn't return a full URL, just a fragment",
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Sets the api version to use.",
+            "x-ms-parameter-grouping": {
+              "name": "custom-parameter-group"
+            }
+          },
+          {
+            "name": "tenant",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Sets the tenant to use.",
+            "x-ms-parameter-grouping": {
+              "name": "custom-parameter-group"
+            }
           },
           {
             "name": "nextLink",

--- a/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/paging_spec.rb
+++ b/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/paging_spec.rb
@@ -129,18 +129,27 @@ describe 'Paging' do
     expect(items.count).to eq(10)
   end
 
-  it 'should get multiple pages with fragmented next link' do
+  it 'should get multiple pages with fragmented next link - lazy' do
     page = @client.paging.get_multiple_pages_fragment_next_link_as_lazy('1.6', 'test_user')
     expect(page.is_a? PagingModule::Models::ProductResult)
     expect(page.odatanext_link).not_to be_nil
 
     all_item = page.get_all_items
     expect(all_item.count).to eq(10)
+  end
 
-    # Get all items at once
+  it 'should get multiple pages with fragmented next link' do
     all_item = @client.paging.get_multiple_pages_fragment_next_link('1.6', 'test_user')
     expect(all_item[0].is_a? PagingModule::Models::ProductResult)
-    expect(page.odatanext_link).to be_nil
+    expect(all_item.count).to eq(10)
+  end
+
+  it 'should get multiple pages with fragmented grouped next link' do
+    grouped_param = PagingModule::Models::CustomParameterGroup.new
+    grouped_param.api_version = '1.6'
+    grouped_param.tenant = 'test_user'
+    all_item = @client.paging.get_multiple_pages_fragment_with_grouping_next_link(grouped_param)
+    expect(all_item[0].is_a? PagingModule::Models::ProductResult)
     expect(all_item.count).to eq(10)
   end
 

--- a/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/paging_spec.rb
+++ b/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/paging_spec.rb
@@ -129,6 +129,21 @@ describe 'Paging' do
     expect(items.count).to eq(10)
   end
 
+  it 'should get multiple pages with fragmented next link' do
+    page = @client.paging.get_multiple_pages_fragment_next_link_as_lazy('1.6', 'test_user')
+    expect(page.is_a? PagingModule::Models::ProductResult)
+    expect(page.odatanext_link).not_to be_nil
+
+    all_item = page.get_all_items
+    expect(all_item.count).to eq(10)
+
+    # Get all items at once
+    all_item = @client.paging.get_multiple_pages_fragment_next_link('1.6', 'test_user')
+    expect(all_item[0].is_a? PagingModule::Models::ProductResult)
+    expect(page.odatanext_link).to be_nil
+    expect(all_item.count).to eq(10)
+  end
+
   # Paging sad path tests
   it 'should get single pages failure' do
     expect { @client.paging.get_single_pages_failure_as_lazy }.to raise_exception(MsRest::HttpOperationError)

--- a/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/paging_spec.rb
+++ b/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/paging_spec.rb
@@ -15,6 +15,9 @@ describe 'Paging' do
     @credentials = MsRest::TokenCredentials.new(dummyToken)
 
     @client = AutoRestPagingTestService.new(@credentials, @base_url)
+
+    @tenant = 'test_user'
+    @api_version = '1.6'
   end
 
   # Paging happy path tests
@@ -130,7 +133,7 @@ describe 'Paging' do
   end
 
   it 'should get multiple pages with fragmented next link - lazy' do
-    page = @client.paging.get_multiple_pages_fragment_next_link_as_lazy('1.6', 'test_user')
+    page = @client.paging.get_multiple_pages_fragment_next_link_as_lazy(@api_version, @tenant)
     expect(page.is_a? PagingModule::Models::ProductResult)
     expect(page.odatanext_link).not_to be_nil
 
@@ -139,7 +142,7 @@ describe 'Paging' do
   end
 
   it 'should get multiple pages with fragmented next link' do
-    all_item = @client.paging.get_multiple_pages_fragment_next_link('1.6', 'test_user')
+    all_item = @client.paging.get_multiple_pages_fragment_next_link(@api_version, @tenant)
     expect(all_item[0].is_a? PagingModule::Models::ProductResult)
     expect(all_item.count).to eq(10)
   end

--- a/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
@@ -64,7 +64,8 @@ namespace AutoRest.Ruby.Azure.TemplateModels
         }
 
         /// <summary>
-        /// Returns string for next method assigned to the Page.
+        /// Returns Ruby code as string which sets `next_method` property of the page with the respective next paging method
+        /// and performs parameter re-assignment when required (ex. parameter grouping cases)
         /// </summary>
         public string AssignNextMethodToPage()
         {

--- a/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby.Azure/TemplateModels/AzureMethodTemplateModel.cs
@@ -64,30 +64,39 @@ namespace AutoRest.Ruby.Azure.TemplateModels
         }
 
         /// <summary>
-        /// Returns invocation string for next method async.
+        /// Returns string for next method assigned to the Page.
         /// </summary>
-        public string InvokeNextMethodAsync()
+        public string AssignNextMethodToPage()
         {
-            StringBuilder builder = new StringBuilder();
             string nextMethodName;
+            Method nextMethod = null;
             PageableExtension pageableExtension = JsonConvert.DeserializeObject<PageableExtension>(Extensions[AzureExtensions.PageableExtension].ToString());
 
-            Method nextMethod = null;
-            if (pageableExtension != null && !string.IsNullOrEmpty(pageableExtension.OperationName))
+            // When pageable extension have operation name
+            if (pageableExtension != null && !string.IsNullOrWhiteSpace(pageableExtension.OperationName))
             {
                 nextMethod = ServiceClient.Methods.FirstOrDefault(m =>
                     pageableExtension.OperationName.Equals(m.SerializedName, StringComparison.OrdinalIgnoreCase));
                 nextMethodName = nextMethod.Name;
             }
+            // When pageable extension does not have operation name
             else
             {
                 nextMethodName = (string)Extensions["nextMethodName"];
                 nextMethod = ServiceClient.Methods.Where(m => m.Name == nextMethodName).FirstOrDefault();
             }
 
+            IndentedStringBuilder builder = new IndentedStringBuilder("  ");
+
+            // As there is no distinguishable property in next link parameter, we'll check to see whether any parameter contains "next" in the parameter name
+            Parameter nextLinkParameter = nextMethod.Parameters.Where(p => p.Name.IndexOf("next", StringComparison.OrdinalIgnoreCase) >= 0).FirstOrDefault();
+            builder.AppendLine(String.Format(CultureInfo.InvariantCulture, "page.next_method = Proc.new do |{0}|", nextLinkParameter.Name));
+
+            // In case of parmeter grouping, next methods parameter needs to be mapped with the origin methods parameter
             IEnumerable<Parameter> origMethodGroupedParameters = Parameters.Where(p => p.Name.Contains(Name));
             if (origMethodGroupedParameters.Count() > 0)
             {
+                builder.Indent();
                 foreach (Parameter param in nextMethod.Parameters)
                 {
                     if (param.Name.Contains(nextMethod.Name) && (param.Name.Length > nextMethod.Name.Length)) //parameter that contains the method name + postfix, it's a grouped param
@@ -97,13 +106,14 @@ namespace AutoRest.Ruby.Azure.TemplateModels
                         builder.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0} = {1}", param.Name, argumentName));
                     }
                 }
+                builder.Outdent();
             }
 
-            IList<string> headerParams = nextMethod.Parameters.Where(p => (p.Location == ParameterLocation.Header || p.Location == ParameterLocation.None) && !p.IsConstant && p.ClientProperty == null).Select(p => p.Name).ToList();
-            headerParams.Add("custom_headers");
-            string nextMethodParamaterInvocation = string.Join(", ", headerParams);
+            // Create AzureMethodTemplateModel from nextMethod to determine nextMethod's MethodParameterInvocation signature
+            AzureMethodTemplateModel nextMethodTemplateModel = new AzureMethodTemplateModel(nextMethod, ServiceClient);
+            builder.Indent().AppendLine(string.Format(CultureInfo.InvariantCulture, "{0}_async({1})", nextMethodName, nextMethodTemplateModel.MethodParameterInvocation));
+            builder.Outdent().Append(String.Format(CultureInfo.InvariantCulture, "end"));
 
-            builder.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0}_async(next_link, {1})", nextMethodName, nextMethodParamaterInvocation));
             return builder.ToString();
         }
 

--- a/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
@@ -34,9 +34,7 @@ def @(Model.Name)_as_lazy(@(Model.MethodParameterDeclaration))
   response = @(Model.Name)_async(@(Model.MethodParameterInvocation)).value!
   unless response.nil?
     page = response.body
-    page.next_method = Proc.new do |next_link|
-      @(Model.InvokeNextMethodAsync())
-    end
+    @(Model.AssignNextMethodToPage())
     page
   end
 end


### PR DESCRIPTION
Fixe for https://github.com/Azure/autorest/issues/1426