### PR TITLE
Generating C# project files based on new -Project flag

### DIFF
--- a/src/core/AutoRest.Core/FileTemplate.cs
+++ b/src/core/AutoRest.Core/FileTemplate.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace AutoRest.Core
+{
+#line 1 "FileTemplate.cshtml"
+
+#line default
+#line hidden
+    using System.Threading.Tasks;
+
+    public class FileTemplate : Template<string>
+    {
+        #line hidden
+        public FileTemplate()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+#line 3 "FileTemplate.cshtml"
+Write(Model);
+
+#line default
+#line hidden
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/src/core/AutoRest.Core/FileTemplate.cshtml
+++ b/src/core/AutoRest.Core/FileTemplate.cshtml
@@ -1,0 +1,2 @@
+﻿@inherits AutoRest.Core.Template<string>
+@Model

--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -402,6 +402,15 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to -{0} is required to use the -Project flag.
+        /// </summary>
+        public static string PackageInfoRequiredForProject {
+            get {
+                return ResourceManager.GetString("PackageInfoRequiredForProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Parameter &apos;{0}&apos; is not expected..
         /// </summary>
         public static string ParameterIsNotValid {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -252,4 +252,7 @@
   <data name="InvalidConstraint" xml:space="preserve">
     <value>Constraint is not supported for this type and will be ignored.</value>
   </data>
+  <data name="PackageInfoRequiredForProject" xml:space="preserve">
+    <value>-{0} is required to use the -Project flag</value>
+  </data>
 </root>

--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -54,6 +54,7 @@ Licensed under the MIT License. See License.txt in the project root for license 
             Modeler = "Swagger";
             ValidationLevel = LogEntrySeverity.Error;
             ModelsName = "Models";
+            Project = false;
         }
 
         /// <summary>
@@ -275,6 +276,14 @@ Licensed under the MIT License. See License.txt in the project root for license 
         public LogEntrySeverity ValidationLevel { get; set; }
 
         /// <summary>
+        /// The input validation severity level that will prevent code generation
+        /// </summary>
+        [SettingsAlias("p")]
+        [SettingsAlias("project")]
+        [SettingsInfo("Whether AutoRest should generate a project for the generated files")]
+        public bool Project { get; set; }
+
+        /// <summary>
         /// Factory method to generate CodeGenerationSettings from command line arguments.
         /// Matches dictionary keys to the settings properties.
         /// </summary>
@@ -444,6 +453,18 @@ Licensed under the MIT License. See License.txt in the project root for license 
                 foreach (var unmatchedSetting in CustomSettings.Keys)
                 {
                     Logger.LogWarning(Resources.ParameterIsNotValid, unmatchedSetting);
+                }
+            }
+
+            if (Project)
+            {
+                if (string.IsNullOrEmpty(PackageName))
+                {
+                    Logger.LogError(new ArgumentException("PackageName"), Resources.PackageInfoRequiredForProject, "PackageName");
+                }
+                if (string.IsNullOrEmpty(PackageVersion))
+                {
+                    Logger.LogError(new ArgumentException("PackageVersion"), Resources.PackageInfoRequiredForProject, "PackageVersion");
                 }
             }
             ErrorManager.ThrowErrors();

--- a/src/generator/AutoRest.CSharp.Azure.Tests/project.json
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/project.json
@@ -32,5 +32,6 @@
     "Microsoft.Rest.ClientRuntime": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
+
   }
 }

--- a/src/generator/AutoRest.CSharp.Azure/AzureCSharpCodeGenerator.cs
+++ b/src/generator/AutoRest.CSharp.Azure/AzureCSharpCodeGenerator.cs
@@ -20,7 +20,9 @@ namespace AutoRest.CSharp.Azure
     {
         private readonly AzureCSharpCodeNamer _namer;
 
-        private const string ClientRuntimePackage = "Microsoft.Rest.ClientRuntime.Azure.3.2.0";
+        private const string ClientRuntimePackageVersion = "3.2.0";
+        private const string ClientRuntimePackageName = "Microsoft.Rest.ClientRuntime.Azure";
+        private const string ClientRuntimePackage = ClientRuntimePackageName + "." + ClientRuntimePackageVersion;
 
         // page extensions class dictionary.
         private IDictionary<KeyValuePair<string, string>, string> pageClasses;
@@ -196,6 +198,23 @@ namespace AutoRest.CSharp.Azure
                     Model = new ModelTemplateModel(exceptionType),
                 };
                 await Write(exceptionTemplate, Path.Combine(Settings.ModelsName, exceptionTemplate.Model.ExceptionTypeDefinitionName + ".cs"));
+            }
+
+            if (Settings.Project)
+            {
+                // Write project.json
+                var projectJsonTemplate = new AzureProjectJsonTemplate
+                {
+                    Model = new ProjectJsonModel(Settings.PackageVersion, Settings.PackageName, ClientRuntimePackageVersion)
+                };
+                await Write(projectJsonTemplate, Path.Combine(Settings.OutputDirectory, "project.json"));
+
+                // Write .xproj
+                var projectTemplate = new XProjTemplate
+                {
+                    Model = Settings.Namespace
+                };
+                await Write(projectTemplate, Path.Combine(Settings.OutputDirectory, Settings.Namespace + ".xproj"));
             }
         }
     }

