### PR TITLE
[Ruby] Fix dual credentials on Ruby Service Clients

### DIFF
--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
@@ -33,10 +33,6 @@ module Petstore
     # is generated and included in each request. Default is true.
     attr_accessor :generate_client_request_id
 
-    # @return Subscription credentials which uniquely identify client
-    # subscription.
-    attr_accessor :credentials
-
     # @return [StorageAccounts] storage_accounts
     attr_reader :storage_accounts
 

--- a/src/generator/AutoRest.Ruby/RubyCodeGenerator.cs
+++ b/src/generator/AutoRest.Ruby/RubyCodeGenerator.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using AutoRest.Core;
 using AutoRest.Core.ClientModel;
+using AutoRest.Core.Utilities;
 using AutoRest.Extensions;
 using AutoRest.Ruby.TemplateModels;
 using AutoRest.Ruby.Templates;
@@ -140,13 +142,16 @@ namespace AutoRest.Ruby
         {
             if (Settings.AddCredentials)
             {
-                serviceClient.Properties.Add(new Property
+                if (!serviceClient.Properties.Any(p => p.Type.IsPrimaryType(KnownPrimaryType.Credentials)))
                 {
-                    Name = "Credentials",
-                    Type = new PrimaryType(KnownPrimaryType.Credentials),
-                    IsRequired = true,
-                    Documentation = "Subscription credentials which uniquely identify client subscription."
-                });
+                    serviceClient.Properties.Add(new Property
+                    {
+                        Name = "Credentials",
+                        Type = new PrimaryType(KnownPrimaryType.Credentials),
+                        IsRequired = true,
+                        Documentation = "Subscription credentials which uniquely identify client subscription."
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
_Problem_: https://github.com/Azure/azure-sdk-for-ruby/issues/479
_Solutions_: Based on the fix from [NodeJS ](https://github.com/Azure/autorest/blob/master/src/generator/AutoRest.NodeJS/NodeJSCodeGenerator.cs#L76) and [Python ](https://github.com/Azure/autorest/blob/master/src/generator/AutoRest.Python/PythonCodeGenerator.cs#L81) language generator we should only populate credentials if they are not already added. 