### PR TITLE
[Ruby] Override into AzureOperationError to expose error_message and error_code

### DIFF
--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_operation_error.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_operation_error.rb
@@ -7,5 +7,19 @@ module MsRestAzure
   # Class which represents an Azure error.
   #
   class AzureOperationError < MsRest::HttpOperationError
+
+    def to_s
+      # Try to parse @body to find error message and set @msg
+      begin
+        unless @body.nil?
+          # Body should meet the error condition response requirements for Microsoft REST API Guidelines
+          # https://github.com/Microsoft/api-guidelines/blob/master/Guidelines.md#7102-error-condition-responses
+          @msg = @body['error']['message']
+        end
+      rescue
+      end
+
+      super
+    end
   end
 end

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_operation_error.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_operation_error.rb
@@ -31,7 +31,7 @@ module MsRestAzure
         unless @body.nil?
           @error_message = @body['error']['message']
           @error_code = @body['error']['code']
-          @msg = "#{@msg}: #{@error_message}"
+          @msg = "#{@msg}: #{@error_code}: #{@error_message}"
         end
       rescue
       end

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_operation_error.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/azure_operation_error.rb
@@ -8,18 +8,33 @@ module MsRestAzure
   #
   class AzureOperationError < MsRest::HttpOperationError
 
-    def to_s
-      # Try to parse @body to find error message and set @msg
+    # @return [String] the error message.
+    attr_accessor :error_message
+
+    # @return [String] the error code.
+    attr_accessor :error_code
+
+    #
+    # Creates and initialize new instance of the AzureOperationError class.
+    # @param [Hash] the HTTP request data (uri, body, headers).
+    # @param [Faraday::Response] the HTTP response object.
+    # @param [String] body the HTTP response body.
+    # @param [String] error message.
+    #
+    def initialize(*args)
+      super(*args)
+
+      # Try to parse @body to find useful error message and code
+      # Body should meet the error condition response requirements for Microsoft REST API Guidelines
+      # https://github.com/Microsoft/api-guidelines/blob/master/Guidelines.md#7102-error-condition-responses
       begin
         unless @body.nil?
-          # Body should meet the error condition response requirements for Microsoft REST API Guidelines
-          # https://github.com/Microsoft/api-guidelines/blob/master/Guidelines.md#7102-error-condition-responses
-          @msg = @body['error']['message']
+          @error_message = @body['error']['message']
+          @error_code = @body['error']['code']
+          @msg = "#{@msg}: #{@error_message}"
         end
       rescue
       end
-
-      super
     end
   end
 end

--- a/src/client/Ruby/ms-rest-azure/spec/azure_operation_error_spec.rb
+++ b/src/client/Ruby/ms-rest-azure/spec/azure_operation_error_spec.rb
@@ -6,11 +6,11 @@ require 'rspec'
 require 'ms_rest_azure'
 
 module MsRestAzure
-
   describe AzureOperationError do
     let(:http_response) { double('http_response', body: nil, headers: nil, status: 500) }
     let(:http_request) { double('http_request') }
-    let(:body) { double('body') }
+    let(:error_message) { 'resource group name is invalid' }
+    let(:body) { { 'error' => { 'code' => 'InvalidResourceGroup', 'message' => error_message } } }
     
     it 'should create error with message' do
       error = AzureOperationError.new 'error_message'
@@ -22,6 +22,7 @@ module MsRestAzure
       expect(error.request).to eq(http_request)
       expect(error.response).to eq(http_response)
       expect(error.body).to eq(nil)
+      # message must not contain message from body but must contains class name
       expect(error.message).to match('MsRestAzure::AzureOperationError') # Default one
     end
 
@@ -30,7 +31,8 @@ module MsRestAzure
       expect(error.request).to eq(http_request)
       expect(error.response).to eq(http_response)
       expect(error.body).to eq(body)
-      expect(error.message).to match('MsRestAzure::AzureOperationError') # Default one
+      # message must contain message from body
+      expect(error.message).to match(error_message)
     end
 
     it 'should create error with request, response, body and message' do
@@ -38,8 +40,8 @@ module MsRestAzure
       expect(error.request).to eq(http_request)
       expect(error.response).to eq(http_response)
       expect(error.body).to eq(body)
-      expect(error.message).to match('error_message')
+      # message must contain message from body
+      expect(error.message).to match(error_message)
     end
   end
-
 end

--- a/src/client/Ruby/ms-rest-azure/spec/azure_operation_error_spec.rb
+++ b/src/client/Ruby/ms-rest-azure/spec/azure_operation_error_spec.rb
@@ -10,8 +10,9 @@ module MsRestAzure
     let(:http_response) { double('http_response', body: nil, headers: nil, status: 500) }
     let(:http_request) { double('http_request') }
     let(:error_message) { 'resource group name is invalid' }
-    let(:body) { { 'error' => { 'code' => 'InvalidResourceGroup', 'message' => error_message } } }
-    
+    let(:error_code) { 'InvalidResourceGroup' }
+    let(:body) { { 'error' => { 'code' => error_code, 'message' => error_message } } }
+
     it 'should create error with message' do
       error = AzureOperationError.new 'error_message'
       expect(error.message).to match('error_message')