--- a/src/generator/AutoRest.CSharp.Azure/Templates/AzureProjectJsonTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.Azure/Templates/AzureProjectJsonTemplate.cshtml
@@ -1,0 +1,53 @@
+﻿@using System.Linq
+@inherits AutoRest.Core.Template<AutoRest.CSharp.TemplateModels.ProjectJsonModel>
+{
+  "version": "@Model.Version",
+  "description": "@Model.Description",
+  "authors": [ "Microsoft" ],
+
+  "packOptions": {
+    "summary": "@Model.Description",
+    "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288890",
+    "tags": [],
+    "projectUrl": "https://github.com/Azure/azure-sdk-for-net",
+    "licenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+    "requireLicenseAcceptance": true
+  },
+
+  "buildOptions": {
+    "delaySign": true,
+    "publicSign": false,
+    "keyFile": "../../../../tools/MSSharedLibKey.snk"
+  },
+
+  "dependencies": {
+  },
+
+  "frameworks": {
+    "net45": {
+      "dependencies": {
+        "Microsoft.Rest.ClientRuntime.Azure": "[@Model.ClientRuntimeVersion,4.0.0)" 
+      }
+    },
+    "netstandard1.5": {
+      "imports": ["dnxcore50"],
+      "buildOptions": { "define": [ "PORTABLE" ] },
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Diagnostics.Tools": "4.0.1",
+        "System.Net.Http": "4.1.0",
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "System.Threading.Tasks": "4.0.11",
+        "Microsoft.Rest.ClientRuntime.Azure": "[@Model.ClientRuntimeVersion,4.0.0)"
+      }
+    },
+    "netstandard1.1": {
+      "imports": [ "dnxcore50" ],
+      "buildOptions": { "define": [ "PORTABLE" ] },
+      "dependencies": {
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "Microsoft.Rest.ClientRuntime.Azure": "[@Model.ClientRuntimeVersion,4.0.0)"
+      }
+    }
+  }
+}

--- a/src/generator/AutoRest.CSharp/CSharpCodeGenerator.cs
+++ b/src/generator/AutoRest.CSharp/CSharpCodeGenerator.cs
@@ -12,13 +12,17 @@ using AutoRest.CSharp.TemplateModels;
 using AutoRest.CSharp.Templates;
 using AutoRest.Extensions;
 using AutoRest = AutoRest.Core.AutoRest;
+using Newtonsoft.Json;
+using AutoRest.Core.Utilities;
 
 namespace AutoRest.CSharp
 {
     public class CSharpCodeGenerator : CodeGenerator
     {
         private readonly CSharpCodeNamer _namer;
-        private const string ClientRuntimePackage = "Microsoft.Rest.ClientRuntime.2.2.0";
+        private const string ClientRuntimePackageVersion = "2.2.0";
+        private const string ClientRuntimePackageName = "Microsoft.Rest.ClientRuntime";
+        private const string ClientRuntimePackage = ClientRuntimePackageName + "." + ClientRuntimePackageVersion;
 
         public CSharpCodeGenerator(Settings settings) : base(settings)
         {
@@ -182,6 +186,22 @@ namespace AutoRest.CSharp
                     Model = new ModelTemplateModel(exceptionType),
                 };
                 await Write(exceptionTemplate, Path.Combine(Settings.ModelsName, exceptionTemplate.Model.ExceptionTypeDefinitionName + ".cs"));
+            }
+
+            if (Settings.Project)
+            {
+                var projectJsonTemplate = new ProjectJsonTemplate
+                {
+                    Model = new ProjectJsonModel(Settings.PackageVersion, Settings.PackageName, ClientRuntimePackageVersion)
+                };
+                await Write(projectJsonTemplate, Path.Combine(Settings.OutputDirectory, "project.json"));
+
+                // Write .xproj
+                var projectTemplate = new XProjTemplate
+                {
+                    Model = Settings.Namespace
+                };
+                await Write(projectTemplate, Path.Combine(Settings.OutputDirectory, Settings.Namespace + ".xproj"));
             }
         }
     }

