### PR TITLE
Fix errant OOM on HEAD REQUEST.

### DIFF
--- a/src/generator/AutoRest.CSharp/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/MethodTemplate.cshtml
@@ -253,13 +253,13 @@ else
     }
 
     cancellationToken.ThrowIfCancellationRequested();
-    @if (!Model.ReturnType.Body.IsPrimaryType(KnownPrimaryType.Stream))
+    @if (Model.ReturnType.Body.IsPrimaryType(KnownPrimaryType.Stream) || Model.HttpMethod == HttpMethod.Head)
     {
-    @:_httpResponse = await @(Model.ClientReference).HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+    @:_httpResponse = await @(Model.ClientReference).HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
     }
     else
     {
-    @:_httpResponse = await @(Model.ClientReference).HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+    @:_httpResponse = await @(Model.ClientReference).HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
     }
     if (_shouldTrace)
     {


### PR DESCRIPTION
On Head Request, always use `HttpCompletionOption.ResponseHeadersRead` on SendAsync