@@ -33,6 +34,9 @@ module MsRestAzure
       expect(error.body).to eq(body)
       # message must contain message from body
       expect(error.message).to match(error_message)
+      # message must have error_message &  error_code property
+      expect(error.error_message).to match(error_message)
+      expect(error.error_code).to match(error_code)
     end
 
     it 'should create error with request, response, body and message' do
@@ -42,6 +46,9 @@ module MsRestAzure
       expect(error.body).to eq(body)
       # message must contain message from body
       expect(error.message).to match(error_message)
+      # message must have error_message &  error_code property
+      expect(error.error_message).to match(error_message)
+      expect(error.error_code).to match(error_code)
     end
   end
 end

--- a/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_error.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_error.rb
@@ -24,6 +24,7 @@ module MsRest
     # @param [Faraday::Response] the HTTP response object.
     # @param [String] body the HTTP response body.
     # @param [String] error message.
+    #
     def initialize(*args)
       @msg = self.class.name
       if args.size == 1


### PR DESCRIPTION
Updating AzureOperationResponse to provide more visibility on `error_message`, `error_code` and `message` properties when available. With this change message field contains the actual inner error message concatenated with outer exception class name. 

**Before**:
```
{
  "message": "MsRestAzure::AzureOperationError",
  "request": {
    "base_uri": "https://management.azure.com",
    "path_template": "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
    "method": "delete",
    "path_params": {
      "resourceGroupName": "~`123",
      "subscriptionId": "530ac4b6-395b-4fc0-97b9-0a2ecb738490"
    },
    "skip_encoding_path_params": null,
    "query_params": {
      "api-version": "2016-02-01"
    },
    "skip_encoding_query_params": null,
    "headers": {
      "x-ms-client-request-id": "50366b85-a35e-4165-b63c-63f5def03103",
      "accept-language": "en-US"
    },
    "body": null,
    "middlewares": [
      [
        "MsRest::RetryPolicyMiddleware",
        {
          "times": 3,
          "retry": 0.02
        }
      ],
      [
        "cookie_jar"
      ]
    ],
    "log": null
  },
  "response": {
    "body": {
      "error": {
        "code": "InvalidResourceGroup",
        "message": "The provided resource group name '~`123' has these invalid characters: '~`'. The name can only be a letter, digit, '-', '.', '(', ')' or '_'."
      }
    },
    "headers": {
      "cache-control": "no-cache",
      "pragma": "no-cache",
      "content-type": "application/json; charset=utf-8",
      "expires": "-1",
      "x-ms-failure-cause": "gateway",
      "x-ms-ratelimit-remaining-subscription-writes": "1198",
      "x-ms-request-id": "ed17ae6d-d75e-490a-a41b-e95357aaf966",
      "x-ms-correlation-request-id": "ed17ae6d-d75e-490a-a41b-e95357aaf966",
      "x-ms-routing-request-id": "WESTUS:20160519T032813Z:ed17ae6d-d75e-490a-a41b-e95357aaf966",
      "strict-transport-security": "max-age=31536000; includeSubDomains",
      "date": "Thu, 19 May 2016 03:28:12 GMT",
      "connection": "close",
      "content-length": "195"
    },
    "status": 400
  }
}
```


**After**:

```
{
  "message": "MsRestAzure::AzureOperationError : The provided resource group name '~`123' has these invalid characters: '~`'. The name can only be a letter, digit, '-', '.', '(', ')' or '_'.",
  "request": {
    "base_uri": "https://management.azure.com",
    "path_template": "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
    "method": "delete",
    "path_params": {
      "resourceGroupName": "~`123",
      "subscriptionId": "530ac4b6-395b-4fc0-97b9-0a2ecb738490"
    },
    "skip_encoding_path_params": null,
    "query_params": {
      "api-version": "2016-02-01"
    },
    "skip_encoding_query_params": null,
    "headers": {
      "x-ms-client-request-id": "8cf98cf8-5634-47da-b473-b2592160bd5c",
      "accept-language": "en-US"
    },
    "body": null,
    "middlewares": [
      [
        "MsRest::RetryPolicyMiddleware",
        {
          "times": 3,
          "retry": 0.02
        }
      ],
      [
        "cookie_jar"
      ]
    ],
    "log": null
  },
  "response": {
    "body": {
      "error": {
        "code": "InvalidResourceGroup",
        "message": "The provided resource group name '~`123' has these invalid characters: '~`'. The name can only be a letter, digit, '-', '.', '(', ')' or '_'."
      }
    },
    "headers": {
      "cache-control": "no-cache",
      "pragma": "no-cache",
      "content-type": "application/json; charset=utf-8",
      "expires": "-1",
      "x-ms-failure-cause": "gateway",
      "x-ms-ratelimit-remaining-subscription-writes": "1198",
      "x-ms-request-id": "ed17ae6d-d75e-490a-a41b-e95357aaf966",
      "x-ms-correlation-request-id": "ed17ae6d-d75e-490a-a41b-e95357aaf966",
      "x-ms-routing-request-id": "WESTUS:20160519T032813Z:ed17ae6d-d75e-490a-a41b-e95357aaf966",
      "strict-transport-security": "max-age=31536000; includeSubDomains",
      "date": "Thu, 19 May 2016 03:28:12 GMT",
      "connection": "close",
      "content-length": "195"
    },
    "status": 400
  }
}
```