--- a/src/generator/AutoRest.CSharp/TemplateModels/ProjectJsonModel.cs
+++ b/src/generator/AutoRest.CSharp/TemplateModels/ProjectJsonModel.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.ClientModel;
+using AutoRest.Core.Utilities;
+
+namespace AutoRest.CSharp.TemplateModels
+{
+    public class ProjectJsonModel
+    {
+        public string Version { get; set; }
+
+        public string Description { get; set; }
+
+        public string ClientRuntimeVersion { get; set; }
+
+        public ProjectJsonModel(string packageVersion, string packageDescription, string runtimeVersion)
+        {
+            this.Version = packageVersion;
+            this.Description = packageDescription;
+            this.ClientRuntimeVersion = runtimeVersion;
+        }
+    }
+}

--- a/src/generator/AutoRest.CSharp/Templates/ProjectJsonTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/ProjectJsonTemplate.cshtml
@@ -1,0 +1,50 @@
+﻿@using System.Linq
+@inherits AutoRest.Core.Template<AutoRest.CSharp.TemplateModels.ProjectJsonModel>
+{
+  "version": "@Model.Version",
+  "description": "@Model.Description",
+  "authors": [ "Microsoft" ],
+
+  "packOptions": {
+    "summary": "@Model.Description",
+    "tags": [],
+    "requireLicenseAcceptance": true
+  },
+
+  "buildOptions": {
+    "delaySign": true,
+    "publicSign": false,
+    "keyFile": "../../../../tools/MSSharedLibKey.snk"
+  },
+
+  "dependencies": {
+  },
+
+  "frameworks": {
+    "net45": {
+      "dependencies": {
+        "Microsoft.Rest.ClientRuntime": "[@Model.ClientRuntimeVersion,4.0.0)" 
+      }
+    },
+    "netstandard1.5": {
+      "imports": ["dnxcore50"],
+      "buildOptions": { "define": [ "PORTABLE" ] },
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Diagnostics.Tools": "4.0.1",
+        "System.Net.Http": "4.1.0",
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "System.Threading.Tasks": "4.0.11",
+        "Microsoft.Rest.ClientRuntime": "[@Model.ClientRuntimeVersion,4.0.0)"
+      }
+    },
+    "netstandard1.1": {
+      "imports": [ "dnxcore50" ],
+      "buildOptions": { "define": [ "PORTABLE" ] },
+      "dependencies": {
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "Microsoft.Rest.ClientRuntime": "[@Model.ClientRuntimeVersion,4.0.0)"
+      }
+    }
+  }
+}

--- a/src/generator/AutoRest.CSharp/Templates/XProjTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/XProjTemplate.cshtml
@@ -1,0 +1,24 @@
+﻿@using System.Linq;
+@using System;
+@inherits AutoRest.Core.Template<string>
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>@Guid.NewGuid()</ProjectGuid>
+    <RootNamespace>@Model</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>


### PR DESCRIPTION
- New flag -Project, which controls whether or not project files are generated
- Adding a FileTemplate (outputs a bare file), an XProjTemplate (outputs an XProj) and ProjectJson/AzureProjectJson templates (might be merged into one template later depending on how much they differ)
- Adding a step in CSharpCodeGenerator and AzureCSharpCodeGenerator that outputs project.json and .xproj files for the generated code if the flag is included

Still todo: 
- Be smarter about overwriting existing project files - this code does not yet update an existing file with the correct info (e.g. ClientRuntime reference)
- Generate a test project for the Azure generator