### PR TITLE
[Not for merge here] Fix unusual client version

### DIFF
--- a/src/client/Microsoft.Rest.ClientRuntime/ServiceClient.cs
+++ b/src/client/Microsoft.Rest.ClientRuntime/ServiceClient.cs
@@ -160,7 +160,9 @@ namespace Microsoft.Rest
                                 .First(c => c.StartsWith("Version=", StringComparison.OrdinalIgnoreCase))
                                 .Substring("Version=".Length);
                     }
-
+                    
+                    // removing all info after the first space
+                    _clientVersion = _clientVersion.Split(' ').First();
                 }
                 return _clientVersion;
             }


### PR DESCRIPTION
Our product version looks like: 1.0.10390.928 (rd_branch_n(abcd).160726-1648), which will fail with the following message. This fix will remove all the info after the first space. For more info about this issue, please see http://stackoverflow.com/questions/13198090/adding-httpclient-headers-generates-a-formatexception-with-some-values 

System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.FormatException: The format of value '1.0.10390.928 (rd_branch_n(abcd).160726-1648)' is invalid.
   at System.Net.Http.Headers.HeaderUtilities.CheckValidToken(String value, String parameterName)
   at System.Net.Http.Headers.ProductHeaderValue..ctor(String name, String version)
   at Microsoft.Rest.ServiceClient`1.InitializeHttpClient(HttpClientHandler httpClientHandler, DelegatingHandler[] handlers)