### PR TITLE
[Ruby] Updating gem specs with minimum Ruby version to 2.0.0

### DIFF
--- a/src/client/Ruby/ms-rest-azure/README.md
+++ b/src/client/Ruby/ms-rest-azure/README.md
@@ -4,7 +4,6 @@ MsRestAzure is a library which supports the Azure clients (SDKs) generated with 
 
 # Supported Ruby Versions
 
-* Ruby 1.9.3
 * Ruby 2.0
 * Ruby 2.1
 * Ruby 2.2

--- a/src/client/Ruby/ms-rest-azure/ms_rest_azure.gemspec
+++ b/src/client/Ruby/ms-rest-azure/ms_rest_azure.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/src/client/Ruby/ms-rest/README.md
+++ b/src/client/Ruby/ms-rest/README.md
@@ -4,7 +4,6 @@ MsRest is a library which supports the clients (SDKs) generated with Autorest to
 
 # Supported Ruby Versions
 
-* Ruby 1.9.3
 * Ruby 2.0
 * Ruby 2.1
 * Ruby 2.2

--- a/src/client/Ruby/ms-rest/ms_rest.gemspec
+++ b/src/client/Ruby/ms-rest/ms_rest.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Aligned with https://github.com/Azure/azure-sdk-for-ruby/pull/480